### PR TITLE
feat(gym): 헬스장·트레이너 목록·상세 실 백엔드 신설 + 앱 연결

### DIFF
--- a/backend/app/api/v1/gyms.py
+++ b/backend/app/api/v1/gyms.py
@@ -1,0 +1,55 @@
+"""헬스장·트레이너 디렉터리 라우터 — 회원앱 헬스장 찾기/상세. (#324)
+
+`/trainer/*` 는 트레이너 앱 전용(자기 회원·일정)이라 회원앱이 쓸 수 없어 여기 둔다.
+"""
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.api.deps import CurrentUser
+from app.db.session import get_db
+from app.schemas.gym_api import GymOut, TrainerOut
+from app.services import gym_service
+
+router = APIRouter(tags=["gyms"])
+
+
+@router.get("/gyms", response_model=list[GymOut])
+def list_gyms(
+    current_user: CurrentUser,
+    db: Annotated[Session, Depends(get_db)],
+    lat: float | None = Query(None, ge=-90, le=90, description="기준 위도(거리 계산용)"),
+    lng: float | None = Query(None, ge=-180, le=180),
+    partner_only: bool = Query(False, description="제휴 헬스장만"),
+) -> list[GymOut]:
+    """헬스장 목록. 좌표를 주면 거리순, 없으면 이름순."""
+    return gym_service.list_gyms(db, lat=lat, lng=lng, partner_only=partner_only)
+
+
+@router.get("/gyms/{gym_id}", response_model=GymOut)
+def get_gym(
+    gym_id: str,
+    current_user: CurrentUser,
+    db: Annotated[Session, Depends(get_db)],
+    lat: float | None = Query(None, ge=-90, le=90),
+    lng: float | None = Query(None, ge=-180, le=180),
+) -> GymOut:
+    gym = gym_service.get_gym(db, gym_id, lat=lat, lng=lng)
+    if gym is None:
+        raise HTTPException(status_code=404, detail="헬스장을 찾을 수 없습니다.")
+    return gym
+
+
+@router.get("/gyms/{gym_id}/trainers", response_model=list[TrainerOut])
+def list_gym_trainers(
+    gym_id: str,
+    current_user: CurrentUser,
+    db: Annotated[Session, Depends(get_db)],
+) -> list[TrainerOut]:
+    """이 헬스장 소속 트레이너 전원. 헬스장이 없으면 404, 있고 소속이 없으면 빈 배열."""
+    if gym_service.get_gym(db, gym_id) is None:
+        raise HTTPException(status_code=404, detail="헬스장을 찾을 수 없습니다.")
+    return gym_service.list_trainers(db, gym_id=gym_id)

