### PR TITLE
fix(consultation): 트레이너 헬스장 소속 검증 추가

### DIFF
--- a/backend/app/services/consultation_service.py
+++ b/backend/app/services/consultation_service.py
@@ -51,10 +51,12 @@ def _validate_target(db: Session, payload: ConsultationCreate) -> None:
     trainer = db.scalar(
         select(User)
         .join(TrainerProfile, TrainerProfile.trainer_id == User.id)
+        .join(Place, Place.id == TrainerProfile.gym_id)
         .where(
             User.id == payload.trainer_id,
             User.role == "trainer",
             User.is_active.is_(True),
+            Place.category == "fitness",
         )
     )
     if trainer is None:

--- a/backend/docs/DEPLOY.md
+++ b/backend/docs/DEPLOY.md
@@ -117,6 +117,11 @@ flutter build web --release \
 ```
 0009_diet_idempotency_key → 0010_diet_entry_macros(#207) → 0011_health_daily_sugar_g(#231)
                           → 0012_trainer_domain(트레이너 도메인) → 0013_trainer_active_coach_uq(active 담당 unique index)
+                          → 0014_consultation_requests ─┐
+                          → 0014_drop_trainer_prof_ix ──┴→ 0015_merge_alembic_heads
+                          → 0016_drop_vitals → 0017_add_diet_exercise_goals
+                          → 0018_diet_entry_sugar_g_float → 0019_trainer_noti_settings
+                          → 0020_gym_profiles_trainer_fk
 ```
 
 **원칙**: 나중에 머지되는 마이그레이션의 `down_revision` 을 현재 main head 로 맞춰 한 줄로 잇는다

--- a/backend/docs/TRAINER_DOMAIN.md
+++ b/backend/docs/TRAINER_DOMAIN.md
@@ -69,6 +69,9 @@
 - 관계 판단의 기준은 `gym_id`다. 기존 `gym_name`, `gym_address`, `gym_hours`,
   `gym_phone`은 트레이너 웹의 `gym {name, address, hours, phone}` 계약을
   유지하기 위한 호환 필드로 당분간 남겨 둔다.
+- 현재 `gym_id`를 채우는 경로는 `seed_gyms.py`의 `gym_name` 이름 매칭
+  백필뿐이다. 설정 API는 아직 없고, 트레이너 앱의 프로필 수정은
+  호환용 `gym_*` 문자열만 바꾼다(후속 과제).
 
 ## 4. 트레이너 API (`/v1/trainer/*`, RequireTrainer)
 
@@ -184,8 +187,13 @@ O2O 코칭의 재등록 고리. 세션 수·완료 수는 `trainer_schedule`, �
 
 ## 8. 마이그레이션 선형화 주의
 
