### PR TITLE
fix(ui): 홈 안전 영역과 하단 탭 위치 조정

### DIFF
--- a/frontend/flutter/lib/app/router/main_shell.dart
+++ b/frontend/flutter/lib/app/router/main_shell.dart
@@ -22,13 +22,20 @@ class MainShell extends StatelessWidget {
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
     final double bottomInset = MediaQuery.of(context).padding.bottom;
-    const double barHeight = 64;
+    const double maxNavBottomPadding = 22;
+    final double navBottomPadding = bottomInset > maxNavBottomPadding
+        ? maxNavBottomPadding
+        : bottomInset;
+    const double barHeight = 56;
     const double lift = 24; // headroom so the + button floats above the bar
     return Scaffold(
+      // Let the page continue behind the transparent FAB headroom instead of
+      // showing a separate white strip above the navigation bar.
+      extendBody: true,
       body: navigationShell,
       floatingActionButton: OniFab(onTap: () => showCoachingSheet(context)),
       bottomNavigationBar: SizedBox(
-        height: barHeight + lift + bottomInset,
+        height: barHeight + lift + navBottomPadding,
         child: Center(
           child: ConstrainedBox(
             constraints: const BoxConstraints(maxWidth: 672),
@@ -42,8 +49,8 @@ class MainShell extends StatelessWidget {
                   right: 0,
                   bottom: 0,
                   child: Container(
-                    height: barHeight + bottomInset,
-                    padding: EdgeInsets.only(bottom: bottomInset),
+                    height: barHeight + navBottomPadding,
+                    padding: EdgeInsets.only(bottom: navBottomPadding),
                     decoration: const BoxDecoration(
                       color: AppColors.background,
                       border: Border(top: BorderSide(color: AppColors.border)),
@@ -131,20 +138,28 @@ class _Destination extends StatelessWidget {
     return Expanded(
       child: InkWell(
         onTap: onTap,
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            Icon(selected ? activeIcon : icon, size: 24, color: color),
-            const SizedBox(height: 4),
-            Text(
-              label,
-              style: TextStyle(
-                fontSize: 12,
-                color: color,
-                fontWeight: selected ? FontWeight.w600 : FontWeight.w400,
-              ),
+        child: Padding(
+          // Keep the original space above the icon while using less space
+          // below the label, so the whole destination sits slightly lower.
+          padding: const EdgeInsets.only(top: 8),
+          child: Transform.translate(
+            offset: const Offset(0, 4),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                Icon(selected ? activeIcon : icon, size: 24, color: color),
+                const SizedBox(height: 4),
+                Text(
+                  label,
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: color,
+                    fontWeight: selected ? FontWeight.w600 : FontWeight.w400,
+                  ),
+                ),
+              ],
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/frontend/flutter/lib/features/dashboard/presentation/pages/dashboard_page.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/pages/dashboard_page.dart
@@ -16,12 +16,15 @@ class DashboardPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: AppColors.background,
-      body: DashboardContent(
-        onNotificationTap: () => showRightSlidePanel<void>(
-          context,
-          content: const NotificationPanelBody(),
+      body: SafeArea(
+        bottom: false,
+        child: DashboardContent(
+          onNotificationTap: () => showRightSlidePanel<void>(
+            context,
+            content: const NotificationPanelBody(),
+          ),
+          onCalendarTap: () => showScheduleCalendarSheet(context),
         ),
-        onCalendarTap: () => showScheduleCalendarSheet(context),
       ),
     );
   }


### PR DESCRIPTION
## Summary

* 홈 화면 헤더가 iPhone 상단 시스템 영역과 겹치지 않도록 안전 영역을 적용했습니다.
* 하단 탭의 높이와 내부 여백을 조정해 탭 아이콘 및 라벨 위치를 자연스럽게 맞췄습니다.
* 가운데 추가 버튼을 위한 투명 영역 뒤로 본문이 이어지게 해 하단 바 위의 흰색 박스를 제거했습니다.

---

## Changes

### ✨ Features

* 없음

### 🔧 Improvements

* 기기별 하단 인셋을 반영하되 탭 하단 여백이 과도해지지 않도록 최대값을 적용했습니다.
* 탭 아이콘 위 여백은 유지하면서 라벨 아래 여백을 줄였습니다.

### 🎨 UI/UX

* 홈 헤더에 상단 `SafeArea`를 적용했습니다.
* 하단 탭 바와 가운데 추가 버튼의 세로 위치를 조정했습니다.
* 하단 바 위의 불필요한 흰색 영역을 제거했습니다.

### 📝 Docs

* 없음

### 🐛 Fixes

* 홈 헤더가 iPhone 상태 영역과 겹치는 문제를 수정했습니다.
* iPhone에서 하단 탭이 지나치게 위에 표시되는 문제를 수정했습니다.

---

## Commits

1. `3be0332` fix(ui): 홈 안전 영역과 하단 탭 위치 조정

---

## Notes

* 이 PR은 #407을 부모로 하는 스택 PR입니다.
* 부모 PR이 먼저 병합된 뒤 이 PR을 병합해야 합니다.
* 변경 범위는 사용자 Flutter 앱의 홈 화면과 공통 하단 내비게이션으로 제한됩니다.

---

## Screenshots (Optional)

| Before | After |
| ------ | ----- |
| 대화에 첨부된 iPhone 시뮬레이터 화면 참고 | 위치 조정 후 iPhone 시뮬레이터에서 확인 |

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [ ] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. iPhone 시뮬레이터에서 홈 화면을 열어 헤더가 상단 시스템 영역과 겹치지 않는지 확인합니다.
2. 하단 탭 아이콘 위 여백과 라벨 아래 여백이 균형 있게 표시되는지 확인합니다.
3. 하단 바 위에 별도의 흰색 박스가 나타나지 않는지 확인합니다.

---

## Related Issues

Closes #413

## Checklist

* [ ] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인
