### PR TITLE
perf(nutrition): 영양 DB 매칭이 요청마다 전건 로드 — 캐시 또는 DB 조회로 전환

### DIFF
--- a/backend/app/services/nutrition/enrich.py
+++ b/backend/app/services/nutrition/enrich.py
@@ -23,15 +23,14 @@
 """
 from __future__ import annotations
 
-from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.models.models import FoodNutrient
 from app.schemas.diet import DietAnalysis, RecognizedFood
 from app.services.nutrition.matcher import match_in_rows
+from app.services.nutrition.table import NutrientRow, load_rows
 
 
-def _grams(food: RecognizedFood, match: FoodNutrient) -> float | None:
+def _grams(food: RecognizedFood, match: NutrientRow) -> float | None:
     """환산에 쓸 양(g). 인식기 추정이 우선, 없으면 알려진 1회 섭취량."""
     if food.amount_g and food.amount_g > 0:
         return float(food.amount_g)
@@ -49,7 +48,7 @@ def enrich_analysis(db: Session, analysis: DietAnalysis, enabled: bool = True) -
                 f.source = "estimate"
         return analysis
 
-    rows = db.scalars(select(FoodNutrient)).all()
+    rows = load_rows(db)
     for food in analysis.foods:
         match = match_in_rows(rows, food.name)
         grams = _grams(food, match) if match is not None else None

--- a/backend/app/services/nutrition/matcher.py
+++ b/backend/app/services/nutrition/matcher.py
@@ -50,10 +50,7 @@ def match_in_rows(rows, name: str):
 
 
 def match_food(db, name: str):
-    """DB 세션으로 food_nutrients 전체를 읽어 매칭(작은 참조표라 전건 로드로 충분)."""
-    from sqlalchemy import select
+    """food_nutrients 전건에 매칭(작은 참조표라 전건 로드로 충분 — 로드는 캐시된다)."""
+    from app.services.nutrition.table import load_rows
 
-    from app.models.models import FoodNutrient
-
-    rows = db.scalars(select(FoodNutrient)).all()
-    return match_in_rows(rows, name)
+    return match_in_rows(load_rows(db), name)

--- a/backend/app/services/nutrition/table.py
+++ b/backend/app/services/nutrition/table.py
@@ -1,0 +1,109 @@
+"""`food_nutrients` 참조표 로딩 + 프로세스 캐시.
+
+이 표는 시딩 후 읽기 전용이고 전체가 2천 행 남짓이라, 요청마다 다시 읽을
+이유가 없다(#424). 전건 로드는 2,127행 기준 중앙값 21.5ms 로 `/diet/analyze`
+한 건의 DB 시간을 사실상 전부 차지한다. 표가 커질수록 선형으로 늘어난다.
+
+## ORM 인스턴스를 캐시하지 않는 이유
+
+`FoodNutrient` 인스턴스는 세션에 묶여 있다. 커밋 시 만료(expire_on_commit)되고
+세션이 닫히면 detached 라, 다음 요청에서 속성을 읽는 순간 터진다. 그래서
+필요한 값만 복사한 불변 스냅샷(`NutrientRow`)을 캐시한다. 매칭기(`matcher`)는
+`.name_norm` 만 보는 덕타이핑이라 이 교체에 영향받지 않는다.
+
+## 무효화
+
+`FoodNutrient` 를 건드린 세션이 커밋/롤백하면 자동으로 비운다(아래 이벤트 훅).
+ORM 을 거치지 않는 변경(Core bulk insert, 마이그레이션, psql 직접 수정)은
+훅이 잡지 못하므로, 그런 경로를 새로 만든다면 `invalidate()` 를 직접 부른다.
+프로세스 밖의 변경(다른 워커·마이그레이션)은 재기동으로 반영된다 — 시딩 후
+바뀌지 않는 표라는 전제가 깨지면 이 캐시 자체를 다시 따져야 한다.
+"""
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, fields
+
+from sqlalchemy import event, select
+from sqlalchemy.orm import Session
+
+from app.models.models import FoodNutrient
+
+
+@dataclass(frozen=True, slots=True)
+class NutrientRow:
+    """세션에 묶이지 않은 `food_nutrients` 한 행. 값은 100g 기준."""
+
+    id: int
+    name: str
+    name_norm: str
+    category: str
+    serving_size_g: float | None
+    calories: float
+    sodium_mg: float
+    sugar_g: float
+    carbs_g: float | None
+    protein_g: float | None
+    fat_g: float | None
+
+
+_lock = threading.Lock()
+_cache: tuple[NutrientRow, ...] | None = None
+# 로드 중에 들어온 무효화를 놓치지 않기 위한 세대 번호. 쿼리 전후로 값이
+# 달라졌으면 그 사이 표가 바뀐 것이므로 결과를 캐시하지 않는다.
+_generation = 0
+
+
+# 컬럼만 읽는다(엔티티 아님). 어차피 스냅샷으로 옮겨 담을 값이라 ORM 인스턴스
+# 2,127개를 만들 이유가 없고, 세션 identity map 도 더럽히지 않는다.
+# 조회 순서를 필드에서 파생시켜야 위치 기반 생성이 어긋날 수 없다 —
+# 필드를 추가하면 컬럼도 같이 따라온다(없는 컬럼이면 import 시점에 터진다).
+_COLUMNS = tuple(getattr(FoodNutrient, f.name) for f in fields(NutrientRow))
+
+
+def load_rows(db: Session) -> tuple[NutrientRow, ...]:
+    """참조표 전건. 캐시가 살아 있으면 DB 를 치지 않는다."""
+    global _cache
+
+    cached = _cache
+    if cached is not None:
+        return cached
+
+    with _lock:
+        generation = _generation
+    rows = tuple(NutrientRow(*r) for r in db.execute(select(*_COLUMNS)))
+
+    with _lock:
+        if generation == _generation:
+            _cache = rows
+    return rows
+
+
+def invalidate() -> None:
+    """캐시를 비운다. 다음 `load_rows` 가 DB 에서 다시 읽는다."""
+    global _cache, _generation
+    with _lock:
+        _cache = None
+        _generation += 1
+
+
+_DIRTY_KEY = "oncare_food_nutrients_dirty"
+
+
+@event.listens_for(Session, "after_flush")
+def _mark_dirty(session: Session, flush_context: object) -> None:
+    if any(
+        isinstance(obj, FoodNutrient)
+        for obj in (*session.new, *session.dirty, *session.deleted)
+    ):
+        session.info[_DIRTY_KEY] = True
+
+
+# 커밋뿐 아니라 롤백에서도 비운다. 커밋 전 같은 세션에서 캐시가 채워졌다면
+# 아직 확정되지 않은 행이 들어갔을 수 있고, 그 트랜잭션이 되돌아가면 캐시만
+# 남는다.
+@event.listens_for(Session, "after_commit")
+@event.listens_for(Session, "after_soft_rollback")
+def _invalidate_if_dirty(session: Session, *_: object) -> None:
+    if session.info.pop(_DIRTY_KEY, False):
+        invalidate()

--- a/backend/tests/test_nutrition.py
+++ b/backend/tests/test_nutrition.py
@@ -259,3 +259,91 @@ def test_vision_parser_keeps_amount_g():
     )
     assert [f.amount_g for f in analysis.foods] == [320.5, None, None]
 
+
+
+# ---------- 참조표 캐시 (#424) ----------
+
+def _count_queries(db, fn):
+    """fn 실행 중 나간 SQL 문 개수."""
+    from sqlalchemy import event
+
+    n = 0
+
+    def _seen(*_args, **_kw):
+        nonlocal n
+        n += 1
+
+    bind = db.get_bind()
+    event.listen(bind, "before_cursor_execute", _seen)
+    try:
+        fn()
+    finally:
+        event.remove(bind, "before_cursor_execute", _seen)
+    return n
+
+
+def test_nutrient_table_loads_once(db_session):
+    """전건 로드가 요청마다 반복되면 안 된다 — 두 번째부터는 DB 를 안 친다."""
+    from app.services.nutrition.table import invalidate, load_rows
+
+    invalidate()
+    assert _count_queries(db_session, lambda: load_rows(db_session)) == 1
+    assert _count_queries(db_session, lambda: load_rows(db_session)) == 0
+    # 캐시된 값도 실제 시드 내용이어야 한다(빈 튜플을 캐시해 놓고 통과하면 곤란).
+    assert any(r.name_norm == "김치찌개" for r in load_rows(db_session))
+
+
+def test_nutrient_table_cache_survives_detach(db_session):
+    """캐시가 ORM 인스턴스면 세션이 닫힌 뒤 속성 접근에서 터진다."""
+    from app.db.session import SessionLocal
+    from app.services.nutrition.table import invalidate, load_rows
+
+    invalidate()
+    other = SessionLocal()
+    try:
+        rows = load_rows(other)
+    finally:
+        other.close()
+    assert [r.name_norm for r in rows]          # detached 여도 읽힌다
+    assert load_rows(db_session) is rows        # 다른 세션도 같은 캐시를 쓴다
+
+
+def test_nutrient_table_cache_invalidated_on_commit(db_session):
+    """시드가 갱신되면 캐시가 비워져야 한다 — 안 그러면 새 음식이 영영 안 잡힌다."""
+    from app.models.models import FoodNutrient
+    from app.services.nutrition.matcher import match_food, normalize
+    from app.services.nutrition.table import load_rows
+
+    load_rows(db_session)                       # 캐시 채우기
+    assert match_food(db_session, "zzcacheinvalidate") is None
+
+    row = FoodNutrient(
+        name="zzcacheinvalidate", name_norm=normalize("zzcacheinvalidate"),
+        calories=100, sodium_mg=10, sugar_g=1, serving_size_g=100,
+    )
+    db_session.add(row)
+    db_session.commit()
+    try:
+        assert match_food(db_session, "zzcacheinvalidate") is not None
+    finally:
+        # 이 테스트는 삽입 전 상태(None)를 확인하므로 흔적을 남기면 재실행이 깨진다.
+        db_session.delete(row)
+        db_session.commit()
+
+
+def test_nutrient_table_cache_invalidated_on_rollback(db_session):
+    """되돌아간 트랜잭션의 행이 캐시에 남으면 안 된다."""
+    from app.models.models import FoodNutrient
+    from app.services.nutrition.matcher import match_food, normalize
+    from app.services.nutrition.table import invalidate, load_rows
+
+    invalidate()
+    db_session.add(FoodNutrient(
+        name="zzrollbackrow", name_norm=normalize("zzrollbackrow"),
+        calories=100, sodium_mg=10, sugar_g=1, serving_size_g=100,
+    ))
+    db_session.flush()
+    load_rows(db_session)                       # 미확정 행이 든 상태로 캐시 채우기
+    db_session.rollback()
+
+    assert match_food(db_session, "zzrollbackrow") is None


### PR DESCRIPTION
Closes #424

## Summary

`/diet/analyze` 는 요청마다 `food_nutrients` 전건을 다시 읽었습니다. 시딩 후 읽기 전용인 표라 프로세스 캐시로 한 번만 읽도록 바꿉니다.

이슈의 선택지 중 **1번(프로세스 캐시)** 을 택했습니다. 변경이 가장 작고 `matcher.py` 의 순수 함수 구조를 그대로 지킵니다.

## Changes

- `app/services/nutrition/table.py` 신설 — 참조표 로딩 + 캐시를 한곳에 모았습니다.
  - **ORM 인스턴스를 캐시하지 않습니다.** `FoodNutrient` 는 세션에 묶여 있어 커밋 시 만료되고 세션이 닫히면 detached 라, 다음 요청에서 속성을 읽는 순간 터집니다. 필요한 값만 복사한 불변 스냅샷 `NutrientRow` 를 캐시합니다.
  - 엔티티 대신 **컬럼만 조회**합니다. 어차피 값으로 옮겨 담을 것이라 ORM 인스턴스 2,127개를 만들 이유가 없고, 세션 identity map 도 안 더럽힙니다. 조회 컬럼 목록은 데이터클래스 필드에서 파생시켜 위치 기반 생성이 어긋날 수 없게 했습니다.
  - 무효화는 `FoodNutrient` 를 건드린 세션의 **커밋·롤백에서 자동**입니다(`after_flush` 로 표시 → `after_commit`/`after_soft_rollback` 에서 비움). 롤백까지 거는 것은 커밋 전에 캐시가 채워졌을 때 미확정 행이 캐시에만 남는 경로를 막기 위해서입니다.
- `enrich_analysis` · `match_food` 가 이 로더를 쓰도록 교체. `matcher.match_in_rows` 는 `.name_norm` 덕타이핑이라 순수 함수 구조 그대로입니다.
- 테스트 4건 추가 — 두 번째 로드는 SQL 을 안 친다 / 세션이 닫혀도 캐시가 읽힌다 / 커밋 후 새 행이 잡힌다 / 롤백된 행은 안 남는다.

## Verification

로컬 Postgres, 2,127행(이슈 실측과 같은 조건):

| | 변경 전 | 변경 후 |
|---|---|---|
| 전건 로드 (최초) | 21.5ms | **16.1ms** |
| 요청 1건(음식 3개) | 23.0ms | **0.04ms** |

컬럼 조회로 바꾼 덕에 최초 로드도 같이 줄었습니다.

`pytest` 전체 **364 passed**.

## Notes

- 이슈가 "지금은 급하지 않다"고 적어 둔 판단은 여전히 맞습니다. 같은 요청의 Gemini 비전 호출이 수 초라 사용자 체감 변화는 없습니다. 표가 커질 때를 대비한 정리이고, 변경 범위가 한 모듈이라 지금 해 두는 비용이 작다고 봤습니다.
- 워커가 여러 개면 캐시도 프로세스마다입니다. ORM 을 거치지 않는 변경(Core bulk insert, 마이그레이션, psql 직접 수정)은 훅이 못 잡으므로 그런 경로를 새로 만들면 `invalidate()` 를 직접 불러야 합니다 — 모듈 docstring 에 적어 뒀습니다.
- 스키마 변경 없음. 마이그레이션 불필요합니다.