-트레이너 마이그레이션은 스택이 **가장 마지막에 머지**되므로 병렬로 갈라졌던 번호를
-재선형화했다: `0010_diet_entry_macros`(#207) → `0011_health_daily_sugar_g`(#230/#231)
-→ **`0012_trainer_domain`**(도메인 테이블) → **`0013_trainer_active_coach_uq`**(회원당
-active 담당 1명 partial unique index). 반드시 `0010`·`0011`이 main에 반영된 뒤 머지해야
-alembic 단일 head가 유지된다. 자세한 배포/마이그레이션 절차는 배포 문서를 참고.
+트레이너 마이그레이션은 `0012_trainer_domain` →
+`0013_trainer_active_coach_uq` 뒤에 상담·트레이너 인덱스의 두 `0014` 분기를
+`0015_merge_alembic_heads`로 합친다. 그 뒤는 `0016_drop_vitals` →
+`0017_add_diet_exercise_goals` → `0018_diet_entry_sugar_g_float` →
+`0019_trainer_noti_settings` → **`0020_gym_profiles_trainer_fk`** 순의 단일
+chain이다. `0020`의 `down_revision`은 `0019_trainer_noti_settings`다.
+
+배포는 이 순서를 따라 `alembic upgrade head`를 실행하며, CI에서
+`alembic heads`가 하나인지 먼저 검증한다. 이미 별도 migration head를 적용한 DB는
+`down_revision`을 임의로 바꾸지 말고 배포 문서의 merge revision 절차를 따른다.

--- a/backend/docs/TRAINER_DOMAIN.md
+++ b/backend/docs/TRAINER_DOMAIN.md
@@ -53,6 +53,23 @@
 > 정책이 복수 담당으로 바뀌면 이 인덱스를 제거하고 회원측 코치·채팅·루틴 API를
 > **목록 기반**으로 바꿔야 한다(현재는 단일 담당 가정).
 
+### 트레이너 헬스장 소속 정책 (`0020_gym_profiles_trainer_fk`)
+
+- 트레이너는 현재 **헬스장 한 곳**에만 소속한다. `TrainerProfile.gym_id`는
+  `places.id`를 참조하는 단일 nullable FK이며, 복수 소속 관계 테이블은 두지 않는다.
+- `gym_id`는 기존 프로필과 헬스장 삭제를 안전하게 처리하기 위해 nullable이다.
+  헬스장 `Place`가 삭제되면 `ON DELETE SET NULL`로 소속만 해제되고 트레이너
+  계정은 남는다. 트레이너 `User`가 삭제되면 프로필은 `ON DELETE CASCADE`로
+  함께 삭제된다.
+- 상담 요청은 `gym_id`가 실제로 존재하는 `Place`를 가리키고 그 장소의
+  `category == "fitness"`일 때만 트레이너를 유효한 대상으로 인정한다. FK만으로는
+  다른 카테고리를 막을 수 없어 `consultation_service._validate_target()`에서 검증한다.
+- 소속 변경 이력은 **현재 보존하지 않는다**. 프로필의 `gym_id`를 교체하며,
+  이력·복수 소속이 실제 요구되면 별도 관계 테이블로 확장한다.
+- 관계 판단의 기준은 `gym_id`다. 기존 `gym_name`, `gym_address`, `gym_hours`,
+  `gym_phone`은 트레이너 웹의 `gym {name, address, hours, phone}` 계약을
+  유지하기 위한 호환 필드로 당분간 남겨 둔다.
+
 ## 4. 트레이너 API (`/v1/trainer/*`, RequireTrainer)
 
 | Method | Path | 설명 |

--- a/backend/tests/test_consultations.py
+++ b/backend/tests/test_consultations.py
@@ -81,8 +81,15 @@ def _create_trainer(
     role: str = "trainer",
     active: bool = True,
     with_profile: bool = True,
+    with_gym: bool = True,
+    gym_category: str = "fitness",
 ) -> User:
     suffix = uuid4().hex[:10]
+    gym = (
+        _create_place(db_session, category=gym_category)
+        if with_profile and with_gym
+        else None
+    )
     trainer = User(
         id=f"consult-trainer-{suffix}",
         email=f"{TEST_EMAIL_PREFIX}trainer-{suffix}@oncare.com",
@@ -93,7 +100,12 @@ def _create_trainer(
     db_session.add(trainer)
     db_session.flush()
     if with_profile:
-        db_session.add(TrainerProfile(trainer_id=trainer.id))
+        db_session.add(
+            TrainerProfile(
+                trainer_id=trainer.id,
+                gym_id=gym.id if gym is not None else None,
+            )
+        )
     db_session.commit()
     return trainer
 
@@ -315,6 +327,32 @@ def test_invalid_trainer_target_is_rejected(
         "/v1/consultations",
         headers=_auth(token),
         json=_payload(target_type="trainer", trainer_id=trainer_id),
+    )
+
+    assert response.status_code == 404
+
+
+def test_trainer_without_gym_is_rejected(client, db_session):
+    _, token = _register_member(client)
+    trainer = _create_trainer(db_session, with_gym=False)
+
+    response = client.post(
+        "/v1/consultations",
+        headers=_auth(token),
+        json=_payload(target_type="trainer", trainer_id=trainer.id),
+    )
+
+    assert response.status_code == 404
+
+
+def test_trainer_at_non_fitness_place_is_rejected(client, db_session):
+    _, token = _register_member(client)
+    trainer = _create_trainer(db_session, gym_category="medical")
+
+    response = client.post(
+        "/v1/consultations",
+        headers=_auth(token),
+        json=_payload(target_type="trainer", trainer_id=trainer.id),
     )
 
     assert response.status_code == 404


### PR DESCRIPTION
## Summary

* 트레이너 상담 요청 시 실제 헬스장 소속을 검증합니다.
* 트레이너 프로필의 `gym_id`가 가리키는 장소가 존재하고 `category == "fitness"`인 경우만 상담 대상으로 허용합니다.
* 기존 상담 API와 트레이너 웹의 단일 `gym` 응답 계약은 변경하지 않습니다.
* 단일 소속, 삭제 동작, 이력 미보존, 기존 문자열 호환 정책을 트레이너 도메인 문서에 명시합니다.

---

## Changes

### ✨ Features

* 기존 `TrainerProfile.gym_id → Place.id` 관계를 상담 대상 검증에 활용했습니다.
* 유효한 fitness Place 소속 트레이너 상담 성공 경로를 테스트 fixture에 반영했습니다.

### 🔧 Improvements

* 기존 User 존재, trainer role, active, TrainerProfile 존재 검증을 그대로 유지했습니다.
* 무소속 트레이너와 non-fitness Place 소속 트레이너가 상담 대상으로 선택되지 않도록 했습니다.

### 🎨 UI/UX

* 변경 없음

### 📝 Docs

* `TRAINER_DOMAIN.md`에 트레이너–헬스장 소속 정책을 추가했습니다.
* 헬스장 삭제 시 `SET NULL`, 트레이너 삭제 시 프로필 `CASCADE`를 명시했습니다.
* 소속 변경 이력을 현재 보존하지 않고, 복수 소속이 필요할 때 관계 테이블로 확장한다는 경계를 남겼습니다.

### 🐛 Fixes

* TrainerProfile만 존재하면 실제 헬스장 소속 없이도 트레이너 상담 요청이 생성되던 문제를 수정했습니다.

---

## Commits

1. `958d091` fix(consultation): 트레이너 헬스장 소속 검증 추가
2. `ac7a945` docs(trainer): 헬스장 소속 정책 명시

---

## Notes

* PR #438에서 추가된 nullable `TrainerProfile.gym_id` FK와 `0020_gym_profiles_trainer_fk` migration을 재사용합니다.
* 기존 `gym_name`, `gym_address`, `gym_hours`, `gym_phone` 문자열 필드는 유지합니다.
* 트레이너 상담 request body는 기존처럼 `trainer_id`만 사용하며 `gym_id`를 추가하지 않습니다.
* 트레이너는 현재 헬스장 한 곳에만 소속하며, 소속 변경 이력은 보존하지 않는 것으로 결정했습니다.
* PR #441은 기존 상담 API를 회원 Flutter에 연결하는 작업으로, 이 PR의 백엔드 검증과 파일 의존성이 없어 병합 순서에 관계없이 호환됩니다.
* 로컬 PostgreSQL이 없어 DB fixture 기반 테스트는 기존 정책에 따라 skip됐고, 대상 검증 쿼리는 in-memory DB로 별도 확인했습니다.

---

## Test Plan

* [x] 유효한 fitness Place 소속 트레이너 허용 확인
* [x] 무소속 트레이너 거부 확인
* [x] non-fitness Place 소속 트레이너 거부 확인
* [x] inactive, non-trainer, 프로필 없음, 사용자 없음 거부 확인
* [x] 기존 gym 상담 검증 유지 확인
* [x] 백엔드 전체 테스트 통과 (`101 passed, 257 skipped`)
* [x] Alembic 단일 head 및 PostgreSQL offline upgrade SQL 생성 확인
* [x] 단일 소속·삭제·이력·호환 정책 문서화

### Manual Test Steps

1. fitness Place에 연결된 trainer의 `trainer_id`로 `POST /v1/consultations`를 호출합니다.
2. 응답이 201이고 기존 응답 계약이 유지되는지 확인합니다.
3. `gym_id`가 없거나 non-fitness Place에 연결된 trainer로 호출해 404를 확인합니다.

---

## Related Issues

Closes #301

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 상담 대상 트레이너가 활성 상태와 올바른 역할뿐 아니라 `fitness` 카테고리의 헬스장에 소속되어 있어야 상담 요청이 가능합니다.
  * 조건을 충족하지 않는 트레이너에 대한 상담 요청은 기존과 같이 404 오류로 처리됩니다.

* **문서**
  * 트레이너의 헬스장 소속 및 상담 대상 유효성 정책을 문서화했습니다.
  * 데이터베이스 변경 사항의 적용 순서와 배포 시 확인 절차를 정리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->