### PR TITLE
feat(gym): 회원↔헬스장 링크 분리 — 트레이너만 해제 지원

### DIFF
--- a/backend/app/api/v1/gyms.py
+++ b/backend/app/api/v1/gyms.py
@@ -42,6 +42,26 @@ def list_gyms(
     return gym_service.list_gyms(db, lat=lat, lng=lng, partner_only=partner_only)
 
 
+@router.get("/me/gym", response_model=GymOut)
+def my_gym(
+    current_user: CurrentUser,
+    db: Annotated[Session, Depends(get_db)],
+    lat: float | None = Query(None, ge=-90, le=90),
+    lng: float | None = Query(None, ge=-180, le=180),
+) -> GymOut:
+    """내 헬스장. 연결이 없으면 404. (#444)
+
+    `GET /me/coach` 와 나눠 둔다 — 담당 트레이너만 해제한 회원은 코치가 404 여도
+    헬스장 카드는 계속 떠야 한다. 응답은 `/gyms/{id}` 와 같은 형태라 앱이 상세를
+    한 번 더 읽지 않아도 된다.
+    """
+    _require_coordinate_pair(lat, lng)
+    gym = gym_service.get_member_gym(db, current_user.id, lat=lat, lng=lng)
+    if gym is None:
+        raise HTTPException(status_code=404, detail="연결된 헬스장이 없습니다.")
+    return gym
+
+
 @router.get("/gyms/{gym_id}", response_model=GymOut)
 def get_gym(
     gym_id: str,

--- a/backend/app/api/v1/member_coach.py
+++ b/backend/app/api/v1/member_coach.py
@@ -50,10 +50,27 @@ def disconnect_my_coach(
     current_user: CurrentUser,
     db: Annotated[Session, Depends(get_db)],
 ) -> None:
-    """담당 트레이너 연결 해제 — MY 탭의 연결 삭제.
+    """코치 관계 전체 해제 — MY 탭의 **헬스장** 휴지통.
 
-    이미 담당이 없으면 404 가 아니라 204 다. 해제는 멱등이어야 하고, 두 번 눌렀다고
+    `GET /me/coach` 가 트레이너와 헬스장을 함께 돌려주듯, 이 삭제도 둘 다 끊는다.
+    떠난 헬스장의 트레이너를 담당으로 남길 수는 없기 때문이다. 트레이너만 끊으려면
+    `DELETE /me/coach/trainer` 를 쓴다. (#444)
+
+    이미 연결이 없으면 404 가 아니라 204 다. 해제는 멱등이어야 하고, 두 번 눌렀다고
     오류 화면을 보일 이유가 없다.
+    """
+    trainer_service.disconnect_member_gym(db, current_user.id)
+
+
+@router.delete("/me/coach/trainer", status_code=204)
+def disconnect_my_trainer(
+    current_user: CurrentUser,
+    db: Annotated[Session, Depends(get_db)],
+) -> None:
+    """담당 트레이너만 해제 — 헬스장 연결은 남는다. MY 탭의 **트레이너** 휴지통.
+
+    헬스장은 그대로 두고 담당만 바꾸는 흐름(트레이너 교체)이 있어야 하므로 전체
+    해제와 나눈다. 전체 해제와 마찬가지로 멱등이다. (#444)
     """
     trainer_service.disconnect_member_coach(db, current_user.id)
 

--- a/backend/app/db/seed_gyms.py
+++ b/backend/app/db/seed_gyms.py
@@ -226,6 +226,36 @@ def _seed_trainers(db: Session) -> int:
     return created
 
 
+def _seed_member_gym_links(db: Session) -> int:
+    """회원↔헬스장 링크(멱등). 담당 트레이너의 소속으로 채운다. (#444)
+
+    마이그레이션 `0021_member_gym_link` 의 백필과 같은 규칙이다. 스키마를
+    `create_all` 로 만드는 경로(로컬·테스트)에는 그 백필이 돌지 않으므로 여기서도
+    채워야 마이그레이션 DB 와 같은 상태가 된다.
+
+    이미 링크가 있는 회원은 건드리지 않는다 — 회원이 트레이너와 다른 헬스장으로
+    옮겼을 수 있고, 시드가 그걸 되돌리면 안 된다.
+    """
+    created = 0
+    rows = db.execute(
+        select(models.TrainerClient.member_id, models.TrainerProfile.gym_id)
+        .join(
+            models.TrainerProfile,
+            models.TrainerProfile.trainer_id == models.TrainerClient.trainer_id,
+        )
+        .where(
+            models.TrainerClient.active.is_(True),
+            models.TrainerProfile.gym_id.is_not(None),
+        )
+    ).all()
+    for member_id, gym_id in rows:
+        if db.get(models.MemberGym, member_id) is not None:
+            continue
+        db.add(models.MemberGym(member_id=member_id, gym_id=gym_id))
+        created += 1
+    return created
+
+
 def seed_partner_gyms() -> None:
     db: Session = SessionLocal()
     try:
@@ -278,10 +308,14 @@ def seed_partner_gyms() -> None:
             linked += 1
         db.commit()
 
-        if partner or discovered or trainers or linked:
+        members = _seed_member_gym_links(db)
+        db.commit()
+
+        if partner or discovered or trainers or linked or members:
             logger.info(
-                "헬스장 시드: 제휴 %d곳, 발견 %d곳, 트레이너 %d명, 소속 연결 %d명",
-                partner, discovered, trainers, linked,
+                "헬스장 시드: 제휴 %d곳, 발견 %d곳, 트레이너 %d명, 소속 연결 %d명, "
+                "회원 헬스장 %d명",
+                partner, discovered, trainers, linked, members,
             )
     finally:
         db.close()

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -277,6 +277,34 @@ class GymProfile(Base):
     )
 
 
+class MemberGym(Base):
+    """회원↔헬스장 링크 — 회원의 '내 헬스장'. (#444)
+
+    전에는 이 링크가 없어서 담당 트레이너의 소속(`TrainerProfile.gym_id`)에서
+    파생시켰다. 그래서 트레이너만 해제해도 헬스장이 함께 사라졌다 — 앱 MY 탭은
+    두 해제를 따로 제공하는데 서버가 그 구분을 표현하지 못했다.
+
+    `TrainerClient` 와 달리 `active` 이력 컬럼이 없다. 담당 링크는 루틴·채팅·일정이
+    참조해 지우면 이력이 끊기지만, 헬스장 링크를 참조하는 것은 없어 해제 시 행을
+    지우면 된다. 회원당 1곳이라는 불변식은 `member_id` 를 PK 로 두어 구조로 강제한다
+    (partial unique index 가 필요 없다).
+    """
+    __tablename__ = "member_gyms"
+
+    member_id: Mapped[str] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+    )
+    #: 헬스장은 `places`(category='fitness'). 장소가 사라지면 링크도 사라진다 —
+    #: gym_id 는 NOT NULL 이라 SET NULL 을 쓸 수 없고, 없어진 헬스장을 '내 헬스장'
+    #: 으로 남겨 둘 이유도 없다.
+    gym_id: Mapped[str] = mapped_column(
+        ForeignKey("places.id", ondelete="CASCADE"), index=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+
 class ConsultationRequest(Base):
     """회원의 헬스장·트레이너 상담 요청."""
     __tablename__ = "consultation_requests"

--- a/backend/app/services/gym_service.py
+++ b/backend/app/services/gym_service.py
@@ -130,12 +130,15 @@ def unlink_member_gym(db: Session, member_id: str) -> bool:
     """헬스장 연결 해제. 끊었으면 True, 원래 없었으면 False.
 
     담당 링크와 달리 행을 지운다 — 이 링크를 참조하는 이력이 없다.
+
+    **커밋하지 않는다.** 헬스장 해제는 담당 트레이너 해제와 함께 일어나므로
+    (`trainer_service.disconnect_member_gym`), 여기서 커밋하면 뒤 단계가 실패했을 때
+    헬스장만 끊기고 담당은 남는 반쪽 상태가 된다. 커밋은 호출부가 한 번만 한다.
     """
     link = db.get(MemberGym, member_id)
     if link is None:
         return False
     db.delete(link)
-    db.commit()
     return True
 
 

--- a/backend/app/services/gym_service.py
+++ b/backend/app/services/gym_service.py
@@ -12,7 +12,7 @@ import math
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.models.models import GymProfile, Place, TrainerProfile, User
+from app.models.models import GymProfile, MemberGym, Place, TrainerProfile, User
 from app.schemas.gym_api import GymOut, TrainerOut
 
 
@@ -104,6 +104,39 @@ def get_gym(
         return None
     place, profile = row
     return _to_gym(place, profile, lat, lng)
+
+
+# ---- 회원의 내 헬스장 (#444) ----
+
+def get_member_gym_id(db: Session, member_id: str) -> str | None:
+    """회원이 직접 연결한 헬스장 id. 없으면 None.
+
+    담당 트레이너의 소속에서 파생하지 않는다 — 트레이너만 해제해도 헬스장은 남아야
+    한다. 트레이너 소속으로의 폴백은 호출부(`trainer_service.build_member_coach`)가
+    아직 백필되지 않은 데이터를 위해 따로 처리한다.
+    """
+    return db.scalar(select(MemberGym.gym_id).where(MemberGym.member_id == member_id))
+
+
+def get_member_gym(
+    db: Session, member_id: str, *, lat: float | None = None, lng: float | None = None
+) -> GymOut | None:
+    """회원의 '내 헬스장' 카드. 연결이 없거나 헬스장이 사라졌으면 None."""
+    gym_id = get_member_gym_id(db, member_id)
+    return None if gym_id is None else get_gym(db, gym_id, lat=lat, lng=lng)
+
+
+def unlink_member_gym(db: Session, member_id: str) -> bool:
+    """헬스장 연결 해제. 끊었으면 True, 원래 없었으면 False.
+
+    담당 링크와 달리 행을 지운다 — 이 링크를 참조하는 이력이 없다.
+    """
+    link = db.get(MemberGym, member_id)
+    if link is None:
+        return False
+    db.delete(link)
+    db.commit()
+    return True
 
 
 def _to_trainer(user: User, profile: TrainerProfile) -> TrainerOut:

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -738,8 +738,24 @@ def get_member_trainer_id(db: Session, member_id: str) -> str | None:
     return link.trainer_id if link is not None else None
 
 
+def disconnect_member_gym(db: Session, member_id: str) -> bool:
+    """회원이 헬스장 연결을 끊는다 — 담당 트레이너도 함께 끊긴다.
+
+    떠난 헬스장의 트레이너를 담당으로 남겨 둘 수는 없다. 앱의 mock 도 같은 규칙이고
+    (`MockGymRepository.disconnectMyGym`), MY 탭의 헬스장 휴지통이 이 경로다.
+    둘 중 하나라도 끊었으면 True.
+    """
+    from app.services import gym_service
+
+    unlinked_gym = gym_service.unlink_member_gym(db, member_id)
+    unlinked_trainer = disconnect_member_coach(db, member_id)
+    return unlinked_gym or unlinked_trainer
+
+
 def disconnect_member_coach(db: Session, member_id: str) -> bool:
-    """회원이 담당 트레이너 연결을 끊는다. 끊었으면 True, 원래 없었으면 False.
+    """회원이 담당 트레이너 연결을 끊는다 — 헬스장 연결은 그대로 둔다.
+
+    끊었으면 True, 원래 없었으면 False.
 
     링크 행을 지우지 않고 `active=False` 로 내린다 — 지난 코칭 기록(루틴·채팅·일정)이
     링크를 참조하므로 삭제하면 이력이 끊긴다. 비활성 링크는 `_active_link` 가 제외해
@@ -766,6 +782,34 @@ def disconnect_member_coach(db: Session, member_id: str) -> bool:
     return True
 
 
+def _member_gym_out(db: Session, member_id: str, profile: TrainerProfile) -> TrainerGymOut:
+    """코치 요약에 실을 헬스장 — **회원 링크가 진실**이고, 트레이너 소속은 폴백이다.
+
+    회원이 트레이너와 다른 헬스장에 연결돼 있을 수 있으므로(트레이너 이적 등) 먼저
+    회원 링크를 본다. 링크가 없는 회원은 마이그레이션 백필 전 데이터이거나 담당만
+    있고 헬스장 연결이 아직 없는 경우라, 예전처럼 트레이너 소속을 보여 준다 —
+    갑자기 빈 카드가 되는 것보다 낫다.
+    """
+    from app.services import gym_service
+
+    gym = gym_service.get_member_gym(db, member_id)
+    if gym is not None:
+        return TrainerGymOut(
+            id=gym.id,
+            name=gym.name,
+            address=gym.address,
+            # TrainerGymOut.hours 는 한 줄이다. 카드가 평일 영업시간을 보여 주므로
+            # 주말 시간까지 합치지 않는다(트레이너 프로필의 gym_hours 와 같은 값).
+            hours=gym.weekday_hours or "",
+            phone=gym.phone or "",
+        )
+    return TrainerGymOut(
+        id=profile.gym_id,
+        name=profile.gym_name, address=profile.gym_address,
+        hours=profile.gym_hours, phone=profile.gym_phone,
+    )
+
+
 def build_member_coach(db: Session, member_id: str) -> MemberCoachOut | None:
     """회원의 '내 담당 코치' 요약. 활성 담당이 없으면 None(라우터 404)."""
     link = _active_link(db, member_id)
@@ -783,11 +827,7 @@ def build_member_coach(db: Session, member_id: str) -> MemberCoachOut | None:
         specialty=profile.specialty,
         career=f"{profile.career_years}년",
         intro=profile.intro,
-        gym=TrainerGymOut(
-            id=profile.gym_id,
-            name=profile.gym_name, address=profile.gym_address,
-            hours=profile.gym_hours, phone=profile.gym_phone,
-        ),
+        gym=_member_gym_out(db, member_id, profile),
         goal=link.goal,
     )
 

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -738,17 +738,43 @@ def get_member_trainer_id(db: Session, member_id: str) -> str | None:
     return link.trainer_id if link is not None else None
 
 
+def _deactivate_coach_links(db: Session, member_id: str) -> bool:
+    """활성 담당 링크를 전부 휴면으로 내린다(커밋 없음). 내린 게 있으면 True.
+
+    링크 행을 지우지 않고 `active=False` 로 내린다 — 지난 코칭 기록(루틴·채팅·일정)이
+    링크를 참조하므로 삭제하면 이력이 끊긴다. 비활성 링크는 `_active_link` 가 제외해
+    이후 조회는 '담당 없음'으로 동작한다.
+
+    **전부** 내리는 이유: partial unique index 가 회원당 1건을 강제하지만, 정합성이
+    깨져 여러 건이 남은 경우 첫 건만 끄면 get_member_trainer_id() 가 계속 다른 링크를
+    반환해 "해제했는데 그대로"가 된다(리뷰 지적).
+    """
+    links = db.scalars(
+        select(TrainerClient).where(
+            TrainerClient.member_id == member_id,
+            TrainerClient.active.is_(True),
+        )
+    ).all()
+    for link in links:
+        link.active = False
+    return bool(links)
+
+
 def disconnect_member_gym(db: Session, member_id: str) -> bool:
     """회원이 헬스장 연결을 끊는다 — 담당 트레이너도 함께 끊긴다.
 
     떠난 헬스장의 트레이너를 담당으로 남겨 둘 수는 없다. 앱의 mock 도 같은 규칙이고
     (`MockGymRepository.disconnectMyGym`), MY 탭의 헬스장 휴지통이 이 경로다.
     둘 중 하나라도 끊었으면 True.
+
+    두 해제를 **한 트랜잭션**으로 커밋한다. 각자 커밋하면 뒤 단계가 실패했을 때
+    헬스장만 사라지고 담당은 살아 있는 반쪽 상태가 남는다.
     """
     from app.services import gym_service
 
     unlinked_gym = gym_service.unlink_member_gym(db, member_id)
-    unlinked_trainer = disconnect_member_coach(db, member_id)
+    unlinked_trainer = _deactivate_coach_links(db, member_id)
+    db.commit()
     return unlinked_gym or unlinked_trainer
 
 
@@ -757,29 +783,13 @@ def disconnect_member_coach(db: Session, member_id: str) -> bool:
 
     끊었으면 True, 원래 없었으면 False.
 
-    링크 행을 지우지 않고 `active=False` 로 내린다 — 지난 코칭 기록(루틴·채팅·일정)이
-    링크를 참조하므로 삭제하면 이력이 끊긴다. 비활성 링크는 `_active_link` 가 제외해
-    이후 조회는 '담당 없음'으로 동작한다.
-
     회원 일방으로 끊을 수 있게 두는 이유: 앱의 MY 탭이 이미 해제 버튼을 제공하고,
     트레이너 승인을 기다리게 하면 회원이 관계를 벗어날 방법이 없어진다. 트레이너
     로스터에서는 즉시 사라진다.
     """
-    # 활성 링크를 **전부** 내린다. partial unique index 가 회원당 1건을 강제하지만,
-    # 정합성이 깨져 여러 건이 남은 경우 첫 건만 끄면 get_member_trainer_id() 가 계속
-    # 다른 링크를 반환해 "해제했는데 그대로"가 된다(리뷰 지적).
-    links = db.scalars(
-        select(TrainerClient).where(
-            TrainerClient.member_id == member_id,
-            TrainerClient.active.is_(True),
-        )
-    ).all()
-    if not links:
-        return False
-    for link in links:
-        link.active = False
+    deactivated = _deactivate_coach_links(db, member_id)
     db.commit()
-    return True
+    return deactivated
 
 
 def _member_gym_out(db: Session, member_id: str, profile: TrainerProfile) -> TrainerGymOut:

--- a/backend/docs/TRAINER_DOMAIN.md
+++ b/backend/docs/TRAINER_DOMAIN.md
@@ -149,10 +149,27 @@ O2O 코칭의 재등록 고리. 세션 수·완료 수는 `trainer_schedule`, �
 | GET | `/me/coach/chat/unread` | 미확인 수 |
 | POST | `/me/coach/chat` | 코치에게 메시지 전송 |
 | POST | `/me/coach/chat/read` | 읽음 처리 |
+| DELETE | `/me/coach` | **헬스장 + 담당 트레이너** 해제(멱등, 204) |
+| DELETE | `/me/coach/trainer` | **담당 트레이너만** 해제 — 헬스장은 유지(멱등, 204) |
 
 - 담당 코치는 **active 링크**만 인정(`get_member_trainer_id` → `active.is_(True)`).
   휴면 링크만 있으면 코치 조회/발신 불가(404/빈 목록).
 - `/me/coach/sessions`는 시간이 지나며 누적되는 PT 세션을 **최근 100건**으로 상한.
+
+### 회원↔헬스장 링크 (#444)
+
+회원의 "내 헬스장"은 `member_gyms`(회원당 1행, `member_id` PK)에 있다. 예전에는 담당
+트레이너의 소속(`trainer_profiles.gym_id`)에서 **파생**시켜, 트레이너만 해제해도 헬스장이
+함께 사라졌다 — 앱 MY 탭은 두 해제를 따로 제공하는데 서버가 그 구분을 표현하지 못했다.
+
+- `GET /me/gym` (헬스장 라우터) — 내 헬스장. 응답은 `/gyms/{id}` 와 같은 `GymOut` 이라
+  앱이 상세를 한 번 더 읽지 않는다. 연결이 없으면 404.
+- `GET /me/coach` 의 `gym` 도 이 링크가 진실이다. 링크가 없는 회원(백필 이전 데이터)만
+  예전처럼 트레이너 소속으로 폴백한다.
+- 헬스장 해제가 트레이너까지 끊는 것은 의도다 — 떠난 헬스장의 트레이너를 담당으로 남길
+  수 없다. 앱 mock(`MockGymRepository`)도 같은 규칙이다.
+- 링크를 **만드는** 경로는 아직 시드/백필뿐이다. 담당 배정 자체가 시드로만 생기는 현재
+  단계와 같다(헬스장 먼저 가입 → 트레이너 나중 선택 흐름은 후속).
 
 ## 7. 데모 시드 (`seed_trainer.py`, `seed_member_data.py`)
 

--- a/backend/migrations/versions/0021_member_gym_link.py
+++ b/backend/migrations/versions/0021_member_gym_link.py
@@ -1,0 +1,75 @@
+"""회원↔헬스장 링크 테이블
+
+회원의 '내 헬스장'이 담당 트레이너의 소속(`trainer_profiles.gym_id`)에서 파생돼,
+트레이너만 해제해도 헬스장이 같이 사라졌다. 앱 MY 탭은 두 해제를 따로 제공하므로
+서버에도 각각의 링크가 있어야 한다. (#444)
+
+기존 회원의 헬스장을 잃지 않도록, 활성 담당 링크가 있는 회원은 그 트레이너의
+소속 헬스장으로 채워 넣는다 — 지금까지 화면에 보이던 값과 같다.
+
+Revision ID: 0021_member_gym_link
+Revises: 0020_gym_profiles_trainer_fk
+Create Date: 2026-08-07
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0021_member_gym_link"
+down_revision: str | Sequence[str] | None = "0020_gym_profiles_trainer_fk"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "member_gyms",
+        # 회원당 헬스장 1곳. PK 로 두면 불변식이 구조로 강제돼 별도 유니크 인덱스가
+        # 필요 없다(담당 링크가 partial unique index 로 하는 일을 여기선 PK 가 한다).
+        sa.Column(
+            "member_id",
+            sa.String(length=64),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        # 헬스장은 places(category='fitness'). 장소가 지워지면 링크도 지운다 —
+        # NOT NULL 이라 SET NULL 을 쓸 수 없다.
+        sa.Column(
+            "gym_id",
+            sa.String(length=64),
+            sa.ForeignKey("places.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+    )
+    # '이 헬스장에 연결된 회원'을 세는 방향(트레이너 앱·운영 통계)이 인덱스 없이는
+    # 전건 스캔이다.
+    op.create_index("ix_member_gyms_gym_id", "member_gyms", ["gym_id"])
+
+    # 백필: 활성 담당이 있고 그 트레이너의 소속 헬스장을 아는 회원.
+    # 지금 화면에 뜨는 '내 헬스장'이 정확히 이 값이라, 마이그레이션 전후로 보이는
+    # 것이 달라지지 않는다. 회원당 active 담당은 1건(partial unique index)이므로
+    # 이 SELECT 는 회원당 최대 한 행이다.
+    op.execute(
+        """
+        INSERT INTO member_gyms (member_id, gym_id)
+        SELECT tc.member_id, tp.gym_id
+        FROM trainer_clients tc
+        JOIN trainer_profiles tp ON tp.trainer_id = tc.trainer_id
+        WHERE tc.active AND tp.gym_id IS NOT NULL
+        ON CONFLICT (member_id) DO NOTHING
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_member_gyms_gym_id", table_name="member_gyms")
+    op.drop_table("member_gyms")

--- a/backend/tests/test_gyms.py
+++ b/backend/tests/test_gyms.py
@@ -4,6 +4,8 @@
 """
 from __future__ import annotations
 
+import pytest
+
 PARTNER_IDS = {"gym-oncare-sinchon", "gym-healthmate", "gym-bodyandsoul"}
 #: 카카오 Local 에서 발견한 실재 업체 — 제휴는 아니지만 상담 대상이어야 한다.
 DISCOVERED_IDS = {"11621774", "1558845892", "328969863", "696444256"}
@@ -217,6 +219,142 @@ def test_disconnect_my_coach_is_idempotent(client):
     # 담당이 없는 회원도 204 — 404 면 앱이 오류를 띄운다.
     assert client.delete("/v1/me/coach", headers=_auth(token)).status_code == 204
     assert client.delete("/v1/me/coach", headers=_auth(token)).status_code == 204
+    assert (
+        client.delete("/v1/me/coach/trainer", headers=_auth(token)).status_code == 204
+    )
+
+
+# ---- 회원↔헬스장 링크 (#444) ----
+
+@pytest.fixture
+def connected_member(client, db_session):
+    """헬스장·담당 트레이너에 모두 연결된 새 회원을 만드는 팩토리. (member_id, token)
+
+    끝나면 만든 링크를 지운다 — 김트레이너의 시드 담당 링크 **수**를 세는 테스트가
+    있어(`test_trainer.test_demo_trainer_client_links_seeded`) 남겨 두면 그쪽이 깨진다.
+    """
+    from uuid import uuid4
+
+    from app.models import models
+    from tests.test_consultations import _register_member
+
+    created: list[tuple[str, str]] = []
+
+    def _make(gym_id: str = "gym-oncare-sinchon") -> tuple[str, str]:
+        member_id, token = _register_member(client)
+        link_id = f"tc-{uuid4().hex[:12]}"
+        db_session.add(models.MemberGym(member_id=member_id, gym_id=gym_id))
+        db_session.add(models.TrainerClient(
+            id=link_id, trainer_id="trainer-demo", member_id=member_id, active=True,
+        ))
+        db_session.commit()
+        created.append((link_id, member_id))
+        return member_id, token
+
+    yield _make
+
+    for link_id, member_id in created:
+        # 테스트가 이미 지웠을 수 있다(해제 경로 검증).
+        for row in (
+            db_session.get(models.TrainerClient, link_id),
+            db_session.get(models.MemberGym, member_id),
+        ):
+            if row is not None:
+                db_session.delete(row)
+    db_session.commit()
+
+
+def test_disconnect_trainer_keeps_the_gym(client, connected_member):
+    """트레이너만 해제 — MY 탭 휴지통 2개가 서버에서도 갈라져야 한다.
+
+    전에는 두 버튼이 같은 엔드포인트로 나가, 트레이너만 끊었는데 헬스장 카드까지
+    사라졌다(mock 과 실 API 가 갈리던 지점).
+    """
+    from tests.test_consultations import _auth
+
+    _member_id, token = connected_member()
+    assert client.get("/v1/me/gym", headers=_auth(token)).status_code == 200
+
+    assert (
+        client.delete("/v1/me/coach/trainer", headers=_auth(token)).status_code == 204
+    )
+
+    assert client.get("/v1/me/coach", headers=_auth(token)).status_code == 404
+    gym = client.get("/v1/me/gym", headers=_auth(token))
+    assert gym.status_code == 200, "트레이너를 끊었다고 헬스장까지 사라지면 안 된다"
+    assert gym.json()["id"] == "gym-oncare-sinchon"
+
+
+def test_disconnect_gym_drops_the_trainer_too(client, connected_member):
+    """헬스장 해제는 둘 다 끊는다 — 떠난 헬스장의 트레이너를 담당으로 둘 수 없다."""
+    from tests.test_consultations import _auth
+
+    _member_id, token = connected_member()
+
+    assert client.delete("/v1/me/coach", headers=_auth(token)).status_code == 204
+
+    assert client.get("/v1/me/coach", headers=_auth(token)).status_code == 404
+    assert client.get("/v1/me/gym", headers=_auth(token)).status_code == 404
+
+
+def test_my_gym_is_404_without_a_link(client):
+    """연결이 없으면 404 — 앱은 이걸 '헬스장 없음' 카드로 바꾼다."""
+    from tests.test_consultations import _auth, _register_member
+
+    _member_id, token = _register_member(client)
+    assert client.get("/v1/me/gym", headers=_auth(token)).status_code == 404
+
+
+def test_my_gym_answers_with_the_same_shape_as_the_directory(client, connected_member):
+    """`/gyms/{id}` 와 같은 형태여야 앱이 상세를 한 번 더 읽지 않는다."""
+    from tests.test_consultations import _auth
+
+    _member_id, token = connected_member()
+
+    mine = client.get("/v1/me/gym", headers=_auth(token), params=SINCHON)
+    detail = client.get(
+        "/v1/gyms/gym-oncare-sinchon", headers=_auth(token), params=SINCHON
+    )
+    assert mine.status_code == 200 and detail.status_code == 200
+    assert mine.json() == detail.json()
+
+
+def test_coach_gym_follows_the_member_link_not_the_trainer(db_session, connected_member):
+    """코치 요약의 헬스장도 회원 링크가 진실이다.
+
+    트레이너 소속에서 파생시키면, 회원이 다른 헬스장으로 옮겨도 카드가 트레이너를
+    따라간다.
+    """
+    from app.models import models
+    from app.services import trainer_service
+
+    member_id, _token = connected_member()
+    # 김트레이너의 소속은 gym-oncare-sinchon 이다. 회원만 다른 곳으로 옮긴다.
+    link = db_session.get(models.MemberGym, member_id)
+    link.gym_id = "gym-healthmate"
+    db_session.commit()
+
+    coach = trainer_service.build_member_coach(db_session, member_id)
+    assert coach is not None
+    assert coach.gym.id == "gym-healthmate"
+    assert coach.gym.name == "헬스메이트 신촌점"
+
+
+def test_coach_gym_falls_back_to_the_trainer_when_unlinked(db_session, connected_member):
+    """링크가 없는 회원(백필 이전 데이터)은 예전처럼 트레이너 소속을 보여 준다.
+
+    빈 카드로 퇴화시키는 것보다 낫다.
+    """
+    from app.models import models
+    from app.services import trainer_service
+
+    member_id, _token = connected_member()
+    db_session.delete(db_session.get(models.MemberGym, member_id))
+    db_session.commit()
+
+    coach = trainer_service.build_member_coach(db_session, member_id)
+    assert coach is not None
+    assert coach.gym.id == "gym-oncare-sinchon"
 
 
 def test_coordinates_must_be_sent_as_a_pair(client):

--- a/backend/tests/test_gyms.py
+++ b/backend/tests/test_gyms.py
@@ -340,6 +340,23 @@ def test_coach_gym_follows_the_member_link_not_the_trainer(db_session, connected
     assert coach.gym.name == "헬스메이트 신촌점"
 
 
+def test_gym_unlink_leaves_the_commit_to_its_caller(db_session, connected_member):
+    """헬스장 해제가 스스로 커밋하면 담당 해제와 원자적으로 묶을 수 없다.
+
+    각자 커밋하면 담당 해제가 실패했을 때 헬스장만 사라지고 트레이너는 살아 있는
+    반쪽 상태가 남는다(리뷰 지적).
+    """
+    from app.models import models
+    from app.services import gym_service
+
+    member_id, _token = connected_member()
+
+    assert gym_service.unlink_member_gym(db_session, member_id) is True
+    db_session.rollback()
+
+    assert db_session.get(models.MemberGym, member_id) is not None
+
+
 def test_coach_gym_falls_back_to_the_trainer_when_unlinked(db_session, connected_member):
     """링크가 없는 회원(백필 이전 데이터)은 예전처럼 트레이너 소속을 보여 준다.
 

--- a/frontend/flutter/lib/features/exercise/data/repositories/dio_gym_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/dio_gym_repository.dart
@@ -7,8 +7,9 @@ import 'package:oncare/features/exercise/domain/repositories/gym_repository.dart
 
 /// 헬스장·트레이너 디렉터리 실 API. (#324)
 ///
-/// 회원의 "내 헬스장/트레이너"는 별도 링크가 아니라 **담당 트레이너의 소속**에서
-/// 나온다(`GET /me/coach`). 백엔드에 회원↔헬스장 링크가 따로 없기 때문이다.
+/// 회원의 "내 헬스장"과 "내 트레이너"는 서버에서도 각각의 링크다 — 헬스장은
+/// `GET /me/gym`, 담당 트레이너는 `GET /me/coach`. 그래서 트레이너만 해제해도
+/// 헬스장 카드는 남는다(#444).
 class DioGymRepository implements GymRepository {
   DioGymRepository(this._dio);
   final Dio _dio;
@@ -94,14 +95,12 @@ class DioGymRepository implements GymRepository {
 
   @override
   Future<Gym?> fetchMyGym() async {
-    final coach = await _coach();
-    final gym = coach?['gym'] as Map<String, Object?>?;
-    final gymId = gym?['id'] as String?;
-    if (gymId == null) return null;
-    // 요약에는 평점·태그가 없다. 상세를 한 번 더 읽어 목록과 같은 카드를 만든다.
+    // 담당 트레이너를 거치지 않는다 — 트레이너만 해제한 회원은 `/me/coach` 가
+    // 404 여도 헬스장은 남아 있어야 한다(#444). 응답이 목록·상세와 같은 형태라
+    // 상세를 한 번 더 읽을 필요도 없다.
     try {
       final res = await _dio.get<Map<String, Object?>>(
-        '/gyms/$gymId',
+        '/me/gym',
         queryParameters: <String, Object?>{'lat': kGymSearchLat, 'lng': kGymSearchLng},
       );
       if (res.data != null) return _gym(res.data!);
@@ -120,12 +119,11 @@ class DioGymRepository implements GymRepository {
     return fetchTrainer(trainerId);
   }
 
+  /// 헬스장과 그곳 담당 트레이너를 함께 끊는다 — 떠난 헬스장의 트레이너를 담당으로
+  /// 남길 수 없다. mock 과 같은 규칙이다.
   @override
   Future<void> disconnectMyGym() => _dio.delete<void>('/me/coach');
 
-  /// 서버에는 회원↔헬스장 링크가 따로 없어 "트레이너만 해제"를 표현할 수 없다.
-  /// 담당 링크를 끊으면 헬스장도 함께 사라진다 — mock 과 달리 헬스장이 남지 않는다.
-  /// 회원↔헬스장 링크가 생기면(#301 후속) 여기를 나눈다.
   @override
-  Future<void> disconnectMyTrainer() => _dio.delete<void>('/me/coach');
+  Future<void> disconnectMyTrainer() => _dio.delete<void>('/me/coach/trainer');
 }

--- a/frontend/flutter/test/features/exercise/dio_gym_repository_test.dart
+++ b/frontend/flutter/test/features/exercise/dio_gym_repository_test.dart
@@ -116,30 +116,34 @@ void main() {
     expect(await repo.fetchMyTrainer(), isNull);
   });
 
-  test('내 헬스장은 요약이 아니라 상세를 읽어 평점·태그를 채운다', () async {
-    const coachJson = '''
-    {"trainer_id":"trainer-demo","name":"김트레이너","specialty":"퍼스널 트레이너",
-     "career":"7년","intro":"소개","goal":"혈압 관리",
-     "gym":{"id":"gym-oncare-sinchon","name":"온케어짐 신촌점",
-            "address":"서울 서대문구 신촌로 120","hours":"06:00 – 23:00",
-            "phone":"02-1234-5678"}}
-    ''';
-    final adapter = _StubAdapter(<String, Object?>{
-      '/me/coach': coachJson,
-      '/gyms/gym-oncare-sinchon': _gymDetailJson,
-    });
+  test('내 헬스장은 담당 트레이너를 거치지 않고 /me/gym 에서 읽는다', () async {
+    // 트레이너만 해제한 회원은 /me/coach 가 404 다. 그걸 거쳐 읽으면 헬스장 카드가
+    // 함께 사라진다(#444).
+    final adapter = _StubAdapter(<String, Object?>{'/me/gym': _gymDetailJson});
 
     final gym = await DioGymRepository(_dio(adapter)).fetchMyGym();
     expect(gym, isNotNull);
-    // 요약(TrainerGymOut)에는 평점·태그가 없다 — 상세를 읽어야 카드가 목록과 같다.
+    // 목록과 같은 형태라 상세를 한 번 더 읽지 않는다.
     expect(gym!.rating, 4.7);
     expect(gym.tags, isNotEmpty);
-    expect(adapter.calls, contains('GET /gyms/gym-oncare-sinchon'));
+    expect(adapter.calls, <String>['GET /me/gym']);
+    // 거리 표시는 서버가 계산한다.
+    final Map<String, dynamic> q = adapter.queryOf('/me/gym');
+    expect(q['lat'], kGymSearchLat);
+    expect(q['lng'], kGymSearchLng);
   });
 
-  test('연결 해제는 DELETE /me/coach 로 나간다', () async {
-    final adapter = _StubAdapter(<String, Object?>{'/me/coach': '{}'});
-    await DioGymRepository(_dio(adapter)).disconnectMyGym();
-    expect(adapter.calls, contains('DELETE /me/coach'));
+  test('헬스장 해제는 DELETE /me/coach, 트레이너 해제는 DELETE /me/coach/trainer', () async {
+    // 두 휴지통이 같은 엔드포인트로 나가면 트레이너만 끊어도 헬스장이 사라진다.
+    final adapter = _StubAdapter(<String, Object?>{
+      '/me/coach': '{}',
+      '/me/coach/trainer': '{}',
+    });
+    final repo = DioGymRepository(_dio(adapter));
+
+    await repo.disconnectMyGym();
+    await repo.disconnectMyTrainer();
+
+    expect(adapter.calls, <String>['DELETE /me/coach', 'DELETE /me/coach/trainer']);
   });
 }


### PR DESCRIPTION
Closes #444

## Summary

회원의 "내 헬스장"이 담당 트레이너의 소속(`trainer_profiles.gym_id`)에서 파생돼, 트레이너만 끊어도 헬스장이 함께 사라졌습니다. 앱 MY 탭은 두 해제를 따로 제공하는데 서버가 그 구분을 표현하지 못해 mock 과 실 API 가 갈리던 지점입니다.

회원↔헬스장 링크를 신설하고, 해제 경로를 둘로 나눕니다.

| 동작 | 데모(mock) | 실 API (전) | 실 API (후) |
|---|---|---|---|
| 헬스장 해제 | 헬스장·트레이너 모두 | 동일 | 동일 |
| 트레이너 해제 | 헬스장 유지 | **헬스장도 사라짐** ❌ | 헬스장 유지 ✅ |

## Changes

**스키마**
- `member_gyms` 신설 — 회원당 1행, `member_id` 를 PK 로 둬 "회원당 헬스장 1곳" 불변식을 구조로 강제합니다(담당 링크가 partial unique index 로 하는 일을 여기선 PK 가 합니다).
- `TrainerClient` 와 달리 `active` 이력 컬럼이 없습니다. 담당 링크는 루틴·채팅·일정이 참조해 지우면 이력이 끊기지만, 헬스장 링크를 참조하는 것은 없어 해제 시 행을 지우면 됩니다.
- 마이그레이션 `0021` 이 **활성 담당이 있는 회원을 트레이너 소속으로 백필**합니다. 지금 화면에 뜨는 '내 헬스장'이 정확히 그 값이라 마이그레이션 전후로 보이는 것이 달라지지 않습니다. 스키마를 `create_all` 로 만드는 경로(로컬·테스트)에는 그 백필이 돌지 않으므로 `seed_gyms` 에 같은 규칙의 멱등 시드를 넣었습니다.

**엔드포인트**
- `DELETE /me/coach` — 헬스장 + 담당 트레이너. `GET /me/coach` 가 둘을 함께 돌려주듯 삭제도 둘 다 끊습니다. 떠난 헬스장의 트레이너를 담당으로 남길 수 없어서이고, mock 도 같은 규칙입니다.
- `DELETE /me/coach/trainer` — 트레이너만. 헬스장은 남습니다. 둘 다 멱등(204)입니다.
- `GET /me/gym` 신설 — 응답이 `/gyms/{id}` 와 같은 `GymOut` 이라 앱이 상세를 한 번 더 읽지 않습니다. 트레이너를 끊어 `/me/coach` 가 404 여도 헬스장 카드는 남아야 하므로 코치와 분리했습니다.
- `GET /me/coach` 의 `gym` 도 회원 링크가 진실입니다. 링크가 없는 회원(백필 이전 데이터)만 예전처럼 트레이너 소속으로 폴백해 빈 카드로 퇴화하지 않게 했습니다.

**앱**
- `DioGymRepository.fetchMyGym` → `/me/gym`(요청 2회 → 1회), `disconnectMyTrainer` → `/me/coach/trainer`. "서버에 링크가 없다"는 주석을 걷어냈습니다.

## Verification

- 백엔드 **366 passed** — 새 DB에 `alembic upgrade head` → `pytest`(CI와 같은 순서).
- 백필은 실데이터로 확인했습니다: 데이터가 있는 DB에서 `downgrade 0020` → `upgrade head` 시 `user-demo`·`user-jisu` 가 담당 트레이너의 헬스장으로 복원됩니다.
- Flutter **305 passed**, `flutter analyze` 무이슈.
- 추가 테스트: 트레이너 해제 후 헬스장 유지 / 헬스장 해제 시 둘 다 해제 / 링크 없을 때 404 / `/me/gym` 과 `/gyms/{id}` 응답 동일 / 코치 요약의 헬스장이 회원 링크를 따름 / 링크 없으면 트레이너 소속 폴백 / Dart 쪽 두 휴지통이 서로 다른 엔드포인트로 나감.

## Notes

- 링크를 **만드는** 경로는 아직 시드/백필뿐입니다. 담당 배정(`TrainerClient`) 자체가 시드로만 생기는 현재 단계와 같아 이번 범위에 넣지 않았습니다. 이슈의 "헬스장에 소속되기만 하고 트레이너는 나중에 정하는 흐름"은 그 연결 API가 생길 때 함께 다루는 편이 맞다고 봤습니다 — 스키마는 이미 그 형태를 허용합니다(헬스장 링크만 있고 담당은 없는 상태가 성립).
- "트레이너를 바꿀 때 헬스장 연결이 유지되는지"는 이번 분리로 성립하고 테스트로 고정했습니다.
- `DELETE /me/coach` 의 의미가 '트레이너 해제'에서 '전체 해제'로 넓어집니다. 이 엔드포인트를 부르던 곳은 앱의 헬스장 휴지통 하나뿐이고, 그쪽이 기대하던 동작이 곧 전체 해제라 호출부 변경은 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 회원이 연결된 헬스장을 직접 조회할 수 있습니다.
- 담당 트레이너와 헬스장 연결을 각각 해제할 수 있습니다.
- 트레이너만 해제할 경우 헬스장 연결은 유지됩니다.

## 개선 사항
- 회원의 헬스장 정보가 트레이너 정보와 독립적으로 관리됩니다.
- 기존 회원 연결 데이터가 자동으로 보존 및 보완됩니다.

## 버그 수정
- 헬스장 연결 해제 시 담당 트레이너 연결도 함께 정리됩니다.
- 연결 상태에 따른 헬스장 정보 조회 및 대체 동작이 안정화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->