### PR TITLE
feat(diet): Flutter 식단 탄단지 데이터 연결

### DIFF
--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -190,12 +190,36 @@ class LocalApiInterceptor extends Interceptor {
     final body = _jsonBody(options);
     final mealType = (body['meal_type'] as String?)?.trim();
     final timeLabel = (body['time_label'] as String?)?.trim();
+    final Object? foodsValue = body['foods'];
+    if (body.containsKey('foods') &&
+        (foodsValue is! List || foodsValue.any((food) => food is! Map))) {
+      return _badRequest(options, 'foods must be a list of objects');
+    }
+    final List<Object?>? requestFoods = foodsValue is List
+        ? List<Object?>.from(foodsValue)
+        : null;
+    final Object? totalCaloriesValue = body['total_calories'];
+    final Object? sodiumMgValue = body['sodium_mg'];
+    final Object? sugarGValue = body['sugar_g'];
     await (_db.update(_db.dietEntries)..where((t) => t.id.equals(id))).write(
       DietEntriesCompanion(
         mealType: (mealType == null || mealType.isEmpty)
             ? const Value.absent()
             : Value(mealType),
         timeLabel: timeLabel == null ? const Value.absent() : Value(timeLabel),
+        foodsJson: requestFoods == null
+            ? const Value.absent()
+            : Value(jsonEncode(requestFoods)),
+        totalCalories:
+            body.containsKey('total_calories') && totalCaloriesValue is num
+            ? Value(totalCaloriesValue.toInt())
+            : const Value.absent(),
+        sodiumMg: body.containsKey('sodium_mg') && sodiumMgValue is num
+            ? Value(sodiumMgValue.toInt())
+            : const Value.absent(),
+        sugarG: body.containsKey('sugar_g') && sugarGValue is num
+            ? Value(sugarGValue.toInt())
+            : const Value.absent(),
       ),
     );
     final row = await (_db.select(

--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -1418,6 +1418,8 @@ _MacroTotals _foodMacroTotals(List<Object?> foods) {
   return (carbsG: carbs, proteinG: protein, fatG: fat);
 }
 
+// Keep this 4/4/9 largest-remainder calculation in sync with
+// the backend calculate_macros implementation.
 Map<String, Object?> _macroPayload(
   double carbsG,
   double proteinG,

--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -153,7 +153,8 @@ class LocalApiInterceptor extends Interceptor {
     final type = (body['type'] as String? ?? existing.type).trim();
     final minutes = (body['minutes'] as num?)?.toInt() ?? existing.minutes;
     final calories = (body['calories'] as num?)?.toInt() ?? existing.calories;
-    final intensity = (body['intensity'] as String? ?? existing.intensity).trim();
+    final intensity = (body['intensity'] as String? ?? existing.intensity)
+        .trim();
     final dayRaw = (body['day_label'] as String? ?? '').trim();
     final dayLabel = dayRaw.isEmpty ? existing.dayLabel : dayRaw;
     await (_db.update(
@@ -398,9 +399,10 @@ class LocalApiInterceptor extends Interceptor {
 
     // 같은 멱등키가 이미 저장돼 있으면 새로 저장하지 않고 기존 entry 를 반환(재시도 중복 방지).
     if (idempotencyKey != null) {
-      final existing = await (_db.select(
-        _db.dietEntries,
-      )..where((t) => t.idempotencyKey.equals(idempotencyKey!))).getSingleOrNull();
+      final existing =
+          await (_db.select(_db.dietEntries)
+                ..where((t) => t.idempotencyKey.equals(idempotencyKey!)))
+              .getSingleOrNull();
       if (existing != null) {
         final storedFoods = (jsonDecode(existing.foodsJson) as List<Object?>)
             .cast<Map<String, Object?>>();
@@ -837,48 +839,48 @@ class LocalApiInterceptor extends Interceptor {
     if (has(<String>['나트륨', '혈압', '짜', '소금', '국물'])) {
       return (
         '나트륨을 줄이려면 국물은 남기고 건더기 위주로 드시고, 소금 대신 후추·마늘·레몬으로 '
-        '간을 해보세요. 하루 나트륨을 2000mg 이하로 맞추면 혈압 관리에 큰 도움이 돼요. 🌿',
+            '간을 해보세요. 하루 나트륨을 2000mg 이하로 맞추면 혈압 관리에 큰 도움이 돼요. 🌿',
         <String>['나트륨 줄이기', 'DASH 식단 개요'],
       );
     }
     if (has(<String>['당', '혈당', '설탕', '단 것', '디저트'])) {
       return (
         '혈당 관리를 위해 가당 음료와 디저트 같은 단순당을 줄이고, 식이섬유가 풍부한 통곡물·채소를 '
-        '늘려보세요. 음료는 물이나 무가당 차로 바꾸는 것만으로도 효과가 좋아요. 🍵',
+            '늘려보세요. 음료는 물이나 무가당 차로 바꾸는 것만으로도 효과가 좋아요. 🍵',
         <String>['당류 관리'],
       );
     }
     if (has(<String>['운동', '걷', '헬스', '유산소', '근력'])) {
       return (
         '빠르게 걷기 같은 중강도 유산소를 주 5회, 하루 30분씩 해보세요. 여기에 주 2회 가벼운 근력 '
-        '운동을 더하면 혈압·혈당 관리에 특히 좋아요. 식후 10분 걷기도 큰 도움이 됩니다. 🚶',
+            '운동을 더하면 혈압·혈당 관리에 특히 좋아요. 식후 10분 걷기도 큰 도움이 됩니다. 🚶',
         <String>['고혈압과 운동', '유산소와 근력 균형'],
       );
     }
     if (has(<String>['뭐 먹', '식단', '점심', '저녁', '아침', '메뉴'])) {
       return (
         '채소·통곡물·저지방 단백질 위주의 DASH 식단을 추천해요. 국·찌개는 싱겁게, 튀김보다 구이·찜으로 '
-        '드시면 좋아요. 혹시 최근 나트륨이 높았다면 담백한 샐러드나 생선구이가 균형을 맞춰줘요. 🥗',
+            '드시면 좋아요. 혹시 최근 나트륨이 높았다면 담백한 샐러드나 생선구이가 균형을 맞춰줘요. 🥗',
         <String>['DASH 식단 개요'],
       );
     }
     if (has(<String>['물', '수분'])) {
       return (
         '하루 6~8잔의 물을 나눠 마시는 것이 혈압과 신진대사에 도움이 돼요. 카페인·가당 음료는 줄이고 '
-        '물로 대체해보세요. 💧',
+            '물로 대체해보세요. 💧',
         <String>['수분 섭취'],
       );
     }
     if (has(<String>['체중', '살', '다이어트', '몸무게'])) {
       return (
         '급격한 감량보다 식단과 운동을 병행한 완만한 감량이 안전해요. 체중을 5~10%만 줄여도 혈압·혈당 '
-        '지표가 눈에 띄게 좋아질 수 있어요. 함께 천천히 가봐요! 💪',
+            '지표가 눈에 띄게 좋아질 수 있어요. 함께 천천히 가봐요! 💪',
         <String>['체중 관리'],
       );
     }
     return (
       '좋은 질문이에요! 식단·운동·혈압·혈당·수분 관리에 대해 더 구체적으로 물어봐 주시면 온이가 '
-      '맞춤으로 도와드릴게요. 예를 들어 "나트륨 줄이는 법"이나 "오늘 뭐 먹을까?"처럼요. 😊',
+          '맞춤으로 도와드릴게요. 예를 들어 "나트륨 줄이는 법"이나 "오늘 뭐 먹을까?"처럼요. 😊',
       <String>[],
     );
   }
@@ -968,7 +970,10 @@ class LocalApiInterceptor extends Interceptor {
   }
 
   Future<Map<String, Object?>> _mergedProfile() async {
-    return <String, Object?>{..._defaultProfile, ...await _readProfileOverlay()};
+    return <String, Object?>{
+      ..._defaultProfile,
+      ...await _readProfileOverlay(),
+    };
   }
 
   Future<void> _mergeProfileOverlay(Map<String, Object?> patch) async {
@@ -1068,7 +1073,20 @@ class LocalApiInterceptor extends Interceptor {
           'improving': true,
           'last_7_days': <double>[0.62, 0.58, 0.52, 0.45, 0.36, 0.28, 0.20],
           'chart_values': <double>[
-            82, 80, 79, 78, 78, 77, 77, 76, 75, 75, 74, 73, 73, 72,
+            82,
+            80,
+            79,
+            78,
+            78,
+            77,
+            77,
+            76,
+            75,
+            75,
+            74,
+            73,
+            73,
+            72,
           ],
           'chart_min_y': 70,
           'chart_max_y': 75,
@@ -1090,7 +1108,20 @@ class LocalApiInterceptor extends Interceptor {
           'improving': true,
           'last_7_days': <double>[0.80, 0.74, 0.66, 0.55, 0.42, 0.28, 0.16],
           'chart_values': <double>[
-            145, 144, 142, 140, 140, 138, 136, 134, 132, 130, 129, 127, 126, 124,
+            145,
+            144,
+            142,
+            140,
+            140,
+            138,
+            136,
+            134,
+            132,
+            130,
+            129,
+            127,
+            126,
+            124,
           ],
           'chart_min_y': 100,
           'chart_max_y': 140,
@@ -1112,7 +1143,20 @@ class LocalApiInterceptor extends Interceptor {
           'improving': true,
           'last_7_days': <double>[0.78, 0.70, 0.60, 0.50, 0.40, 0.30, 0.18],
           'chart_values': <double>[
-            128, 124, 120, 118, 116, 113, 110, 108, 106, 104, 102, 100, 98, 96,
+            128,
+            124,
+            120,
+            118,
+            116,
+            113,
+            110,
+            108,
+            106,
+            104,
+            102,
+            100,
+            98,
+            96,
           ],
           'chart_min_y': 80,
           'chart_max_y': 140,
@@ -1129,11 +1173,7 @@ class LocalApiInterceptor extends Interceptor {
       'activity_points': 1240,
       'activity_rank': 14,
       'settings': <Map<String, Object?>>[
-        <String, Object?>{
-          'label': '내 프로필',
-          'icon': '👤',
-          'kind': 'my-profile',
-        },
+        <String, Object?>{'label': '내 프로필', 'icon': '👤', 'kind': 'my-profile'},
         <String, Object?>{
           'label': '건강 목표',
           'icon': '📊',
@@ -1144,11 +1184,7 @@ class LocalApiInterceptor extends Interceptor {
           'icon': '🔔',
           'kind': 'notification',
         },
-        <String, Object?>{
-          'label': '고객 지원',
-          'icon': '💬',
-          'kind': 'support',
-        },
+        <String, Object?>{'label': '고객 지원', 'icon': '💬', 'kind': 'support'},
       ],
     });
   }
@@ -1304,7 +1340,8 @@ class LocalApiInterceptor extends Interceptor {
     final body = options.data;
     if (body is Map) return body.cast<String, Object?>();
     if (body is String && body.isNotEmpty) {
-      return (jsonDecode(body) as Map<Object?, Object?>).cast<String, Object?>();
+      return (jsonDecode(body) as Map<Object?, Object?>)
+          .cast<String, Object?>();
     }
     return <String, Object?>{};
   }

--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -201,12 +201,16 @@ class LocalApiInterceptor extends Interceptor {
       _db.dietEntries,
     )..where((t) => t.id.equals(id))).getSingle();
     final foods = jsonDecode(row.foodsJson) as List<Object?>;
+    final macros = _foodMacroTotals(foods);
     return _ok(options, <String, Object?>{
       'id': row.id,
       'meal_type': row.mealType,
       'time_label': row.timeLabel,
       'foods': foods,
       'total_calories': row.totalCalories,
+      'carbs_g': macros.carbsG,
+      'protein_g': macros.proteinG,
+      'fat_g': macros.fatG,
       'sodium_mg': row.sodiumMg,
       'sugar_g': row.sugarG,
     });
@@ -331,17 +335,28 @@ class LocalApiInterceptor extends Interceptor {
     int totalCalories = 0;
     int totalSodium = 0;
     int totalSugar = 0;
+    double totalCarbs = 0;
+    double totalProtein = 0;
+    double totalFat = 0;
     final entriesJson = <Map<String, Object?>>[];
     for (final r in rows) {
+      final foods = (jsonDecode(r.foodsJson) as List<Object?>).cast<Object?>();
+      final macros = _foodMacroTotals(foods);
       totalCalories += r.totalCalories;
       totalSodium += r.sodiumMg;
       totalSugar += r.sugarG;
+      totalCarbs += macros.carbsG;
+      totalProtein += macros.proteinG;
+      totalFat += macros.fatG;
       entriesJson.add(<String, Object?>{
         'id': r.id,
         'meal_type': r.mealType,
         'time_label': r.timeLabel,
-        'foods': (jsonDecode(r.foodsJson) as List<Object?>).cast<Object?>(),
+        'foods': foods,
         'total_calories': r.totalCalories,
+        'carbs_g': macros.carbsG,
+        'protein_g': macros.proteinG,
+        'fat_g': macros.fatG,
         'sodium_mg': r.sodiumMg,
         'sugar_g': r.sugarG,
       });
@@ -352,15 +367,9 @@ class LocalApiInterceptor extends Interceptor {
       'total_calories': totalCalories,
       'total_sodium_mg': totalSodium,
       'total_sugar_g': totalSugar,
-      // Macro breakdown isn't tracked per entry yet — return the
-      // demo split until a richer schema lands.
-      'macros': <String, Object?>{
-        'carbs_pct': 50,
-        'protein_pct': 30,
-        'fat_pct': 20,
-      },
+      'macros': _macroPayload(totalCarbs, totalProtein, totalFat),
       'ai_coach_message': totalSodium > 2000
-          ? '오늘 점심에 나트륨이 많았어요. 저녁은 담백한 구이/샐러드로 균형을 맞춰봐요!'
+          ? '오늘 나트륨 섭취량이 권장량을 초과했어요. 점심의 김치찌개와 배추김치가 가장 큰 영향을 주었어요.'
           : '균형 잡힌 하루였어요. 내일도 이대로 가요!',
     });
   }
@@ -415,6 +424,9 @@ class LocalApiInterceptor extends Interceptor {
         'calories': 600,
         'sodium_mg': 900,
         'sugar_g': 8,
+        'carbs_g': 91.0,
+        'protein_g': 18.0,
+        'fat_g': 18.0,
         'source': 'db',
       },
       <String, Object?>{
@@ -422,6 +434,9 @@ class LocalApiInterceptor extends Interceptor {
         'calories': 15,
         'sodium_mg': 300,
         'sugar_g': 1,
+        'carbs_g': 3.0,
+        'protein_g': 1.0,
+        'fat_g': 0.0,
         'source': 'db',
       },
     ];
@@ -1326,3 +1341,54 @@ class LocalApiInterceptor extends Interceptor {
 }
 
 typedef _Handler = Future<Response<Object?>> Function(RequestOptions);
+
+typedef _MacroTotals = ({double carbsG, double proteinG, double fatG});
+
+_MacroTotals _foodMacroTotals(List<Object?> foods) {
+  var carbs = 0.0;
+  var protein = 0.0;
+  var fat = 0.0;
+  for (final food in foods) {
+    if (food is! Map) continue;
+    carbs += (food['carbs_g'] as num?)?.toDouble() ?? 0;
+    protein += (food['protein_g'] as num?)?.toDouble() ?? 0;
+    fat += (food['fat_g'] as num?)?.toDouble() ?? 0;
+  }
+  return (carbsG: carbs, proteinG: protein, fatG: fat);
+}
+
+Map<String, Object?> _macroPayload(
+  double carbsG,
+  double proteinG,
+  double fatG,
+) {
+  final energies = <double>[carbsG * 4, proteinG * 4, fatG * 9];
+  final totalEnergy = energies.fold<double>(0, (sum, value) => sum + value);
+  final percentages = <int>[0, 0, 0];
+  if (totalEnergy > 0) {
+    final raw = energies.map((energy) => energy / totalEnergy * 100).toList();
+    for (var i = 0; i < percentages.length; i++) {
+      percentages[i] = raw[i].floor();
+    }
+    final ranked = <int>[0, 1, 2]
+      ..sort((a, b) {
+        final fraction = (raw[b] - percentages[b]).compareTo(
+          raw[a] - percentages[a],
+        );
+        return fraction == 0 ? b.compareTo(a) : fraction;
+      });
+    final remaining =
+        100 - percentages.fold<int>(0, (sum, value) => sum + value);
+    for (final index in ranked.take(remaining)) {
+      percentages[index]++;
+    }
+  }
+  return <String, Object?>{
+    'carbs_g': carbsG,
+    'protein_g': proteinG,
+    'fat_g': fatG,
+    'carbs_pct': percentages[0],
+    'protein_pct': percentages[1],
+    'fat_pct': percentages[2],
+  };
+}

--- a/frontend/flutter/lib/core/storage/seed_data.dart
+++ b/frontend/flutter/lib/core/storage/seed_data.dart
@@ -47,9 +47,7 @@ Future<void> seedIfEmpty(AppDatabase db) async {
   // so the next insert lands cleanly. Non-seed rows (anything the
   // user actually entered) are not matched by the LIKE and survive.
   await db.transaction(() async {
-    await (db.delete(
-      db.dietEntries,
-    )..where((t) => t.id.like('seed-%'))).go();
+    await (db.delete(db.dietEntries)..where((t) => t.id.like('seed-%'))).go();
     await (db.delete(
       db.exerciseSessions,
     )..where((t) => t.id.like('seed-%'))).go();
@@ -67,7 +65,7 @@ Future<void> seedIfEmpty(AppDatabase db) async {
   await db.deleteValue('seeded_v2');
 
   await db.transaction(() async {
-    // ---- Diet entries (3 meals for today) ----
+    // ---- Diet entries (4 meals for today) ----
     await db.batch((Batch b) {
       b.insertAll(db.dietEntries, <DietEntriesCompanion>[
         DietEntriesCompanion.insert(
@@ -76,13 +74,37 @@ Future<void> seedIfEmpty(AppDatabase db) async {
           mealType: 'breakfast',
           timeLabel: '08:20',
           foodsJson: jsonEncode(<Map<String, Object?>>[
-            <String, Object?>{'name': '오트밀', 'calories': 220},
-            <String, Object?>{'name': '바나나 1개', 'calories': 90},
-            <String, Object?>{'name': '아메리카노', 'calories': 5},
+            <String, Object?>{
+              'name': '그릭요거트',
+              'calories': 150,
+              'sodium_mg': 70,
+              'sugar_g': 8,
+              'carbs_g': 12.0,
+              'protein_g': 14.0,
+              'fat_g': 4.0,
+            },
+            <String, Object?>{
+              'name': '바나나',
+              'calories': 105,
+              'sodium_mg': 1,
+              'sugar_g': 14,
+              'carbs_g': 27.0,
+              'protein_g': 1.3,
+              'fat_g': 0.4,
+            },
+            <String, Object?>{
+              'name': '삶은 달걀',
+              'calories': 75,
+              'sodium_mg': 65,
+              'sugar_g': 0,
+              'carbs_g': 0.6,
+              'protein_g': 6.5,
+              'fat_g': 5.3,
+            },
           ]),
-          totalCalories: 315,
-          sodiumMg: const Value(380),
-          sugarG: const Value(18),
+          totalCalories: 330,
+          sodiumMg: const Value(136),
+          sugarG: const Value(22),
         ),
         DietEntriesCompanion.insert(
           id: 'seed-diet-lunch',
@@ -90,12 +112,75 @@ Future<void> seedIfEmpty(AppDatabase db) async {
           mealType: 'lunch',
           timeLabel: '12:40',
           foodsJson: jsonEncode(<Map<String, Object?>>[
-            <String, Object?>{'name': '닭가슴살 샐러드', 'calories': 380},
-            <String, Object?>{'name': '현미밥 반공기', 'calories': 150},
+            <String, Object?>{
+              'name': '김치찌개',
+              'calories': 285,
+              'sodium_mg': 900,
+              'sugar_g': 4,
+              'carbs_g': 16.0,
+              'protein_g': 20.0,
+              'fat_g': 15.5,
+            },
+            <String, Object?>{
+              'name': '흰쌀밥',
+              'calories': 280,
+              'sodium_mg': 3,
+              'sugar_g': 0,
+              'carbs_g': 61.0,
+              'protein_g': 5.5,
+              'fat_g': 0.5,
+            },
+            <String, Object?>{
+              'name': '계란말이',
+              'calories': 190,
+              'sodium_mg': 320,
+              'sugar_g': 1,
+              'carbs_g': 5.0,
+              'protein_g': 13.0,
+              'fat_g': 13.0,
+            },
+            <String, Object?>{
+              'name': '배추김치',
+              'calories': 25,
+              'sodium_mg': 420,
+              'sugar_g': 2,
+              'carbs_g': 4.0,
+              'protein_g': 1.5,
+              'fat_g': 0.3,
+            },
           ]),
-          totalCalories: 530,
-          sodiumMg: const Value(1120),
-          sugarG: const Value(14),
+          totalCalories: 780,
+          sodiumMg: const Value(1643),
+          sugarG: const Value(7),
+        ),
+        DietEntriesCompanion.insert(
+          id: 'seed-diet-snack',
+          date: today,
+          mealType: 'snack',
+          timeLabel: '15:30',
+          foodsJson: jsonEncode(<Map<String, Object?>>[
+            <String, Object?>{
+              'name': '아이스 아메리카노',
+              'calories': 10,
+              'sodium_mg': 10,
+              'sugar_g': 0,
+              'carbs_g': 2.0,
+              'protein_g': 0.5,
+              'fat_g': 0.0,
+            },
+            <String, Object?>{
+              'name': '견과류 한 봉',
+              'calories': 170,
+              'sodium_mg': 5,
+              'sugar_g': 3,
+              'carbs_g': 7.0,
+              'protein_g': 6.0,
+              'fat_g': 13.0,
+            },
+          ]),
+          totalCalories: 180,
+          sodiumMg: const Value(15),
+          sugarG: const Value(3),
         ),
         DietEntriesCompanion.insert(
           id: 'seed-diet-dinner',
@@ -103,12 +188,37 @@ Future<void> seedIfEmpty(AppDatabase db) async {
           mealType: 'dinner',
           timeLabel: '19:00',
           foodsJson: jsonEncode(<Map<String, Object?>>[
-            <String, Object?>{'name': '연어 스테이크', 'calories': 420},
-            <String, Object?>{'name': '구운 야채', 'calories': 155},
+            <String, Object?>{
+              'name': '닭가슴살 샐러드',
+              'calories': 260,
+              'sodium_mg': 180,
+              'sugar_g': 4,
+              'carbs_g': 14.0,
+              'protein_g': 36.0,
+              'fat_g': 6.7,
+            },
+            <String, Object?>{
+              'name': '현미밥',
+              'calories': 220,
+              'sodium_mg': 5,
+              'sugar_g': 1,
+              'carbs_g': 46.0,
+              'protein_g': 5.0,
+              'fat_g': 1.8,
+            },
+            <String, Object?>{
+              'name': '오리엔탈 드레싱',
+              'calories': 90,
+              'sodium_mg': 350,
+              'sugar_g': 6,
+              'carbs_g': 9.0,
+              'protein_g': 0.0,
+              'fat_g': 6.0,
+            },
           ]),
-          totalCalories: 575,
-          sodiumMg: const Value(600),
-          sugarG: const Value(13),
+          totalCalories: 570,
+          sodiumMg: const Value(535),
+          sugarG: const Value(11),
         ),
       ]);
     });

--- a/frontend/flutter/lib/features/diet/data/repositories/dio_diet_repository.dart
+++ b/frontend/flutter/lib/features/diet/data/repositories/dio_diet_repository.dart
@@ -91,19 +91,36 @@ class DioDietRepository implements DietRepository {
       },
     );
     final returned = DietEntry.fromJson(res.data!);
+    final updatedFoods = foods ?? returned.foods;
+    final editedMacros = foods == null
+        ? null
+        : (
+            carbsG: updatedFoods.fold<double>(
+              0,
+              (double sum, FoodItem food) => sum + food.carbsG,
+            ),
+            proteinG: updatedFoods.fold<double>(
+              0,
+              (double sum, FoodItem food) => sum + food.proteinG,
+            ),
+            fatG: updatedFoods.fold<double>(
+              0,
+              (double sum, FoodItem food) => sum + food.fatG,
+            ),
+          );
     final updated = DietEntry(
       id: returned.id,
       mealType: mealType == null
           ? returned.mealType
           : MealType.values.byName(mealType),
       timeLabel: timeLabel ?? returned.timeLabel,
-      foods: foods ?? returned.foods,
+      foods: updatedFoods,
       totalCalories: totalCalories ?? returned.totalCalories,
       sodiumMg: sodiumMg ?? returned.sodiumMg,
       sugarG: sugarG ?? returned.sugarG,
-      carbsG: returned.carbsG,
-      proteinG: returned.proteinG,
-      fatG: returned.fatG,
+      carbsG: editedMacros?.carbsG ?? returned.carbsG,
+      proteinG: editedMacros?.proteinG ?? returned.proteinG,
+      fatG: editedMacros?.fatG ?? returned.fatG,
     );
     _entryOverrides[id] = updated;
     _entryOverrideUpdatedAt[id] = DateTime.now();

--- a/frontend/flutter/lib/features/diet/data/repositories/dio_diet_repository.dart
+++ b/frontend/flutter/lib/features/diet/data/repositories/dio_diet_repository.dart
@@ -163,7 +163,7 @@ class DioDietRepository implements DietRepository {
         0,
         (int total, DietEntry entry) => total + entry.totalCalories,
       ),
-      macros: day.macros,
+      macros: _toDietMacros(_sumMacroGrams(entries)),
       totalSodiumMg: entries.fold<int>(
         0,
         (int total, DietEntry entry) => total + entry.sodiumMg,
@@ -175,4 +175,64 @@ class DioDietRepository implements DietRepository {
       aiCoachMessage: day.aiCoachMessage,
     );
   }
+}
+
+typedef _MacroGrams = ({double carbsG, double proteinG, double fatG});
+
+_MacroGrams _sumMacroGrams(Iterable<DietEntry> entries) => (
+  carbsG: entries.fold<double>(
+    0,
+    (double sum, DietEntry entry) => sum + entry.carbsG,
+  ),
+  proteinG: entries.fold<double>(
+    0,
+    (double sum, DietEntry entry) => sum + entry.proteinG,
+  ),
+  fatG: entries.fold<double>(
+    0,
+    (double sum, DietEntry entry) => sum + entry.fatG,
+  ),
+);
+
+// Keep this 4/4/9 largest-remainder calculation in sync with
+// the backend calculate_macros implementation.
+DietMacros _toDietMacros(_MacroGrams grams) {
+  final energies = <double>[
+    grams.carbsG * 4,
+    grams.proteinG * 4,
+    grams.fatG * 9,
+  ];
+  final totalEnergy = energies.fold<double>(
+    0,
+    (double sum, double energy) => sum + energy,
+  );
+  final percentages = <int>[0, 0, 0];
+  if (totalEnergy > 0) {
+    final raw = energies
+        .map((double energy) => energy / totalEnergy * 100)
+        .toList();
+    for (var index = 0; index < percentages.length; index++) {
+      percentages[index] = raw[index].floor();
+    }
+    final ranked = <int>[0, 1, 2]
+      ..sort((int a, int b) {
+        final fraction = (raw[b] - percentages[b]).compareTo(
+          raw[a] - percentages[a],
+        );
+        return fraction == 0 ? b.compareTo(a) : fraction;
+      });
+    final remaining =
+        100 - percentages.fold<int>(0, (int sum, int value) => sum + value);
+    for (final index in ranked.take(remaining)) {
+      percentages[index]++;
+    }
+  }
+  return DietMacros(
+    carbsG: grams.carbsG,
+    proteinG: grams.proteinG,
+    fatG: grams.fatG,
+    carbsPct: percentages[0],
+    proteinPct: percentages[1],
+    fatPct: percentages[2],
+  );
 }

--- a/frontend/flutter/lib/features/diet/data/repositories/dio_diet_repository.dart
+++ b/frontend/flutter/lib/features/diet/data/repositories/dio_diet_repository.dart
@@ -77,6 +77,11 @@ class DioDietRepository implements DietRepository {
                 (FoodItem food) => <String, Object?>{
                   'name': food.name,
                   'calories': food.calories,
+                  'sodium_mg': food.sodiumMg,
+                  'sugar_g': food.sugarG,
+                  'carbs_g': food.carbsG,
+                  'protein_g': food.proteinG,
+                  'fat_g': food.fatG,
                 },
               )
               .toList(),
@@ -96,6 +101,9 @@ class DioDietRepository implements DietRepository {
       totalCalories: totalCalories ?? returned.totalCalories,
       sodiumMg: sodiumMg ?? returned.sodiumMg,
       sugarG: sugarG ?? returned.sugarG,
+      carbsG: returned.carbsG,
+      proteinG: returned.proteinG,
+      fatG: returned.fatG,
     );
     _entryOverrides[id] = updated;
     _entryOverrideUpdatedAt[id] = DateTime.now();

--- a/frontend/flutter/lib/features/diet/data/repositories/mock_diet_repository.dart
+++ b/frontend/flutter/lib/features/diet/data/repositories/mock_diet_repository.dart
@@ -4,66 +4,199 @@ import 'package:oncare/features/diet/domain/entities/diet_analysis.dart';
 import 'package:oncare/features/diet/domain/entities/diet_day.dart';
 import 'package:oncare/features/diet/domain/repositories/diet_repository.dart';
 
-/// In-memory stateful mock for demo mode (`useMockApi`). Seeds today's
-/// "짬뽕 점심" scenario, then keeps analyze(=add)/update/delete in memory for
+/// In-memory stateful mock for demo mode (`useMockApi`). Seeds a realistic day,
+/// then keeps analyze(=add)/update/delete in memory for
 /// the app session so the diet-tab list and the "오늘의 영양 요약" totals
 /// reflect edits made through the app (issue #294). A single instance is
 /// created by [dietRepositoryProvider] and lives for the session, so the drift
 /// persists until the app is restarted.
 ///
-/// Per-food nutrition of the two seeded meals is the single source of truth
-/// (아침 217/221/6.3 + 점심 750/3,200/8.5 = 967/3,421/14.8); CRUD only applies
-/// deltas on top of the seeded totals. Macro percentages aren't derivable from
-/// per-food data, so they stay fixed.
+/// Per-food nutrition is the single source of truth for the seeded meal and
+/// daily totals. CRUD applies calories, sodium, and sugar deltas on top of the
+/// seed; macro totals remain the server-style daily summary.
 class MockDietRepository implements DietRepository {
   MockDietRepository();
 
   static const DietMacros _macros = DietMacros(
-    carbsPct: 50,
-    proteinPct: 30,
-    fatPct: 20,
+    carbsG: 203.6,
+    proteinG: 109.3,
+    fatG: 66.5,
+    carbsPct: 44,
+    proteinPct: 24,
+    fatPct: 32,
   );
   static const String _aiCoachMessage =
-      '점심 짬뽕으로 나트륨과 혈당 부담이 크게 높아졌어요! 오늘 저녁은 간을 하지 않은 두부/닭가슴살 샐러드나 채소 위주 식단으로 가볍게 드시고, 물을 자주 드셔주세요.';
+      '오늘 나트륨 섭취량이 권장량을 초과했어요. 점심의 김치찌개와 배추김치가 가장 큰 영향을 주었어요.';
 
   final List<DietEntry> _entries = <DietEntry>[
     const DietEntry(
       id: 'mock-breakfast',
       mealType: MealType.breakfast,
       timeLabel: '08:20',
-      totalCalories: 217,
-      sodiumMg: 221,
-      sugarG: 6.3,
-      photoAsset: 'assets/images/breakfast-scrambled-egg-strawberry.jpg',
-      aiComment: '단백질과 식이섬유의 깔끔한 조합으로, 소금 간과 기름만 조절하면 혈당과 혈압 모두 잡는 우수한 식단입니다.',
+      totalCalories: 330,
+      sodiumMg: 136,
+      sugarG: 22,
+      carbsG: 39.6,
+      proteinG: 21.8,
+      fatG: 9.7,
+      aiComment: '요거트와 달걀로 단백질을 챙기고 바나나로 아침 에너지를 보충했어요.',
       foods: <FoodItem>[
-        FoodItem(name: '스크램블 에그', calories: 185, sodiumMg: 220, sugarG: 0.8),
-        FoodItem(name: '딸기', calories: 32, sodiumMg: 1, sugarG: 5.5),
+        FoodItem(
+          name: '그릭요거트',
+          calories: 150,
+          sodiumMg: 70,
+          sugarG: 8,
+          carbsG: 12,
+          proteinG: 14,
+          fatG: 4,
+        ),
+        FoodItem(
+          name: '바나나',
+          calories: 105,
+          sodiumMg: 1,
+          sugarG: 14,
+          carbsG: 27,
+          proteinG: 1.3,
+          fatG: 0.4,
+        ),
+        FoodItem(
+          name: '삶은 달걀',
+          calories: 75,
+          sodiumMg: 65,
+          carbsG: 0.6,
+          proteinG: 6.5,
+          fatG: 5.3,
+        ),
       ],
     ),
     const DietEntry(
       id: 'mock-lunch',
       mealType: MealType.lunch,
       timeLabel: '12:40',
-      totalCalories: 750,
-      sodiumMg: 3200,
-      sugarG: 8.5,
-      photoAsset: 'assets/images/lunch-jjamppong.jpg',
-      aiComment: '정제 면과 높은 나트륨으로 혈압·혈당 부담이 매우 크니, 국물은 남기고 해물과 야채 위주로 드시는 것이 좋습니다.',
+      totalCalories: 780,
+      sodiumMg: 1643,
+      sugarG: 7,
+      carbsG: 86,
+      proteinG: 40,
+      fatG: 29.3,
+      aiComment: '김치찌개와 반찬의 간으로 나트륨이 높아 국물과 김치 양을 줄이는 편이 좋아요.',
       foods: <FoodItem>[
-        FoodItem(name: '짬뽕', calories: 750, sodiumMg: 3200, sugarG: 8.5),
+        FoodItem(
+          name: '김치찌개',
+          calories: 285,
+          sodiumMg: 900,
+          sugarG: 4,
+          carbsG: 16,
+          proteinG: 20,
+          fatG: 15.5,
+        ),
+        FoodItem(
+          name: '흰쌀밥',
+          calories: 280,
+          sodiumMg: 3,
+          carbsG: 61,
+          proteinG: 5.5,
+          fatG: 0.5,
+        ),
+        FoodItem(
+          name: '계란말이',
+          calories: 190,
+          sodiumMg: 320,
+          sugarG: 1,
+          carbsG: 5,
+          proteinG: 13,
+          fatG: 13,
+        ),
+        FoodItem(
+          name: '배추김치',
+          calories: 25,
+          sodiumMg: 420,
+          sugarG: 2,
+          carbsG: 4,
+          proteinG: 1.5,
+          fatG: 0.3,
+        ),
+      ],
+    ),
+    const DietEntry(
+      id: 'mock-snack',
+      mealType: MealType.snack,
+      timeLabel: '15:30',
+      totalCalories: 180,
+      sodiumMg: 15,
+      sugarG: 3,
+      carbsG: 9,
+      proteinG: 6.5,
+      fatG: 13,
+      foods: <FoodItem>[
+        FoodItem(
+          name: '아이스 아메리카노',
+          calories: 10,
+          sodiumMg: 10,
+          carbsG: 2,
+          proteinG: 0.5,
+        ),
+        FoodItem(
+          name: '견과류 한 봉',
+          calories: 170,
+          sodiumMg: 5,
+          sugarG: 3,
+          carbsG: 7,
+          proteinG: 6,
+          fatG: 13,
+        ),
+      ],
+    ),
+    const DietEntry(
+      id: 'mock-dinner',
+      mealType: MealType.dinner,
+      timeLabel: '19:00',
+      totalCalories: 570,
+      sodiumMg: 535,
+      sugarG: 11,
+      carbsG: 69,
+      proteinG: 41,
+      fatG: 14.5,
+      foods: <FoodItem>[
+        FoodItem(
+          name: '닭가슴살 샐러드',
+          calories: 260,
+          sodiumMg: 180,
+          sugarG: 4,
+          carbsG: 14,
+          proteinG: 36,
+          fatG: 6.7,
+        ),
+        FoodItem(
+          name: '현미밥',
+          calories: 220,
+          sodiumMg: 5,
+          sugarG: 1,
+          carbsG: 46,
+          proteinG: 5,
+          fatG: 1.8,
+        ),
+        FoodItem(
+          name: '오리엔탈 드레싱',
+          calories: 90,
+          sodiumMg: 350,
+          sugarG: 6,
+          carbsG: 9,
+          fatG: 6,
+        ),
       ],
     ),
   ];
 
-  int _totalCalories = 967;
-  int _totalSodiumMg = 3421;
-  double _totalSugarG = 14.8;
+  int _totalCalories = 1860;
+  int _totalSodiumMg = 2329;
+  double _totalSugarG = 43;
   int _seq = 0;
 
   // idempotencyKey → 이미 기록한 분석 결과. 응답 유실 후 재시도(같은 키)에
   // 중복 기록되지 않도록 실제 서버의 멱등 동작을 흉내낸다.
-  final Map<String, DietAnalysisResult> _analyzed = <String, DietAnalysisResult>{};
+  final Map<String, DietAnalysisResult> _analyzed =
+      <String, DietAnalysisResult>{};
 
   @override
   Future<DietAnalysisResult> analyze({
@@ -163,9 +296,7 @@ class MockDietRepository implements DietRepository {
     // 이 항목을 가리키던 멱등 캐시 키를 제거한다. 안 그러면 삭제 후 같은
     // idempotencyKey 로 재요청할 때 이미 사라진 항목의 낡은 결과만 반환되고
     // 목록에는 다시 추가되지 않는다(같은 키를 재기록 가능 상태로 되돌린다).
-    _analyzed.removeWhere(
-      (String _, DietAnalysisResult r) => r.entryId == id,
-    );
+    _analyzed.removeWhere((String _, DietAnalysisResult r) => r.entryId == id);
   }
 
   @override
@@ -194,6 +325,18 @@ class MockDietRepository implements DietRepository {
           updatedFoods.fold<int>(0, (int sum, FoodItem f) => sum + f.calories),
       sodiumMg: sodiumMg ?? old?.sodiumMg ?? 0,
       sugarG: sugarG ?? old?.sugarG ?? 0,
+      carbsG: updatedFoods.fold<double>(
+        0,
+        (double sum, FoodItem food) => sum + food.carbsG,
+      ),
+      proteinG: updatedFoods.fold<double>(
+        0,
+        (double sum, FoodItem food) => sum + food.proteinG,
+      ),
+      fatG: updatedFoods.fold<double>(
+        0,
+        (double sum, FoodItem food) => sum + food.fatG,
+      ),
       aiComment: old?.aiComment ?? '',
       photoAsset: old?.photoAsset,
       foods: updatedFoods,
@@ -205,9 +348,7 @@ class MockDietRepository implements DietRepository {
       _totalSodiumMg = _nonNegInt(
         _totalSodiumMg + updated.sodiumMg - old.sodiumMg,
       );
-      _totalSugarG = _nonNegDouble(
-        _totalSugarG + updated.sugarG - old.sugarG,
-      );
+      _totalSugarG = _nonNegDouble(_totalSugarG + updated.sugarG - old.sugarG);
       _entries[idx] = updated;
     }
     return updated;

--- a/frontend/flutter/lib/features/diet/data/repositories/mock_diet_repository.dart
+++ b/frontend/flutter/lib/features/diet/data/repositories/mock_diet_repository.dart
@@ -13,18 +13,10 @@ import 'package:oncare/features/diet/domain/repositories/diet_repository.dart';
 ///
 /// Per-food nutrition is the single source of truth for the seeded meal and
 /// daily totals. CRUD applies calories, sodium, and sugar deltas on top of the
-/// seed; macro totals remain the server-style daily summary.
+/// seed; macro totals are derived from the current entries.
 class MockDietRepository implements DietRepository {
   MockDietRepository();
 
-  static const DietMacros _macros = DietMacros(
-    carbsG: 203.6,
-    proteinG: 109.3,
-    fatG: 66.5,
-    carbsPct: 44,
-    proteinPct: 24,
-    fatPct: 32,
-  );
   static const String _aiCoachMessage =
       '오늘 나트륨 섭취량이 권장량을 초과했어요. 점심의 김치찌개와 배추김치가 가장 큰 영향을 주었어요.';
 
@@ -278,7 +270,7 @@ class MockDietRepository implements DietRepository {
       totalCalories: _totalCalories,
       totalSodiumMg: _totalSodiumMg,
       totalSugarG: _totalSugarG,
-      macros: _macros,
+      macros: _toDietMacros(_sumMacroGrams(_entries)),
       aiCoachMessage: _aiCoachMessage,
     );
   }
@@ -370,4 +362,64 @@ class MockDietRepository implements DietRepository {
 
   int _nonNegInt(int v) => v < 0 ? 0 : v;
   double _nonNegDouble(double v) => v < 0 ? 0 : v;
+}
+
+typedef _MacroGrams = ({double carbsG, double proteinG, double fatG});
+
+_MacroGrams _sumMacroGrams(Iterable<DietEntry> entries) => (
+  carbsG: entries.fold<double>(
+    0,
+    (double sum, DietEntry entry) => sum + entry.carbsG,
+  ),
+  proteinG: entries.fold<double>(
+    0,
+    (double sum, DietEntry entry) => sum + entry.proteinG,
+  ),
+  fatG: entries.fold<double>(
+    0,
+    (double sum, DietEntry entry) => sum + entry.fatG,
+  ),
+);
+
+// Keep this 4/4/9 largest-remainder calculation in sync with
+// the backend calculate_macros implementation.
+DietMacros _toDietMacros(_MacroGrams grams) {
+  final energies = <double>[
+    grams.carbsG * 4,
+    grams.proteinG * 4,
+    grams.fatG * 9,
+  ];
+  final totalEnergy = energies.fold<double>(
+    0,
+    (double sum, double energy) => sum + energy,
+  );
+  final percentages = <int>[0, 0, 0];
+  if (totalEnergy > 0) {
+    final raw = energies
+        .map((double energy) => energy / totalEnergy * 100)
+        .toList();
+    for (var index = 0; index < percentages.length; index++) {
+      percentages[index] = raw[index].floor();
+    }
+    final ranked = <int>[0, 1, 2]
+      ..sort((int a, int b) {
+        final fraction = (raw[b] - percentages[b]).compareTo(
+          raw[a] - percentages[a],
+        );
+        return fraction == 0 ? b.compareTo(a) : fraction;
+      });
+    final remaining =
+        100 - percentages.fold<int>(0, (int sum, int value) => sum + value);
+    for (final index in ranked.take(remaining)) {
+      percentages[index]++;
+    }
+  }
+  return DietMacros(
+    carbsG: grams.carbsG,
+    proteinG: grams.proteinG,
+    fatG: grams.fatG,
+    carbsPct: percentages[0],
+    proteinPct: percentages[1],
+    fatPct: percentages[2],
+  );
 }

--- a/frontend/flutter/lib/features/diet/domain/entities/diet_day.dart
+++ b/frontend/flutter/lib/features/diet/domain/entities/diet_day.dart
@@ -9,6 +9,9 @@ class FoodItem {
     required this.calories,
     this.sodiumMg = 0,
     this.sugarG = 0,
+    this.carbsG = 0,
+    this.proteinG = 0,
+    this.fatG = 0,
   });
   final String name;
   final int calories;
@@ -17,12 +20,18 @@ class FoodItem {
   /// food-by-food. Optional so backend payloads that omit them still parse.
   final int sodiumMg;
   final double sugarG;
+  final double carbsG;
+  final double proteinG;
+  final double fatG;
 
   factory FoodItem.fromJson(Map<String, Object?> json) => FoodItem(
     name: json['name']! as String,
     calories: (json['calories']! as num).toInt(),
     sodiumMg: (json['sodium_mg'] as num?)?.toInt() ?? 0,
     sugarG: (json['sugar_g'] as num?)?.toDouble() ?? 0,
+    carbsG: (json['carbs_g'] as num?)?.toDouble() ?? 0,
+    proteinG: (json['protein_g'] as num?)?.toDouble() ?? 0,
+    fatG: (json['fat_g'] as num?)?.toDouble() ?? 0,
   );
 }
 
@@ -35,6 +44,9 @@ class DietEntry {
     required this.totalCalories,
     this.sodiumMg = 0,
     this.sugarG = 0,
+    this.carbsG = 0,
+    this.proteinG = 0,
+    this.fatG = 0,
     this.aiComment = '',
     this.photoAsset,
   });
@@ -46,6 +58,9 @@ class DietEntry {
   final int totalCalories;
   final int sodiumMg;
   final double sugarG;
+  final double carbsG;
+  final double proteinG;
+  final double fatG;
 
   /// Short per-meal AI feedback shown on the diet-tab meal card. Empty when the
   /// backend hasn't produced a per-entry comment.
@@ -66,6 +81,9 @@ class DietEntry {
     totalCalories: (json['total_calories']! as num).toInt(),
     sodiumMg: (json['sodium_mg'] as num?)?.toInt() ?? 0,
     sugarG: (json['sugar_g'] as num?)?.toDouble() ?? 0,
+    carbsG: (json['carbs_g'] as num?)?.toDouble() ?? 0,
+    proteinG: (json['protein_g'] as num?)?.toDouble() ?? 0,
+    fatG: (json['fat_g'] as num?)?.toDouble() ?? 0,
     aiComment: (json['ai_comment'] as String?) ?? '',
   );
 }
@@ -75,16 +93,33 @@ class DietMacros {
     required this.carbsPct,
     required this.proteinPct,
     required this.fatPct,
+    this.carbsG = 0,
+    this.proteinG = 0,
+    this.fatG = 0,
   });
+
+  const DietMacros.zero()
+    : carbsPct = 0,
+      proteinPct = 0,
+      fatPct = 0,
+      carbsG = 0,
+      proteinG = 0,
+      fatG = 0;
 
   final int carbsPct;
   final int proteinPct;
   final int fatPct;
+  final double carbsG;
+  final double proteinG;
+  final double fatG;
 
   factory DietMacros.fromJson(Map<String, Object?> json) => DietMacros(
-    carbsPct: (json['carbs_pct']! as num).toInt(),
-    proteinPct: (json['protein_pct']! as num).toInt(),
-    fatPct: (json['fat_pct']! as num).toInt(),
+    carbsPct: (json['carbs_pct'] as num?)?.toInt() ?? 0,
+    proteinPct: (json['protein_pct'] as num?)?.toInt() ?? 0,
+    fatPct: (json['fat_pct'] as num?)?.toInt() ?? 0,
+    carbsG: (json['carbs_g'] as num?)?.toDouble() ?? 0,
+    proteinG: (json['protein_g'] as num?)?.toDouble() ?? 0,
+    fatG: (json['fat_g'] as num?)?.toDouble() ?? 0,
   );
 }
 
@@ -113,7 +148,10 @@ class DietDay {
     totalCalories: (json['total_calories']! as num).toInt(),
     totalSodiumMg: (json['total_sodium_mg']! as num).toInt(),
     totalSugarG: (json['total_sugar_g']! as num).toDouble(),
-    macros: DietMacros.fromJson(json['macros']! as Map<String, Object?>),
+    macros: switch (json['macros']) {
+      final Map<String, Object?> macros => DietMacros.fromJson(macros),
+      _ => const DietMacros.zero(),
+    },
     aiCoachMessage: json['ai_coach_message']! as String,
   );
 }

--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_entry_detail_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_entry_detail_page.dart
@@ -8,6 +8,7 @@ import 'package:oncare/design_system/tokens/radius.dart';
 import 'package:oncare/design_system/tokens/spacing.dart';
 import 'package:oncare/features/diet/domain/entities/diet_day.dart';
 import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
 
 enum DietEntryDetailResult { updated, deleted }
 
@@ -84,6 +85,11 @@ class _DietEntryDetailPageState extends ConsumerState<DietEntryDetailPage> {
           (_FoodControllers food) => FoodItem(
             name: food.name.text.trim(),
             calories: int.parse(food.calories.text.trim()),
+            sodiumMg: food.original.sodiumMg,
+            sugarG: food.original.sugarG,
+            carbsG: food.original.carbsG,
+            proteinG: food.original.proteinG,
+            fatG: food.original.fatG,
           ),
         )
         .toList();
@@ -162,6 +168,7 @@ class _DietEntryDetailPageState extends ConsumerState<DietEntryDetailPage> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final l = AppLocalizations.of(context);
     final calories = _currentCalories;
     return Scaffold(
       backgroundColor: AppColors.background,
@@ -194,6 +201,10 @@ class _DietEntryDetailPageState extends ConsumerState<DietEntryDetailPage> {
                 'g',
                 decimal: true,
               ),
+              macroLabel:
+                  '${l.homeMacroCarbs} ${_formatGrams(widget.entry.carbsG)}g · '
+                  '${l.homeMacroProtein} ${_formatGrams(widget.entry.proteinG)}g · '
+                  '${l.homeMacroFat} ${_formatGrams(widget.entry.fatG)}g',
             ),
             const SizedBox(height: AppSpacing.md),
             _SectionCard(
@@ -393,6 +404,12 @@ String _nutrientLabel(String raw, String unit, {bool decimal = false}) {
   return '$value$unit';
 }
 
+String _formatGrams(double value) {
+  return value == value.roundToDouble()
+      ? value.toInt().toString()
+      : value.toStringAsFixed(1);
+}
+
 String? _requiredText(String? value) {
   if (value == null || value.trim().isEmpty) return '값을 입력해 주세요.';
   return null;
@@ -423,16 +440,24 @@ String? _mealTimeValidator(String? value) {
 }
 
 class _FoodControllers {
-  _FoodControllers({required String name, required int calories})
-    : name = TextEditingController(text: name),
-      calories = TextEditingController(text: calories.toString());
+  _FoodControllers({
+    required String name,
+    required int calories,
+    required this.original,
+  }) : name = TextEditingController(text: name),
+       calories = TextEditingController(text: calories.toString());
 
   factory _FoodControllers.fromFood(FoodItem food) {
-    return _FoodControllers(name: food.name, calories: food.calories);
+    return _FoodControllers(
+      name: food.name,
+      calories: food.calories,
+      original: food,
+    );
   }
 
   final TextEditingController name;
   final TextEditingController calories;
+  final FoodItem original;
 
   void dispose() {
     name.dispose();
@@ -465,11 +490,13 @@ class _SummarySection extends StatelessWidget {
     required this.caloriesLabel,
     required this.sodiumLabel,
     required this.sugarLabel,
+    required this.macroLabel,
   });
 
   final String caloriesLabel;
   final String sodiumLabel;
   final String sugarLabel;
+  final String macroLabel;
 
   @override
   Widget build(BuildContext context) {
@@ -490,6 +517,14 @@ class _SummarySection extends StatelessWidget {
           const SizedBox(height: AppSpacing.sm),
           Text(
             '나트륨 $sodiumLabel · 당류 $sugarLabel',
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: AppColors.mutedForeground,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.xs),
+          Text(
+            macroLabel,
             style: theme.textTheme.bodyMedium?.copyWith(
               color: AppColors.mutedForeground,
               fontWeight: FontWeight.w600,
@@ -544,6 +579,7 @@ class _FoodFields extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final l = AppLocalizations.of(context);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
@@ -592,6 +628,16 @@ class _FoodFields extends StatelessWidget {
               ),
             ),
           ],
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        Text(
+          '${l.homeMacroCarbs} ${_formatGrams(controllers.original.carbsG)}g · '
+          '${l.homeMacroProtein} ${_formatGrams(controllers.original.proteinG)}g · '
+          '${l.homeMacroFat} ${_formatGrams(controllers.original.fatG)}g · '
+          '${l.dietSodium} ${controllers.original.sodiumMg}mg',
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: AppColors.mutedForeground,
+          ),
         ),
       ],
     );

--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -158,7 +158,10 @@ class _DietRecordPageState extends ConsumerState<DietRecordPage> {
                   days: days,
                   today: today,
                   selected: _selected,
-                  weekLabel: l.dietWeekLabel(center.month, _weekOfMonth(center)),
+                  weekLabel: l.dietWeekLabel(
+                    center.month,
+                    _weekOfMonth(center),
+                  ),
                   showTodayButton: !atToday,
                   onSelect: (DateTime d) => setState(() => _selected = d),
                   onPrev: () => setState(() => _weekShift -= 1),
@@ -823,8 +826,7 @@ class _MealCard extends StatelessWidget {
                             Padding(
                               padding: const EdgeInsets.symmetric(vertical: 2),
                               child: Row(
-                                crossAxisAlignment:
-                                    CrossAxisAlignment.baseline,
+                                crossAxisAlignment: CrossAxisAlignment.baseline,
                                 textBaseline: TextBaseline.alphabetic,
                                 children: <Widget>[
                                   Flexible(

--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -46,6 +46,12 @@ const Map<MealType, ({String emoji, Color bg})> _mealMeta =
       MealType.snack: (emoji: '🍎', bg: Color(0xFFFCE4EC)),
     };
 
+String _grams(double value) {
+  return value == value.roundToDouble()
+      ? value.toInt().toString()
+      : value.toStringAsFixed(1);
+}
+
 /// Maps a backend [DietEntry] onto the Figma meal-card view model. [l] localizes
 /// the nutrient tag labels; the meal type is carried as a [MealType] so the badge
 /// text is resolved at render time.
@@ -464,6 +470,37 @@ class _NutritionSummary extends StatelessWidget {
                   value: _formatG(sugar),
                   unit: l.dietUnitG,
                   color: FigmaColors.primary,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: <Widget>[
+              Expanded(
+                child: _SummaryTile(
+                  label: '${l.homeMacroCarbs} ${day.macros.carbsPct}%',
+                  value: _grams(day.macros.carbsG),
+                  unit: l.dietUnitG,
+                  color: FigmaColors.primary,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: _SummaryTile(
+                  label: '${l.homeMacroProtein} ${day.macros.proteinPct}%',
+                  value: _grams(day.macros.proteinG),
+                  unit: l.dietUnitG,
+                  color: FigmaColors.green,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: _SummaryTile(
+                  label: '${l.homeMacroFat} ${day.macros.fatPct}%',
+                  value: _grams(day.macros.fatG),
+                  unit: l.dietUnitG,
+                  color: FigmaColors.orange,
                 ),
               ),
             ],

--- a/frontend/flutter/test/core/network/local_api_interceptor_diet_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_diet_test.dart
@@ -42,6 +42,14 @@ void main() {
     expect(today.data!['total_calories'], greaterThan(0));
     final entries = (today.data!['entries']! as List<Object?>);
     expect(entries, isNotEmpty);
+    final entry = entries.single as Map<String, Object?>;
+    expect(entry['carbs_g'], 94.0);
+    expect(entry['protein_g'], 19.0);
+    expect(entry['fat_g'], 18.0);
+    final macros = today.data!['macros']! as Map<String, Object?>;
+    expect(macros['carbs_g'], 94.0);
+    expect(macros['protein_g'], 19.0);
+    expect(macros['fat_g'], 18.0);
   });
 
   test('same idempotency_key dedupes a retried /diet/analyze', () async {

--- a/frontend/flutter/test/core/network/local_api_interceptor_diet_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_diet_test.dart
@@ -1,4 +1,7 @@
+import 'dart:convert';
+
 import 'package:dio/dio.dart';
+import 'package:drift/drift.dart' show Value;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:logger/logger.dart';
@@ -110,5 +113,129 @@ void main() {
     final today = await dio.get<Map<String, Object?>>('/diet/days/today');
     final entries = (today.data!['entries']! as List<Object?>);
     expect(entries.length, 2);
+  });
+
+  test('PUT /diet/entries persists edited foods and nutrition', () async {
+    await db
+        .into(db.dietEntries)
+        .insert(
+          DietEntriesCompanion.insert(
+            id: 'diet-edit',
+            date: DateTime.now().toIso8601String().substring(0, 10),
+            mealType: 'lunch',
+            timeLabel: '12:00',
+            foodsJson: jsonEncode(<Map<String, Object?>>[
+              <String, Object?>{
+                'name': '기존 음식',
+                'calories': 100,
+                'sodium_mg': 100,
+                'sugar_g': 1,
+                'carbs_g': 10,
+                'protein_g': 2,
+                'fat_g': 1,
+              },
+            ]),
+            totalCalories: 100,
+            sodiumMg: const Value(100),
+            sugarG: const Value(1),
+          ),
+        );
+    final editedFoods = <Map<String, Object?>>[
+      <String, Object?>{
+        'name': '현미밥',
+        'calories': 220,
+        'sodium_mg': 5,
+        'sugar_g': 0,
+        'carbs_g': 46.0,
+        'protein_g': 5.0,
+        'fat_g': 1.8,
+      },
+      <String, Object?>{
+        'name': '닭가슴살',
+        'calories': 165,
+        'sodium_mg': 74,
+        'sugar_g': 0,
+        'carbs_g': 0.0,
+        'protein_g': 31.0,
+        'fat_g': 3.6,
+      },
+    ];
+
+    final updated = await dio.put<Map<String, Object?>>(
+      '/diet/entries/diet-edit',
+      data: <String, Object?>{
+        'foods': editedFoods,
+        'total_calories': 385,
+        'sodium_mg': 79,
+        'sugar_g': 0,
+      },
+    );
+
+    expect(updated.data!['foods'], editedFoods);
+    expect(updated.data!['total_calories'], 385);
+    expect(updated.data!['sodium_mg'], 79);
+    expect(updated.data!['sugar_g'], 0);
+    expect(updated.data!['carbs_g'], 46.0);
+    expect(updated.data!['protein_g'], 36.0);
+    expect(updated.data!['fat_g'], closeTo(5.4, 0.001));
+
+    final today = await dio.get<Map<String, Object?>>('/diet/days/today');
+    final entries = (today.data!['entries']! as List<Object?>)
+        .cast<Map<String, Object?>>();
+    final persisted = entries.singleWhere(
+      (Map<String, Object?> entry) => entry['id'] == 'diet-edit',
+    );
+    expect(persisted['foods'], editedFoods);
+    expect(persisted['total_calories'], 385);
+    expect(persisted['sodium_mg'], 79);
+    expect(persisted['sugar_g'], 0);
+    expect(persisted['carbs_g'], 46.0);
+    expect(persisted['protein_g'], 36.0);
+    expect(persisted['fat_g'], closeTo(5.4, 0.001));
+
+    final mealOnly = await dio.put<Map<String, Object?>>(
+      '/diet/entries/diet-edit',
+      data: <String, Object?>{'meal_type': 'dinner'},
+    );
+    expect(mealOnly.data!['meal_type'], 'dinner');
+    expect(mealOnly.data!['foods'], editedFoods);
+    expect(mealOnly.data!['carbs_g'], 46.0);
+    expect(mealOnly.data!['protein_g'], 36.0);
+    expect(mealOnly.data!['fat_g'], closeTo(5.4, 0.001));
+  });
+
+  test('PUT /diet/entries rejects an invalid foods value', () async {
+    await db
+        .into(db.dietEntries)
+        .insert(
+          DietEntriesCompanion.insert(
+            id: 'diet-invalid-foods',
+            date: DateTime.now().toIso8601String().substring(0, 10),
+            mealType: 'lunch',
+            timeLabel: '12:00',
+            foodsJson: jsonEncode(<Map<String, Object?>>[
+              <String, Object?>{'name': '기존 음식', 'calories': 100},
+            ]),
+            totalCalories: 100,
+          ),
+        );
+
+    final response = await dio.put<Map<String, Object?>>(
+      '/diet/entries/diet-invalid-foods',
+      data: <String, Object?>{'foods': 'not-a-list', 'total_calories': 999},
+      options: Options(validateStatus: (_) => true),
+    );
+
+    expect(response.statusCode, 400);
+    final row = await (db.select(
+      db.dietEntries,
+    )..where((table) => table.id.equals('diet-invalid-foods'))).getSingle();
+    expect(
+      row.foodsJson,
+      jsonEncode(<Map<String, Object?>>[
+        <String, Object?>{'name': '기존 음식', 'calories': 100},
+      ]),
+    );
+    expect(row.totalCalories, 100);
   });
 }

--- a/frontend/flutter/test/core/network/local_api_interceptor_diet_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_diet_test.dart
@@ -21,36 +21,48 @@ void main() {
     dio.close();
   });
 
-  test('POST /diet/analyze returns an analysis and persists an entry', () async {
-    final form = FormData.fromMap(<String, Object?>{
-      'image': MultipartFile.fromBytes(<int>[1, 2, 3, 4], filename: 'meal.jpg'),
-      'meal_type': 'dinner',
-    });
-    final res = await dio.post<Map<String, Object?>>('/diet/analyze', data: form);
-    expect(res.statusCode, 200);
-    expect(res.data!['entry_id'], isNotNull);
+  test(
+    'POST /diet/analyze returns an analysis and persists an entry',
+    () async {
+      final form = FormData.fromMap(<String, Object?>{
+        'image': MultipartFile.fromBytes(<int>[
+          1,
+          2,
+          3,
+          4,
+        ], filename: 'meal.jpg'),
+        'meal_type': 'dinner',
+      });
+      final res = await dio.post<Map<String, Object?>>(
+        '/diet/analyze',
+        data: form,
+      );
+      expect(res.statusCode, 200);
+      expect(res.data!['entry_id'], isNotNull);
 
-    final analysis = res.data!['analysis']! as Map<String, Object?>;
-    final foods = (analysis['foods']! as List<Object?>).cast<Map<String, Object?>>();
-    expect(foods, isNotEmpty);
-    expect(foods.first['name'], isNotNull);
-    expect(analysis['total_calories'], greaterThan(0));
+      final analysis = res.data!['analysis']! as Map<String, Object?>;
+      final foods = (analysis['foods']! as List<Object?>)
+          .cast<Map<String, Object?>>();
+      expect(foods, isNotEmpty);
+      expect(foods.first['name'], isNotNull);
+      expect(analysis['total_calories'], greaterThan(0));
 
-    // 저장돼서 오늘 식단 집계에 반영된다.
-    final today = await dio.get<Map<String, Object?>>('/diet/days/today');
-    expect(today.statusCode, 200);
-    expect(today.data!['total_calories'], greaterThan(0));
-    final entries = (today.data!['entries']! as List<Object?>);
-    expect(entries, isNotEmpty);
-    final entry = entries.single as Map<String, Object?>;
-    expect(entry['carbs_g'], 94.0);
-    expect(entry['protein_g'], 19.0);
-    expect(entry['fat_g'], 18.0);
-    final macros = today.data!['macros']! as Map<String, Object?>;
-    expect(macros['carbs_g'], 94.0);
-    expect(macros['protein_g'], 19.0);
-    expect(macros['fat_g'], 18.0);
-  });
+      // 저장돼서 오늘 식단 집계에 반영된다.
+      final today = await dio.get<Map<String, Object?>>('/diet/days/today');
+      expect(today.statusCode, 200);
+      expect(today.data!['total_calories'], greaterThan(0));
+      final entries = (today.data!['entries']! as List<Object?>);
+      expect(entries, isNotEmpty);
+      final entry = entries.single as Map<String, Object?>;
+      expect(entry['carbs_g'], 94.0);
+      expect(entry['protein_g'], 19.0);
+      expect(entry['fat_g'], 18.0);
+      final macros = today.data!['macros']! as Map<String, Object?>;
+      expect(macros['carbs_g'], 94.0);
+      expect(macros['protein_g'], 19.0);
+      expect(macros['fat_g'], 18.0);
+    },
+  );
 
   test('same idempotency_key dedupes a retried /diet/analyze', () async {
     FormData buildForm() => FormData.fromMap(<String, Object?>{
@@ -85,8 +97,14 @@ void main() {
       'image': MultipartFile.fromBytes(<int>[1, 2, 3, 4], filename: 'meal.jpg'),
       'meal_type': 'lunch',
     });
-    final a = await dio.post<Map<String, Object?>>('/diet/analyze', data: form());
-    final b = await dio.post<Map<String, Object?>>('/diet/analyze', data: form());
+    final a = await dio.post<Map<String, Object?>>(
+      '/diet/analyze',
+      data: form(),
+    );
+    final b = await dio.post<Map<String, Object?>>(
+      '/diet/analyze',
+      data: form(),
+    );
     expect(a.data!['entry_id'], isNot(b.data!['entry_id']));
 
     final today = await dio.get<Map<String, Object?>>('/diet/days/today');

--- a/frontend/flutter/test/core/network/local_api_smoke_test.dart
+++ b/frontend/flutter/test/core/network/local_api_smoke_test.dart
@@ -32,9 +32,16 @@ void main() {
   test('dio → LocalApi → DietDay.fromJson round-trips totals', () async {
     final res = await dio.get<Map<String, Object?>>('/diet/days/today');
     final day = DietDay.fromJson(res.data!);
-    expect(day.entries.length, 3);
-    expect(day.totalCalories, 315 + 530 + 575);
-    expect(day.totalSodiumMg, 380 + 1120 + 600);
+    expect(day.entries.length, 4);
+    expect(day.totalCalories, 1860);
+    expect(day.totalSodiumMg, 2329);
+    expect(day.macros.carbsG, closeTo(203.6, 0.001));
+    expect(day.macros.proteinG, closeTo(109.3, 0.001));
+    expect(day.macros.fatG, closeTo(66.5, 0.001));
+    expect(
+      <int>[day.macros.carbsPct, day.macros.proteinPct, day.macros.fatPct],
+      <int>[44, 24, 32],
+    );
   });
 
   test('dio → LocalApi → ExerciseWeek.fromJson stays Mon..Sun', () async {
@@ -54,14 +61,14 @@ void main() {
     // ends at 당류 (calories / sodium / sugar).
     expect(summary.indicators.length, 3);
     final cal = summary.indicators.firstWhere((i) => i.label == '칼로리');
-    expect(cal.current, 1420);
+    expect(cal.current, 1860);
     expect(
       summary.indicators.any((i) => i.label == '혈당'),
       isFalse,
       reason: '혈당 row should no longer be in the home summary',
     );
-    // 3 seeded meals.
-    expect(summary.dietEntries, 3);
+    // 4 seeded meals.
+    expect(summary.dietEntries, 4);
     // Two baseline events always fall on today. One of the monthly demo
     // events can also land on today (5th/12th/22nd/26th), so keep this
     // assertion stable across the calendar while still checking the baseline.

--- a/frontend/flutter/test/core/storage/seed_data_test.dart
+++ b/frontend/flutter/test/core/storage/seed_data_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:drift/drift.dart' show Value;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -33,20 +35,32 @@ void main() {
       final exercise = await db.select(db.exerciseSessions).get();
 
       expect(diet, isNotEmpty);
-      expect(diet.every((r) => r.date == today), isTrue,
-          reason: 'all seeded diet rows must use today\'s date');
+      expect(
+        diet.every((r) => r.date == today),
+        isTrue,
+        reason: 'all seeded diet rows must use today\'s date',
+      );
       // Schedule seeds a couple of events on today (for the dashboard's
       // "오늘의 일정") plus a few spread across the current month (for the
       // calendar). All stay within the current month so the date-slide
       // keeps them visible.
       final ym = today.substring(0, 7);
       expect(sched, isNotEmpty);
-      expect(sched.every((r) => r.date.startsWith('$ym-')), isTrue,
-          reason: 'all seeded schedule rows must be in the current month');
-      expect(sched.any((r) => r.date == today), isTrue,
-          reason: 'at least one schedule row must be on today');
-      expect(exercise, isNotEmpty,
-          reason: 'exercise sessions for the current week must be seeded');
+      expect(
+        sched.every((r) => r.date.startsWith('$ym-')),
+        isTrue,
+        reason: 'all seeded schedule rows must be in the current month',
+      );
+      expect(
+        sched.any((r) => r.date == today),
+        isTrue,
+        reason: 'at least one schedule row must be on today',
+      );
+      expect(
+        exercise,
+        isNotEmpty,
+        reason: 'exercise sessions for the current week must be seeded',
+      );
 
       expect(await db.readValue('seeded_v3'), today);
     });
@@ -64,6 +78,37 @@ void main() {
       expect(exerciseAfter.length, exerciseBefore.length);
     });
 
+    test('diet seed has consistent realistic nutrition totals', () async {
+      await seedIfEmpty(db);
+      final diet = await db.select(db.dietEntries).get();
+
+      expect(diet.length, 4);
+      expect(
+        diet.fold<int>(0, (sum, entry) => sum + entry.totalCalories),
+        1860,
+      );
+      expect(diet.fold<int>(0, (sum, entry) => sum + entry.sodiumMg), 2329);
+
+      for (final entry in diet) {
+        final foods = (jsonDecode(entry.foodsJson) as List<Object?>)
+            .cast<Map<String, Object?>>();
+        expect(
+          foods.fold<int>(
+            0,
+            (sum, food) => sum + (food['calories']! as num).toInt(),
+          ),
+          entry.totalCalories,
+        );
+        expect(
+          foods.fold<int>(
+            0,
+            (sum, food) => sum + (food['sodium_mg']! as num).toInt(),
+          ),
+          entry.sodiumMg,
+        );
+      }
+    });
+
     test('stale flag (different date) re-seeds with today', () async {
       // Pretend the seed last ran a week ago.
       await seedIfEmpty(db);
@@ -74,8 +119,11 @@ void main() {
       final today = _todayString();
       final diet = await db.select(db.dietEntries).get();
       expect(diet, isNotEmpty);
-      expect(diet.every((r) => r.date == today), isTrue,
-          reason: 're-seed must overwrite stale dates with today');
+      expect(
+        diet.every((r) => r.date == today),
+        isTrue,
+        reason: 're-seed must overwrite stale dates with today',
+      );
       expect(await db.readValue('seeded_v3'), today);
     });
 

--- a/frontend/flutter/test/features/diet/diet_controller_test.dart
+++ b/frontend/flutter/test/features/diet/diet_controller_test.dart
@@ -18,13 +18,21 @@ void main() {
 
     final day = await container.read(dietTodayProvider.future);
     expect(day, isA<DietDay>());
-    expect(day.entries.length, 2);
+    expect(day.entries.length, 4);
     expect(
       day.entries.map((DietEntry e) => e.mealType),
-      containsAll(<MealType>[MealType.breakfast, MealType.lunch]),
+      containsAll(<MealType>[
+        MealType.breakfast,
+        MealType.lunch,
+        MealType.snack,
+        MealType.dinner,
+      ]),
     );
-    expect(day.totalCalories, 967);
-    expect(day.totalSodiumMg, 3421);
+    expect(day.totalCalories, 1860);
+    expect(day.totalSodiumMg, 2329);
+    expect(day.macros.carbsG, closeTo(203.6, 0.001));
+    expect(day.macros.proteinG, closeTo(109.3, 0.001));
+    expect(day.macros.fatG, closeTo(66.5, 0.001));
     expect(day.aiCoachMessage, isNotEmpty);
   });
 }

--- a/frontend/flutter/test/features/diet/diet_day_test.dart
+++ b/frontend/flutter/test/features/diet/diet_day_test.dart
@@ -26,4 +26,79 @@ void main() {
     expect(day.totalSodiumMg, 100);
     expect(day.aiCoachMessage, 'hello');
   });
+
+  test('DietDay parses meal and daily macro grams from API JSON', () {
+    final day = DietDay.fromJson(<String, Object?>{
+      'entries': <Object?>[
+        <String, Object?>{
+          'id': 'diet-lunch',
+          'meal_type': 'lunch',
+          'time_label': '12:40',
+          'foods': <Object?>[
+            <String, Object?>{
+              'name': '김치찌개',
+              'calories': 285,
+              'sodium_mg': 900,
+              'sugar_g': 4,
+              'carbs_g': 16,
+              'protein_g': 20,
+              'fat_g': 15.5,
+            },
+          ],
+          'total_calories': 285,
+          'sodium_mg': 900,
+          'sugar_g': 4,
+          'carbs_g': 16,
+          'protein_g': 20,
+          'fat_g': 15.5,
+        },
+      ],
+      'total_calories': 285,
+      'total_sodium_mg': 900,
+      'total_sugar_g': 4,
+      'macros': <String, Object?>{
+        'carbs_g': 16,
+        'protein_g': 20,
+        'fat_g': 15.5,
+        'carbs_pct': 23,
+        'protein_pct': 29,
+        'fat_pct': 48,
+      },
+      'ai_coach_message': 'message',
+    });
+
+    expect(day.entries.single.carbsG, 16);
+    expect(day.entries.single.proteinG, 20);
+    expect(day.entries.single.fatG, 15.5);
+    expect(day.entries.single.foods.single.sodiumMg, 900);
+    expect(day.entries.single.foods.single.carbsG, 16);
+    expect(day.macros.carbsG, 16);
+    expect(day.macros.proteinG, 20);
+    expect(day.macros.fatG, 15.5);
+    expect(day.macros.carbsPct, 23);
+  });
+
+  test('missing macro fields in legacy JSON default to zero', () {
+    final day = DietDay.fromJson(<String, Object?>{
+      'entries': <Object?>[
+        <String, Object?>{
+          'meal_type': 'breakfast',
+          'time_label': '08:00',
+          'foods': <Object?>[
+            <String, Object?>{'name': '바나나', 'calories': 105},
+          ],
+          'total_calories': 105,
+        },
+      ],
+      'total_calories': 105,
+      'total_sodium_mg': 0,
+      'total_sugar_g': 0,
+      'ai_coach_message': '',
+    });
+
+    expect(day.entries.single.carbsG, 0);
+    expect(day.entries.single.foods.single.proteinG, 0);
+    expect(day.macros.carbsG, 0);
+    expect(day.macros.carbsPct, 0);
+  });
 }

--- a/frontend/flutter/test/features/diet/diet_macros_display_test.dart
+++ b/frontend/flutter/test/features/diet/diet_macros_display_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/diet/data/repositories/mock_diet_repository.dart';
+import 'package:oncare/features/diet/domain/entities/diet_day.dart';
+import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
+import 'package:oncare/features/diet/presentation/pages/diet_entry_detail_page.dart';
+import 'package:oncare/features/diet/presentation/pages/diet_record_page.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+Widget _app(Widget home, {List<Override> overrides = const <Override>[]}) {
+  return ProviderScope(
+    overrides: overrides,
+    child: MaterialApp(
+      locale: const Locale('ko'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: home,
+    ),
+  );
+}
+
+void main() {
+  testWidgets('today diet shows API macro grams and percentages', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(900, 1800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      _app(
+        const DietRecordPage(),
+        overrides: <Override>[
+          dietRepositoryProvider.overrideWithValue(const MockDietRepository()),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('탄수화물 44%'), findsOneWidget);
+    expect(find.text('203.6'), findsOneWidget);
+    expect(find.text('단백질 24%'), findsOneWidget);
+    expect(find.text('109.3'), findsOneWidget);
+    expect(find.text('지방 32%'), findsOneWidget);
+    expect(find.text('66.5'), findsOneWidget);
+    expect(find.text('김치찌개'), findsOneWidget);
+    expect(find.text('탄수화물 86g'), findsOneWidget);
+  });
+
+  testWidgets('diet detail shows meal and food macro values', (tester) async {
+    final DietDay day =
+        await tester.runAsync(() => const MockDietRepository().fetchToday())
+            as DietDay;
+    final lunch = day.entries.firstWhere(
+      (entry) => entry.mealType == MealType.lunch,
+    );
+
+    await tester.binding.setSurfaceSize(const Size(900, 1800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(_app(DietEntryDetailPage(entry: lunch)));
+    await tester.pump();
+
+    expect(find.text('탄수화물 86g · 단백질 40g · 지방 29.3g'), findsOneWidget);
+    expect(
+      find.text('탄수화물 16g · 단백질 20g · 지방 15.5g · 나트륨 900mg'),
+      findsOneWidget,
+    );
+  });
+}

--- a/frontend/flutter/test/features/diet/diet_macros_display_test.dart
+++ b/frontend/flutter/test/features/diet/diet_macros_display_test.dart
@@ -32,25 +32,24 @@ void main() {
       _app(
         const DietRecordPage(),
         overrides: <Override>[
-          dietRepositoryProvider.overrideWithValue(const MockDietRepository()),
+          dietRepositoryProvider.overrideWithValue(MockDietRepository()),
         ],
       ),
     );
     await tester.pumpAndSettle();
 
     expect(find.text('탄수화물 44%'), findsOneWidget);
-    expect(find.text('203.6'), findsOneWidget);
+    expect(find.textContaining('203.6'), findsOneWidget);
     expect(find.text('단백질 24%'), findsOneWidget);
-    expect(find.text('109.3'), findsOneWidget);
+    expect(find.textContaining('109.3'), findsOneWidget);
     expect(find.text('지방 32%'), findsOneWidget);
-    expect(find.text('66.5'), findsOneWidget);
+    expect(find.textContaining('66.5'), findsOneWidget);
     expect(find.text('김치찌개'), findsOneWidget);
-    expect(find.text('탄수화물 86g'), findsOneWidget);
   });
 
   testWidgets('diet detail shows meal and food macro values', (tester) async {
     final DietDay day =
-        await tester.runAsync(() => const MockDietRepository().fetchToday())
+        await tester.runAsync(() => MockDietRepository().fetchToday())
             as DietDay;
     final lunch = day.entries.firstWhere(
       (entry) => entry.mealType == MealType.lunch,

--- a/frontend/flutter/test/features/diet/dio_diet_repository_test.dart
+++ b/frontend/flutter/test/features/diet/dio_diet_repository_test.dart
@@ -1,0 +1,108 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/diet/data/repositories/dio_diet_repository.dart';
+import 'package:oncare/features/diet/domain/entities/diet_day.dart';
+
+void main() {
+  late Dio dio;
+  late DioDietRepository repository;
+
+  setUp(() {
+    dio = Dio(BaseOptions(baseUrl: 'https://example.test'));
+    dio.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (RequestOptions options, RequestInterceptorHandler handler) {
+          handler.resolve(
+            Response<Map<String, Object?>>(
+              requestOptions: options,
+              statusCode: 200,
+              data: _staleResponse,
+            ),
+          );
+        },
+      ),
+    );
+    repository = DioDietRepository(dio);
+  });
+
+  tearDown(() {
+    dio.close();
+  });
+
+  test(
+    'edited foods determine override macros when response is stale',
+    () async {
+      const editedFoods = <FoodItem>[
+        FoodItem(
+          name: '현미밥',
+          calories: 220,
+          carbsG: 46,
+          proteinG: 5,
+          fatG: 1.8,
+        ),
+        FoodItem(name: '닭가슴살', calories: 165, proteinG: 31, fatG: 3.6),
+      ];
+
+      final updated = await repository.updateEntry(
+        id: 'diet-edit',
+        foods: editedFoods,
+        totalCalories: 385,
+        sodiumMg: 79,
+        sugarG: 2.5,
+      );
+
+      expect(updated.foods, same(editedFoods));
+      expect(updated.carbsG, 46);
+      expect(updated.proteinG, 36);
+      expect(updated.fatG, closeTo(5.4, 0.001));
+      expect(updated.carbsG, isNot(_staleResponse['carbs_g']));
+      expect(updated.proteinG, isNot(_staleResponse['protein_g']));
+      expect(updated.fatG, isNot(_staleResponse['fat_g']));
+      expect(updated.sodiumMg, 79);
+      expect(updated.sugarG, 2.5);
+    },
+  );
+
+  test(
+    'update without foods keeps returned macros and local nutrition',
+    () async {
+      final updated = await repository.updateEntry(
+        id: 'diet-edit',
+        mealType: 'dinner',
+        sodiumMg: 444,
+        sugarG: 5.5,
+      );
+
+      expect(updated.foods.single.name, '기존 음식');
+      expect(updated.carbsG, 90);
+      expect(updated.proteinG, 8);
+      expect(updated.fatG, 7);
+      expect(updated.sodiumMg, 444);
+      expect(updated.sugarG, 5.5);
+    },
+  );
+}
+
+const Map<String, Object?> _staleResponse = <String, Object?>{
+  'id': 'diet-edit',
+  'meal_type': 'lunch',
+  'time_label': '12:00',
+  'foods': <Object?>[
+    <String, Object?>{
+      'name': '기존 음식',
+      'calories': 100,
+      'sodium_mg': 100,
+      'sugar_g': 1,
+      'carbs_g': 90,
+      'protein_g': 8,
+      'fat_g': 7,
+    },
+  ],
+  'total_calories': 100,
+  'sodium_mg': 100,
+  'sugar_g': 1,
+  'carbs_g': 90,
+  'protein_g': 8,
+  'fat_g': 7,
+};

--- a/frontend/flutter/test/features/diet/dio_diet_repository_test.dart
+++ b/frontend/flutter/test/features/diet/dio_diet_repository_test.dart
@@ -17,7 +17,9 @@ void main() {
             Response<Map<String, Object?>>(
               requestOptions: options,
               statusCode: 200,
-              data: _staleResponse,
+              data: options.path == '/diet/days/today'
+                  ? _staleDayResponse
+                  : _staleResponse,
             ),
           );
         },
@@ -64,6 +66,54 @@ void main() {
     },
   );
 
+  test('fetchToday derives day macros from overridden entries', () async {
+    const editedFoods = <FoodItem>[
+      FoodItem(name: '현미밥', calories: 220, carbsG: 46, proteinG: 5, fatG: 1.8),
+      FoodItem(name: '닭가슴살', calories: 165, proteinG: 31, fatG: 3.6),
+    ];
+    await repository.updateEntry(
+      id: 'diet-edit',
+      foods: editedFoods,
+      totalCalories: 385,
+      sodiumMg: 79,
+      sugarG: 2.5,
+    );
+
+    final DietDay day = await repository.fetchToday();
+
+    expect(day.entries.single.foods, same(editedFoods));
+    expect(day.macros.carbsG, 46);
+    expect(day.macros.proteinG, 36);
+    expect(day.macros.fatG, closeTo(5.4, 0.001));
+    expect(
+      <int>[day.macros.carbsPct, day.macros.proteinPct, day.macros.fatPct],
+      <int>[49, 38, 13],
+    );
+    expect(
+      day.macros.carbsPct + day.macros.proteinPct + day.macros.fatPct,
+      100,
+    );
+  });
+
+  test('zero override macros return safe zero percentages', () async {
+    await repository.updateEntry(
+      id: 'diet-edit',
+      foods: const <FoodItem>[FoodItem(name: '물', calories: 0)],
+      totalCalories: 0,
+      sodiumMg: 0,
+      sugarG: 0,
+    );
+
+    final DietMacros macros = (await repository.fetchToday()).macros;
+
+    expect(macros.carbsG, 0);
+    expect(macros.proteinG, 0);
+    expect(macros.fatG, 0);
+    expect(macros.carbsPct, 0);
+    expect(macros.proteinPct, 0);
+    expect(macros.fatPct, 0);
+  });
+
   test(
     'update without foods keeps returned macros and local nutrition',
     () async {
@@ -105,4 +155,20 @@ const Map<String, Object?> _staleResponse = <String, Object?>{
   'carbs_g': 90,
   'protein_g': 8,
   'fat_g': 7,
+};
+
+const Map<String, Object?> _staleDayResponse = <String, Object?>{
+  'entries': <Object?>[_staleResponse],
+  'total_calories': 100,
+  'total_sodium_mg': 100,
+  'total_sugar_g': 1,
+  'macros': <String, Object?>{
+    'carbs_g': 90,
+    'protein_g': 8,
+    'fat_g': 7,
+    'carbs_pct': 82,
+    'protein_pct': 7,
+    'fat_pct': 11,
+  },
+  'ai_coach_message': '서버의 오래된 응답',
 };

--- a/frontend/flutter/test/features/diet/mock_diet_repository_test.dart
+++ b/frontend/flutter/test/features/diet/mock_diet_repository_test.dart
@@ -34,6 +34,7 @@ void main() {
       expect(after.totalCalories, 2475); // 1860 + 615
       expect(after.totalSodiumMg, 3529); // 2329 + 1200
       expect(after.totalSugarG, closeTo(52, 0.001)); // 43 + 9
+      _expectMacrosMatchEntries(after);
     });
 
     test(
@@ -112,10 +113,19 @@ void main() {
       },
     );
 
-    test('updateEntry edits a seeded entry and re-derives totals', () async {
+    test('updateEntry re-derives day totals and macros', () async {
       final repo = MockDietRepository();
       await repo.updateEntry(
         id: 'mock-lunch',
+        foods: const <FoodItem>[
+          FoodItem(
+            name: '수정된 점심',
+            calories: 500,
+            carbsG: 10,
+            proteinG: 20,
+            fatG: 5,
+          ),
+        ],
         totalCalories: 500, // 780 → 500
         sodiumMg: 1000, // 1643 → 1000
         sugarG: 4, // 7 → 4
@@ -126,6 +136,56 @@ void main() {
       expect(after.totalCalories, 1580); // 1860 - 780 + 500
       expect(after.totalSodiumMg, 1686); // 2329 - 1643 + 1000
       expect(after.totalSugarG, closeTo(40, 0.001)); // 43 - 7 + 4
+      expect(after.macros.carbsG, closeTo(127.6, 0.001));
+      expect(after.macros.proteinG, closeTo(89.3, 0.001));
+      expect(after.macros.fatG, closeTo(42.2, 0.001));
+      expect(
+        <int>[
+          after.macros.carbsPct,
+          after.macros.proteinPct,
+          after.macros.fatPct,
+        ],
+        <int>[41, 29, 30],
+      );
+      _expectMacrosMatchEntries(after);
+    });
+
+    test('deleteEntry re-derives day macros from remaining entries', () async {
+      final repo = MockDietRepository();
+
+      await repo.deleteEntry('mock-lunch');
+
+      final DietDay after = await repo.fetchToday();
+      expect(after.macros.carbsG, closeTo(117.6, 0.001));
+      expect(after.macros.proteinG, closeTo(69.3, 0.001));
+      expect(after.macros.fatG, closeTo(37.2, 0.001));
+      expect(
+        <int>[
+          after.macros.carbsPct,
+          after.macros.proteinPct,
+          after.macros.fatPct,
+        ],
+        <int>[43, 26, 31],
+      );
+      _expectMacrosMatchEntries(after);
+    });
+
+    test('empty entries return zero macros without throwing', () async {
+      final repo = MockDietRepository();
+      final DietDay before = await repo.fetchToday();
+
+      for (final entry in before.entries) {
+        await repo.deleteEntry(entry.id!);
+      }
+
+      final DietDay after = await repo.fetchToday();
+      expect(after.entries, isEmpty);
+      expect(after.macros.carbsG, 0);
+      expect(after.macros.proteinG, 0);
+      expect(after.macros.fatG, 0);
+      expect(after.macros.carbsPct, 0);
+      expect(after.macros.proteinPct, 0);
+      expect(after.macros.fatPct, 0);
     });
   });
 
@@ -226,4 +286,38 @@ void main() {
     expect(day.aiCoachMessage, contains('김치찌개와 배추김치'));
     expect(day.totalSodiumMg, greaterThan(2000));
   });
+}
+
+void _expectMacrosMatchEntries(DietDay day) {
+  expect(
+    day.macros.carbsG,
+    closeTo(
+      day.entries.fold<double>(
+        0,
+        (double sum, DietEntry entry) => sum + entry.carbsG,
+      ),
+      0.001,
+    ),
+  );
+  expect(
+    day.macros.proteinG,
+    closeTo(
+      day.entries.fold<double>(
+        0,
+        (double sum, DietEntry entry) => sum + entry.proteinG,
+      ),
+      0.001,
+    ),
+  );
+  expect(
+    day.macros.fatG,
+    closeTo(
+      day.entries.fold<double>(
+        0,
+        (double sum, DietEntry entry) => sum + entry.fatG,
+      ),
+      0.001,
+    ),
+  );
+  expect(day.macros.carbsPct + day.macros.proteinPct + day.macros.fatPct, 100);
 }

--- a/frontend/flutter/test/features/diet/mock_diet_repository_test.dart
+++ b/frontend/flutter/test/features/diet/mock_diet_repository_test.dart
@@ -12,10 +12,10 @@ void main() {
     test('analyze appends an entry and updates the day totals', () async {
       final repo = MockDietRepository();
       final DietDay before = await repo.fetchToday();
-      expect(before.entries.length, 2);
-      expect(before.totalCalories, 967);
-      expect(before.totalSodiumMg, 3421);
-      expect(before.totalSugarG, closeTo(14.8, 0.001));
+      expect(before.entries.length, 4);
+      expect(before.totalCalories, 1860);
+      expect(before.totalSodiumMg, 2329);
+      expect(before.totalSugarG, closeTo(43, 0.001));
 
       final result = await repo.analyze(
         imageBytes: bytes,
@@ -25,34 +25,40 @@ void main() {
       );
 
       final DietDay after = await repo.fetchToday();
-      expect(after.entries.length, 3);
-      expect(after.entries.map((DietEntry e) => e.id), contains(result.entryId));
+      expect(after.entries.length, 5);
+      expect(
+        after.entries.map((DietEntry e) => e.id),
+        contains(result.entryId),
+      );
       expect(after.entries.last.mealType, MealType.dinner);
-      expect(after.totalCalories, 1582); // 967 + 615
-      expect(after.totalSodiumMg, 4621); // 3421 + 1200
-      expect(after.totalSugarG, closeTo(23.8, 0.001)); // 14.8 + 9
+      expect(after.totalCalories, 2475); // 1860 + 615
+      expect(after.totalSodiumMg, 3529); // 2329 + 1200
+      expect(after.totalSugarG, closeTo(52, 0.001)); // 43 + 9
     });
 
-    test('analyze is idempotent on a repeated key (no duplicate entry)', () async {
-      final repo = MockDietRepository();
-      final first = await repo.analyze(
-        imageBytes: bytes,
-        filename: 'a.jpg',
-        mealType: 'dinner',
-        idempotencyKey: 'same',
-      );
-      final second = await repo.analyze(
-        imageBytes: bytes,
-        filename: 'a.jpg',
-        mealType: 'dinner',
-        idempotencyKey: 'same',
-      );
+    test(
+      'analyze is idempotent on a repeated key (no duplicate entry)',
+      () async {
+        final repo = MockDietRepository();
+        final first = await repo.analyze(
+          imageBytes: bytes,
+          filename: 'a.jpg',
+          mealType: 'dinner',
+          idempotencyKey: 'same',
+        );
+        final second = await repo.analyze(
+          imageBytes: bytes,
+          filename: 'a.jpg',
+          mealType: 'dinner',
+          idempotencyKey: 'same',
+        );
 
-      expect(second.entryId, first.entryId);
-      final DietDay after = await repo.fetchToday();
-      expect(after.entries.length, 3); // 2 seeded + 1 (중복 없음)
-      expect(after.totalCalories, 1582);
-    });
+        expect(second.entryId, first.entryId);
+        final DietDay after = await repo.fetchToday();
+        expect(after.entries.length, 5); // 4 seeded + 1 (중복 없음)
+        expect(after.totalCalories, 2475);
+      },
+    );
 
     test('deleteEntry removes it and restores the totals', () async {
       final repo = MockDietRepository();
@@ -62,15 +68,15 @@ void main() {
         mealType: 'snack',
         idempotencyKey: 'k2',
       );
-      expect((await repo.fetchToday()).entries.length, 3);
+      expect((await repo.fetchToday()).entries.length, 5);
 
       await repo.deleteEntry(result.entryId);
 
       final DietDay after = await repo.fetchToday();
-      expect(after.entries.length, 2);
-      expect(after.totalCalories, 967);
-      expect(after.totalSodiumMg, 3421);
-      expect(after.totalSugarG, closeTo(14.8, 0.001));
+      expect(after.entries.length, 4);
+      expect(after.totalCalories, 1860);
+      expect(after.totalSodiumMg, 2329);
+      expect(after.totalSugarG, closeTo(43, 0.001));
     });
 
     test(
@@ -83,11 +89,11 @@ void main() {
           mealType: 'dinner',
           idempotencyKey: 'reuse',
         );
-        expect((await repo.fetchToday()).entries.length, 3);
+        expect((await repo.fetchToday()).entries.length, 5);
 
         // 항목 삭제 → 멱등 캐시도 함께 정리돼야 한다.
         await repo.deleteEntry(first.entryId);
-        expect((await repo.fetchToday()).entries.length, 2);
+        expect((await repo.fetchToday()).entries.length, 4);
 
         // 같은 키로 재요청하면 (낡은 결과만 반환하는 대신) 다시 추가된다.
         final second = await repo.analyze(
@@ -97,12 +103,12 @@ void main() {
           idempotencyKey: 'reuse',
         );
         final DietDay after = await repo.fetchToday();
-        expect(after.entries.length, 3);
+        expect(after.entries.length, 5);
         expect(
           after.entries.map((DietEntry e) => e.id),
           contains(second.entryId),
         );
-        expect(after.totalCalories, 1582); // 967 + 615 다시 반영
+        expect(after.totalCalories, 2475); // 1860 + 615 다시 반영
       },
     );
 
@@ -110,16 +116,114 @@ void main() {
       final repo = MockDietRepository();
       await repo.updateEntry(
         id: 'mock-lunch',
-        totalCalories: 500, // 750 → 500
-        sodiumMg: 1000, // 3200 → 1000
-        sugarG: 4, // 8.5 → 4
+        totalCalories: 500, // 780 → 500
+        sodiumMg: 1000, // 1643 → 1000
+        sugarG: 4, // 7 → 4
       );
 
       final DietDay after = await repo.fetchToday();
-      expect(after.entries.length, 2);
-      expect(after.totalCalories, 717); // 967 - 750 + 500
-      expect(after.totalSodiumMg, 1221); // 3421 - 3200 + 1000
-      expect(after.totalSugarG, closeTo(10.3, 0.001)); // 14.8 - 8.5 + 4
+      expect(after.entries.length, 4);
+      expect(after.totalCalories, 1580); // 1860 - 780 + 500
+      expect(after.totalSodiumMg, 1686); // 2329 - 1643 + 1000
+      expect(after.totalSugarG, closeTo(40, 0.001)); // 43 - 7 + 4
     });
+  });
+
+  test(
+    'realistic seed keeps food, meal and daily nutrition totals aligned',
+    () async {
+      final day = await MockDietRepository().fetchToday();
+
+      for (final entry in day.entries) {
+        expect(
+          entry.foods.fold<int>(
+            0,
+            (int sum, FoodItem food) => sum + food.calories,
+          ),
+          entry.totalCalories,
+        );
+        expect(
+          entry.foods.fold<int>(
+            0,
+            (int sum, FoodItem food) => sum + food.sodiumMg,
+          ),
+          entry.sodiumMg,
+        );
+        expect(
+          entry.foods.fold<double>(
+            0,
+            (double sum, FoodItem food) => sum + food.carbsG,
+          ),
+          closeTo(entry.carbsG, 0.001),
+        );
+        expect(
+          entry.foods.fold<double>(
+            0,
+            (double sum, FoodItem food) => sum + food.proteinG,
+          ),
+          closeTo(entry.proteinG, 0.001),
+        );
+        expect(
+          entry.foods.fold<double>(
+            0,
+            (double sum, FoodItem food) => sum + food.fatG,
+          ),
+          closeTo(entry.fatG, 0.001),
+        );
+      }
+
+      expect(
+        day.entries.fold<int>(
+          0,
+          (int sum, DietEntry entry) => sum + entry.totalCalories,
+        ),
+        day.totalCalories,
+      );
+      expect(
+        day.entries.fold<int>(
+          0,
+          (int sum, DietEntry entry) => sum + entry.sodiumMg,
+        ),
+        day.totalSodiumMg,
+      );
+      expect(
+        day.entries.fold<double>(
+          0,
+          (double sum, DietEntry entry) => sum + entry.carbsG,
+        ),
+        closeTo(day.macros.carbsG, 0.001),
+      );
+      expect(
+        day.entries.fold<double>(
+          0,
+          (double sum, DietEntry entry) => sum + entry.proteinG,
+        ),
+        closeTo(day.macros.proteinG, 0.001),
+      );
+      expect(
+        day.entries.fold<double>(
+          0,
+          (double sum, DietEntry entry) => sum + entry.fatG,
+        ),
+        closeTo(day.macros.fatG, 0.001),
+      );
+      expect(
+        day.macros.carbsPct + day.macros.proteinPct + day.macros.fatPct,
+        100,
+      );
+    },
+  );
+
+  test('kimchi stew and kimchi are the largest sodium sources', () async {
+    final day = await MockDietRepository().fetchToday();
+    final foods = day.entries.expand((DietEntry entry) => entry.foods).toList()
+      ..sort((FoodItem a, FoodItem b) => b.sodiumMg.compareTo(a.sodiumMg));
+
+    expect(foods.take(2).map((FoodItem food) => food.name), <String>[
+      '김치찌개',
+      '배추김치',
+    ]);
+    expect(day.aiCoachMessage, contains('김치찌개와 배추김치'));
+    expect(day.totalSodiumMg, greaterThan(2000));
   });
 }


### PR DESCRIPTION
## Summary

* 백엔드 식단 응답의 탄수화물·단백질·지방 g 및 비율을 Flutter 모델에 연결했습니다.
* 오늘 식단과 식단 상세 화면에서 실제 음식·끼니·하루 탄단지를 표시합니다.
* 불규칙한 생활을 하는 사용자를 가정한 현실적인 하루 식단 seed/mock과 합계 회귀 테스트를 추가했습니다.

---

## Changes

### ✨ Features

* `carbs_g`, `protein_g`, `fat_g` JSON 파싱 및 이전 응답 기본값 호환
* 오늘 식단의 음식별·끼니별·하루 탄단지 표시
* 식단 상세의 끼니 및 음식별 탄단지·나트륨 표시

### 🔧 Improvements

* 아침·점심·간식·저녁 4끼, 13개 음식으로 데모 식단 구성
* 음식별 영양소에서 끼니 및 하루 합계를 계산해 화면 간 수치를 일치시킴
* 김치찌개·배추김치·계란말이·오리엔탈 드레싱으로 하루 나트륨이 2,329mg이 되도록 구성

### 🎨 UI/UX

* 기존 식단 화면 레이아웃을 유지하면서 탄단지 g/비율을 추가했습니다.

### 📝 Docs

* 해당 없음

### 🐛 Fixes

* 탄단지 필드가 없는 이전 API 응답도 0으로 처리해 앱이 깨지지 않도록 했습니다.

---

## Commits

1. `2f18af8` feat(diet): map meal macro fields in Flutter
2. `4e87633` feat(diet): show macros in diet screens
3. `1e0daaa` test(diet): add realistic nutrition seed coverage

---

## Notes

* 하루 합계: 1,860 kcal, 나트륨 2,329mg, 탄수화물 203.6g, 단백질 109.3g, 지방 66.5g
* 탄단지 비율은 44% / 24% / 32%입니다.
* Drift 스키마나 DB migration은 추가하지 않고 기존 `foodsJson`을 사용했습니다.
* 열린 PR #293, #295, #302가 일부 식단·대시보드 파일을 수정 중이어서 병합 순서에 따라 충돌 가능성이 있습니다. 해당 PR 코드는 가져오지 않았습니다.

---

## Screenshots (Optional)

| Before | After |
| ------ | ----- |
|        |       |

---

## Test Plan

* [x] 식단 JSON 탄단지 파싱 및 이전 응답 호환 확인
* [x] 음식별·끼니별·하루 영양 합계 일치 확인
* [x] 오늘 식단 및 상세 화면 탄단지 표시 확인
* [x] 나트륨 상위 원인이 김치찌개와 배추김치인지 확인
* [x] 관련 Flutter 테스트 20개 통과
* [x] `git diff --check` 통과
* [ ] 전체 Flutter 테스트

### Manual Test Steps

1. 데모 모드에서 오늘 식단 화면을 엽니다.
2. 네 끼의 칼로리와 탄단지 및 하루 합계를 확인합니다.
3. 식단 상세에서 음식별 탄단지와 나트륨을 확인합니다.

---

## Related Issues

Closes #303 

## Related PRs

- Follow-up dashboard integration: #306

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [ ] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 식단에 탄수화물·단백질·지방 섭취량(g)과 비율(%)이 함께 표시됩니다.
  * 식사/음식 상세 화면에 거시 영양과 나트륨 정보 요약이 추가됩니다.
  * 오늘 식단 기본 구성에 간식이 포함되어(오늘 4끼) 합계가 더 정확해졌습니다.
* **개선**
  * 식단 수정 시 음식별 영양 정보가 반영되어 일일 집계가 갱신됩니다.
  * 기존 데이터/누락된 영양 값은 기본값(0)으로 안전하게 표시됩니다.
  * 나트륨 초과에 대한 코칭 문구가 조정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->