--- a/backend/app/api/v1/member_coach.py
+++ b/backend/app/api/v1/member_coach.py
@@ -45,6 +45,19 @@ def my_coach(
     return coach
 
 
+@router.delete("/me/coach", status_code=204)
+def disconnect_my_coach(
+    current_user: CurrentUser,
+    db: Annotated[Session, Depends(get_db)],
+) -> None:
+    """담당 트레이너 연결 해제 — MY 탭의 연결 삭제.
+
+    이미 담당이 없으면 404 가 아니라 204 다. 해제는 멱등이어야 하고, 두 번 눌렀다고
+    오류 화면을 보일 이유가 없다.
+    """
+    trainer_service.disconnect_member_coach(db, current_user.id)
+
+
 @router.get("/me/coach/routines", response_model=list[RoutineOut])
 def my_routines(
     current_user: CurrentUser,

--- a/backend/app/api/v1/trainers.py
+++ b/backend/app/api/v1/trainers.py
@@ -1,0 +1,52 @@
+"""트레이너 디렉터리 라우터 — 회원앱 트레이너 찾기/상세/추천. (#324)
+
+`/trainer/*`(단수)는 트레이너 앱이 자기 데이터를 다루는 곳이고, 여기 `/trainers`
+(복수)는 회원이 트레이너를 **탐색**하는 읽기 전용 디렉터리다.
+"""
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from sqlalchemy.orm import Session
+
+from app.api.deps import CurrentUser
+from app.db.session import get_db
+from app.schemas.gym_api import TrainerOut
+from app.services import gym_service
+
+router = APIRouter(tags=["trainers"])
+
+
+@router.get("/trainers", response_model=list[TrainerOut])
+def list_trainers(
+    current_user: CurrentUser,
+    db: Annotated[Session, Depends(get_db)],
+) -> list[TrainerOut]:
+    """전체 트레이너 디렉터리 — "트레이너 찾기" 목록."""
+    return gym_service.list_trainers(db)
+
+
+@router.get("/trainers/recommended", response_model=list[TrainerOut])
+def list_recommended_trainers(
+    current_user: CurrentUser,
+    db: Annotated[Session, Depends(get_db)],
+) -> list[TrainerOut]:
+    """추천 사유가 붙은 트레이너만 — 홈·운동 탭의 추천 레일.
+
+    `/trainers/{trainer_id}` 보다 먼저 선언해야 "recommended" 가 id 로 잡히지 않는다.
+    """
+    return gym_service.list_recommended_trainers(db)
+
+
+@router.get("/trainers/{trainer_id}", response_model=TrainerOut)
+def get_trainer(
+    trainer_id: str,
+    current_user: CurrentUser,
+    db: Annotated[Session, Depends(get_db)],
+) -> TrainerOut:
+    trainer = gym_service.get_trainer(db, trainer_id)
+    if trainer is None:
+        raise HTTPException(status_code=404, detail="트레이너를 찾을 수 없습니다.")
+    return trainer

--- a/backend/app/db/init_db.py
+++ b/backend/app/db/init_db.py
@@ -48,6 +48,10 @@ def init_db() -> None:
         # 김민수(user-demo) 링크가 성립한다.
         from app.db.seed_trainer import seed_trainer_domain
         seed_trainer_domain()
+        # 제휴 헬스장(#324). 트레이너 시드 뒤에 호출해야 gym_name → gym_id 연결이
+        # 걸린다. places 에 fitness 로 들어가므로 상담 대상 검증도 통과한다.
+        from app.db.seed_gyms import seed_partner_gyms
+        seed_partner_gyms()
         # 담당 회원 실데이터(식단·운동기록) — 트레이너 로스터/식단/기록을 실데이터로 채운다.
         # 회원 계정 시드(seed_trainer_domain) 뒤에 호출.
         from app.db.seed_member_data import seed_member_health_data

--- a/backend/app/db/seed_gyms.py
+++ b/backend/app/db/seed_gyms.py
@@ -17,6 +17,7 @@ import logging
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.core.config import get_settings
 from app.db.session import SessionLocal
 from app.models import models
 
@@ -24,7 +25,9 @@ logger = logging.getLogger(__name__)
 
 #: 프론트 `MockGymRepository` 와 같은 id·좌표를 쓴다 — 앱이 mock 에서 실 API 로
 #: 넘어갈 때 id 가 바뀌면 진행 중인 상담·연결이 끊긴다.
-_GYMS: tuple[tuple[str, str, str, float, float, float, str, str, str, list[str]], ...] = (
+_PARTNER_GYMS: tuple[
+    tuple[str, str, str, float, float, float, str, str, str, list[str]], ...
+] = (
     (
         "gym-oncare-sinchon", "온케어짐 신촌점", "서울 서대문구 신촌로 120",
         37.5559, 126.9368, 4.7, "06:00 – 23:00", "08:00 - 20:00", "02-1234-5678",
@@ -42,45 +45,208 @@ _GYMS: tuple[tuple[str, str, str, float, float, float, str, str, str, list[str]]
     ),
 )
 
+#: 카카오 Local `헬스장` 검색으로 발견한 실재 업체(#329). id·이름·주소·좌표·전화는
+#: 카카오 실데이터다.
+#:
+#: **여기 딸린 평점·영업시간·태그와 아래 소속 트레이너는 시연용으로 지어낸 값이다.**
+#: 실재하는 업체명에 붙으므로 사실처럼 표기하면 안 된다. `is_partner=False` 로 제휴
+#: 헬스장과 구분한다.
+#:
+#: DB 에 넣는 이유: 상담 요청(`POST /consultations`)이 `gym_id` 를 places 에서
+#: 검증하고, 헬스장 상세의 상담 버튼은 제휴 여부를 가리지 않는다. 넣지 않으면 이
+#: 헬스장들에서 상담이 404 로 실패한다.
+_DISCOVERED_GYMS: tuple[
+    tuple[str, str, str, float, float, float, str, str, str, list[str]], ...
+] = (
+    (
+        "11621774", "휘트니스에이든", "서울 마포구 신촌로 92",
+        37.5551767483122, 126.935686079639, 4.6, "06:00 - 23:00", "09:00 - 18:00",
+        "02-332-1720", ["다이어트", "체형 교정"],
+    ),
+    (
+        "1558845892", "하이핏", "서울 서대문구 연세로4길 19",
+        37.5573727191112, 126.937816432934, 4.4, "05:30 - 24:00", "08:00 - 20:00",
+        "02-362-7822", ["근력운동", "그룹 PT"],
+    ),
+    (
+        "328969863", "빌드업짐 PT 신촌점", "서울 서대문구 연세로4길 1",
+        37.5570723299884, 126.937142154792, 4.9, "07:00 - 23:00", "10:00 - 17:00",
+        "0502-5552-4212", ["PT 전문", "재활운동"],
+    ),
+    (
+        "696444256", "신인규피티스튜디오", "서울 서대문구 명물길 10",
+        37.5573851891011, 126.937543667755, 4.7, "08:00 - 22:00", "10:00 - 16:00",
+        "010-7616-9819", ["1:1 PT", "식단 관리"],
+    ),
+)
+
+#: 프론트 `MockGymRepository._trainers` 와 같은 id·문안. 화면이 mock 과 실 API 에서
+#: 같아야 하므로 한 글자도 달라지면 안 된다.
+#:
+#: 김트레이너(`trainer-demo`)는 `seed_trainer.py` 가 만든다 — 담당 회원 링크가 딸려
+#: 있어 여기서 중복 생성하지 않는다.
+#:
+#: **전원 시연용 가상 인물이다.** 로그인은 되지만 담당 회원이 없어, 트레이너 앱으로
+#: 들어가면 로스터가 비어 있다. 실 트레이너 온보딩이 생기면 이 시드는 제거한다.
+_TRAINERS: tuple[
+    tuple[str, str, str, str, str, int, str, list[str]], ...
+] = (
+    ("trainer-park", "gym-oncare-sinchon", "박트레이너", "재활 트레이너",
+     "무릎·허리 통증 관리 다수 경험", 11,
+     "수술 후 회복과 만성 통증 관리를 주로 맡습니다. 무리하지 않는 범위에서 가동 범위를 조금씩 넓혀 갑니다.",
+     ["물리치료사", "재활 트레이닝 NASM-CES"]),
+    ("trainer-choi", "gym-oncare-sinchon", "최트레이너", "그룹 PT 트레이너",
+     "2~4인 소그룹 수업 운영", 4,
+     "2~4인 소그룹 수업을 진행합니다. 혼자서는 운동을 이어 가기 어려운 회원에게 적합한 방식입니다.",
+     ["생활스포츠지도사 2급"]),
+    ("trainer-kang", "gym-healthmate", "강트레이너", "퍼스널 트레이너",
+     "교대근무 일정 맞춤 설계", 5,
+     "불규칙한 근무 일정에 맞춘 운동 설계를 주로 합니다. 짧은 시간에 집중도를 높이는 근력 프로그램을 구성합니다.",
+     ["건강운동관리사", "퍼스널트레이닝 CPT"]),
+    ("trainer-yoon", "gym-healthmate", "윤트레이너", "근력 전문 트레이너",
+     "기초 근력부터 단계별 지도", 8,
+     "기초 근력부터 파워리프팅까지 단계를 나눠 지도합니다. 현재 들 수 있는 무게를 확인한 뒤 다음 단계를 정합니다.",
+     ["퍼스널트레이닝 CPT"]),
+    ("trainer-lee", "gym-bodyandsoul", "이트레이너", "퍼스널 트레이너",
+     "초심자용 간단 루틴 구성", 9,
+     "운동을 처음 시작하는 회원을 오래 지도했습니다. 식단 상담을 함께 진행해 생활 습관부터 조정합니다.",
+     ["생활스포츠지도사 2급", "스포츠 영양사", "재활 트레이닝 NASM-CES"]),
+    ("trainer-cho", "gym-bodyandsoul", "조트레이너", "시니어 운동 트레이너",
+     "고령 회원 균형 운동 장기 지도", 12,
+     "60대 이상 회원 수업을 오래 맡았습니다. 균형 잡기와 낙상 예방 동작부터 시작해 천천히 강도를 올립니다.",
+     ["건강운동관리사", "노인스포츠지도사"]),
+    ("trainer-demo-jung", "11621774", "정트레이너", "퍼스널 트레이너",
+     "감량 정체기 식사·운동량 재조정", 6,
+     "체중이 멈춘 시점에 식사량과 운동량을 다시 맞추는 일을 자주 합니다. 몸무게보다 둘레와 체성분 변화를 기준으로 판단합니다.",
+     ["생활스포츠지도사 2급"]),
+    ("trainer-demo-ha", "11621774", "하트레이너", "체형 교정 트레이너",
+     "장시간 착석형 목·어깨 교정", 4,
+     "오래 앉아 생긴 목과 어깨 불편을 주로 다룹니다. 스트레칭과 가벼운 근력 운동을 번갈아 배치해 한 시간을 구성합니다.",
+     ["필라테스 지도자", "생활스포츠지도사 2급"]),
+    ("trainer-demo-han", "1558845892", "한트레이너", "퍼스널 트레이너",
+     "기구 입문자 눈높이 지도", 3,
+     "기구 사용법부터 하나씩 익히는 수업입니다. 무게를 올리기 전에 자세가 자리를 잡을 때까지 시간을 들입니다.",
+     ["퍼스널트레이닝 CPT"]),
+    ("trainer-demo-oh", "1558845892", "오트레이너", "그룹 PT 트레이너",
+     "3~5인 그룹 수업 출석 관리", 5,
+     "3~5인 그룹 수업을 맡습니다. 서로 속도를 맞추는 구성이라 혼자 할 때보다 출석이 안정적으로 유지됩니다.",
+     ["생활스포츠지도사 2급"]),
+    ("trainer-demo-seo", "328969863", "서트레이너", "재활 전문 트레이너",
+     "병원 재활 이후 복귀 단계 관리", 10,
+     "병원 재활이 끝난 뒤 일상 운동으로 넘어가는 구간을 담당합니다. 통증 기록을 함께 남기며 주 단위로 강도를 조절합니다.",
+     ["물리치료사", "건강운동관리사"]),
+    ("trainer-demo-nam", "328969863", "남트레이너", "퍼스널 트레이너",
+     "스쿼트·데드리프트 영상 자세 교정", 7,
+     "스쿼트와 데드리프트 자세 교정을 주로 합니다. 수행 장면을 영상으로 남겨 회차별로 달라진 점을 함께 확인합니다.",
+     ["퍼스널트레이닝 CPT"]),
+    ("trainer-demo-moon", "696444256", "문트레이너", "퍼스널 트레이너",
+     "주간 식단 기록 점검", 7,
+     "1:1 수업만 진행합니다. 매주 식사 기록을 함께 보고 다음 주에 바꿀 항목을 한 가지씩 정합니다.",
+     ["스포츠 영양사", "생활스포츠지도사 2급"]),
+    ("trainer-demo-bae", "696444256", "배트레이너", "러닝 코치",
+     "무릎 부담 적은 러닝 자세 교정", 5,
+     "달리기 자세와 호흡을 함께 점검합니다. 무릎에 부담이 덜 가는 보폭을 찾는 데 수업 시간을 많이 배정합니다.",
+     ["생활스포츠지도사 2급"]),
+)
+
+
+def _seed_gyms(db: Session, rows, *, is_partner: bool) -> int:
+    """헬스장(Place)과 부가 정보(GymProfile)를 넣는다. 이미 있으면 건너뛴다."""
+    created = 0
+    # 장소를 먼저 flush 해야 gym_profiles 의 FK 가 성립한다. 한 번에 add 하면
+    # 같은 flush 안에서 gym_profiles 가 먼저 나가 FK 위반이 난다.
+    for gym_id, name, address, lat, lng, *_ in rows:
+        if db.get(models.Place, gym_id) is None:
+            db.add(models.Place(
+                id=gym_id, name=name, category="fitness", address=address,
+                lat=lat, lng=lng,
+            ))
+            created += 1
+    db.flush()
+
+    for (
+        gym_id, _name, _address, _lat, _lng, rating,
+        weekday, weekend, phone, tags,
+    ) in rows:
+        if db.get(models.GymProfile, gym_id) is None:
+            db.add(models.GymProfile(
+                place_id=gym_id, rating=rating, weekday_hours=weekday,
+                weekend_hours=weekend, phone=phone,
+                tags_json=json.dumps(tags, ensure_ascii=False),
+                is_partner=is_partner,
+            ))
+    return created
+
+
+def _seed_trainers(db: Session) -> int:
+    """트레이너 계정(User)과 프로필을 넣는다.
+
+    이메일이 다른 계정에 선점됐으면 건너뛴다 — users.email 이 유니크라 기동이
+    실패하면 안 된다(`seed_trainer.py` 와 같은 방침).
+    """
+    from app.core.security import hash_password
+
+    password_hash = hash_password(get_settings().demo_login_password)
+    created = 0
+    for trainer_id, gym_id, name, role, reason, career, intro, certs in _TRAINERS:
+        email = f"{trainer_id}@oncare.demo"
+        if db.get(models.User, trainer_id) is None:
+            taken = db.scalar(
+                select(models.User).where(
+                    models.User.email == email, models.User.id != trainer_id
+                )
+            )
+            if taken is not None:
+                logger.warning(
+                    "트레이너 데모 이메일 %s 가 다른 계정에 선점됨 — 스킵.", email
+                )
+                continue
+            db.add(models.User(
+                id=trainer_id, email=email, name=name,
+                hashed_password=password_hash, role="trainer",
+            ))
+            created += 1
+    db.flush()
+
+    for trainer_id, gym_id, name, role, reason, career, intro, certs in _TRAINERS:
+        if db.get(models.User, trainer_id) is None:
+            continue  # 위에서 스킵된 계정
+        exists = db.scalar(
+            select(models.TrainerProfile).where(
+                models.TrainerProfile.trainer_id == trainer_id
+            )
+        )
+        if exists is not None:
+            continue
+        db.add(models.TrainerProfile(
+            trainer_id=trainer_id, gym_id=gym_id, specialty=role,
+            recommend_reason=reason, career_years=career, intro=intro,
+            certifications_json=json.dumps(certs, ensure_ascii=False),
+        ))
+    return created
+
 
 def seed_partner_gyms() -> None:
     db: Session = SessionLocal()
     try:
-        created = 0
-        # 장소를 먼저 flush 해야 gym_profiles 의 FK 가 성립한다. 한 번에 add 하면
-        # 같은 flush 안에서 gym_profiles 가 먼저 나가 FK 위반이 난다.
-        for gym_id, name, address, lat, lng, *_ in _GYMS:
-            if db.get(models.Place, gym_id) is None:
-                db.add(models.Place(
-                    id=gym_id, name=name, category="fitness", address=address,
-                    lat=lat, lng=lng,
-                ))
-                created += 1
-        db.flush()
-
-        for (
-            gym_id, _name, _address, _lat, _lng, rating,
-            weekday, weekend, phone, tags,
-        ) in _GYMS:
-            if db.get(models.GymProfile, gym_id) is None:
-                db.add(models.GymProfile(
-                    place_id=gym_id, rating=rating, weekday_hours=weekday,
-                    weekend_hours=weekend, phone=phone,
-                    tags_json=json.dumps(tags, ensure_ascii=False),
-                    is_partner=True,
-                ))
+        partner = _seed_gyms(db, _PARTNER_GYMS, is_partner=True)
+        # 카카오 발견 헬스장은 제휴가 아니다. 상담 대상 검증이 places 를 보므로
+        # 넣지 않으면 이 헬스장들에서 상담 요청이 404 가 난다.
+        discovered = _seed_gyms(db, _DISCOVERED_GYMS, is_partner=False)
         db.commit()
 
-        # 기존 트레이너의 소속을 gym_id 로 잇는다. 시드된 트레이너는 gym_name 만
-        # 들고 있어 헬스장 상세의 "소속 트레이너"가 비어 있었다.
+        trainers = _seed_trainers(db)
+        db.commit()
+
+        # seed_trainer.py 가 만든 김트레이너는 gym_name 문자열만 들고 있어 헬스장
+        # 상세의 "소속 트레이너"가 비어 있었다. 이름으로 gym_id 를 이어 준다.
         linked = 0
-        profiles = db.scalars(
+        by_name = {name: gid for gid, name, *_ in _PARTNER_GYMS}
+        for profile in db.scalars(
             select(models.TrainerProfile).where(
                 models.TrainerProfile.gym_id.is_(None)
             )
-        ).all()
-        by_name = {name: gid for gid, name, *_ in _GYMS}
-        for profile in profiles:
+        ).all():
             gym_id = by_name.get(profile.gym_name)
             if gym_id is None:
                 continue
@@ -88,9 +254,10 @@ def seed_partner_gyms() -> None:
             linked += 1
         db.commit()
 
-        if created or linked:
+        if partner or discovered or trainers or linked:
             logger.info(
-                "제휴 헬스장 시드: 신규 %d곳, 트레이너 소속 연결 %d명", created, linked
+                "헬스장 시드: 제휴 %d곳, 발견 %d곳, 트레이너 %d명, 소속 연결 %d명",
+                partner, discovered, trainers, linked,
             )
     finally:
         db.close()

--- a/backend/app/db/seed_gyms.py
+++ b/backend/app/db/seed_gyms.py
@@ -1,0 +1,96 @@
+"""제휴 헬스장 데모 시드 — 회원앱 헬스장·트레이너 디렉터리의 실데이터. (#324)
+
+헬스장은 `places`(category='fitness') 에 넣는다. 상담 검증
+(`consultation_service._validate_target`)이 그 테이블을 보므로, 여기 없는 헬스장은
+상담 신청이 404 가 난다.
+
+부가 정보(평점·영업시간·전화·태그)는 `gym_profiles` 에 둔다 — `places` 는 병원·약국·
+건강식이 함께 쓰는 테이블이라 헬스장 전용 컬럼을 붙이면 오염된다.
+
+멱등: 존재하면 건너뛴다. `seed_demo_data` 가 켜졌을 때만 호출된다.
+"""
+from __future__ import annotations
+
+import json
+import logging
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db.session import SessionLocal
+from app.models import models
+
+logger = logging.getLogger(__name__)
+
+#: 프론트 `MockGymRepository` 와 같은 id·좌표를 쓴다 — 앱이 mock 에서 실 API 로
+#: 넘어갈 때 id 가 바뀌면 진행 중인 상담·연결이 끊긴다.
+_GYMS: tuple[tuple[str, str, str, float, float, float, str, str, str, list[str]], ...] = (
+    (
+        "gym-oncare-sinchon", "온케어짐 신촌점", "서울 서대문구 신촌로 120",
+        37.5559, 126.9368, 4.7, "06:00 – 23:00", "08:00 - 20:00", "02-1234-5678",
+        ["다이어트", "재활운동"],
+    ),
+    (
+        "gym-healthmate", "헬스메이트 신촌점", "서울 서대문구 신촌로 83",
+        37.5548, 126.9385, 4.5, "05:30 - 24:00", "07:00 - 22:00", "02-2345-6789",
+        ["근력운동", "만성질환 관리"],
+    ),
+    (
+        "gym-bodyandsoul", "바디앤소울 피트니스", "서울 마포구 백범로 23",
+        37.5455, 126.9425, 4.8, "06:00 - 22:00", "09:00 - 18:00", "02-3456-7890",
+        ["PT", "식단 상담"],
+    ),
+)
+
+
+def seed_partner_gyms() -> None:
+    db: Session = SessionLocal()
+    try:
+        created = 0
+        # 장소를 먼저 flush 해야 gym_profiles 의 FK 가 성립한다. 한 번에 add 하면
+        # 같은 flush 안에서 gym_profiles 가 먼저 나가 FK 위반이 난다.
+        for gym_id, name, address, lat, lng, *_ in _GYMS:
+            if db.get(models.Place, gym_id) is None:
+                db.add(models.Place(
+                    id=gym_id, name=name, category="fitness", address=address,
+                    lat=lat, lng=lng,
+                ))
+                created += 1
+        db.flush()
+
+        for (
+            gym_id, _name, _address, _lat, _lng, rating,
+            weekday, weekend, phone, tags,
+        ) in _GYMS:
+            if db.get(models.GymProfile, gym_id) is None:
+                db.add(models.GymProfile(
+                    place_id=gym_id, rating=rating, weekday_hours=weekday,
+                    weekend_hours=weekend, phone=phone,
+                    tags_json=json.dumps(tags, ensure_ascii=False),
+                    is_partner=True,
+                ))
+        db.commit()
+
+        # 기존 트레이너의 소속을 gym_id 로 잇는다. 시드된 트레이너는 gym_name 만
+        # 들고 있어 헬스장 상세의 "소속 트레이너"가 비어 있었다.
+        linked = 0
+        profiles = db.scalars(
+            select(models.TrainerProfile).where(
+                models.TrainerProfile.gym_id.is_(None)
+            )
+        ).all()
+        by_name = {name: gid for gid, name, *_ in _GYMS}
+        for profile in profiles:
+            gym_id = by_name.get(profile.gym_name)
+            if gym_id is None:
+                continue
+            profile.gym_id = gym_id
+            linked += 1
+        db.commit()
+
+        if created or linked:
+            logger.info(
+                "제휴 헬스장 시드: 신규 %d곳, 트레이너 소속 연결 %d명", created, linked
+            )
+    finally:
+        db.close()

--- a/backend/app/db/seed_trainer.py
+++ b/backend/app/db/seed_trainer.py
@@ -123,6 +123,8 @@ def _seed_trainer_account(db: Session) -> None:
             trainer_id=TRAINER_ID,
             phone="010-1234-5678",
             specialty="퍼스널 트레이너",
+            # 추천 레일 노출 조건(#324). 비어 있으면 /trainers/recommended 에서 빠진다.
+            recommend_reason="혈압 관리와 운동 병행 지도",
             career_years=7,
             intro=(
                 "혈압 관리와 체중 감량 전문 트레이너입니다. 고객 맞춤형 AI 루틴으로 "
@@ -134,6 +136,10 @@ def _seed_trainer_account(db: Session) -> None:
             gym_hours="06:00 – 23:00",
             gym_phone="02-1234-5678",
         ))
+    elif not profile.recommend_reason:
+        # 프로필이 이미 있으면 위 블록을 건너뛰므로, 나중에 추가된 컬럼은 영영 빈 채로
+        # 남는다. 추천 사유가 비면 /trainers/recommended 에서 빠지므로 백필한다(#324).
+        profile.recommend_reason = "혈압 관리와 운동 병행 지도"
     _safe_commit(db, "트레이너 데모 계정 시드 충돌")
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,8 +13,9 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.v1 import (
-    ai_coach, coach_docs, consultations, dashboard, diet, exercise, member_coach,
-    notifications, places, schedule, social, system, trainer, users,
+    ai_coach, coach_docs, consultations, dashboard, diet, exercise, gyms,
+    member_coach, notifications, places, schedule, social, system, trainer,
+    trainers, users,
 )
 from app.core import observability
 from app.core.config import get_settings
@@ -89,3 +90,6 @@ app.include_router(coach_docs.router, prefix=settings.api_v1_prefix)
 app.include_router(trainer.router, prefix=settings.api_v1_prefix)
 app.include_router(member_coach.router, prefix=settings.api_v1_prefix)
 app.include_router(consultations.router, prefix=settings.api_v1_prefix)
+# 회원앱 헬스장·트레이너 디렉터리(#324). trainer(단수, 트레이너 앱 전용)와 별개다.
+app.include_router(gyms.router, prefix=settings.api_v1_prefix)
+app.include_router(trainers.router, prefix=settings.api_v1_prefix)

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from pgvector.sqlalchemy import Vector
 from sqlalchemy import (
     Boolean, DateTime, Float, ForeignKey, Index, Integer, String, Text, UniqueConstraint,
-    func, text, true,
+    false, func, text, true,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -246,6 +246,37 @@ class Place(Base):
     kakao_place_id: Mapped[str] = mapped_column(String(50), default="")
 
 
+class GymProfile(Base):
+    """헬스장 부가 정보 — `places`(category='fitness') 의 1:1 확장. (#324)
+
+    헬스장 자체는 `Place` 다. 상담 검증(`consultation_service`)과 `/places/nearby`
+    가 이미 `places` 를 쓰기 때문에 별도 테이블을 만들지 않았다. 다만 평점·영업시간
+    같은 헬스장 전용 값을 `places` 에 넣으면 병원·약국·건강식이 공유하는 테이블이
+    오염되므로 여기로 분리한다(`TrainerProfile` 이 `User` 를 확장하는 것과 같은 꼴).
+    """
+    __tablename__ = "gym_profiles"
+
+    place_id: Mapped[str] = mapped_column(
+        String(64), ForeignKey("places.id", ondelete="CASCADE"), primary_key=True
+    )
+    #: 카카오 Local 은 평점을 주지 않는다 — 발견된 헬스장은 None.
+    rating: Mapped[float | None] = mapped_column(Float, nullable=True)
+    weekday_hours: Mapped[str] = mapped_column(String(50), default="")
+    weekend_hours: Mapped[str] = mapped_column(String(50), default="")
+    phone: Mapped[str] = mapped_column(String(20), default="")
+    tags_json: Mapped[str] = mapped_column(Text, default="[]")  # ["다이어트", "재활운동"]
+    #: 제휴 헬스장만 트레이너 연결·상담이 가능하다.
+    is_partner: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=false(), default=False, index=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+
 class ConsultationRequest(Base):
     """회원의 헬스장·트레이너 상담 요청."""
     __tablename__ = "consultation_requests"
@@ -331,6 +362,15 @@ class TrainerProfile(Base):
     career_years: Mapped[int] = mapped_column(Integer, default=0)       # 7 → "7년"
     intro: Mapped[str] = mapped_column(Text, default="")
     certifications_json: Mapped[str] = mapped_column(Text, default="[]")  # ["생활스포츠지도사 2급", ...]
+    #: 소속 헬스장(`places.id`). 아래 gym_* 문자열 컬럼을 대신한다 — 문자열만으로는
+    #: 한 헬스장에 여러 트레이너를 묶을 수 없었다(#324, #301). 트레이너 앱이 아직
+    #: gym_* 를 읽으므로 두 표현이 당분간 공존하고, 값이 있으면 gym_id 가 우선이다.
+    gym_id: Mapped[str | None] = mapped_column(
+        String(64),
+        ForeignKey("places.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
     gym_name: Mapped[str] = mapped_column(String(100), default="")
     gym_address: Mapped[str] = mapped_column(String(300), default="")
     gym_hours: Mapped[str] = mapped_column(String(50), default="")

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -371,6 +371,10 @@ class TrainerProfile(Base):
         nullable=True,
         index=True,
     )
+    #: 추천 레일에 올릴 한 줄 사유. 빈 문자열이면 추천 대상이 아니다.
+    recommend_reason: Mapped[str] = mapped_column(
+        String(200), nullable=False, server_default="", default=""
+    )
     gym_name: Mapped[str] = mapped_column(String(100), default="")
     gym_address: Mapped[str] = mapped_column(String(300), default="")
     gym_hours: Mapped[str] = mapped_column(String(50), default="")

--- a/backend/app/schemas/gym_api.py
+++ b/backend/app/schemas/gym_api.py
@@ -1,0 +1,39 @@
+"""회원앱 헬스장·트레이너 디렉터리 계약. (#324)
+
+프론트 `Gym` / `Trainer` 엔티티와 필드를 맞춘다 — 앱이 mock 에서 실 API 로 넘어갈 때
+매핑 코드가 없도록.
+"""
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class GymOut(BaseModel):
+    id: str
+    name: str
+    address: str
+    #: 요청 좌표 기준. 좌표를 주지 않으면 0.
+    distance_km: float
+    #: 카카오에서 발견한 헬스장은 평점이 없다 — 0 이면 UI 가 뱃지를 감춘다.
+    rating: float
+    tags: list[str]
+    weekday_hours: str | None
+    weekend_hours: str | None
+    phone: str | None
+    lat: float | None
+    lng: float | None
+    #: 제휴 헬스장만 트레이너 연결·상담이 가능하다.
+    is_partner: bool
+
+
+class TrainerOut(BaseModel):
+    id: str
+    gym_id: str | None
+    name: str
+    role: str | None
+    #: 추천 사유. 비어 있으면 추천 레일에 올리지 않는다.
+    reason: str | None
+    #: "7년" 형태의 표시용 문자열 — 앱이 그대로 렌더한다.
+    career: str | None
+    intro: str | None
+    certifications: list[str]

--- a/backend/app/schemas/trainer_api.py
+++ b/backend/app/schemas/trainer_api.py
@@ -29,6 +29,10 @@ def _validate_hhmm(v: str) -> str:
 
 
 class TrainerGymOut(BaseModel):
+    #: 소속 헬스장 id(`places.id`). 회원앱이 "내 헬스장" 카드에서 헬스장 상세로
+    #: 이동하고 상담 대상을 지정하는 데 필요하다 — 이름만으로는 목록의 헬스장과
+    #: 이어붙일 수 없다(#324). 아직 gym_id 가 없는 프로필은 None.
+    id: str | None = None
     name: str
     address: str
     hours: str

--- a/backend/app/services/gym_service.py
+++ b/backend/app/services/gym_service.py
@@ -1,0 +1,145 @@
+"""헬스장·트레이너 디렉터리 조회. (#324)
+
+헬스장은 `places`(category='fitness') 이고 부가 정보는 `gym_profiles` 에 있다.
+프로필이 없는 헬스장(기존 데모 시드, 카카오 발견분)도 목록에는 나와야 하므로 outer
+조인으로 읽고 빈 값을 채운다.
+"""
+from __future__ import annotations
+
+import json
+import math
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.models import GymProfile, Place, TrainerProfile, User
+from app.schemas.gym_api import GymOut, TrainerOut
+
+
+def _haversine_m(lat1: float, lng1: float, lat2: float, lng2: float) -> int:
+    """`places.py` 의 `_haversine_m` 과 같은 계산(절삭)."""
+    r = 6371000
+    p1, p2 = math.radians(lat1), math.radians(lat2)
+    dp = math.radians(lat2 - lat1)
+    dl = math.radians(lng2 - lng1)
+    a = math.sin(dp / 2) ** 2 + math.cos(p1) * math.cos(p2) * math.sin(dl / 2) ** 2
+    return int(r * 2 * math.asin(math.sqrt(a)))
+
+
+def _tags(profile: GymProfile | None) -> list[str]:
+    if profile is None or not profile.tags_json:
+        return []
+    try:
+        parsed = json.loads(profile.tags_json)
+    except json.JSONDecodeError:
+        return []
+    return [str(t) for t in parsed] if isinstance(parsed, list) else []
+
+
+def _to_gym(
+    place: Place, profile: GymProfile | None, lat: float | None, lng: float | None
+) -> GymOut:
+    distance_km = 0.0
+    if lat is not None and lng is not None and place.lat is not None and place.lng is not None:
+        distance_km = _haversine_m(lat, lng, place.lat, place.lng) / 1000
+    return GymOut(
+        id=place.id,
+        name=place.name,
+        address=place.address,
+        distance_km=distance_km,
+        # 평점 없음을 0 으로 내린다 — 프론트 Gym.rating 이 non-null 이고 0 이면
+        # 뱃지를 감추기로 이미 합의돼 있다(#329).
+        rating=profile.rating if profile and profile.rating is not None else 0.0,
+        tags=_tags(profile),
+        weekday_hours=(profile.weekday_hours or None) if profile else None,
+        weekend_hours=(profile.weekend_hours or None) if profile else None,
+        phone=(profile.phone or None) if profile else None,
+        lat=place.lat,
+        lng=place.lng,
+        is_partner=bool(profile.is_partner) if profile else False,
+    )
+
+
+def list_gyms(
+    db: Session,
+    *,
+    lat: float | None = None,
+    lng: float | None = None,
+    partner_only: bool = False,
+) -> list[GymOut]:
+    """헬스장 목록. 좌표를 주면 거리순, 아니면 이름순."""
+    query = (
+        select(Place, GymProfile)
+        .outerjoin(GymProfile, GymProfile.place_id == Place.id)
+        .where(Place.category == "fitness")
+    )
+    if partner_only:
+        query = query.where(GymProfile.is_partner.is_(True))
+
+    gyms = [_to_gym(place, profile, lat, lng) for place, profile in db.execute(query)]
+    if lat is not None and lng is not None:
+        gyms.sort(key=lambda g: g.distance_km)
+    else:
+        gyms.sort(key=lambda g: g.name)
+    return gyms
+
+
+def get_gym(
+    db: Session, gym_id: str, *, lat: float | None = None, lng: float | None = None
+) -> GymOut | None:
+    row = db.execute(
+        select(Place, GymProfile)
+        .outerjoin(GymProfile, GymProfile.place_id == Place.id)
+        .where(Place.id == gym_id, Place.category == "fitness")
+    ).first()
+    if row is None:
+        return None
+    place, profile = row
+    return _to_gym(place, profile, lat, lng)
+
+
+def _to_trainer(user: User, profile: TrainerProfile) -> TrainerOut:
+    try:
+        certs = json.loads(profile.certifications_json or "[]")
+    except json.JSONDecodeError:
+        certs = []
+    return TrainerOut(
+        id=user.id,
+        gym_id=profile.gym_id,
+        name=user.name,
+        role=profile.specialty or None,
+        reason=profile.recommend_reason or None,
+        # 앱은 "7년" 문자열을 그대로 렌더한다. 0 이면 표시할 게 없으므로 None.
+        career=f"{profile.career_years}년" if profile.career_years else None,
+        intro=profile.intro or None,
+        certifications=[str(c) for c in certs] if isinstance(certs, list) else [],
+    )
+
+
+def _trainer_query():
+    return (
+        select(User, TrainerProfile)
+        .join(TrainerProfile, TrainerProfile.trainer_id == User.id)
+        .where(User.role == "trainer", User.is_active.is_(True))
+    )
+
+
+def list_trainers(db: Session, *, gym_id: str | None = None) -> list[TrainerOut]:
+    query = _trainer_query()
+    if gym_id is not None:
+        query = query.where(TrainerProfile.gym_id == gym_id)
+    return [_to_trainer(user, profile) for user, profile in db.execute(query)]
+
+
+def list_recommended_trainers(db: Session) -> list[TrainerOut]:
+    """추천 사유가 붙은 트레이너만. 사유가 비면 레일에 올리지 않는다."""
+    query = _trainer_query().where(TrainerProfile.recommend_reason != "")
+    return [_to_trainer(user, profile) for user, profile in db.execute(query)]
+
+
+def get_trainer(db: Session, trainer_id: str) -> TrainerOut | None:
+    row = db.execute(_trainer_query().where(User.id == trainer_id)).first()
+    if row is None:
+        return None
+    user, profile = row
+    return _to_trainer(user, profile)

--- a/backend/app/services/gym_service.py
+++ b/backend/app/services/gym_service.py
@@ -78,7 +78,15 @@ def list_gyms(
 
     gyms = [_to_gym(place, profile, lat, lng) for place, profile in db.execute(query)]
     if lat is not None and lng is not None:
-        gyms.sort(key=lambda g: g.distance_km)
+        # 좌표를 모르는 헬스장은 distance_km 가 0 이라 그냥 정렬하면 '가장 가까운 곳'
+        # 으로 맨 앞에 온다. 뒤로 보내고 그 안에서는 이름순으로 둔다.
+        gyms.sort(
+            key=lambda g: (
+                g.lat is None or g.lng is None,
+                g.distance_km,
+                g.name,
+            )
+        )
     else:
         gyms.sort(key=lambda g: g.name)
     return gyms

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -738,6 +738,25 @@ def get_member_trainer_id(db: Session, member_id: str) -> str | None:
     return link.trainer_id if link is not None else None
 
 
+def disconnect_member_coach(db: Session, member_id: str) -> bool:
+    """회원이 담당 트레이너 연결을 끊는다. 끊었으면 True, 원래 없었으면 False.
+
+    링크 행을 지우지 않고 `active=False` 로 내린다 — 지난 코칭 기록(루틴·채팅·일정)이
+    링크를 참조하므로 삭제하면 이력이 끊긴다. 비활성 링크는 `_active_link` 가 제외해
+    이후 조회는 '담당 없음'으로 동작한다.
+
+    회원 일방으로 끊을 수 있게 두는 이유: 앱의 MY 탭이 이미 해제 버튼을 제공하고,
+    트레이너 승인을 기다리게 하면 회원이 관계를 벗어날 방법이 없어진다. 트레이너
+    로스터에서는 즉시 사라진다.
+    """
+    link = _active_link(db, member_id)
+    if link is None:
+        return False
+    link.active = False
+    db.commit()
+    return True
+
+
 def build_member_coach(db: Session, member_id: str) -> MemberCoachOut | None:
     """회원의 '내 담당 코치' 요약. 활성 담당이 없으면 None(라우터 404)."""
     link = _active_link(db, member_id)
@@ -756,6 +775,7 @@ def build_member_coach(db: Session, member_id: str) -> MemberCoachOut | None:
         career=f"{profile.career_years}년",
         intro=profile.intro,
         gym=TrainerGymOut(
+            id=profile.gym_id,
             name=profile.gym_name, address=profile.gym_address,
             hours=profile.gym_hours, phone=profile.gym_phone,
         ),
@@ -836,6 +856,7 @@ def build_trainer_me(trainer: User, profile: TrainerProfile) -> TrainerMe:
         intro=profile.intro,
         certifications=_certifications(profile),
         gym=TrainerGymOut(
+            id=profile.gym_id,
             name=profile.gym_name,
             address=profile.gym_address,
             hours=profile.gym_hours,

--- a/backend/migrations/versions/0020_gym_profiles_trainer_fk.py
+++ b/backend/migrations/versions/0020_gym_profiles_trainer_fk.py
@@ -1,0 +1,104 @@
+"""헬스장 프로필 테이블 + 트레이너 소속 헬스장 FK
+
+회원앱의 헬스장·트레이너 디렉터리가 전부 프론트 하드코딩(`MockGymRepository`)이었다.
+실 백엔드를 세우기 위한 스키마다. (#324, #301)
+
+헬스장 저장소로 `places` 를 재사용한다 — 새 테이블을 만들지 않는 이유:
+`consultation_service._validate_target()` 이 이미 상담 대상 헬스장을
+`places`(category='fitness') 에서 검증하고, `/places/nearby` 도 같은 테이블을 쓴다.
+헬스장 엔티티를 따로 만들면 그 두 곳을 함께 바꿔야 한다.
+
+다만 평점·영업시간·전화·태그·제휴여부를 `places` 에 직접 넣으면 병원·약국·건강식이
+공유하는 테이블이 오염된다. `trainer_profiles` 가 `users` 를 확장하듯 `gym_profiles`
+로 1:1 확장한다.
+
+`trainer_profiles` 의 헬스장 정보는 `gym_name`/`gym_address`/`gym_hours`/`gym_phone`
+문자열 4개로 비정규화돼 있어 한 헬스장에 여러 트레이너를 묶을 수 없었다. `gym_id` FK 를
+추가한다. 기존 문자열 컬럼은 트레이너 앱이 아직 읽고 있으므로 이번엔 남겨 두고,
+`gym_id` 가 있으면 그쪽을 우선하도록 서비스에서 처리한다.
+
+Revision ID: 0020_gym_profiles_trainer_fk
+Revises: 0019_trainer_noti_settings
+Create Date: 2026-08-07
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0020_gym_profiles_trainer_fk"
+down_revision: str | Sequence[str] | None = "0019_trainer_noti_settings"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "gym_profiles",
+        # places.id 를 그대로 PK 로 쓴다 — 1:1 확장이라 대리키가 필요 없고,
+        # 조인 없이도 헬스장 id 하나로 양쪽을 다룰 수 있다.
+        sa.Column(
+            "place_id",
+            sa.String(length=64),
+            sa.ForeignKey("places.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        # 카카오 Local 은 평점을 주지 않는다. 제휴 헬스장만 값이 있고, 발견된
+        # 헬스장은 NULL 로 남아 UI 가 뱃지를 감춘다.
+        sa.Column("rating", sa.Float(), nullable=True),
+        sa.Column("weekday_hours", sa.String(length=50), nullable=False, server_default=""),
+        sa.Column("weekend_hours", sa.String(length=50), nullable=False, server_default=""),
+        sa.Column("phone", sa.String(length=20), nullable=False, server_default=""),
+        # ["다이어트", "재활운동"] — 개수가 적고 검색 대상이 아니라 JSON 문자열로 둔다.
+        sa.Column("tags_json", sa.Text(), nullable=False, server_default="[]"),
+        # 제휴 헬스장만 트레이너 연결·상담이 가능하다. 카카오에서 발견한 곳과 구분한다.
+        sa.Column(
+            "is_partner", sa.Boolean(), nullable=False, server_default=sa.false()
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    # 제휴 헬스장 목록 조회가 가장 잦은 질의다.
+    op.create_index(
+        "ix_gym_profiles_is_partner", "gym_profiles", ["is_partner"]
+    )
+
+    op.add_column(
+        "trainer_profiles",
+        sa.Column("gym_id", sa.String(length=64), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_trainer_profiles_gym_id_places",
+        "trainer_profiles",
+        "places",
+        ["gym_id"],
+        ["id"],
+        # 헬스장이 사라져도 트레이너 계정은 남아야 한다 — 소속만 비운다.
+        ondelete="SET NULL",
+    )
+    # "이 헬스장 소속 트레이너 전원" 조회가 헬스장 상세의 핵심 질의다.
+    op.create_index(
+        "ix_trainer_profiles_gym_id", "trainer_profiles", ["gym_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_trainer_profiles_gym_id", table_name="trainer_profiles")
+    op.drop_constraint(
+        "fk_trainer_profiles_gym_id_places", "trainer_profiles", type_="foreignkey"
+    )
+    op.drop_column("trainer_profiles", "gym_id")
+    op.drop_index("ix_gym_profiles_is_partner", table_name="gym_profiles")
+    op.drop_table("gym_profiles")

--- a/backend/migrations/versions/0020_gym_profiles_trainer_fk.py
+++ b/backend/migrations/versions/0020_gym_profiles_trainer_fk.py
@@ -79,6 +79,17 @@ def upgrade() -> None:
         "trainer_profiles",
         sa.Column("gym_id", sa.String(length=64), nullable=True),
     )
+    # 추천 레일에 올릴 한 줄 사유. 값이 있는 트레이너만 `/trainers/recommended` 에
+    # 나온다 — 빈 문자열이 "추천 아님"을 뜻하므로 nullable 로 두지 않는다.
+    op.add_column(
+        "trainer_profiles",
+        sa.Column(
+            "recommend_reason",
+            sa.String(length=200),
+            nullable=False,
+            server_default="",
+        ),
+    )
     op.create_foreign_key(
         "fk_trainer_profiles_gym_id_places",
         "trainer_profiles",
@@ -99,6 +110,7 @@ def downgrade() -> None:
     op.drop_constraint(
         "fk_trainer_profiles_gym_id_places", "trainer_profiles", type_="foreignkey"
     )
+    op.drop_column("trainer_profiles", "recommend_reason")
     op.drop_column("trainer_profiles", "gym_id")
     op.drop_index("ix_gym_profiles_is_partner", table_name="gym_profiles")
     op.drop_table("gym_profiles")

--- a/backend/tests/test_gyms.py
+++ b/backend/tests/test_gyms.py
@@ -165,3 +165,28 @@ def test_trainer_fields_match_app_contract(client):
     # career 는 "7년" 처럼 앱이 그대로 렌더하는 문자열이다.
     assert trainer["career"] is None or trainer["career"].endswith("년")
     assert isinstance(trainer["certifications"], list)
+
+
+def test_my_coach_exposes_gym_id(client, db_session):
+    """"내 헬스장" 카드가 헬스장 상세로 이동하려면 id 가 필요하다(#324).
+
+    데모 회원(user-demo)은 hashed_password 가 비어 있어 로그인할 수 없으므로
+    서비스를 직접 호출해 확인한다.
+    """
+    from app.services import trainer_service
+
+    coach = trainer_service.build_member_coach(db_session, "user-demo")
+    assert coach is not None, "시드가 user-demo ↔ 김트레이너를 연결해야 한다"
+    # 이름만으로는 목록의 헬스장과 이어붙일 수 없다.
+    assert coach.gym.id == "gym-oncare-sinchon"
+    assert coach.gym.name == "온케어짐 신촌점"
+
+
+def test_disconnect_my_coach_is_idempotent(client):
+    """해제는 두 번 눌러도 오류 화면이 뜨면 안 된다."""
+    from tests.test_consultations import _auth, _register_member
+
+    _member_id, token = _register_member(client)
+    # 담당이 없는 회원도 204 — 404 면 앱이 오류를 띄운다.
+    assert client.delete("/v1/me/coach", headers=_auth(token)).status_code == 204
+    assert client.delete("/v1/me/coach", headers=_auth(token)).status_code == 204

--- a/backend/tests/test_gyms.py
+++ b/backend/tests/test_gyms.py
@@ -1,0 +1,126 @@
+"""헬스장·트레이너 디렉터리 API. (#324)
+
+시드(`seed_gyms.seed_partner_gyms`)가 만든 제휴 헬스장 3곳과 트레이너 1명을 전제로 한다.
+"""
+from __future__ import annotations
+
+PARTNER_IDS = {"gym-oncare-sinchon", "gym-healthmate", "gym-bodyandsoul"}
+SINCHON = {"lat": 37.5559, "lng": 126.9368}
+
+
+def test_list_gyms_returns_partner_gyms(client):
+    r = client.get("/v1/gyms")
+    assert r.status_code == 200, r.text
+    ids = {g["id"] for g in r.json()}
+    assert PARTNER_IDS <= ids
+
+
+def test_list_gyms_partner_only_filters(client):
+    everything = client.get("/v1/gyms").json()
+    partners = client.get("/v1/gyms", params={"partner_only": True}).json()
+
+    assert {g["id"] for g in partners} == PARTNER_IDS
+    assert all(g["is_partner"] for g in partners)
+    # 기존 데모 시드의 fitness 장소(프로필 없음)는 제휴가 아니라 걸러진다.
+    assert len(partners) < len(everything)
+
+
+def test_list_gyms_sorts_by_distance_when_coordinates_given(client):
+    r = client.get("/v1/gyms", params={**SINCHON, "partner_only": True})
+    assert r.status_code == 200, r.text
+    gyms = r.json()
+
+    distances = [g["distance_km"] for g in gyms]
+    assert distances == sorted(distances)
+    # 신촌 중심이므로 온케어짐(같은 좌표)이 가장 가깝다.
+    assert gyms[0]["id"] == "gym-oncare-sinchon"
+    assert gyms[0]["distance_km"] == 0
+
+
+def test_list_gyms_without_coordinates_has_zero_distance(client):
+    gyms = client.get("/v1/gyms", params={"partner_only": True}).json()
+    # 기준점이 없으면 거리를 지어내지 않는다.
+    assert all(g["distance_km"] == 0 for g in gyms)
+
+
+def test_gym_detail_exposes_profile_fields(client):
+    r = client.get("/v1/gyms/gym-oncare-sinchon")
+    assert r.status_code == 200, r.text
+    gym = r.json()
+
+    assert gym["name"] == "온케어짐 신촌점"
+    assert gym["address"] == "서울 서대문구 신촌로 120"
+    assert gym["rating"] == 4.7
+    assert gym["phone"] == "02-1234-5678"
+    assert gym["tags"] == ["다이어트", "재활운동"]
+    assert gym["is_partner"] is True
+    # 지도 핀을 찍으려면 좌표가 있어야 한다.
+    assert gym["lat"] is not None and gym["lng"] is not None
+
+
+def test_gym_detail_404_for_unknown(client):
+    assert client.get("/v1/gyms/no-such-gym").status_code == 404
+
+
+def test_gym_detail_404_for_non_fitness_place(client):
+    # place-1 은 medical 이다 — 헬스장 API 로 새어 나오면 안 된다.
+    assert client.get("/v1/gyms/place-1").status_code == 404
+
+
+def test_gym_trainers_are_scoped_to_that_gym(client):
+    r = client.get("/v1/gyms/gym-oncare-sinchon/trainers")
+    assert r.status_code == 200, r.text
+    trainers = r.json()
+
+    assert trainers, "시드 트레이너가 소속으로 연결돼야 한다"
+    assert all(t["gym_id"] == "gym-oncare-sinchon" for t in trainers)
+
+
+def test_gym_trainers_404_for_unknown_gym(client):
+    assert client.get("/v1/gyms/no-such-gym/trainers").status_code == 404
+
+
+def test_gym_without_trainers_returns_empty_list(client):
+    # 소속 트레이너가 없는 제휴 헬스장은 404 가 아니라 빈 배열이어야 한다.
+    r = client.get("/v1/gyms/gym-bodyandsoul/trainers")
+    assert r.status_code == 200, r.text
+    assert r.json() == []
+
+
+def test_trainer_directory_and_detail(client):
+    listed = client.get("/v1/trainers").json()
+    assert listed, "시드 트레이너가 디렉터리에 나와야 한다"
+
+    trainer_id = listed[0]["id"]
+    detail = client.get(f"/v1/trainers/{trainer_id}")
+    assert detail.status_code == 200, detail.text
+    assert detail.json()["id"] == trainer_id
+
+
+def test_trainer_detail_404_for_unknown(client):
+    assert client.get("/v1/trainers/no-such-trainer").status_code == 404
+
+
+def test_recommended_route_is_not_shadowed_by_detail(client):
+    """`/trainers/recommended` 가 `/trainers/{id}` 에 잡히면 404 가 난다."""
+    r = client.get("/v1/trainers/recommended")
+    assert r.status_code == 200, r.text
+    assert isinstance(r.json(), list)
+
+
+def test_recommended_only_includes_trainers_with_reason(client):
+    recommended = client.get("/v1/trainers/recommended").json()
+    assert recommended, "시드 트레이너에 추천 사유가 있어야 한다"
+    assert all(t["reason"] for t in recommended)
+
+
+def test_trainer_fields_match_app_contract(client):
+    trainer = client.get("/v1/trainers/recommended").json()[0]
+    # 앱 Trainer 엔티티와 같은 필드여야 매핑 코드가 없다.
+    assert set(trainer) == {
+        "id", "gym_id", "name", "role", "reason", "career", "intro",
+        "certifications",
+    }
+    # career 는 "7년" 처럼 앱이 그대로 렌더하는 문자열이다.
+    assert trainer["career"] is None or trainer["career"].endswith("년")
+    assert isinstance(trainer["certifications"], list)

--- a/backend/tests/test_gyms.py
+++ b/backend/tests/test_gyms.py
@@ -5,6 +5,9 @@
 from __future__ import annotations
 
 PARTNER_IDS = {"gym-oncare-sinchon", "gym-healthmate", "gym-bodyandsoul"}
+#: 카카오 Local 에서 발견한 실재 업체 — 제휴는 아니지만 상담 대상이어야 한다.
+DISCOVERED_IDS = {"11621774", "1558845892", "328969863", "696444256"}
+SEEDED_IDS = PARTNER_IDS | DISCOVERED_IDS
 SINCHON = {"lat": 37.5559, "lng": 126.9368}
 
 
@@ -80,11 +83,20 @@ def test_gym_trainers_404_for_unknown_gym(client):
     assert client.get("/v1/gyms/no-such-gym/trainers").status_code == 404
 
 
-def test_gym_without_trainers_returns_empty_list(client):
-    # 소속 트레이너가 없는 제휴 헬스장은 404 가 아니라 빈 배열이어야 한다.
-    r = client.get("/v1/gyms/gym-bodyandsoul/trainers")
-    assert r.status_code == 200, r.text
-    assert r.json() == []
+def test_every_seeded_gym_has_at_least_two_trainers(client):
+    """앱 화면과 같은 구성이어야 한다 — 헬스장마다 트레이너 2명 이상."""
+    for gym_id in SEEDED_IDS:
+        trainers = client.get(f"/v1/gyms/{gym_id}/trainers").json()
+        assert len(trainers) >= 2, f"{gym_id} 소속 트레이너 {len(trainers)}명"
+
+
+def test_discovered_gyms_are_not_partners(client):
+    """카카오에서 발견한 실재 업체는 제휴가 아니다 — 구분이 유지돼야 한다."""
+    for gym_id in DISCOVERED_IDS:
+        gym = client.get(f"/v1/gyms/{gym_id}").json()
+        assert gym["is_partner"] is False, gym["name"]
+    partners = client.get("/v1/gyms", params={"partner_only": True}).json()
+    assert {g["id"] for g in partners} == PARTNER_IDS
 
 
 def test_trainer_directory_and_detail(client):
@@ -112,6 +124,35 @@ def test_recommended_only_includes_trainers_with_reason(client):
     recommended = client.get("/v1/trainers/recommended").json()
     assert recommended, "시드 트레이너에 추천 사유가 있어야 한다"
     assert all(t["reason"] for t in recommended)
+
+
+def test_seeded_trainers_cover_every_gym(client):
+    """앱 mock 과 같은 15명이 디렉터리에 있어야 화면이 달라지지 않는다."""
+    trainers = client.get("/v1/trainers").json()
+    assert len(trainers) >= 15
+
+    gym_ids = {t["gym_id"] for t in trainers if t["gym_id"]}
+    assert SEEDED_IDS <= gym_ids
+
+    # 이름이 겹치면 목록에서 서로 구분되지 않는다.
+    names = [t["name"] for t in trainers]
+    assert len(set(names)) == len(names), "트레이너 이름 중복"
+
+
+def test_consultation_works_for_a_discovered_gym(client):
+    """카카오 발견 헬스장이 places 에 없으면 상담이 404 로 실패한다.
+
+    헬스장 상세의 상담 버튼은 제휴 여부를 가리지 않으므로, 발견 헬스장도 상담
+    대상이어야 화면과 백엔드가 어긋나지 않는다(#324 → #327).
+    """
+    from tests.test_consultations import _auth, _payload, _register_member
+
+    _member_id, token = _register_member(client)
+    payload = _payload(gym_id="328969863")  # 빌드업짐 PT 신촌점
+    r = client.post("/v1/consultations", headers=_auth(token), json=payload)
+
+    assert r.status_code == 201, r.text
+    assert r.json()["gym_id"] == "328969863"
 
 
 def test_trainer_fields_match_app_contract(client):

--- a/backend/tests/test_gyms.py
+++ b/backend/tests/test_gyms.py
@@ -40,6 +40,33 @@ def test_list_gyms_sorts_by_distance_when_coordinates_given(client):
     assert gyms[0]["distance_km"] == 0
 
 
+def test_gyms_without_coordinates_sort_last(client, db_session):
+    """좌표를 모르는 헬스장은 distance_km 가 0 이라, 그냥 정렬하면 '가장 가까운 곳'
+    으로 맨 앞에 온다."""
+    from app.models.models import Place
+
+    db_session.add(
+        Place(
+            id="gym-no-coords-test",
+            name="좌표없는테스트짐",
+            category="fitness",
+            address="주소 미상",
+        )
+    )
+    db_session.commit()
+    try:
+        gyms = client.get("/v1/gyms", params=SINCHON).json()
+        ids = [g["id"] for g in gyms]
+        assert "gym-no-coords-test" in ids
+        assert ids[-1] == "gym-no-coords-test", ids
+        assert ids[0] == "gym-oncare-sinchon", ids
+    finally:
+        db_session.query(Place).filter(
+            Place.id == "gym-no-coords-test"
+        ).delete()
+        db_session.commit()
+
+
 def test_list_gyms_without_coordinates_has_zero_distance(client):
     gyms = client.get("/v1/gyms", params={"partner_only": True}).json()
     # 기준점이 없으면 거리를 지어내지 않는다.

--- a/frontend/flutter/lib/features/exercise/data/repositories/dio_gym_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/dio_gym_repository.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 
 import 'package:oncare/features/exercise/domain/entities/gym.dart';
+import 'package:oncare/features/exercise/domain/entities/gym_search_area.dart';
 import 'package:oncare/features/exercise/domain/entities/trainer.dart';
 import 'package:oncare/features/exercise/domain/repositories/gym_repository.dart';
 
@@ -11,10 +12,6 @@ import 'package:oncare/features/exercise/domain/repositories/gym_repository.dart
 class DioGymRepository implements GymRepository {
   DioGymRepository(this._dio);
   final Dio _dio;
-
-  /// 헬스장 찾기가 쓰는 기준 좌표(신촌). 거리를 서버가 계산하도록 함께 보낸다.
-  static const double _centerLat = 37.5559;
-  static const double _centerLng = 126.9368;
 
   static Gym _gym(Map<String, Object?> j) => Gym(
     id: j['id']! as String,
@@ -70,7 +67,7 @@ class DioGymRepository implements GymRepository {
   Future<List<Gym>> fetchNearby() => _list(
     '/gyms',
     _gym,
-    query: <String, Object?>{'lat': _centerLat, 'lng': _centerLng},
+    query: <String, Object?>{'lat': kGymSearchLat, 'lng': kGymSearchLng},
   );
 
   @override
@@ -105,7 +102,7 @@ class DioGymRepository implements GymRepository {
     try {
       final res = await _dio.get<Map<String, Object?>>(
         '/gyms/$gymId',
-        queryParameters: <String, Object?>{'lat': _centerLat, 'lng': _centerLng},
+        queryParameters: <String, Object?>{'lat': kGymSearchLat, 'lng': kGymSearchLng},
       );
       if (res.data != null) return _gym(res.data!);
     } on DioException catch (e) {

--- a/frontend/flutter/lib/features/exercise/data/repositories/dio_gym_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/dio_gym_repository.dart
@@ -1,0 +1,134 @@
+import 'package:dio/dio.dart';
+
+import 'package:oncare/features/exercise/domain/entities/gym.dart';
+import 'package:oncare/features/exercise/domain/entities/trainer.dart';
+import 'package:oncare/features/exercise/domain/repositories/gym_repository.dart';
+
+/// 헬스장·트레이너 디렉터리 실 API. (#324)
+///
+/// 회원의 "내 헬스장/트레이너"는 별도 링크가 아니라 **담당 트레이너의 소속**에서
+/// 나온다(`GET /me/coach`). 백엔드에 회원↔헬스장 링크가 따로 없기 때문이다.
+class DioGymRepository implements GymRepository {
+  DioGymRepository(this._dio);
+  final Dio _dio;
+
+  /// 헬스장 찾기가 쓰는 기준 좌표(신촌). 거리를 서버가 계산하도록 함께 보낸다.
+  static const double _centerLat = 37.5559;
+  static const double _centerLng = 126.9368;
+
+  static Gym _gym(Map<String, Object?> j) => Gym(
+    id: j['id']! as String,
+    name: j['name']! as String,
+    address: (j['address'] as String?) ?? '',
+    distanceKm: ((j['distance_km'] as num?) ?? 0).toDouble(),
+    rating: ((j['rating'] as num?) ?? 0).toDouble(),
+    tags: <String>[...?(j['tags'] as List<Object?>?)?.cast<String>()],
+    weekdayHours: j['weekday_hours'] as String?,
+    weekendHours: j['weekend_hours'] as String?,
+    phone: j['phone'] as String?,
+    lat: (j['lat'] as num?)?.toDouble(),
+    lng: (j['lng'] as num?)?.toDouble(),
+  );
+
+  static Trainer _trainer(Map<String, Object?> j) => Trainer(
+    id: j['id']! as String,
+    gymId: (j['gym_id'] as String?) ?? '',
+    name: j['name']! as String,
+    role: j['role'] as String?,
+    reason: j['reason'] as String?,
+    career: j['career'] as String?,
+    intro: j['intro'] as String?,
+    certifications: <String>[
+      ...?(j['certifications'] as List<Object?>?)?.cast<String>(),
+    ],
+  );
+
+  Future<List<T>> _list<T>(
+    String path,
+    T Function(Map<String, Object?>) map, {
+    Map<String, Object?>? query,
+  }) async {
+    final res = await _dio.get<List<Object?>>(path, queryParameters: query);
+    return (res.data ?? const <Object?>[])
+        .cast<Map<String, Object?>>()
+        .map(map)
+        .toList();
+  }
+
+  /// 담당 트레이너 요약. 담당이 없으면 서버가 404 를 주므로 null 로 바꾼다.
+  Future<Map<String, Object?>?> _coach() async {
+    try {
+      final res = await _dio.get<Map<String, Object?>>('/me/coach');
+      return res.data;
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 404) return null;
+      rethrow;
+    }
+  }
+
+  @override
+  Future<List<Gym>> fetchNearby() => _list(
+    '/gyms',
+    _gym,
+    query: <String, Object?>{'lat': _centerLat, 'lng': _centerLng},
+  );
+
+  @override
+  Future<List<Trainer>> fetchTrainersByGym(String gymId) =>
+      _list('/gyms/$gymId/trainers', _trainer);
+
+  @override
+  Future<List<Trainer>> fetchAllTrainers() => _list('/trainers', _trainer);
+
+  @override
+  Future<List<Trainer>> fetchRecommendedTrainers() =>
+      _list('/trainers/recommended', _trainer);
+
+  @override
+  Future<Trainer?> fetchTrainer(String trainerId) async {
+    try {
+      final res = await _dio.get<Map<String, Object?>>('/trainers/$trainerId');
+      return res.data == null ? null : _trainer(res.data!);
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 404) return null;
+      rethrow;
+    }
+  }
+
+  @override
+  Future<Gym?> fetchMyGym() async {
+    final coach = await _coach();
+    final gym = coach?['gym'] as Map<String, Object?>?;
+    final gymId = gym?['id'] as String?;
+    if (gymId == null) return null;
+    // 요약에는 평점·태그가 없다. 상세를 한 번 더 읽어 목록과 같은 카드를 만든다.
+    try {
+      final res = await _dio.get<Map<String, Object?>>(
+        '/gyms/$gymId',
+        queryParameters: <String, Object?>{'lat': _centerLat, 'lng': _centerLng},
+      );
+      if (res.data != null) return _gym(res.data!);
+    } on DioException catch (e) {
+      if (e.response?.statusCode != 404) rethrow;
+    }
+    return null;
+  }
+
+  @override
+  Future<Trainer?> fetchMyTrainer() async {
+    final coach = await _coach();
+    final trainerId = coach?['trainer_id'] as String?;
+    if (trainerId == null) return null;
+    // 요약에는 자격증·추천 사유가 없어 상세를 읽는다.
+    return fetchTrainer(trainerId);
+  }
+
+  @override
+  Future<void> disconnectMyGym() => _dio.delete<void>('/me/coach');
+
+  /// 서버에는 회원↔헬스장 링크가 따로 없어 "트레이너만 해제"를 표현할 수 없다.
+  /// 담당 링크를 끊으면 헬스장도 함께 사라진다 — mock 과 달리 헬스장이 남지 않는다.
+  /// 회원↔헬스장 링크가 생기면(#301 후속) 여기를 나눈다.
+  @override
+  Future<void> disconnectMyTrainer() => _dio.delete<void>('/me/coach');
+}

--- a/frontend/flutter/lib/features/exercise/domain/entities/gym_search_area.dart
+++ b/frontend/flutter/lib/features/exercise/domain/entities/gym_search_area.dart
@@ -1,0 +1,11 @@
+/// 헬스장 찾기의 기준 좌표 — 지도 중심이자 조회 기준. (#324, #329)
+///
+/// 지도(`_GymMap`)와 목록 조회(`DioGymRepository`, `gymFinderResultsProvider`)가
+/// **같은 값**을 써야 한다. 두 곳에 따로 두면 한쪽만 바뀌었을 때 지도 중심과 검색
+/// 중심이 조용히 어긋난다.
+///
+/// 기기 위치 권한이 붙기 전까지의 고정값이다(제휴 헬스장이 있는 신촌 권역).
+library;
+
+const double kGymSearchLat = 37.5559;
+const double kGymSearchLng = 126.9368;

--- a/frontend/flutter/lib/features/exercise/presentation/controllers/exercise_controller.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/controllers/exercise_controller.dart
@@ -4,6 +4,7 @@ import 'package:oncare/core/config/app_config.dart';
 import 'package:oncare/core/network/dio_client.dart';
 import 'package:oncare/features/exercise/data/kakao_gym_demo_profile.dart';
 import 'package:oncare/features/exercise/data/repositories/dio_exercise_repository.dart';
+import 'package:oncare/features/exercise/data/repositories/dio_gym_repository.dart';
 import 'package:oncare/features/exercise/data/repositories/mock_exercise_repository.dart';
 import 'package:oncare/features/exercise/data/repositories/mock_gym_repository.dart';
 import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
@@ -146,15 +147,19 @@ final exerciseWeekViewProvider = Provider<AsyncValue<ExerciseWeek>>((ref) {
       .whenData((ExerciseWeek w) => applyTodayBonus(w, bonus));
 }, name: 'exerciseWeekView');
 
-/// Gym data has no backend endpoint yet — the prototype shipped only
-/// mock data, so wire the page to a static repository for now. A real
-/// `DioGymRepository` can be swapped in once `/gyms/*` lands.
-final gymRepositoryProvider = Provider<GymRepository>(
-  // 한 인스턴스를 provider 수명 동안 유지해, 연결 해제 상태가 MY 탭과
-  // 운동 탭에 함께 반영된다.
-  (ref) => MockGymRepository(),
-  name: 'gymRepository',
-);
+/// 헬스장·트레이너 디렉터리. 실 API 는 `/gyms`·`/trainers`(#324).
+///
+/// 데모(mock) 경로를 유지하는 이유: `LocalApiInterceptor` 에 `/gyms` 계열 핸들러가
+/// 없어 데모에서 실 repository 를 쓰면 요청이 갈 곳이 없다. 시드가 mock 과 같은
+/// id·문안이라 두 경로의 화면은 같다.
+final gymRepositoryProvider = Provider<GymRepository>((ref) {
+  if (ref.watch(appConfigProvider).useMockApi) {
+    // 한 인스턴스를 provider 수명 동안 유지해, 연결 해제 상태가 MY 탭과
+    // 운동 탭에 함께 반영된다.
+    return MockGymRepository();
+  }
+  return DioGymRepository(ref.watch(dioProvider));
+}, name: 'gymRepository');
 
 final myGymProvider = FutureProvider<Gym?>((ref) {
   return ref.watch(gymRepositoryProvider).fetchMyGym();

--- a/frontend/flutter/lib/features/exercise/presentation/controllers/exercise_controller.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/controllers/exercise_controller.dart
@@ -9,6 +9,7 @@ import 'package:oncare/features/exercise/data/repositories/mock_exercise_reposit
 import 'package:oncare/features/exercise/data/repositories/mock_gym_repository.dart';
 import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
 import 'package:oncare/features/exercise/domain/entities/gym.dart';
+import 'package:oncare/features/exercise/domain/entities/gym_search_area.dart';
 import 'package:oncare/features/exercise/domain/entities/trainer.dart';
 import 'package:oncare/features/exercise/domain/repositories/exercise_repository.dart';
 import 'package:oncare/features/exercise/domain/repositories/gym_repository.dart';
@@ -169,11 +170,11 @@ final nearbyGymsProvider = FutureProvider<List<Gym>>((ref) {
   return ref.watch(gymRepositoryProvider).fetchNearby();
 }, name: 'nearbyGyms');
 
-/// 헬스장 찾기가 지도 중심으로 삼는 좌표 — 제휴 헬스장(온케어짐 신촌점)이
-/// 있는 신촌 권역. 기기 위치 권한이 붙기 전까지의 고정값이다.
+/// 헬스장 찾기의 카카오 Local 조회 조건. 좌표는 지도 중심·실 API 조회와 같은
+/// 상수를 쓴다(`gym_search_area.dart`) — 따로 두면 조용히 어긋난다.
 const PlaceQuery kGymFinderArea = PlaceQuery(
-  lat: 37.5559,
-  lng: 126.9368,
+  lat: kGymSearchLat,
+  lng: kGymSearchLng,
   category: PlaceCategory.fitness,
 );
 

--- a/frontend/flutter/test/features/exercise/dio_gym_repository_test.dart
+++ b/frontend/flutter/test/features/exercise/dio_gym_repository_test.dart
@@ -1,0 +1,134 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/exercise/data/repositories/dio_gym_repository.dart';
+import 'package:oncare/features/exercise/domain/entities/gym.dart';
+import 'package:oncare/features/exercise/domain/entities/trainer.dart';
+
+/// 백엔드 실응답을 그대로 돌려주는 어댑터. 필드명이 어긋나면 여기서 걸린다.
+class _StubAdapter implements HttpClientAdapter {
+  _StubAdapter(this.routes);
+  final Map<String, Object?> routes;
+  final List<String> calls = <String>[];
+
+  @override
+  Future<ResponseBody> fetch(RequestOptions options, _, _) async {
+    calls.add('${options.method} ${options.path}');
+    final body = routes[options.path];
+    if (body == null) {
+      return ResponseBody.fromString('{"detail":"not found"}', 404,
+          headers: <String, List<String>>{
+            Headers.contentTypeHeader: <String>[Headers.jsonContentType],
+          });
+    }
+    return ResponseBody.fromString(_encode(body), 200,
+        headers: <String, List<String>>{
+          Headers.contentTypeHeader: <String>[Headers.jsonContentType],
+        });
+  }
+
+  static String _encode(Object? v) {
+    // dart:convert 를 쓰지 않고 미리 만든 JSON 문자열을 그대로 쓴다.
+    return v! as String;
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+/// `GET /v1/gyms` 실응답(gym_service.GymOut) 그대로.
+const String _gymsJson = '''
+[{"id":"gym-oncare-sinchon","name":"온케어짐 신촌점","address":"서울 서대문구 신촌로 120",
+  "distance_km":0.0,"rating":4.7,"tags":["다이어트","재활운동"],
+  "weekday_hours":"06:00 – 23:00","weekend_hours":"08:00 - 20:00",
+  "phone":"02-1234-5678","lat":37.5559,"lng":126.9368,"is_partner":true}]
+''';
+
+/// `GET /v1/gyms/{id}` 실응답(단일 객체).
+const String _gymDetailJson = '''
+{"id":"gym-oncare-sinchon","name":"온케어짐 신촌점","address":"서울 서대문구 신촌로 120",
+ "distance_km":0.0,"rating":4.7,"tags":["다이어트","재활운동"],
+ "weekday_hours":"06:00 – 23:00","weekend_hours":"08:00 - 20:00",
+ "phone":"02-1234-5678","lat":37.5559,"lng":126.9368,"is_partner":true}
+''';
+
+const String _trainersJson = '''
+[{"id":"trainer-demo","gym_id":"gym-oncare-sinchon","name":"김트레이너",
+  "role":"퍼스널 트레이너","reason":"혈압 관리와 운동 병행 지도","career":"7년",
+  "intro":"혈압 관리와 체중 감량을 함께 다루는 퍼스널 트레이너입니다.",
+  "certifications":["생활스포츠지도사 2급","퍼스널트레이닝 CPT"]}]
+''';
+
+Dio _dio(_StubAdapter adapter) =>
+    Dio(BaseOptions(baseUrl: 'http://x/v1'))..httpClientAdapter = adapter;
+
+void main() {
+  test('GET /gyms 응답이 Gym 으로 매핑된다', () async {
+    final adapter = _StubAdapter(<String, Object?>{'/gyms': _gymsJson});
+    final gyms = await DioGymRepository(_dio(adapter)).fetchNearby();
+
+    expect(gyms, hasLength(1));
+    final Gym g = gyms.single;
+    expect(g.id, 'gym-oncare-sinchon');
+    expect(g.name, '온케어짐 신촌점');
+    expect(g.rating, 4.7);
+    expect(g.tags, <String>['다이어트', '재활운동']);
+    expect(g.phone, '02-1234-5678');
+    expect(g.weekdayHours, '06:00 – 23:00');
+    // 지도 핀에 필요하다.
+    expect(g.hasCoordinates, isTrue);
+  });
+
+  test('거리 계산을 서버가 하도록 좌표를 함께 보낸다', () async {
+    final adapter = _StubAdapter(<String, Object?>{'/gyms': _gymsJson});
+    await DioGymRepository(_dio(adapter)).fetchNearby();
+    expect(adapter.calls, contains('GET /gyms'));
+  });
+
+  test('GET /trainers 응답이 Trainer 로 매핑된다', () async {
+    final adapter = _StubAdapter(<String, Object?>{'/trainers': _trainersJson});
+    final trainers = await DioGymRepository(_dio(adapter)).fetchAllTrainers();
+
+    final Trainer t = trainers.single;
+    expect(t.id, 'trainer-demo');
+    expect(t.gymId, 'gym-oncare-sinchon');
+    expect(t.role, '퍼스널 트레이너');
+    expect(t.reason, '혈압 관리와 운동 병행 지도');
+    expect(t.career, '7년');
+    expect(t.certifications, hasLength(2));
+  });
+
+  test('담당이 없으면 404 를 null 로 바꾼다', () async {
+    // /me/coach 미등록 → 404. 예외가 그대로 올라가면 화면이 오류로 덮인다.
+    final repo = DioGymRepository(_dio(_StubAdapter(<String, Object?>{})));
+    expect(await repo.fetchMyGym(), isNull);
+    expect(await repo.fetchMyTrainer(), isNull);
+  });
+
+  test('내 헬스장은 요약이 아니라 상세를 읽어 평점·태그를 채운다', () async {
+    const coachJson = '''
+    {"trainer_id":"trainer-demo","name":"김트레이너","specialty":"퍼스널 트레이너",
+     "career":"7년","intro":"소개","goal":"혈압 관리",
+     "gym":{"id":"gym-oncare-sinchon","name":"온케어짐 신촌점",
+            "address":"서울 서대문구 신촌로 120","hours":"06:00 – 23:00",
+            "phone":"02-1234-5678"}}
+    ''';
+    final adapter = _StubAdapter(<String, Object?>{
+      '/me/coach': coachJson,
+      '/gyms/gym-oncare-sinchon': _gymDetailJson,
+    });
+
+    final gym = await DioGymRepository(_dio(adapter)).fetchMyGym();
+    expect(gym, isNotNull);
+    // 요약(TrainerGymOut)에는 평점·태그가 없다 — 상세를 읽어야 카드가 목록과 같다.
+    expect(gym!.rating, 4.7);
+    expect(gym.tags, isNotEmpty);
+    expect(adapter.calls, contains('GET /gyms/gym-oncare-sinchon'));
+  });
+
+  test('연결 해제는 DELETE /me/coach 로 나간다', () async {
+    final adapter = _StubAdapter(<String, Object?>{'/me/coach': '{}'});
+    await DioGymRepository(_dio(adapter)).disconnectMyGym();
+    expect(adapter.calls, contains('DELETE /me/coach'));
+  });
+}

--- a/frontend/flutter/test/features/exercise/gym_detail_pages_test.dart
+++ b/frontend/flutter/test/features/exercise/gym_detail_pages_test.dart
@@ -64,6 +64,8 @@ void main() {
         overrides: <Override>[
           nearbyGymsProvider.overrideWith((ref) async => gyms),
           // 헬스장 상세·찾기는 제휴 + 카카오를 합친 provider 를 본다(#329).
+          // gymRepositoryProvider 가 mock/실 API 를 이 값으로 고른다(#324).
+          appConfigProvider.overrideWithValue(_config),
           gymFinderResultsProvider.overrideWith((ref) async => gyms),
           myGymProvider.overrideWith((ref) async => myGym),
           myTrainerProvider.overrideWith((ref) async => null),

--- a/frontend/flutter/test/features/exercise/gym_finder_results_test.dart
+++ b/frontend/flutter/test/features/exercise/gym_finder_results_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:oncare/core/config/app_config.dart';
 
+import 'package:oncare/features/exercise/data/repositories/mock_gym_repository.dart';
 import 'package:oncare/features/exercise/domain/entities/gym.dart';
 import 'package:oncare/features/exercise/domain/entities/trainer.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
@@ -74,6 +75,10 @@ ProviderContainer _containerWith(
   final container = ProviderContainer(
     overrides: <Override>[
       placeRepositoryProvider.overrideWithValue(repo),
+      // 이 테스트가 보는 건 카카오(place) 경로다. useMockApi:false 일 때
+      // gymRepositoryProvider 가 실 API repo 를 만들면 dio 의존성이 딸려오므로
+      // 제휴 목록은 mock 으로 고정한다.
+      gymRepositoryProvider.overrideWithValue(MockGymRepository()),
       appConfigProvider.overrideWithValue(
         AppConfig(
           environment: Environment.dev,


### PR DESCRIPTION
Closes #324

관련: #301 (일부 선반영 — 아래 참고. 이 PR 은 #301 을 닫지 않습니다)

## Summary

회원앱의 헬스장·트레이너가 전부 프론트 하드코딩(`MockGymRepository`)이었습니다. 실 백엔드를 세우고 앱을 연결합니다.

기존 `/trainer/*`(단수)는 트레이너 앱이 **자기** 회원·일정을 다루는 곳이라 회원앱이 쓸 수 없었습니다. 회원이 트레이너를 **탐색**하는 읽기 전용 디렉터리를 `/trainers`(복수)로 따로 둡니다.

**데모 화면은 변하지 않습니다.** `gymRepositoryProvider`를 `useMockApi`로 분기해 데모는 기존 mock 경로를 그대로 타고, 시드가 mock과 같은 id·문안이라 실 API 경로도 같은 화면을 냅니다. 브라우저로 대조했습니다(아래 Verification).

#301(트레이너↔헬스장 소속 관계, @seoyeon0516)의 **일부를 선반영합니다** — 소속을 FK로 정규화하지 않으면 "한 헬스장 여러 트레이너"가 성립하지 않아 #324를 반쪽으로 만들기 때문입니다.

다만 #301 을 닫지는 않습니다. 이 PR 이 덮는 것은 `trainer_profiles.gym_id` FK·마이그레이션(`0020`)·소속 기반 조회까지고, #301 의 완료 기준 중 **상담 요청 시 소속 유효성 검증**(`consultation_service._validate_target` 은 아직 `gym_id` 의 존재만 확인합니다), **트레이너 탈퇴·헬스장 삭제 시 소속 처리 정책**, **단일/복수 소속·이력 보존을 문서와 DB 제약으로 명시**, **기존 `gym_name`·`gym_address` 문자열 필드 이전 여부 결정**은 남습니다. 남은 범위는 이슈 담당자가 마무리한 뒤 닫는 것이 맞다고 봅니다.

## Changes

### 스키마 — `places` 재사용 + 확장 테이블

헬스장 저장소로 **`places`(category='fitness')를 재사용**했습니다. 새 테이블을 만들지 않은 이유는 `consultation_service._validate_target()`이 이미 상담 대상 헬스장을 그 테이블에서 검증하고 `/places/nearby`도 같은 테이블을 쓰기 때문입니다 — 헬스장 엔티티를 따로 두면 두 곳을 함께 바꿔야 합니다.

- **`gym_profiles`** — `places`의 1:1 확장(평점·영업시간·전화·태그·제휴여부). 평점·영업시간을 `places`에 직접 넣으면 병원·약국·건강식이 공유하는 테이블이 오염됩니다. `trainer_profiles`가 `users`를 확장하는 것과 같은 꼴입니다
- **`trainer_profiles.gym_id` FK** — 소속이 `gym_name` 문자열이라 한 헬스장에 여러 트레이너를 묶을 수 없었습니다. 트레이너 앱이 아직 `gym_*` 문자열을 읽으므로 두 표현을 공존시키고 `gym_id`를 우선합니다
- **`trainer_profiles.recommend_reason`** — 추천 레일 노출 조건

### 엔드포인트

| 엔드포인트 | 비고 |
|---|---|
| `GET /gyms` | `lat`/`lng` 주면 거리순, `partner_only` 필터 |
| `GET /gyms/{id}` · `GET /gyms/{id}/trainers` | 헬스장 없으면 404, 소속 없으면 빈 배열 |
| `GET /trainers` · `/trainers/recommended` · `/trainers/{id}` | |
| `DELETE /me/coach` | MY 탭 연결 해제. 링크를 지우지 않고 `active=False` — 지난 루틴·채팅·일정이 링크를 참조합니다 |

`TrainerGymOut.id`를 추가했습니다. "내 헬스장" 카드가 헬스장 상세로 이동하려면 id가 필요한데 이름만 있었습니다. 필드 **추가**라 트레이너 앱은 영향받지 않습니다.

### 시드 — 앱 화면과 동일 구성

헬스장 7곳·트레이너 15명을 **프론트 mock과 같은 id·문안**으로 시드합니다. id가 바뀌면 진행 중인 상담·연결이 끊깁니다.

카카오 Local에서 발견한 실재 업체 4곳도 `places`에 넣되 `is_partner=false`로 제휴와 구분합니다. **넣지 않으면 이 헬스장들에서 상담 요청이 404로 실패합니다** — 헬스장 상세의 상담 버튼이 제휴 여부를 가리지 않기 때문입니다(`gym_detail_page.dart:225`).

> ⚠️ 발견 헬스장의 평점·영업시간·태그와 소속 트레이너는 **시연용으로 지어낸 값**입니다. 실재 상호에 붙으므로 사실처럼 표기하면 안 되고, 시드 파일 주석에 명시했습니다. 실 트레이너 온보딩이 생기면 제거 대상입니다.

### 앱

- `DioGymRepository` — `/me/coach` 요약에는 평점·태그·자격증이 없어 상세를 한 번 더 읽어 목록과 같은 카드를 만듭니다. 담당이 없을 때의 404는 `null`로 바꿉니다(예외가 올라가면 화면이 오류로 덮입니다)
- `gymRepositoryProvider`를 `useMockApi`로 분기. `LocalApiInterceptor`에 `/gyms` 계열 핸들러가 없어 데모에서 실 repository를 쓰면 요청이 갈 곳이 없습니다

## Verification

- 백엔드 **355건** — 기존 DB와 **빈 DB(마이그레이션 21개 처음부터 적용)** 양쪽에서 통과
- 프론트 **281건**, `flutter analyze` 이슈 0
- `alembic upgrade`/`downgrade` 왕복, `alembic check`로 모델↔스키마 대조(신규 테이블 드리프트 0)
- 시드 2~3회 반복 실행해 멱등 확인
- **브라우저 대조** — 배선 전후 데모 화면 동일: 7개 결과 / 온케어짐 0.8km ★4.7 / 헬스메이트 1.2km ★4.5 / 카카오맵 마커 7개 / 지도 680×225

특히 잡아낸 것:
- 시드가 멱등이라 나중에 추가된 `recommend_reason`이 기존 행에 영영 비었습니다 → 백필 추가
- `/trainers/recommended`를 `/trainers/{id}` 뒤에 두면 "recommended"가 id로 잡혀 404 → 순서 고정 테스트
- 발견 헬스장 상담이 201로 접수되는지 검증 — 시드가 빠지면 이 테스트가 404로 깨집니다

## Notes

**`disconnectMyTrainer`가 실 API에서 mock과 다르게 동작합니다.** 서버에 회원↔헬스장 링크가 따로 없어 "트레이너만 해제"를 표현할 수 없고, 담당 링크를 끊으면 헬스장도 함께 사라집니다. 코드 주석에 남겼고 회원↔헬스장 링크가 생기면 분리해야 합니다.

시드 트레이너 15명은 로그인은 되지만 **담당 회원이 없어 트레이너 앱 로스터가 비어 있습니다.** 비밀번호는 `DEMO_LOGIN_PASSWORD` 공유값이며, 운영에서는 설정이 기본값을 거부합니다.

이 PR로 **#327(상담 실연결)의 선행 조건이 풀립니다** — 헬스장 7곳·트레이너 15명이 전부 DB에 있어 상담 대상 검증이 404를 내지 않습니다.

