### PR TITLE
fix(dashboard): 영어 로케일에서 홈 카드 헤더가 넘치던 문제

### DIFF
--- a/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
@@ -286,6 +286,50 @@ class _HomeCard extends StatelessWidget {
   }
 }
 
+/// 홈 카드 헤더 — 제목 + AI 필 + 더보기 링크. 식단·운동 카드가 같은 구조라
+/// 한 곳에 둔다.
+///
+/// 셋 다 고유 폭을 요구하고 `Spacer` 로 밀어내던 예전 구조는 문구가 긴
+/// 로케일에서 그대로 넘쳤다(영어 폰 폭에서 `RenderFlex overflowed`, #440).
+/// 더보기 링크는 누를 것이라 항상 남기고, 제목·필이 남는 폭에 맞춰 줄어든다.
+class _CardHeader extends StatelessWidget {
+  const _CardHeader({required this.icon, required this.label, this.onOpen});
+
+  final IconData icon;
+  final String label;
+  final VoidCallback? onOpen;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations l = AppLocalizations.of(context);
+    return Row(
+      children: <Widget>[
+        Expanded(
+          child: Row(
+            children: <Widget>[
+              Flexible(child: _CardTitle(icon: icon, label: label)),
+              const SizedBox(width: 6),
+              // 필은 글자를 자르면 'AI ana…' 처럼 읽히지 않아 통째로 축소한다.
+              Flexible(
+                child: FittedBox(
+                  fit: BoxFit.scaleDown,
+                  alignment: Alignment.centerLeft,
+                  child: AiPill(
+                    l.homeAiAnalysisPill,
+                    background: FigmaColors.primaryA(0.10),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(width: 8),
+        _DetailLink(onTap: onOpen),
+      ],
+    );
+  }
+}
+
 class _CardTitle extends StatelessWidget {
   const _CardTitle({required this.icon, required this.label});
   final IconData icon;
@@ -294,6 +338,7 @@ class _CardTitle extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Row(
+      mainAxisSize: MainAxisSize.min,
       children: <Widget>[
         Container(
           width: 24,
@@ -305,12 +350,17 @@ class _CardTitle extends StatelessWidget {
           child: Icon(icon, size: 14, color: FigmaColors.primary),
         ),
         const SizedBox(width: 6),
-        Text(
-          label,
-          style: const TextStyle(
-            fontSize: 12.5,
-            fontWeight: FontWeight.w700,
-            color: FigmaColors.ink,
+        // 폭이 모자라면 제목부터 줄인다 — 아이콘·필·더보기는 남긴다(#440).
+        Flexible(
+          child: Text(
+            label,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: const TextStyle(
+              fontSize: 12.5,
+              fontWeight: FontWeight.w700,
+              color: FigmaColors.ink,
+            ),
           ),
         ),
       ],
@@ -355,20 +405,10 @@ class _DietNutritionCardState extends State<_DietNutritionCard> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          Row(
-            children: <Widget>[
-              _CardTitle(
-                icon: Icons.restaurant_rounded,
-                label: l.homeDietNutritionTitle,
-              ),
-              const SizedBox(width: 6),
-              AiPill(
-                l.homeAiAnalysisPill,
-                background: FigmaColors.primaryA(0.10),
-              ),
-              const Spacer(),
-              _DetailLink(onTap: widget.onOpen),
-            ],
+          _CardHeader(
+            icon: Icons.restaurant_rounded,
+            label: l.homeDietNutritionTitle,
+            onOpen: widget.onOpen,
           ),
           const SizedBox(height: 14),
           // 상단: 칼로리·나트륨·당류를 큰 숫자 카드로 나란히. 탭하면 아래
@@ -807,20 +847,10 @@ class _ExerciseCard extends ConsumerWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          Row(
-            children: <Widget>[
-              _CardTitle(
-                icon: Icons.fitness_center_rounded,
-                label: l.dashboardMetricExercise,
-              ),
-              const SizedBox(width: 6),
-              AiPill(
-                l.homeAiAnalysisPill,
-                background: FigmaColors.primaryA(0.10),
-              ),
-              const Spacer(),
-              _DetailLink(onTap: onOpen),
-            ],
+          _CardHeader(
+            icon: Icons.fitness_center_rounded,
+            label: l.dashboardMetricExercise,
+            onOpen: onOpen,
           ),
           const SizedBox(height: 14),
           // 지표 3개는 왼쪽에 세로로, 주간 추이 그래프는 오른쪽에 나란히 둔다.

--- a/frontend/flutter/test/features/dashboard/dashboard_content_state_test.dart
+++ b/frontend/flutter/test/features/dashboard/dashboard_content_state_test.dart
@@ -54,6 +54,7 @@ void main() {
     WidgetTester tester, {
     required Future<DashboardSummary> Function() load,
     Size size = const Size(800, 1600),
+    Locale locale = const Locale('ko'),
   }) async {
     await tester.binding.setSurfaceSize(size);
     addTearDown(() => tester.binding.setSurfaceSize(null));
@@ -72,11 +73,11 @@ void main() {
             MockMemberCoachRepository(),
           ),
         ],
-        child: const MaterialApp(
-          locale: Locale('ko'),
+        child: MaterialApp(
+          locale: locale,
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
-          home: Scaffold(body: DashboardContent()),
+          home: const Scaffold(body: DashboardContent()),
         ),
       ),
     );
@@ -340,6 +341,29 @@ void main() {
         find.byKey(const ValueKey<String>('dashboard-exercise-chart')),
         findsOneWidget,
       );
+      expect(tester.takeException(), isNull);
+    });
+  }
+
+  // 위 회귀 테스트는 한국어로만 돌아, 영어에서 카드 헤더가 넘치는 것을 놓쳤다
+  // (#440). 같은 문구가 영어에서 훨씬 길다 — '식단 · 영양' vs
+  // 'Diet & nutrition', '✦ AI 분석' vs '✦ AI analysis'.
+  for (final double width in <double>[360, 390, 480]) {
+    testWidgets('영어 로케일도 ${width}px 에서 넘치지 않는다 (#440)', (
+      WidgetTester tester,
+    ) async {
+      await pumpDashboard(
+        tester,
+        load: () async => liveSummary,
+        size: Size(width, 2200),
+        locale: const Locale('en'),
+      );
+      await tester.pumpAndSettle();
+
+      final AppLocalizations en = lookupAppLocalizations(const Locale('en'));
+      // 헤더가 잘리면 더보기 링크부터 사라진다.
+      expect(find.text(en.homeDetails), findsWidgets);
+      expect(find.text(en.homeAiAnalysisPill), findsWidgets);
       expect(tester.takeException(), isNull);
     });
   }


### PR DESCRIPTION
Closes #440

## Summary

영어 로케일에서 홈 카드 헤더가 폰 폭(360~480px)에서 가로로 넘치던 문제를 고쳤습니다. 넘친 쪽이 더보기 링크라 잘려서 보이지 않았습니다.

한국어에서는 재현되지 않았습니다 — 같은 문구가 영어에서 훨씬 깁니다(`식단 · 영양` / `Diet & nutrition`, `✦ AI 분석` / `✦ AI analysis`).

## Root cause

카드 헤더 `Row` 의 세 자식(제목·AI 필·더보기)이 **전부 고유 폭을 요구**하고 `Spacer` 로 밀어내는 구조였습니다. `Spacer` 는 남는 공간을 먹을 뿐이라, 공간이 모자라면 줄어들 곳이 없어 그대로 넘칩니다. `_CardTitle` 의 `Text` 에도 `overflow`/`maxLines` 가 없었습니다.

식단 카드(`:357`)와 운동 카드(`:809`)가 같은 구조를 복붙하고 있어 양쪽 다 넘쳤습니다.

## Changes

두 카드의 헤더를 `_CardHeader` 하나로 묶고, 우선순위를 정해 줄어들게 했습니다.

- **더보기 링크는 항상 남깁니다** — 누르라고 있는 것이라 먼저 잘리면 안 됩니다
- **제목이 먼저 줄어듭니다** — `Flexible` + `TextOverflow.ellipsis`
- **필은 통째로 축소합니다** — `FittedBox(scaleDown)`. 글자를 자르면 `✦ AI ana…` 처럼 읽히지 않습니다

## Verification

- `flutter analyze` 이슈 0
- `flutter test` **288건 통과**
- 기존 오버플로 회귀 테스트가 **한국어로만** 돌아 이걸 놓쳤습니다. `pumpDashboard` 가 `locale` 을 받게 하고 **영어 360·390·480 세 폭**을 추가했습니다 — 수정 전에는 세 건 모두 `RenderFlex overflowed` 로 실패하는 것을 확인했습니다
- 한국어 레이아웃은 그대로입니다(기존 360·480·800 회귀 테스트 통과)
- 브라우저 육안 확인은 하지 못했습니다 — 프리뷰 브라우저의 시스템 로케일이 한국어라 영어 화면이 뜨지 않고, 한글 폰트도 없어 두부(□)로 그려집니다. 대신 위 세 폭 테스트가 `tester.takeException()` 으로 오버플로 예외를 직접 잡습니다

## Notes

하단 내비 라벨(`main_shell.dart:147`)도 영어에서 넘치지만 #437 이 이미 다루고 있어 건드리지 않았습니다.

PR #439(조언 문구 현지화)는 이 문제를 피하려고 영어 테스트만 넓은 폭으로 돌립니다. 두 PR 이 모두 머지되면 그 폭 제한을 풀 수 있습니다 — 같은 파일을 건드리지만 영역이 달라 충돌은 없습니다.
