### PR TITLE
refactor(exercise): 남은 placeholder 지도 정리

### DIFF
--- a/frontend/flutter/lib/features/exercise/presentation/widgets/exercise_flows.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/exercise_flows.dart
@@ -7,6 +7,7 @@ import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
 import 'package:oncare/features/exercise/domain/entities/gym.dart';
 import 'package:oncare/features/exercise/domain/entities/trainer.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
+import 'package:oncare/features/exercise/presentation/widgets/kakao_map/kakao_map_view.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 
 // Backend value sent as `dayLabel` — DO NOT localize (persisted to the server).
@@ -453,6 +454,9 @@ class _GymLocatorSheetState extends ConsumerState<_GymLocatorSheet> {
     // 제휴 헬스장 + 카카오 Local 주변 헬스장(#329). 트레이너 흐름이 쓰는
     // nearbyGymsProvider 와 달리, 이 시트만 카카오 결과를 함께 본다.
     final AsyncValue<List<Gym>> async = ref.watch(gymFinderResultsProvider);
+    // 지도 핀은 아래 목록과 같은 것을 가리켜야 한다 — 검색어로 거른 뒤의 결과를
+    // 쓴다. 아직 로딩 중이면 핀 0개로 그려지고, 결과가 도착하면 다시 찍힌다.
+    final List<Gym> pinned = _filter(async.valueOrNull ?? const <Gym>[]);
     return _shell(
       context,
       Column(
@@ -554,7 +558,7 @@ class _GymLocatorSheetState extends ConsumerState<_GymLocatorSheet> {
                   ),
                 ),
                 const SizedBox(height: 12),
-                const _MapPlaceholder(),
+                _LocatorMap(gyms: pinned),
                 const SizedBox(height: 16),
                 Row(
                   children: <Widget>[
@@ -894,71 +898,50 @@ Future<void> _sendHealthSummary(BuildContext context, String gymName) async {
   );
 }
 
-Widget _closeBtn(BuildContext ctx) => Material(
-  color: const Color(0xFFF4F6F8),
-  shape: const CircleBorder(),
-  clipBehavior: Clip.antiAlias,
-  child: InkWell(
-    onTap: () => Navigator.of(ctx).pop(),
-    child: const SizedBox(
-      width: 32,
-      height: 32,
-      child: Icon(Icons.close, size: 16, color: FigmaColors.textSub),
-    ),
-  ),
-);
+// ─────────────────────────────────────────────────────────────── 지도 ──
 
-Widget _infoRow(IconData icon, String label, String value) => Padding(
-  padding: const EdgeInsets.symmetric(vertical: 6),
-  child: Row(
-    crossAxisAlignment: CrossAxisAlignment.start,
-    children: <Widget>[
-      Container(
-        width: 32,
-        height: 32,
-        decoration: BoxDecoration(
-          color: FigmaColors.softBlue,
-          borderRadius: BorderRadius.circular(10),
-        ),
-        child: Icon(icon, size: 16, color: FigmaColors.primary),
-      ),
-      const SizedBox(width: 12),
-      SizedBox(
-        width: 78,
-        child: Padding(
-          padding: const EdgeInsets.only(top: 7),
-          child: Text(
-            label,
-            style: const TextStyle(
-              fontSize: 12,
-              fontWeight: FontWeight.w600,
-              color: FigmaColors.textMuted,
-            ),
-          ),
-        ),
-      ),
-      Expanded(
-        child: Padding(
-          padding: const EdgeInsets.only(top: 6),
-          child: Text(
-            value,
-            style: const TextStyle(
-              fontSize: 13.5,
-              fontWeight: FontWeight.w700,
-              color: FigmaColors.ink,
-              height: 1.35,
-            ),
-          ),
-        ),
-      ),
-    ],
-  ),
-);
+/// 로케이터 시트 지도의 높이. 실지도와 폴백 그래픽이 같은 자리를 차지해야
+/// 폴백으로 떨어질 때 시트 레이아웃이 흔들리지 않는다.
+const double _kLocatorMapHeight = 190;
 
-// ─────────────────────────────────────────────────────── 지도 그래픽 ──
+/// 시트 목록에 보이는 헬스장을 카카오맵 핀으로 찍는다. `KAKAO_JS_KEY` 가
+/// 없거나 web 이 아니거나 SDK 로드가 실패하면 [_MapPlaceholder] 그래픽으로
+/// 폴백한다(#329) — 데모가 비지 않게 하기 위한 요건이다.
+class _LocatorMap extends StatelessWidget {
+  const _LocatorMap({required this.gyms});
+
+  final List<Gym> gyms;
+
+  @override
+  Widget build(BuildContext context) {
+    final List<Gym> located = gyms
+        .where((Gym g) => g.hasCoordinates)
+        .toList(growable: false);
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(14),
+      child: SizedBox(
+        height: _kLocatorMapHeight,
+        width: double.infinity,
+        child: KakaoMapView(
+          // 지도 중심은 언제나 검색 중심([kGymFinderArea])이다. 첫 결과 좌표를
+          // 쓰면 검색어에 따라 중심이 흔들려, 지도 중심과 장소 검색 중심이
+          // 같아야 한다는 요건이 깨진다.
+          centerLat: kGymFinderArea.lat,
+          centerLng: kGymFinderArea.lng,
+          markers: <KakaoMapMarker>[
+            for (final Gym g in located)
+              KakaoMapMarker(lat: g.lat!, lng: g.lng!, title: g.name),
+          ],
+          fallback: const _MapPlaceholder(),
+        ),
+      ),
+    );
+  }
+}
 
 /// A lightweight stylised map (roads, blocks, pins) so the locator reads as a
-/// map area without embedding a live Kakao Map.
+/// map area when the live Kakao Map is unavailable.
 class _MapPlaceholder extends StatelessWidget {
   const _MapPlaceholder();
 
@@ -968,7 +951,7 @@ class _MapPlaceholder extends StatelessWidget {
     return ClipRRect(
       borderRadius: BorderRadius.circular(14),
       child: SizedBox(
-        height: 140,
+        height: _kLocatorMapHeight,
         width: double.infinity,
         child: Stack(
           children: <Widget>[
@@ -1082,112 +1065,4 @@ class _MapPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
-}
-
-// ─────────────────────────────────────────────────────── 헬스장 정보 ──
-
-/// Gym detail sheet opened from the "헬스장 정보" button, driven by [gym].
-Future<void> showGymInfoSheet(
-  BuildContext context,
-  Gym gym, {
-  Trainer? trainer,
-}) {
-  final AppLocalizations l = AppLocalizations.of(context);
-  final String hours = gym.weekdayHours != null
-      ? l.exGymWeekdayHours(gym.weekdayHours!) +
-            (gym.weekendHours != null
-                ? '\n${l.exGymWeekendHours(gym.weekendHours!)}'
-                : '')
-      : '';
-  final String trainerLabel = trainer == null
-      ? ''
-      : '${trainer.name}${trainer.role != null ? ' · ${trainer.role}' : ''}';
-  return showModalBottomSheet<void>(
-    context: context,
-    isScrollControlled: true,
-    backgroundColor: Colors.transparent,
-    barrierColor: FigmaColors.sheetScrim,
-    builder: (BuildContext ctx) => _shell(
-      ctx,
-      Column(
-        mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          Center(child: _handle()),
-          Padding(
-            padding: const EdgeInsets.fromLTRB(20, 8, 20, 8),
-            child: Row(
-              children: <Widget>[
-                Expanded(
-                  child: Text(
-                    l.exGymInfo,
-                    style: const TextStyle(
-                      fontSize: 18,
-                      fontWeight: FontWeight.w800,
-                      color: FigmaColors.ink,
-                    ),
-                  ),
-                ),
-                _closeBtn(ctx),
-              ],
-            ),
-          ),
-          Flexible(
-            child: ListView(
-              shrinkWrap: true,
-              padding: const EdgeInsets.fromLTRB(20, 4, 20, 28),
-              children: <Widget>[
-                const _MapPlaceholder(),
-                const SizedBox(height: 14),
-                Text(
-                  gym.name,
-                  style: const TextStyle(
-                    fontSize: 18,
-                    fontWeight: FontWeight.w800,
-                    color: FigmaColors.ink,
-                  ),
-                ),
-                const SizedBox(height: 4),
-                Row(
-                  children: <Widget>[
-                    const Icon(Icons.star, size: 15, color: Color(0xFFF5B400)),
-                    const SizedBox(width: 3),
-                    Text(
-                      gym.rating.toStringAsFixed(1),
-                      style: const TextStyle(
-                        fontSize: 13,
-                        fontWeight: FontWeight.w800,
-                        color: FigmaColors.ink,
-                      ),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 14),
-                _infoRow(
-                  Icons.place_outlined,
-                  l.exAddress,
-                  '${gym.address} · ${gym.distanceKm.toStringAsFixed(1)}km',
-                ),
-                if (hours.isNotEmpty)
-                  _infoRow(Icons.schedule, l.exHours, hours),
-                if (gym.phone != null)
-                  _infoRow(Icons.call_outlined, l.exPhone, gym.phone!),
-                if (gym.tags.isNotEmpty)
-                  _infoRow(
-                    Icons.fitness_center,
-                    l.exSpecialty,
-                    gym.tags.join(' · '),
-                  ),
-                if (trainerLabel.isNotEmpty)
-                  _infoRow(
-                    Icons.person_outline,
-                    l.exTrainerDedicated,
-                    trainerLabel,
-                  ),
-              ],
-            ),
-          ),
-        ],
-      ),
-    ),
-  );
 }

--- a/frontend/flutter/lib/features/place/presentation/pages/place_page.dart
+++ b/frontend/flutter/lib/features/place/presentation/pages/place_page.dart
@@ -8,6 +8,7 @@ import 'package:oncare/design_system/molecules/section_header.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
 import 'package:oncare/design_system/tokens/radius.dart';
 import 'package:oncare/design_system/tokens/spacing.dart';
+import 'package:oncare/features/exercise/presentation/widgets/kakao_map/kakao_map_view.dart';
 import 'package:oncare/features/place/domain/entities/place.dart';
 import 'package:oncare/features/place/presentation/controllers/place_controller.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
@@ -51,7 +52,7 @@ class _Body extends StatelessWidget {
     return ListView(
       padding: const EdgeInsets.all(AppSpacing.lg),
       children: <Widget>[
-        const _MapPlaceholder(),
+        _PlaceMap(places: places),
         const SizedBox(height: AppSpacing.lg),
         const SectionHeader('가까운 추천 장소'),
         for (final p in places) ...<Widget>[
@@ -63,6 +64,38 @@ class _Body extends StatelessWidget {
   }
 }
 
+/// 실지도와 폴백이 같은 높이를 차지해야 폴백으로 떨어질 때 목록이 밀리지 않는다.
+const double _kPlaceMapHeight = 160;
+
+/// 주변 장소를 카카오맵 핀으로 찍는다. `KAKAO_JS_KEY` 가 없거나 web 이 아니거나
+/// SDK 로드가 실패하면 [_MapPlaceholder] 로 폴백한다(#329).
+class _PlaceMap extends ConsumerWidget {
+  const _PlaceMap({required this.places});
+
+  final List<Place> places;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // 지도 중심은 목록을 가져온 검색 중심([placeQueryProvider])과 같아야 한다.
+    final query = ref.watch(placeQueryProvider);
+    return ClipRRect(
+      borderRadius: const BorderRadius.all(AppRadius.lg),
+      child: SizedBox(
+        height: _kPlaceMapHeight,
+        child: KakaoMapView(
+          centerLat: query.lat,
+          centerLng: query.lng,
+          markers: <KakaoMapMarker>[
+            for (final Place p in places)
+              KakaoMapMarker(lat: p.lat, lng: p.lng, title: p.name),
+          ],
+          fallback: const _MapPlaceholder(),
+        ),
+      ),
+    );
+  }
+}
+
 class _MapPlaceholder extends StatelessWidget {
   const _MapPlaceholder();
 
@@ -70,7 +103,7 @@ class _MapPlaceholder extends StatelessWidget {
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
     return Container(
-      height: 160,
+      height: _kPlaceMapHeight,
       decoration: BoxDecoration(
         color: scheme.surfaceContainerHigh,
         borderRadius: const BorderRadius.all(AppRadius.lg),
@@ -82,12 +115,12 @@ class _MapPlaceholder extends StatelessWidget {
           Icon(Icons.map_outlined, size: 36, color: scheme.onSurfaceVariant),
           const SizedBox(height: AppSpacing.sm),
           Text(
-            'Google Maps Flutter (API key needed)',
+            '지도를 표시할 수 없어요',
             style: Theme.of(context).textTheme.bodyMedium,
           ),
           const SizedBox(height: 2),
           Text(
-            '실제 지도 위젯은 Stage 7 릴리즈 전에 활성화',
+            '아래 목록은 그대로 볼 수 있어요',
             style: Theme.of(context).textTheme.bodySmall,
           ),
         ],

--- a/frontend/flutter/test/features/exercise/gym_locator_sheet_test.dart
+++ b/frontend/flutter/test/features/exercise/gym_locator_sheet_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/exercise/domain/entities/gym.dart';
+import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
+import 'package:oncare/features/exercise/presentation/widgets/exercise_flows.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+/// 제휴 헬스장 — `MockGymRepository` 와 같이 좌표가 없다.
+const Gym _withoutCoordinates = Gym(
+  id: 'gym-no-coords',
+  name: '좌표없는 헬스장',
+  address: '서울시 서대문구 신촌로 1',
+  distanceKm: 0.4,
+  rating: 4.7,
+  tags: <String>['PT'],
+);
+
+/// 카카오 Local 이 준 헬스장 — 좌표가 있다.
+const Gym _withCoordinates = Gym(
+  id: 'gym-with-coords',
+  name: '좌표있는 헬스장',
+  address: '서울시 서대문구 신촌로 2',
+  distanceKm: 0.9,
+  rating: 0,
+  tags: <String>[],
+  lat: 37.5559,
+  lng: 126.9368,
+);
+
+void main() {
+  Future<void> openSheet(WidgetTester tester, List<Gym> gyms) async {
+    await tester.binding.setSurfaceSize(const Size(390, 844));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          gymFinderResultsProvider.overrideWith((ref) async => gyms),
+        ],
+        child: MaterialApp(
+          locale: const Locale('ko'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) => TextButton(
+                onPressed: () => showGymLocatorSheet(context),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  AppLocalizations localizations(WidgetTester tester) =>
+      AppLocalizations.of(tester.element(find.byType(Scaffold).first));
+
+  testWidgets('좌표가 없는 헬스장만 있어도 시트가 뜨고 지도 자리가 남는다', (
+    WidgetTester tester,
+  ) async {
+    // 마커 목록은 폴백으로 떨어지기 전에 만들어지므로, 좌표 없는 헬스장을
+    // 걸러내지 않으면 여기서 터진다.
+    await openSheet(tester, const <Gym>[_withoutCoordinates]);
+
+    expect(tester.takeException(), isNull);
+    // 테스트는 web 이 아니라 언제나 폴백 그래픽이 그려진다.
+    expect(find.text(localizations(tester).exKakaoMapArea), findsOneWidget);
+    expect(find.text(_withoutCoordinates.name), findsOneWidget);
+  });
+
+  testWidgets('좌표 유무가 섞여도 결과가 모두 나온다', (WidgetTester tester) async {
+    await openSheet(
+      tester,
+      const <Gym>[_withoutCoordinates, _withCoordinates],
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(find.text(_withoutCoordinates.name), findsOneWidget);
+    // 두 번째 카드는 시트 아래로 밀려 화면 밖이라 skipOffstage 를 끈다 — 여기서
+    // 볼 것은 스크롤 위치가 아니라 두 결과가 모두 목록에 올랐는지다.
+    expect(
+      find.text(_withCoordinates.name, skipOffstage: false),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('검색어로 거르면 지도와 목록이 같은 결과를 가리킨다', (
+    WidgetTester tester,
+  ) async {
+    await openSheet(
+      tester,
+      const <Gym>[_withoutCoordinates, _withCoordinates],
+    );
+
+    await tester.enterText(find.byType(TextField), '좌표있는');
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text(_withoutCoordinates.name), findsNothing);
+    expect(find.text(_withCoordinates.name), findsOneWidget);
+    // 목록이 하나로 줄어도 지도 자리는 그대로다.
+    expect(find.text(localizations(tester).exKakaoMapArea), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #431

## Summary

PR #430(#329)이 남겨둔 placeholder 지도 3곳을 정리했습니다. 실제로 사용자가 보는 곳은 **헬스장 로케이터 시트 1곳**뿐이고, 나머지 2곳은 도달 불가 화면이었습니다.

## Changes

### 로케이터 시트 — 실지도 연결 (도달 가능)

운동 탭 → 헬스장 찾기로 열리는 시트가 그림 지도를 그대로 쓰고 있었습니다. 목록에 보이는 결과를 카카오맵 핀으로 찍고, `gym_list_page` 와 같은 방식으로 폴백을 둡니다.

- **지도 중심은 검색 중심(`kGymFinderArea`) 고정** — 첫 결과 좌표를 쓰면 검색어에 따라 중심이 흔들려, 지도 중심과 장소 검색 중심이 같아야 한다는 요건이 깨집니다
- **핀은 검색어로 거른 뒤의 목록** — 지도와 아래 목록이 항상 같은 결과를 가리킵니다
- **폴백 3경우**(키 없음 / web 아님 / SDK 로드 실패) 모두 기존 그림 지도로 되돌아갑니다. 실지도와 폴백의 높이를 같은 상수로 묶어, 폴백으로 떨어져도 시트 레이아웃이 흔들리지 않습니다

마커 목록은 **폴백으로 떨어지기 전에 만들어지므로**, 좌표 없는 제휴 헬스장을 걸러내지 않으면 거기서 터집니다. 테스트 3건으로 막았습니다.

### `showGymInfoSheet` 삭제 (도달 불가)

`4b1ddb2 feat(member): simplify gym trainer card actions` 에서 호출부가 사라진 뒤로 `lib/` 어디서도 열리지 않았고, 테스트 참조도 없습니다. 같은 내용을 `gym_detail_page` 가 대체하며, 이쪽은 평점 0을 그대로 노출하는 등 현재 규칙과도 어긋나 있었습니다. 전용 헬퍼(`_closeBtn`·`_infoRow`)도 함께 정리했습니다.

`exGymInfo` l10n 키는 **남깁니다** — 그 버튼이 사라졌음을 확인하는 회귀 테스트(`gym_tab_action_test.dart`)가 여전히 참조합니다.

### `place_page.dart` — 문구 정정 (도달 불가)

`/place` 는 라우터에 등록만 되어 있고 이동 경로가 없어 여전히 도달 불가입니다. 다만 폴백 문구가 `Google Maps Flutter (API key needed)` / `실제 지도 위젯은 Stage 7 릴리즈 전에 활성화` 로, **PR #430이 제거한 `google_maps_flutter` 를 가리켜 사실과 달랐습니다.** 같은 카카오맵 위젯으로 바꾸고 문구를 현재 동작에 맞췄습니다. 페이지 자체는 실 데이터를 부르고 있어 삭제하지 않았습니다.

## Verification

- `flutter analyze` 이슈 0
- `flutter test` **278건 통과** (신규 3건: 좌표 없는 헬스장만 있을 때 / 좌표 유무가 섞일 때 / 검색어로 거를 때)
- 브라우저 실지도 확인은 하지 못했습니다 — 카카오 JavaScript SDK 도메인에 등록된 origin(`localhost:5187`)을 다른 세션의 dev server 가 점유 중이라 다시 빌드해 확인할 수 없었습니다. 실지도 렌더 경로는 #430에서 검증된 `KakaoMapView` 와 동일하고, 폴백·마커 구성은 위 테스트가 덮습니다

## Notes

현재 위치(geolocator) 도입은 범위 밖입니다 — 데모 재현이 어려워 만들지 않기로 했고, 지도 중심은 `kGymFinderArea`(신촌) 고정을 유지합니다.
