### PR TITLE
feat(exercise): align trainer profiles and restore the demo dashboard

### DIFF
--- a/frontend/flutter/lib/features/dashboard/presentation/controllers/dashboard_controller.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/controllers/dashboard_controller.dart
@@ -1,14 +1,20 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:oncare/core/config/app_config.dart';
 import 'package:oncare/core/network/dio_client.dart';
 import 'package:oncare/features/dashboard/data/repositories/dio_dashboard_repository.dart';
+import 'package:oncare/features/dashboard/data/repositories/mock_dashboard_repository.dart';
 import 'package:oncare/features/dashboard/domain/entities/dashboard_summary.dart';
 import 'package:oncare/features/dashboard/domain/repositories/dashboard_repository.dart';
 
-final dashboardRepositoryProvider = Provider<DashboardRepository>(
-  (ref) => DioDashboardRepository(ref.watch(dioProvider)),
-  name: 'dashboardRepository',
-);
+final dashboardRepositoryProvider = Provider<DashboardRepository>((ref) {
+  // diet·exercise·my_health 와 같은 분기. 이 갈래가 없으면 백엔드 미연결
+  // 데모에서 홈이 "대시보드 정보를 불러오지 못했어요" 만 띄운다.
+  if (ref.watch(appConfigProvider).useMockApi) {
+    return const MockDashboardRepository();
+  }
+  return DioDashboardRepository(ref.watch(dioProvider));
+}, name: 'dashboardRepository');
 
 final dashboardSummaryProvider = FutureProvider.autoDispose<DashboardSummary>((
   ref,

--- a/frontend/flutter/lib/features/exercise/data/repositories/mock_gym_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/mock_gym_repository.dart
@@ -26,6 +26,15 @@ class MockGymRepository implements GymRepository {
     tags: <String>['다이어트', '재활운동'],
     trainerName: '김트레이너',
     trainerRole: '퍼스널 트레이너',
+    trainerCareer: '7년',
+    trainerIntro:
+        '혈압 관리와 체중 감량 전문 트레이너입니다. 고객 맞춤형 AI 루틴으로 '
+        '안전하고 효과적인 운동을 도와드려요.',
+    trainerCertifications: <String>[
+      '생활스포츠지도사 2급',
+      '퍼스널트레이닝 CPT',
+      '스포츠 영양사',
+    ],
     weekdayHours: '06:00 - 23:00',
     weekendHours: '08:00 - 20:00',
     phone: '02-1234-5678',
@@ -52,7 +61,12 @@ class MockGymRepository implements GymRepository {
     rating: 4.5,
     tags: <String>['근력운동', '만성질환 관리'],
     trainerName: '강트레이너',
+    trainerRole: '퍼스널 트레이너',
     trainerReason: '교대근무 스케줄 케어 경험이 풍부해요',
+    trainerCareer: '5년',
+    trainerIntro: '불규칙한 근무 일정에 맞춘 운동 설계를 주로 합니다. 짧은 시간에 '
+        '집중도를 높이는 근력 프로그램을 준비해 드려요.',
+    trainerCertifications: <String>['건강운동관리사', '퍼스널트레이닝 CPT'],
     weekdayHours: '05:30 - 24:00',
     weekendHours: '07:00 - 22:00',
     phone: '02-2345-6789',
@@ -66,7 +80,12 @@ class MockGymRepository implements GymRepository {
     rating: 4.8,
     tags: <String>['PT', '식단 상담'],
     trainerName: '이트레이너',
+    trainerRole: '퍼스널 트레이너',
     trainerReason: '간단한 운동 루틴에 특화되어 있어요',
+    trainerCareer: '9년',
+    trainerIntro: '운동을 처음 시작하는 분을 오래 지도했습니다. 식단 상담을 함께 '
+        '진행해 생활 습관부터 차근차근 바꿔 드려요.',
+    trainerCertifications: <String>['생활스포츠지도사 2급', '스포츠 영양사', '재활 트레이닝 NASM-CES'],
     weekdayHours: '06:00 - 22:00',
     weekendHours: '09:00 - 18:00',
     phone: '02-3456-7890',

--- a/frontend/flutter/lib/features/exercise/data/repositories/mock_gym_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/mock_gym_repository.dart
@@ -30,12 +30,8 @@ class MockGymRepository implements GymRepository {
     trainerIntro:
         '혈압 관리와 체중 감량 전문 트레이너입니다. 고객 맞춤형 AI 루틴으로 '
         '안전하고 효과적인 운동을 도와드려요.',
-    trainerCertifications: <String>[
-      '생활스포츠지도사 2급',
-      '퍼스널트레이닝 CPT',
-      '스포츠 영양사',
-    ],
-    weekdayHours: '06:00 - 23:00',
+    trainerCertifications: <String>['생활스포츠지도사 2급', '퍼스널트레이닝 CPT', '스포츠 영양사'],
+    weekdayHours: '06:00 – 23:00',
     weekendHours: '08:00 - 20:00',
     phone: '02-1234-5678',
   );
@@ -48,7 +44,7 @@ class MockGymRepository implements GymRepository {
     distanceKm: 0.8,
     rating: 4.7,
     tags: <String>['다이어트', '재활운동'],
-    weekdayHours: '06:00 - 23:00',
+    weekdayHours: '06:00 – 23:00',
     weekendHours: '08:00 - 20:00',
     phone: '02-1234-5678',
   );
@@ -64,7 +60,8 @@ class MockGymRepository implements GymRepository {
     trainerRole: '퍼스널 트레이너',
     trainerReason: '교대근무 스케줄 케어 경험이 풍부해요',
     trainerCareer: '5년',
-    trainerIntro: '불규칙한 근무 일정에 맞춘 운동 설계를 주로 합니다. 짧은 시간에 '
+    trainerIntro:
+        '불규칙한 근무 일정에 맞춘 운동 설계를 주로 합니다. 짧은 시간에 '
         '집중도를 높이는 근력 프로그램을 준비해 드려요.',
     trainerCertifications: <String>['건강운동관리사', '퍼스널트레이닝 CPT'],
     weekdayHours: '05:30 - 24:00',
@@ -83,9 +80,14 @@ class MockGymRepository implements GymRepository {
     trainerRole: '퍼스널 트레이너',
     trainerReason: '간단한 운동 루틴에 특화되어 있어요',
     trainerCareer: '9년',
-    trainerIntro: '운동을 처음 시작하는 분을 오래 지도했습니다. 식단 상담을 함께 '
+    trainerIntro:
+        '운동을 처음 시작하는 분을 오래 지도했습니다. 식단 상담을 함께 '
         '진행해 생활 습관부터 차근차근 바꿔 드려요.',
-    trainerCertifications: <String>['생활스포츠지도사 2급', '스포츠 영양사', '재활 트레이닝 NASM-CES'],
+    trainerCertifications: <String>[
+      '생활스포츠지도사 2급',
+      '스포츠 영양사',
+      '재활 트레이닝 NASM-CES',
+    ],
     weekdayHours: '06:00 - 22:00',
     weekendHours: '09:00 - 18:00',
     phone: '02-3456-7890',

--- a/frontend/flutter/lib/features/exercise/domain/entities/gym.dart
+++ b/frontend/flutter/lib/features/exercise/domain/entities/gym.dart
@@ -12,6 +12,9 @@ class Gym {
     this.trainerName,
     this.trainerRole,
     this.trainerReason,
+    this.trainerCareer,
+    this.trainerIntro,
+    this.trainerCertifications = const <String>[],
     this.weekdayHours,
     this.weekendHours,
     this.phone,
@@ -29,6 +32,18 @@ class Gym {
   /// Per-trainer recommendation reason shown on the 추천 트레이너 card/detail.
   /// Null falls back to the generic localized reason.
   final String? trainerReason;
+
+  /// Years of experience as free text (e.g. "7년"), mirroring the trainer
+  /// app's `TrainerProfile.career`. Null hides the row.
+  final String? trainerCareer;
+
+  /// Self-introduction shown on the trainer detail page, mirroring the
+  /// trainer app's `TrainerProfile.intro`. Null hides the section.
+  final String? trainerIntro;
+
+  /// Licences and certifications, mirroring the trainer app's
+  /// `TrainerProfile.certifications`. Empty hides the section.
+  final List<String> trainerCertifications;
   final String? weekdayHours;
   final String? weekendHours;
   final String? phone;

--- a/frontend/flutter/lib/features/exercise/presentation/pages/trainer_detail_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/trainer_detail_page.dart
@@ -103,6 +103,12 @@ class _TrainerDetails extends StatelessWidget {
   final bool hasPending;
   final bool isMyTrainer;
 
+  /// 소개·경력·자격증 중 하나라도 있으면 프로필 섹션을 그린다.
+  bool get _hasProfile =>
+      (gym.trainerIntro?.isNotEmpty ?? false) ||
+      (gym.trainerCareer?.isNotEmpty ?? false) ||
+      gym.trainerCertifications.isNotEmpty;
+
   @override
   Widget build(BuildContext context) {
     final AppLocalizations l = AppLocalizations.of(context);
@@ -154,6 +160,73 @@ class _TrainerDetails extends StatelessWidget {
               ),
             ],
             const SizedBox(height: 22),
+            // 트레이너 앱 프로필(소개·경력·자격증)과 같은 값을 보여준다.
+            // 세 항목이 모두 비면 섹션 자체를 숨긴다.
+            if (_hasProfile) ...<Widget>[
+              _DetailSection(
+                icon: Icons.badge_outlined,
+                title: l.exTrainerIntroSection,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    if (gym.trainerIntro?.isNotEmpty ?? false)
+                      Text(
+                        gym.trainerIntro!,
+                        style: const TextStyle(
+                          fontSize: 13,
+                          height: 1.5,
+                          color: FigmaColors.textBody,
+                        ),
+                      ),
+                    if (gym.trainerCareer?.isNotEmpty ?? false) ...<Widget>[
+                      if (gym.trainerIntro?.isNotEmpty ?? false)
+                        const SizedBox(height: 12),
+                      Row(
+                        children: <Widget>[
+                          const Icon(
+                            Icons.workspace_premium_outlined,
+                            size: 15,
+                            color: FigmaColors.primary,
+                          ),
+                          const SizedBox(width: 6),
+                          Expanded(
+                            child: Text(
+                              l.exTrainerCareer(gym.trainerCareer!),
+                              style: const TextStyle(
+                                fontSize: 12.5,
+                                fontWeight: FontWeight.w700,
+                                color: FigmaColors.ink,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                    if (gym.trainerCertifications.isNotEmpty) ...<Widget>[
+                      const SizedBox(height: 14),
+                      Text(
+                        l.exTrainerCertifications,
+                        style: const TextStyle(
+                          fontSize: 11.5,
+                          fontWeight: FontWeight.w700,
+                          color: FigmaColors.textMuted,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Wrap(
+                        spacing: 6,
+                        runSpacing: 6,
+                        children: <Widget>[
+                          for (final String cert in gym.trainerCertifications)
+                            _CertChip(label: cert),
+                        ],
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+              const SizedBox(height: 12),
+            ],
             _DetailSection(
               icon: Icons.auto_awesome_outlined,
               title: l.exRecommendationReason,
@@ -274,6 +347,32 @@ class _TrainerDetails extends StatelessWidget {
               ),
             ],
           ],
+        ),
+      ),
+    );
+  }
+}
+
+/// 자격증 한 건을 나타내는 칩. 헬스장 태그 칩과 같은 톤을 쓴다.
+class _CertChip extends StatelessWidget {
+  const _CertChip({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 4),
+      decoration: BoxDecoration(
+        color: FigmaColors.primaryA(0.09),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(
+        label,
+        style: const TextStyle(
+          fontSize: 10.5,
+          fontWeight: FontWeight.w700,
+          color: FigmaColors.primary,
         ),
       ),
     );

--- a/frontend/flutter/lib/features/exercise/presentation/pages/trainer_detail_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/trainer_detail_page.dart
@@ -103,15 +103,17 @@ class _TrainerDetails extends StatelessWidget {
   final bool hasPending;
   final bool isMyTrainer;
 
-  /// 소개·경력·자격증 중 하나라도 있으면 프로필 섹션을 그린다.
-  bool get _hasProfile =>
-      (gym.trainerIntro?.isNotEmpty ?? false) ||
-      (gym.trainerCareer?.isNotEmpty ?? false) ||
-      gym.trainerCertifications.isNotEmpty;
-
   @override
   Widget build(BuildContext context) {
     final AppLocalizations l = AppLocalizations.of(context);
+    final String intro = gym.trainerIntro?.trim() ?? '';
+    final String career = gym.trainerCareer?.trim() ?? '';
+    final List<String> certifications = gym.trainerCertifications
+        .map((String certification) => certification.trim())
+        .where((String certification) => certification.isNotEmpty)
+        .toList(growable: false);
+    final bool hasProfile =
+        intro.isNotEmpty || career.isNotEmpty || certifications.isNotEmpty;
     return Center(
       child: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 720),
@@ -162,25 +164,24 @@ class _TrainerDetails extends StatelessWidget {
             const SizedBox(height: 22),
             // 트레이너 앱 프로필(소개·경력·자격증)과 같은 값을 보여준다.
             // 세 항목이 모두 비면 섹션 자체를 숨긴다.
-            if (_hasProfile) ...<Widget>[
+            if (hasProfile) ...<Widget>[
               _DetailSection(
                 icon: Icons.badge_outlined,
                 title: l.exTrainerIntroSection,
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: <Widget>[
-                    if (gym.trainerIntro?.isNotEmpty ?? false)
+                    if (intro.isNotEmpty)
                       Text(
-                        gym.trainerIntro!,
+                        intro,
                         style: const TextStyle(
                           fontSize: 13,
                           height: 1.5,
                           color: FigmaColors.textBody,
                         ),
                       ),
-                    if (gym.trainerCareer?.isNotEmpty ?? false) ...<Widget>[
-                      if (gym.trainerIntro?.isNotEmpty ?? false)
-                        const SizedBox(height: 12),
+                    if (career.isNotEmpty) ...<Widget>[
+                      if (intro.isNotEmpty) const SizedBox(height: 12),
                       Row(
                         children: <Widget>[
                           const Icon(
@@ -191,7 +192,7 @@ class _TrainerDetails extends StatelessWidget {
                           const SizedBox(width: 6),
                           Expanded(
                             child: Text(
-                              l.exTrainerCareer(gym.trainerCareer!),
+                              l.exTrainerCareer(career),
                               style: const TextStyle(
                                 fontSize: 12.5,
                                 fontWeight: FontWeight.w700,
@@ -202,7 +203,7 @@ class _TrainerDetails extends StatelessWidget {
                         ],
                       ),
                     ],
-                    if (gym.trainerCertifications.isNotEmpty) ...<Widget>[
+                    if (certifications.isNotEmpty) ...<Widget>[
                       const SizedBox(height: 14),
                       Text(
                         l.exTrainerCertifications,
@@ -217,7 +218,7 @@ class _TrainerDetails extends StatelessWidget {
                         spacing: 6,
                         runSpacing: 6,
                         children: <Widget>[
-                          for (final String cert in gym.trainerCertifications)
+                          for (final String cert in certifications)
                             _CertChip(label: cert),
                         ],
                       ),

--- a/frontend/flutter/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations.dart
@@ -1388,6 +1388,24 @@ abstract class AppLocalizations {
   /// **'Gym'**
   String get exTrainerAffiliation;
 
+  /// No description provided for @exTrainerIntroSection.
+  ///
+  /// In en, this message translates to:
+  /// **'About the trainer'**
+  String get exTrainerIntroSection;
+
+  /// No description provided for @exTrainerCareer.
+  ///
+  /// In en, this message translates to:
+  /// **'{career} of experience'**
+  String exTrainerCareer(String career);
+
+  /// No description provided for @exTrainerCertifications.
+  ///
+  /// In en, this message translates to:
+  /// **'Certifications'**
+  String get exTrainerCertifications;
+
   /// No description provided for @exTrainerRecommendationReason.
   ///
   /// In en, this message translates to:

--- a/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
@@ -705,6 +705,17 @@ class AppLocalizationsEn extends AppLocalizations {
   String get exTrainerAffiliation => 'Gym';
 
   @override
+  String get exTrainerIntroSection => 'About the trainer';
+
+  @override
+  String exTrainerCareer(String career) {
+    return '$career of experience';
+  }
+
+  @override
+  String get exTrainerCertifications => 'Certifications';
+
+  @override
   String get exTrainerRecommendationReason =>
       'A great fit for reaching my health goals';
 

--- a/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
@@ -697,6 +697,17 @@ class AppLocalizationsKo extends AppLocalizations {
   String get exTrainerAffiliation => '소속 헬스장';
 
   @override
+  String get exTrainerIntroSection => '트레이너 소개';
+
+  @override
+  String exTrainerCareer(String career) {
+    return '경력 $career';
+  }
+
+  @override
+  String get exTrainerCertifications => '자격증 · 인증';
+
+  @override
   String get exTrainerRecommendationReason => '내 건강 목표 달성에 잘 맞는 트레이너예요';
 
   @override

--- a/frontend/flutter/lib/l10n/app_en.arb
+++ b/frontend/flutter/lib/l10n/app_en.arb
@@ -353,6 +353,17 @@
   "exNoRecommendedGyms": "No gym recommendations yet.",
   "exNoRecommendedTrainers": "No trainer recommendations yet.",
   "exTrainerAffiliation": "Gym",
+  "exTrainerIntroSection": "About the trainer",
+  "exTrainerCareer": "{career} of experience",
+  "@exTrainerCareer": {
+    "placeholders": {
+      "career": {
+        "type": "String",
+        "example": "7 years"
+      }
+    }
+  },
+  "exTrainerCertifications": "Certifications",
   "exTrainerRecommendationReason": "A great fit for reaching my health goals",
   "exNearbyGymsMapLabel": "Gyms near me",
   "exWeekSummary": "This Week's Summary",

--- a/frontend/flutter/lib/l10n/app_ko.arb
+++ b/frontend/flutter/lib/l10n/app_ko.arb
@@ -236,6 +236,17 @@
   "exNoRecommendedGyms": "추천할 헬스장이 아직 없어요.",
   "exNoRecommendedTrainers": "추천할 트레이너가 아직 없어요.",
   "exTrainerAffiliation": "소속 헬스장",
+  "exTrainerIntroSection": "트레이너 소개",
+  "exTrainerCareer": "경력 {career}",
+  "@exTrainerCareer": {
+    "placeholders": {
+      "career": {
+        "type": "String",
+        "example": "7년"
+      }
+    }
+  },
+  "exTrainerCertifications": "자격증 · 인증",
   "exTrainerRecommendationReason": "내 건강 목표 달성에 잘 맞는 트레이너예요",
   "exNearbyGymsMapLabel": "내 주변 헬스장",
   "exWeekSummary": "이번 주 운동 요약",

--- a/frontend/flutter/test/features/dashboard/dashboard_repository_mode_test.dart
+++ b/frontend/flutter/test/features/dashboard/dashboard_repository_mode_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
+
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/core/logging/app_logger.dart';
+import 'package:oncare/features/dashboard/data/repositories/dio_dashboard_repository.dart';
+import 'package:oncare/features/dashboard/data/repositories/mock_dashboard_repository.dart';
+import 'package:oncare/features/dashboard/presentation/controllers/dashboard_controller.dart';
+
+/// 이 분기가 두 번 유실되어 데모 홈이 "대시보드 정보를 불러오지 못했어요" 만
+/// 띄운 적이 있다. my_health 의 같은 이름 테스트와 짝을 이루는 회귀 방지용.
+void main() {
+  group('dashboardRepositoryProvider 모드 분기', () {
+    ProviderContainer makeContainer({required bool useMockApi}) {
+      final container = ProviderContainer(
+        overrides: <Override>[
+          appConfigProvider.overrideWithValue(
+            AppConfig(
+              environment: Environment.dev,
+              apiBaseUrl: 'https://dev.api.test/v1',
+              useMockApi: useMockApi,
+            ),
+          ),
+          // Dio 저장소 경로는 dioProvider → appLogger 를 타므로 조용한 로거로 오버라이드.
+          appLoggerProvider.overrideWithValue(Logger(level: Level.off)),
+        ],
+      );
+      addTearDown(container.dispose);
+      return container;
+    }
+
+    test('USE_MOCK_API=false 면 Dio 저장소를 쓴다', () {
+      final container = makeContainer(useMockApi: false);
+      expect(
+        container.read(dashboardRepositoryProvider),
+        isA<DioDashboardRepository>(),
+      );
+    });
+
+    test('USE_MOCK_API=true 면 Mock 저장소를 쓴다', () {
+      final container = makeContainer(useMockApi: true);
+      expect(
+        container.read(dashboardRepositoryProvider),
+        isA<MockDashboardRepository>(),
+      );
+    });
+
+    test('데모 기본값(USE_MOCK_API 미지정)은 Mock 저장소다', () {
+      final container = ProviderContainer(
+        overrides: <Override>[
+          appConfigProvider.overrideWithValue(AppConfig.fromEnvironment()),
+          appLoggerProvider.overrideWithValue(Logger(level: Level.off)),
+        ],
+      );
+      addTearDown(container.dispose);
+      expect(
+        container.read(dashboardRepositoryProvider),
+        isA<MockDashboardRepository>(),
+      );
+    });
+  });
+}

--- a/frontend/flutter/test/features/exercise/trainer_profile_test.dart
+++ b/frontend/flutter/test/features/exercise/trainer_profile_test.dart
@@ -37,6 +37,20 @@ const Gym _withoutProfile = Gym(
   trainerRole: '퍼스널 트레이너',
 );
 
+const Gym _withWhitespaceOnlyProfile = Gym(
+  id: 'gym-whitespace-profile',
+  name: '공백 프로필 헬스장',
+  address: '서울 서대문구 테스트로 3',
+  distanceKm: 1.1,
+  rating: 4.0,
+  tags: <String>[],
+  trainerName: '공백테스트',
+  trainerRole: '퍼스널 트레이너',
+  trainerCareer: '  ',
+  trainerIntro: '\n ',
+  trainerCertifications: <String>['', '  '],
+);
+
 const AppConfig _config = AppConfig(
   environment: Environment.dev,
   apiBaseUrl: 'https://dev.api.test',
@@ -89,6 +103,14 @@ void main() {
     expect(find.text('자격증 · 인증'), findsNothing);
   });
 
+  testWidgets('공백뿐인 프로필 정보는 소개 섹션과 빈 칩을 만들지 않는다', (WidgetTester tester) async {
+    await pumpTrainerDetail(tester, _withWhitespaceOnlyProfile);
+
+    expect(find.text(_withWhitespaceOnlyProfile.trainerName!), findsOneWidget);
+    expect(find.text('트레이너 소개'), findsNothing);
+    expect(find.text('자격증 · 인증'), findsNothing);
+  });
+
   // 트레이너 앱은 별도 패키지라 seedTrainerProfile 을 import 할 수 없다.
   // 기대값을 여기 고정해 두어, 사용자 앱 목 데이터가 바뀌면 실패하도록 한다.
   // 값을 고칠 때는 frontend/flutter_trainer/lib/shared/models/trainer_profile.dart
@@ -100,7 +122,7 @@ void main() {
     expect(gym!.name, '온케어짐 신촌점');
     expect(gym.address, '서울 서대문구 신촌로 120');
     expect(gym.phone, '02-1234-5678');
-    expect(gym.weekdayHours, '06:00 - 23:00');
+    expect(gym.weekdayHours, '06:00 – 23:00');
     expect(gym.trainerName, '김트레이너');
     expect(gym.trainerRole, '퍼스널 트레이너');
     expect(gym.trainerCareer, '7년');
@@ -113,5 +135,18 @@ void main() {
       '퍼스널트레이닝 CPT',
       '스포츠 영양사',
     ]);
+  });
+
+  test('트레이너 연결 해제 후에도 같은 헬스장의 운영시간을 유지한다', () async {
+    final MockGymRepository repository = MockGymRepository();
+    final Gym? before = await repository.fetchMyGym();
+
+    await repository.disconnectMyTrainer();
+    final Gym? after = await repository.fetchMyGym();
+
+    expect(after, isNotNull);
+    expect(after!.id, before!.id);
+    expect(after.weekdayHours, before.weekdayHours);
+    expect(after.trainerName, isNull);
   });
 }

--- a/frontend/flutter/test/features/exercise/trainer_profile_test.dart
+++ b/frontend/flutter/test/features/exercise/trainer_profile_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:oncare/app/router/app_router.dart';
+import 'package:oncare/app/router/routes.dart';
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/features/exercise/data/repositories/mock_gym_repository.dart';
+import 'package:oncare/features/exercise/domain/entities/gym.dart';
+import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+const Gym _withProfile = Gym(
+  id: 'gym-profile',
+  name: '프로필 헬스장',
+  address: '서울 서대문구 테스트로 1',
+  distanceKm: 0.4,
+  rating: 4.6,
+  tags: <String>['PT'],
+  trainerName: '김테스트',
+  trainerRole: '퍼스널 트레이너',
+  trainerCareer: '7년',
+  trainerIntro: '혈압 관리와 체중 감량을 주로 담당합니다.',
+  trainerCertifications: <String>['생활스포츠지도사 2급', '스포츠 영양사'],
+);
+
+/// 이름·직함만 있고 소개/경력/자격증이 없는 트레이너.
+const Gym _withoutProfile = Gym(
+  id: 'gym-bare',
+  name: '기본 헬스장',
+  address: '서울 서대문구 테스트로 2',
+  distanceKm: 0.9,
+  rating: 4.1,
+  tags: <String>[],
+  trainerName: '박테스트',
+  trainerRole: '퍼스널 트레이너',
+);
+
+const AppConfig _config = AppConfig(
+  environment: Environment.dev,
+  apiBaseUrl: 'https://dev.api.test',
+  useMockApi: true,
+);
+
+void main() {
+  Future<void> pumpTrainerDetail(WidgetTester tester, Gym gym) async {
+    await tester.binding.setSurfaceSize(const Size(390, 844));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    final GoRouter router = buildAppRouter(config: _config);
+    addTearDown(router.dispose);
+    router.go(AppRoutes.trainerDetailPath(gym.id));
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          nearbyGymsProvider.overrideWith((ref) async => <Gym>[gym]),
+          myGymProvider.overrideWith((ref) async => null),
+        ],
+        child: MaterialApp.router(
+          routerConfig: router,
+          locale: const Locale('ko'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('트레이너 상세가 소개·경력·자격증을 보여준다', (WidgetTester tester) async {
+    await pumpTrainerDetail(tester, _withProfile);
+
+    expect(find.text('트레이너 소개'), findsOneWidget);
+    expect(find.text(_withProfile.trainerIntro!), findsOneWidget);
+    expect(find.text('경력 7년'), findsOneWidget);
+    expect(find.text('자격증 · 인증'), findsOneWidget);
+    for (final String cert in _withProfile.trainerCertifications) {
+      expect(find.text(cert), findsOneWidget);
+    }
+  });
+
+  testWidgets('프로필 정보가 없으면 소개 섹션을 그리지 않는다', (WidgetTester tester) async {
+    await pumpTrainerDetail(tester, _withoutProfile);
+
+    // 트레이너 자체는 존재하므로 이름은 보이되, 소개 섹션만 빠진다.
+    expect(find.text(_withoutProfile.trainerName!), findsOneWidget);
+    expect(find.text('트레이너 소개'), findsNothing);
+    expect(find.text('자격증 · 인증'), findsNothing);
+  });
+
+  // 트레이너 앱은 별도 패키지라 seedTrainerProfile 을 import 할 수 없다.
+  // 기대값을 여기 고정해 두어, 사용자 앱 목 데이터가 바뀌면 실패하도록 한다.
+  // 값을 고칠 때는 frontend/flutter_trainer/lib/shared/models/trainer_profile.dart
+  // 의 seedTrainerProfile 과 함께 맞춰야 한다.
+  test('연결된 트레이너가 트레이너 앱 seedTrainerProfile 과 같은 값을 쓴다', () async {
+    final Gym? gym = await MockGymRepository().fetchMyGym();
+
+    expect(gym, isNotNull);
+    expect(gym!.name, '온케어짐 신촌점');
+    expect(gym.address, '서울 서대문구 신촌로 120');
+    expect(gym.phone, '02-1234-5678');
+    expect(gym.weekdayHours, '06:00 - 23:00');
+    expect(gym.trainerName, '김트레이너');
+    expect(gym.trainerRole, '퍼스널 트레이너');
+    expect(gym.trainerCareer, '7년');
+    expect(
+      gym.trainerIntro,
+      '혈압 관리와 체중 감량 전문 트레이너입니다. 고객 맞춤형 AI 루틴으로 안전하고 효과적인 운동을 도와드려요.',
+    );
+    expect(gym.trainerCertifications, <String>[
+      '생활스포츠지도사 2급',
+      '퍼스널트레이닝 CPT',
+      '스포츠 영양사',
+    ]);
+  });
+}


### PR DESCRIPTION
## Summary

* 사용자 앱의 트레이너 상세 화면에 `트레이너 소개` 섹션을 추가해 소개문, 경력, 자격증을 표시합니다.
* `Gym` 모델에 `trainerCareer`, `trainerIntro`, `trainerCertifications`를 추가하고, 김트레이너의 프로필과 헬스장 정보를 트레이너 앱 `seedTrainerProfile`과 일치시켰습니다.
* 강트레이너·이트레이너 목 데이터에도 소개·경력·자격증을 채워 모든 추천 트레이너 상세 화면이 완성된 상태로 표시됩니다.
* `dashboardRepositoryProvider`가 `useMockApi`를 따르도록 수정해 데모 홈이 Dio 저장소를 호출하다 로드 오류를 표시하던 문제를 해결했습니다.
* 공백뿐인 프로필 데이터는 숨기고, 트레이너 연결 해제 후에도 헬스장 정보가 일관되게 유지되도록 경계값 처리를 보강했습니다.

## Notes

* base: `fix/home-exercise-label-overflow` (#420)
* 스택 순서: #407 → #412 → #416 → #420 → #421
* #420까지 누적된 회원용 프론트 화면을 유지하면서 트레이너 프로필·대시보드 기능을 추가했습니다.
* 헬스장·추천 트레이너 데이터는 아직 별도 백엔드 API가 없어 기존 `MockGymRepository`를 사용합니다.
* 대시보드 모드 분기는 과거 두 번 유실된 이력이 있어 `my_health`의 기존 모드 분기 테스트와 같은 형태로 회귀 테스트를 추가했습니다. `USE_MOCK_API` 미지정 기본값도 Mock 저장소를 선택하는지 검증하며, 데모 실행이 이 경로를 사용합니다.

## Test Plan

* [x] 변경 Dart 파일 `dart analyze` 통과
* [x] 사용자 앱 Flutter 테스트 255개 통과
* [x] Mock/Dio 대시보드 저장소 모드 분기 테스트
* [x] 트레이너 소개·경력·자격증 표시 및 빈 프로필 테스트
* [x] 트레이너 앱 시드 데이터 일치 테스트
* [x] 트레이너 연결 해제 후 헬스장 정보 유지 테스트

### Manual

1. 사용자 앱을 실행하고 데모로 진입합니다.
2. 운동 탭에서 추천 트레이너의 상세 화면을 엽니다.
3. `트레이너 소개`에 소개문 → `경력 7년` → `자격증 · 인증` 순서로 표시되는지 확인합니다.
4. 강트레이너·이트레이너 상세에서도 소개·경력·자격증이 정상적으로 표시되는지 확인합니다.
5. 앱을 재시작하고 데모로 진입한 뒤 홈 탭이 로드 오류 없이 표시되는지 확인합니다.

## Related Issues

Closes #401
Closes #402

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 대시보드, 운동, 식단, 건강 화면에 트레이너 채팅 바로가기를 추가했습니다.
  - 트레이너 상세 화면에서 소개, 경력, 자격증 정보를 확인할 수 있습니다.
  - 담당 트레이너와 헬스장 정보를 쉽게 확인하고 상세 화면으로 이동할 수 있습니다.
  - 읽지 않은 채팅이 있을 때 알림 표시를 제공합니다.

- **개선**
  - 하단 내비게이션과 대시보드 레이아웃을 더 간결하게 조정했습니다.
  - 운동 지표 및 헬스장 섹션의 표시 방식을 개선했습니다.
  - 상담 신청 및 채팅 메시지 화면의 표시와 동작을 정리했습니다.

- **버그 수정**
  - 연결된 헬스장이나 트레이너에 대한 중복 상담 요청을 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->