### PR TITLE
feat(ai): AI 코치 채팅 실 Gemini(RAG) 연동 + 대화 영속화

### DIFF
--- a/backend/app/api/v1/ai_coach.py
+++ b/backend/app/api/v1/ai_coach.py
@@ -1,7 +1,9 @@
 """
 AI 코치 라우터 — 프론트 계약 정렬.
 
-  GET /ai-coach/feedback  -> { greeting, suggestions[] }
+  GET  /ai-coach/feedback  -> { greeting, suggestions[] }
+  GET  /ai-coach/messages  -> 저장된 대화 복원
+  POST /ai-coach/chat      -> RAG 근거 기반 답변 + 대화 저장
 
 도메인(식단/운동)별 코치를 각각 생성해 합친 결과.
 STEP 7에서 내부가 RAG+LLM 으로 교체되지만 응답 형식은 동일.
@@ -14,8 +16,17 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from app.api.deps import CurrentUser
+from app.core.config import get_settings
+from app.core.rate_limit import rate_limit
 from app.db.session import get_db
-from app.schemas.misc_api import AiCoachFeedback, ChatReply, ChatRequest
+from app.schemas.misc_api import (
+    AiCoachFeedback,
+    ChatHistory,
+    ChatMessageOut,
+    ChatReply,
+    ChatRequest,
+)
+from app.services.coach import conversation
 from app.services.coach.chat import answer
 from app.services.coach_service import build_feedback
 
@@ -30,15 +41,57 @@ def ai_coach_feedback(
     return build_feedback(db, current_user.id, current_user.name)
 
 
-@router.post("/ai-coach/chat", response_model=ChatReply)
+@router.get("/ai-coach/messages", response_model=ChatHistory)
+def ai_coach_messages(
+    current_user: CurrentUser,
+    db: Annotated[Session, Depends(get_db)],
+) -> ChatHistory:
+    """저장된 대화 복원 — 재접속·다기기에서 히스토리를 잇는다.
+
+    아직 한 마디도 나누지 않았으면 빈 목록이다(이 경로는 대화 스레드를 만들지 않는다).
+    """
+    rows = conversation.load_messages(db, current_user.id)
+    return ChatHistory(
+        messages=[
+            ChatMessageOut(
+                role=m.role,
+                content=m.content,
+                sources=conversation.parse_sources(m.sources_json),
+                created_at=m.created_at,
+            )
+            for m in rows
+        ]
+    )
+
+
+@router.post(
+    "/ai-coach/chat",
+    response_model=ChatReply,
+    dependencies=[
+        Depends(rate_limit("coach-chat", get_settings().coach_chat_per_minute))
+    ],
+)
 def ai_coach_chat(
     payload: ChatRequest,
     current_user: CurrentUser,
     db: Annotated[Session, Depends(get_db)],
 ) -> ChatReply:
-    """대화형 코칭: RAG 근거 기반 답변(개인/공공 격리). LLM 키 없으면 검색 기반 폴백."""
+    """대화형 코칭: RAG 근거 기반 답변(개인/공공 격리). LLM 키 없으면 검색 기반 폴백.
+
+    대화는 서버에 저장된다. 히스토리도 서버 저장분을 우선 쓰므로 클라이언트가
+    `history` 를 보내지 않아도 맥락이 이어진다. 다만 저장분이 아직 없을 때는
+    요청에 실려 온 `history` 를 쓴다 — 목업 모드로 대화하다 실 서버로 전환한
+    클라이언트의 맥락을 버리지 않기 위해서다.
+    """
     message = payload.message.strip()
     if not message:
         raise HTTPException(status_code=400, detail="메시지가 비어 있습니다.")
-    reply, sources = answer(db, current_user.id, message, payload.history)
+
+    stored = conversation.load_messages(db, current_user.id)
+    history = stored or payload.history
+
+    reply, sources = answer(db, current_user.id, message, history)
+    conversation.append_exchange(
+        db, current_user.id, question=message, reply=reply, sources=sources
+    )
     return ChatReply(reply=reply, sources=sources)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -101,6 +101,9 @@ class Settings(BaseSettings):
     # --- Rate limit (인증 엔드포인트 브루트포스 방어) ---
     rate_limit_enabled: bool = True
     rate_limit_auth_per_minute: int = 10  # IP·엔드포인트당 분당 시도 한도
+    # AI 코치 채팅 한도. 브루트포스 방어가 아니라 LLM 비용 가드라서 목적이 다르다.
+    # 사람이 대화하는 속도로는 걸리지 않되, 폭주하는 클라이언트는 막는 값.
+    coach_chat_per_minute: int = 20
 
     @property
     def admin_email_set(self) -> set[str]:

--- a/backend/app/core/rate_limit.py
+++ b/backend/app/core/rate_limit.py
@@ -43,14 +43,20 @@ class RateLimiter:
 limiter = RateLimiter()
 
 
-def rate_limit(bucket: str):
-    """엔드포인트에 붙일 의존성 팩토리. bucket 은 엔드포인트 구분자."""
+def rate_limit(bucket: str, per_minute: int | None = None):
+    """엔드포인트에 붙일 의존성 팩토리. bucket 은 엔드포인트 구분자.
+
+    `per_minute` 를 주면 그 한도를, 안 주면 인증용 기본 한도를 쓴다. LLM 호출처럼
+    실패해도 비용이 나가는 엔드포인트는 브루트포스 방어와 목적이 달라 한도를 따로
+    잡는다.
+    """
 
     def _dep(request: Request) -> None:
         settings = get_settings()
         if not settings.rate_limit_enabled:
             return
         ip = request.client.host if request.client else "unknown"
-        limiter.check(f"{bucket}:{ip}", settings.rate_limit_auth_per_minute, 60.0)
+        limit = per_minute or settings.rate_limit_auth_per_minute
+        limiter.check(f"{bucket}:{ip}", limit, 60.0)
 
     return _dep

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -570,3 +570,61 @@ class AuditLog(Base):
     success: Mapped[bool] = mapped_column(Boolean, default=True)
     detail: Mapped[str] = mapped_column(Text, default="")
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
+class AiConversation(Base):
+    """AI 코치(온이)와의 대화 스레드.
+
+    앱에는 대화 목록 UI 가 없고 채팅 시트 하나만 있으므로, 사용자당 활성 스레드
+    1개를 get-or-create 해서 쓴다(coach_service 참고). 나중에 스레드 목록이 필요해질
+    때를 대비해 테이블은 분리해 둔다 — 그때 컬럼 추가 없이 archived_at 만 채우면 된다.
+
+    트레이너↔회원 채팅(chat_messages)과는 다른 도메인이다. 이쪽은 사람 간 대화가
+    아니라 LLM 대화라 sender 대신 role(user|coach)을 쓰고 근거 문서를 함께 남긴다.
+    """
+    __tablename__ = "ai_conversations"
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    user_id: Mapped[str] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
+    #: 비우면 활성 스레드. 값이 있으면 보관된 스레드(현재는 쓰지 않음).
+    archived_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+
+class AiMessage(Base):
+    """AI 코치 대화의 한 줄.
+
+    `sources_json` 은 그 답변의 근거로 쓰인 공공 가이드라인 제목들이다. 답변과 함께
+    저장해야 대화를 복원했을 때도 근거 표시가 남는다(재접속 시 근거가 사라지면
+    "왜 이렇게 답했는지"를 되짚을 수 없다).
+    """
+    __tablename__ = "ai_messages"
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    conversation_id: Mapped[str] = mapped_column(
+        ForeignKey("ai_conversations.id", ondelete="CASCADE"), index=True
+    )
+    #: 대화 내 순번(0부터). created_at 으로 정렬하면 안 되기 때문에 둔다 —
+    #: PostgreSQL 의 now() 는 트랜잭션 시각이라 같은 커밋에 저장되는 질문과 답변이
+    #: **동일한 created_at** 을 갖고, 그러면 정렬이 랜덤한 id 순으로 무너져 답변이
+    #: 질문보다 먼저 보인다(실제로 그렇게 나왔다).
+    seq: Mapped[int] = mapped_column(Integer, default=0)
+    role: Mapped[str] = mapped_column(String(10))  # user|coach
+    content: Mapped[str] = mapped_column(Text)
+    sources_json: Mapped[str] = mapped_column(Text, default="[]")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    __table_args__ = (
+        UniqueConstraint("conversation_id", "seq", name="uq_ai_messages_convo_seq"),
+    )

--- a/backend/app/schemas/misc_api.py
+++ b/backend/app/schemas/misc_api.py
@@ -129,9 +129,23 @@ class ChatTurn(BaseModel):
 
 class ChatRequest(BaseModel):
     message: str
-    history: list[ChatTurn] = []   # 직전 대화(선택). 최근 것부터가 아니라 시간순.
+    # 직전 대화(선택). 이제 서버가 대화를 저장하므로 보내지 않아도 맥락이 이어진다.
+    # 서버에 저장분이 없을 때만 쓰인다(목업→실 서버 전환 클라이언트 호환).
+    history: list[ChatTurn] = []
 
 
 class ChatReply(BaseModel):
     reply: str
     sources: list[str] = []        # 답변 근거로 쓰인 공공 가이드라인 제목
+
+
+class ChatMessageOut(BaseModel):
+    """저장된 대화 한 줄. sources 는 그 답변의 근거 문서 제목."""
+    role: str                      # user | coach
+    content: str
+    sources: list[str] = []
+    created_at: datetime
+
+
+class ChatHistory(BaseModel):
+    messages: list[ChatMessageOut] = []

--- a/backend/app/services/coach/conversation.py
+++ b/backend/app/services/coach/conversation.py
@@ -1,0 +1,141 @@
+"""
+AI 코치 대화 영속화.
+
+`/ai-coach/chat` 은 원래 무상태였다. 히스토리를 클라가 매번 실어 보내는 구조라
+앱을 다시 켜거나 다른 기기로 옮기면 대화가 사라졌다(#274). 여기서 대화를 서버에
+저장하고 복원한다.
+
+설계 메모:
+- 앱에는 대화 목록 UI 가 없고 채팅 시트 하나만 있다. 그래서 사용자당 **활성 스레드
+  1개**를 get-or-create 해서 쓴다. 스레드 개념 자체는 테이블로 분리해 뒀으므로,
+  나중에 목록이 필요해지면 archived_at 을 채우는 것으로 확장된다.
+- 저장은 요청 단위로 사용자 메시지 + 코치 답변을 함께 커밋한다. 답변 생성이
+  실패해도 폴백 문구가 반환되므로 "질문만 남고 답이 없는" 상태는 생기지 않는다.
+- 근거 문서 제목(sources)은 답변과 함께 저장한다. 복원했을 때 근거가 사라지면
+  왜 그렇게 답했는지 되짚을 수 없다.
+"""
+from __future__ import annotations
+
+import json
+import uuid
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.models.models import AiConversation, AiMessage
+
+#: 한 대화에서 복원·프롬프트에 쓰는 최대 메시지 수. 오래된 대화가 길어져도
+#: 프롬프트가 무한정 커지지 않게 막는다(비용·지연 가드).
+MAX_HISTORY_MESSAGES = 50
+
+ROLE_USER = "user"
+ROLE_COACH = "coach"
+
+
+def _new_id(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:16]}"
+
+
+def get_or_create_active(db: Session, user_id: str) -> AiConversation:
+    """사용자의 활성 대화 스레드. 없으면 만든다."""
+    convo = db.scalar(
+        select(AiConversation)
+        .where(
+            AiConversation.user_id == user_id,
+            AiConversation.archived_at.is_(None),
+        )
+        .order_by(AiConversation.created_at.desc())
+        .limit(1)
+    )
+    if convo is not None:
+        return convo
+
+    convo = AiConversation(id=_new_id("aiconv"), user_id=user_id)
+    db.add(convo)
+    db.commit()
+    db.refresh(convo)
+    return convo
+
+
+def load_messages(db: Session, user_id: str) -> list[AiMessage]:
+    """활성 대화의 메시지를 시간순으로. 대화가 없으면 빈 목록.
+
+    스레드를 만들지 않는 조회 전용 경로다. 채팅 화면을 열기만 하고 아무 말도 하지
+    않은 사용자에게 빈 대화 레코드를 남기지 않는다.
+    """
+    convo = db.scalar(
+        select(AiConversation)
+        .where(
+            AiConversation.user_id == user_id,
+            AiConversation.archived_at.is_(None),
+        )
+        .order_by(AiConversation.created_at.desc())
+        .limit(1)
+    )
+    if convo is None:
+        return []
+
+    rows = db.scalars(
+        select(AiMessage)
+        .where(AiMessage.conversation_id == convo.id)
+        .order_by(AiMessage.seq.asc())
+    ).all()
+    return list(rows)[-MAX_HISTORY_MESSAGES:]
+
+
+def append_exchange(
+    db: Session,
+    user_id: str,
+    *,
+    question: str,
+    reply: str,
+    sources: list[str],
+) -> AiConversation:
+    """질문과 답변을 한 번에 저장한다.
+
+    두 줄을 한 커밋으로 묶어야 중간에 실패했을 때 질문만 남는 반쪽 대화가 생기지
+    않는다. 순서는 `seq` 로 고정한다 — created_at 은 쓸 수 없다. PostgreSQL 의
+    now() 는 트랜잭션 시각이라 같은 커밋의 두 줄이 **동일한 created_at** 을 갖고,
+    그러면 정렬이 랜덤한 id 순으로 무너져 답변이 질문보다 먼저 보인다.
+    """
+    convo = get_or_create_active(db, user_id)
+    # 빈 대화면 max 가 NULL 이라 coalesce 로 -1 → 첫 순번이 0 이 된다.
+    next_seq = db.scalar(
+        select(func.coalesce(func.max(AiMessage.seq), -1) + 1).where(
+            AiMessage.conversation_id == convo.id
+        )
+    )
+
+    db.add(
+        AiMessage(
+            id=_new_id("aimsg"),
+            conversation_id=convo.id,
+            seq=next_seq,
+            role=ROLE_USER,
+            content=question,
+            sources_json="[]",
+        )
+    )
+    db.add(
+        AiMessage(
+            id=_new_id("aimsg"),
+            conversation_id=convo.id,
+            seq=next_seq + 1,
+            role=ROLE_COACH,
+            content=reply,
+            sources_json=json.dumps(sources, ensure_ascii=False),
+        )
+    )
+    db.commit()
+    return convo
+
+
+def parse_sources(raw: str) -> list[str]:
+    """저장된 sources_json → 리스트. 깨진 값이면 빈 목록(화면이 죽으면 안 된다)."""
+    try:
+        value = json.loads(raw or "[]")
+    except (TypeError, ValueError):
+        return []
+    if not isinstance(value, list):
+        return []
+    return [str(v) for v in value]

--- a/backend/migrations/versions/0022_ai_conversations.py
+++ b/backend/migrations/versions/0022_ai_conversations.py
@@ -1,0 +1,89 @@
+"""AI 코치 대화 영속화
+
+`/ai-coach/chat` 이 무상태라 대화가 서버에 남지 않았다. 히스토리를 클라가 매번
+실어 보내는 구조여서 앱을 다시 켜거나 다른 기기로 옮기면 대화가 사라졌다. (#274)
+
+대화 스레드(ai_conversations)와 메시지(ai_messages)를 나눠 저장한다. 답변의 근거
+문서 제목은 메시지에 함께 남긴다 — 복원했을 때 근거 표시가 사라지면 "왜 그렇게
+답했는지"를 되짚을 수 없기 때문이다.
+
+트레이너↔회원 채팅(chat_messages)과는 별개 도메인이라 테이블을 공유하지 않는다.
+
+Revision ID: 0022_ai_conversations
+Revises: 0021_member_gym_link
+Create Date: 2026-08-08
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0022_ai_conversations"
+down_revision: str | Sequence[str] | None = "0021_member_gym_link"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "ai_conversations",
+        sa.Column("id", sa.String(length=64), nullable=False),
+        sa.Column("user_id", sa.String(length=64), nullable=False),
+        sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_ai_conversations_user_id", "ai_conversations", ["user_id"]
+    )
+
+    op.create_table(
+        "ai_messages",
+        sa.Column("id", sa.String(length=64), nullable=False),
+        sa.Column("conversation_id", sa.String(length=64), nullable=False),
+        # 대화 내 순번. created_at 으로 정렬할 수 없어서 둔다 — now() 는 트랜잭션
+        # 시각이라 같은 커밋의 질문·답변이 동일한 값을 갖는다.
+        sa.Column("seq", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("role", sa.String(length=10), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column(
+            "sources_json", sa.Text(), server_default="[]", nullable=False
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["conversation_id"], ["ai_conversations.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "conversation_id", "seq", name="uq_ai_messages_convo_seq"
+        ),
+    )
+    op.create_index(
+        "ix_ai_messages_conversation_id", "ai_messages", ["conversation_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ai_messages_conversation_id", table_name="ai_messages")
+    op.drop_table("ai_messages")
+    op.drop_index("ix_ai_conversations_user_id", table_name="ai_conversations")
+    op.drop_table("ai_conversations")

--- a/backend/tests/test_coach_conversation.py
+++ b/backend/tests/test_coach_conversation.py
@@ -1,0 +1,192 @@
+"""AI 코치 대화 영속화(#274).
+
+`/ai-coach/chat` 은 원래 무상태라 재접속·다기기에서 대화가 사라졌다. 여기서
+저장·복원 계약을 고정한다.
+
+LLM 은 호출하지 않는다. 실 Gemini 는 CI 에 키가 없어 재현이 안 되고, 여기서 보려는
+건 답변 품질이 아니라 "무엇이 어떤 순서로 저장되고 복원되는가"이기 때문이다.
+LLM 을 실패시키면 검색 기반 폴백 경로가 도는데, 그 경로에서도 저장이 되어야 한다는
+것 자체가 검증 대상이다(graceful degrade).
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import delete
+
+from app.models.models import AiConversation, AiMessage, User
+from app.services.coach import conversation
+
+
+def _h(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture(autouse=True)
+def _no_llm(monkeypatch):
+    """LLM 을 항상 실패시켜 검색 기반 폴백으로 고정한다(결정론 + 네트워크 차단)."""
+    def _boom(*args, **kwargs):
+        raise RuntimeError("LLM disabled in tests")
+
+    monkeypatch.setattr("app.services.coach.chat.get_coach_llm", _boom)
+    yield
+
+
+@pytest.fixture
+def member(client, db_session):
+    """대화가 비어 있는 새 회원. 테스트 간 히스토리 오염을 피한다."""
+    from app.core.security import hash_password
+
+    email = f"coach-chat-{uuid.uuid4().hex[:8]}@example.com"
+    user = User(
+        id=f"user-{uuid.uuid4().hex[:12]}", email=email, name="대화 테스트",
+        hashed_password=hash_password("pw!"), role="member",
+    )
+    db_session.add(user)
+    db_session.commit()
+
+    token = client.post(
+        "/v1/auth/login", data={"username": email, "password": "pw!"}
+    ).json()["access_token"]
+    yield user, token
+
+    convo_ids = [
+        c.id for c in db_session.scalars(
+            __import__("sqlalchemy").select(AiConversation).where(
+                AiConversation.user_id == user.id
+            )
+        )
+    ]
+    if convo_ids:
+        db_session.execute(
+            delete(AiMessage).where(AiMessage.conversation_id.in_(convo_ids))
+        )
+    db_session.execute(delete(AiConversation).where(AiConversation.user_id == user.id))
+    db_session.execute(delete(User).where(User.id == user.id))
+    db_session.commit()
+
+
+def test_history_is_empty_before_any_chat(client, member):
+    _, token = member
+    body = client.get("/v1/ai-coach/messages", headers=_h(token)).json()
+    assert body["messages"] == []
+
+
+def test_reading_history_does_not_create_a_conversation(client, db_session, member):
+    """채팅 화면만 열고 아무 말도 안 한 사용자에게 빈 대화 레코드를 남기지 않는다."""
+    import sqlalchemy as sa
+
+    user, token = member
+    client.get("/v1/ai-coach/messages", headers=_h(token))
+
+    count = db_session.scalar(
+        sa.select(sa.func.count()).select_from(AiConversation).where(
+            AiConversation.user_id == user.id
+        )
+    )
+    assert count == 0
+
+
+def test_chat_persists_question_and_reply_in_order(client, member):
+    """#274 수용 기준: 재접속에서 히스토리가 유지된다.
+
+    순서가 핵심이다 — created_at 으로 정렬하면 안 된다. PostgreSQL 의 now() 는
+    트랜잭션 시각이라 같은 커밋의 질문·답변이 동일한 값을 갖고, 실제로 답변이
+    질문보다 먼저 나왔다. seq 로 고정한다.
+    """
+    _, token = member
+    res = client.post(
+        "/v1/ai-coach/chat", json={"message": "나트륨 줄이는 법 알려주세요"},
+        headers=_h(token),
+    )
+    assert res.status_code == 200
+    reply = res.json()["reply"]
+    assert reply  # LLM 이 죽어도 폴백 답변이 온다
+
+    messages = client.get("/v1/ai-coach/messages", headers=_h(token)).json()["messages"]
+    assert [m["role"] for m in messages] == ["user", "coach"]
+    assert messages[0]["content"] == "나트륨 줄이는 법 알려주세요"
+    assert messages[1]["content"] == reply
+
+
+def test_multiple_turns_keep_their_order(client, member):
+    _, token = member
+    for i in range(3):
+        client.post(
+            "/v1/ai-coach/chat", json={"message": f"질문 {i}"}, headers=_h(token)
+        )
+
+    messages = client.get("/v1/ai-coach/messages", headers=_h(token)).json()["messages"]
+    assert [m["role"] for m in messages] == ["user", "coach"] * 3
+    assert [m["content"] for m in messages if m["role"] == "user"] == [
+        "질문 0", "질문 1", "질문 2",
+    ]
+
+
+def test_sources_survive_a_reload(client, member):
+    """복원했을 때 근거가 사라지면 왜 그렇게 답했는지 되짚을 수 없다."""
+    _, token = member
+    sent = client.post(
+        "/v1/ai-coach/chat", json={"message": "나트륨"}, headers=_h(token)
+    ).json()
+
+    messages = client.get("/v1/ai-coach/messages", headers=_h(token)).json()["messages"]
+    coach_turn = messages[1]
+    assert coach_turn["sources"] == sent["sources"]
+    assert messages[0]["sources"] == []  # 사용자 발화엔 근거가 없다
+
+
+def test_history_is_isolated_per_user(client, db_session, member):
+    """다른 사용자의 대화가 섞이면 개인정보 유출이다."""
+    from app.core.security import hash_password
+
+    user_a, token_a = member
+    client.post("/v1/ai-coach/chat", json={"message": "A 의 비밀"}, headers=_h(token_a))
+
+    email_b = f"coach-other-{uuid.uuid4().hex[:8]}@example.com"
+    user_b = User(
+        id=f"user-{uuid.uuid4().hex[:12]}", email=email_b, name="다른 사용자",
+        hashed_password=hash_password("pw!"), role="member",
+    )
+    db_session.add(user_b)
+    db_session.commit()
+    try:
+        token_b = client.post(
+            "/v1/auth/login", data={"username": email_b, "password": "pw!"}
+        ).json()["access_token"]
+        body = client.get("/v1/ai-coach/messages", headers=_h(token_b)).json()
+        assert body["messages"] == []
+    finally:
+        db_session.execute(delete(User).where(User.id == user_b.id))
+        db_session.commit()
+
+
+def test_server_history_is_used_without_client_history(client, db_session, member):
+    """클라가 history 를 안 보내도 서버 저장분이 맥락으로 쓰인다.
+
+    이게 성립해야 다른 기기에서 대화를 이어받을 수 있다.
+    """
+    user, token = member
+    client.post("/v1/ai-coach/chat", json={"message": "첫 질문"}, headers=_h(token))
+
+    stored = conversation.load_messages(db_session, user.id)
+    assert [m.role for m in stored] == ["user", "coach"]
+    assert stored[0].content == "첫 질문"
+    assert stored[0].seq < stored[1].seq
+
+
+def test_empty_message_is_rejected_and_stores_nothing(client, member):
+    user, token = member
+    assert client.post(
+        "/v1/ai-coach/chat", json={"message": "   "}, headers=_h(token)
+    ).status_code == 400
+    assert client.get("/v1/ai-coach/messages", headers=_h(token)).json()["messages"] == []
+
+
+def test_parse_sources_survives_corrupt_values():
+    """저장값이 깨져도 화면이 죽으면 안 된다."""
+    assert conversation.parse_sources('["a", "b"]') == ["a", "b"]
+    assert conversation.parse_sources("") == []
+    assert conversation.parse_sources("not json") == []
+    assert conversation.parse_sources('{"not": "a list"}') == []

--- a/backend/tests/test_coach_personalization.py
+++ b/backend/tests/test_coach_personalization.py
@@ -1,0 +1,181 @@
+"""AI 코치 답변의 개인화(#274 수용 기준: "개인 최근 식단이 답변 근거로 반영").
+
+검증하는 사슬은 이렇다:
+
+    POST /diet/analyze  →  diet_entries 저장  →  record_diet 로 개인 RAG 문서 적재
+                        →  retrieve 가 그 문서를 찾음  →  채팅 프롬프트에 실림
+
+마지막 단계를 **모델의 말투가 아니라 프롬프트 내용**으로 검증한다. "답변에 '비빔밥'
+이 나오는지"로 확인하면 LLM 이 그 단어를 안 쓰기만 해도 깨지는, 실패를 신뢰할 수 없는
+테스트가 된다. 프롬프트에 근거가 실렸는지는 결정론적이다.
+
+임베딩은 키가 없으면 해시 임베더로 폴백하므로(embedder/factory) CI 에서도 돈다.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import delete
+
+from app.models.models import AiConversation, AiMessage, CoachDocument, DietEntry, User
+from app.services.coach.llm_base import LLMResult
+
+_JPEG = b"\xff\xd8\xff\xe0\x00\x10JFIF fake-image-bytes"
+
+
+def _h(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+class _RecordingLLM:
+    """프롬프트를 붙잡아 두는 가짜 LLM. 답변 내용은 검증 대상이 아니다."""
+
+    name = "recording"
+
+    def __init__(self) -> None:
+        self.system_prompt = ""
+        self.user_prompt = ""
+
+    def generate(self, system_prompt: str, user_prompt: str, **kwargs) -> LLMResult:
+        self.system_prompt = system_prompt
+        self.user_prompt = user_prompt
+        return LLMResult(text="네, 참고해서 답변드릴게요.", model=self.name)
+
+
+@pytest.fixture
+def recording_llm(monkeypatch) -> _RecordingLLM:
+    llm = _RecordingLLM()
+    monkeypatch.setattr("app.services.coach.chat.get_coach_llm", lambda *a, **k: llm)
+    return llm
+
+
+@pytest.fixture
+def member(client, db_session):
+    from app.core.security import hash_password
+
+    email = f"coach-personal-{uuid.uuid4().hex[:8]}@example.com"
+    user = User(
+        id=f"user-{uuid.uuid4().hex[:12]}", email=email, name="개인화 테스트",
+        hashed_password=hash_password("pw!"), role="member",
+    )
+    db_session.add(user)
+    db_session.commit()
+
+    token = client.post(
+        "/v1/auth/login", data={"username": email, "password": "pw!"}
+    ).json()["access_token"]
+    yield user, token
+
+    convo_ids = [
+        c.id
+        for c in db_session.scalars(
+            __import__("sqlalchemy").select(AiConversation).where(
+                AiConversation.user_id == user.id
+            )
+        )
+    ]
+    if convo_ids:
+        db_session.execute(
+            delete(AiMessage).where(AiMessage.conversation_id.in_(convo_ids))
+        )
+    db_session.execute(delete(AiConversation).where(AiConversation.user_id == user.id))
+    db_session.execute(delete(CoachDocument).where(CoachDocument.user_id == user.id))
+    db_session.execute(delete(DietEntry).where(DietEntry.user_id == user.id))
+    db_session.execute(delete(User).where(User.id == user.id))
+    db_session.commit()
+
+
+def test_saved_diet_becomes_a_personal_rag_document(client, db_session, member):
+    """식단을 기록하면 코치가 검색할 수 있는 개인 문서가 생긴다."""
+    import sqlalchemy as sa
+
+    user, token = member
+    res = client.post(
+        "/v1/diet/analyze",
+        files={"image": ("meal.jpg", _JPEG, "image/jpeg")},
+        data={"meal_type": "lunch"},
+        headers=_h(token),
+    )
+    assert res.status_code == 200, res.text
+
+    docs = db_session.scalars(
+        sa.select(CoachDocument).where(CoachDocument.user_id == user.id)
+    ).all()
+    assert docs, "식단 저장이 개인 RAG 문서를 만들지 않았다"
+    joined = " ".join(d.content for d in docs)
+    assert "비빔밥" in joined          # 스텁 인식기가 낸 음식
+    assert "나트륨" in joined
+
+
+def test_recent_diet_is_grounded_into_the_chat_prompt(
+    client, db_session, member, recording_llm
+):
+    """#274 수용 기준: 개인 최근 식단이 답변 근거로 반영된다.
+
+    모델이 뭐라고 답했는지가 아니라, 개인 기록이 프롬프트의 근거로 들어갔는지를 본다.
+    """
+    _, token = member
+    client.post(
+        "/v1/diet/analyze",
+        files={"image": ("meal.jpg", _JPEG, "image/jpeg")},
+        data={"meal_type": "lunch"},
+        headers=_h(token),
+    )
+
+    res = client.post(
+        "/v1/ai-coach/chat",
+        json={"message": "오늘 먹은 걸 보고 저녁을 추천해 주세요"},
+        headers=_h(token),
+    )
+    assert res.status_code == 200
+
+    prompt = recording_llm.user_prompt
+    assert "[내 건강 기록]" in prompt
+    assert "비빔밥" in prompt, "개인 식단 기록이 프롬프트 근거로 실리지 않았다"
+
+
+def test_other_users_diet_never_reaches_my_prompt(
+    client, db_session, member, recording_llm
+):
+    """개인 기록이 남의 프롬프트에 섞이면 개인정보 유출이다."""
+    from app.core.security import hash_password
+    from app.services.coach.rag import ingest_personal_text
+
+    _, token = member
+
+    other = User(
+        id=f"user-{uuid.uuid4().hex[:12]}",
+        email=f"coach-other-{uuid.uuid4().hex[:8]}@example.com",
+        name="다른 사용자", hashed_password=hash_password("pw!"), role="member",
+    )
+    db_session.add(other)
+    db_session.commit()
+    try:
+        ingest_personal_text(
+            db_session, other.id, "남의 비밀 기록: 삼겹살 500g",
+            domain="diet", source="diet",
+        )
+        client.post(
+            "/v1/ai-coach/chat",
+            json={"message": "제 식단 기록 알려주세요"},
+            headers=_h(token),
+        )
+        assert "비밀 기록" not in recording_llm.user_prompt
+        assert "삼겹살" not in recording_llm.user_prompt
+    finally:
+        db_session.execute(delete(CoachDocument).where(CoachDocument.user_id == other.id))
+        db_session.execute(delete(User).where(User.id == other.id))
+        db_session.commit()
+
+
+def test_system_prompt_keeps_the_medical_disclaimer(client, member, recording_llm):
+    """의료 조언 면책 — 진단 단정 금지와 전문의 상담 권유가 지시에 남아 있어야 한다."""
+    _, token = member
+    client.post(
+        "/v1/ai-coach/chat", json={"message": "혈압약 끊어도 될까요?"}, headers=_h(token)
+    )
+
+    system = recording_llm.system_prompt
+    assert "진단" in system
+    assert "전문의" in system

--- a/frontend/flutter/lib/features/ai_coach/data/repositories/dio_ai_coach_repository.dart
+++ b/frontend/flutter/lib/features/ai_coach/data/repositories/dio_ai_coach_repository.dart
@@ -15,6 +15,16 @@ class DioAiCoachRepository implements AiCoachRepository {
   }
 
   @override
+  Future<List<ChatMessage>> fetchHistory() async {
+    final res = await _dio.get<Map<String, Object?>>('/ai-coach/messages');
+    final raw = (res.data?['messages'] as List<Object?>?) ?? const <Object?>[];
+    return <ChatMessage>[
+      for (final Object? m in raw)
+        ChatMessage.fromStored(m! as Map<String, Object?>),
+    ];
+  }
+
+  @override
   Future<ChatMessage> sendMessage({
     required String message,
     required List<ChatMessage> history,

--- a/frontend/flutter/lib/features/ai_coach/data/repositories/dio_ai_coach_repository.dart
+++ b/frontend/flutter/lib/features/ai_coach/data/repositories/dio_ai_coach_repository.dart
@@ -8,6 +8,14 @@ class DioAiCoachRepository implements AiCoachRepository {
   DioAiCoachRepository(this._dio);
   final Dio _dio;
 
+  /// 채팅 응답 대기 시간. 전역 receiveTimeout(15초)으로는 모자란다.
+  ///
+  /// 코치 답변은 RAG 검색 + Gemini 생성이라 로컬 실측이 7.6~12.8초였다. 15초는
+  /// 로컬에서도 여유가 2초뿐이고 배포 후 네트워크 지연이 붙으면 정기적으로 넘는다.
+  /// 게다가 서버는 답변을 저장하므로, 앱만 타임아웃되면 사용자는 실패 메시지를 본
+  /// 뒤 다음에 채팅을 열었을 때 **본 적 없는 답변**을 발견하게 된다.
+  static const Duration _chatTimeout = Duration(seconds: 60);
+
   @override
   Future<AiCoachState> fetchState() async {
     final res = await _dio.get<Map<String, Object?>>('/ai-coach/feedback');
@@ -31,6 +39,7 @@ class DioAiCoachRepository implements AiCoachRepository {
   }) async {
     final res = await _dio.post<Map<String, Object?>>(
       '/ai-coach/chat',
+      options: Options(receiveTimeout: _chatTimeout),
       data: <String, Object?>{
         'message': message,
         'history': <Map<String, Object?>>[for (final m in history) m.toJson()],

--- a/frontend/flutter/lib/features/ai_coach/data/repositories/mock_ai_coach_repository.dart
+++ b/frontend/flutter/lib/features/ai_coach/data/repositories/mock_ai_coach_repository.dart
@@ -6,6 +6,13 @@ class MockAiCoachRepository implements AiCoachRepository {
   const MockAiCoachRepository();
 
   @override
+  Future<List<ChatMessage>> fetchHistory() async {
+    // 목업/데모 모드는 서버에 저장된 대화가 없다. 빈 목록을 주면 채팅이 지금처럼
+    // welcome 메시지 하나로 시작한다(데모 화면 불변).
+    return const <ChatMessage>[];
+  }
+
+  @override
   Future<ChatMessage> sendMessage({
     required String message,
     required List<ChatMessage> history,

--- a/frontend/flutter/lib/features/ai_coach/domain/entities/chat_message.dart
+++ b/frontend/flutter/lib/features/ai_coach/domain/entities/chat_message.dart
@@ -23,6 +23,17 @@ class ChatMessage {
     'content': content,
   };
 
+  /// Parse a stored turn from `GET /ai-coach/messages` → `{ role, content, sources }`.
+  factory ChatMessage.fromStored(Map<String, Object?> json) => ChatMessage(
+    role: (json['role'] as String?) == 'user' ? ChatRole.user : ChatRole.coach,
+    content: ((json['content'] as String?) ?? '').trim(),
+    sources: <String>[
+      for (final Object? s
+          in (json['sources'] as List<Object?>?) ?? const <Object?>[])
+        s.toString(),
+    ],
+  );
+
   /// Parse a coach reply from `POST /ai-coach/chat` → `{ reply, sources }`.
   factory ChatMessage.coachFromReply(Map<String, Object?> json) => ChatMessage(
     role: ChatRole.coach,

--- a/frontend/flutter/lib/features/ai_coach/domain/repositories/ai_coach_repository.dart
+++ b/frontend/flutter/lib/features/ai_coach/domain/repositories/ai_coach_repository.dart
@@ -4,7 +4,16 @@ import 'package:oncare/features/ai_coach/domain/entities/chat_message.dart';
 abstract class AiCoachRepository {
   Future<AiCoachState> fetchState();
 
+  /// GET /ai-coach/messages — 서버에 저장된 이전 대화.
+  ///
+  /// 채팅을 열 때 불러 재접속·다른 기기에서도 대화가 이어지게 한다. 아직 나눈
+  /// 대화가 없으면 빈 목록이다.
+  Future<List<ChatMessage>> fetchHistory();
+
   /// Send a user message (+ prior turns) and get the coach's reply.
+  ///
+  /// 서버가 대화를 저장하므로 [history] 를 보내지 않아도 맥락이 이어진다. 서버에
+  /// 저장분이 없을 때(목업으로 대화하다 실 서버로 전환한 경우)를 위해 계속 보낸다.
   Future<ChatMessage> sendMessage({
     required String message,
     required List<ChatMessage> history,

--- a/frontend/flutter/lib/features/ai_coach/presentation/controllers/chat_controller.dart
+++ b/frontend/flutter/lib/features/ai_coach/presentation/controllers/chat_controller.dart
@@ -31,9 +31,28 @@ class ChatState {
 }
 
 class ChatController extends StateNotifier<ChatState> {
-  ChatController(this._repo) : super(const ChatState());
+  ChatController(this._repo) : super(const ChatState()) {
+    _restore();
+  }
 
   final AiCoachRepository _repo;
+
+  /// 서버에 저장된 이전 대화를 불러온다(재접속·다른 기기에서 대화 잇기).
+  ///
+  /// 실패해도 조용히 넘어간다. 히스토리를 못 불러온 것 때문에 채팅을 못 쓰게
+  /// 만들 이유가 없고, 화면은 welcome 메시지로 정상 동작한다. 목업 모드는 항상
+  /// 빈 목록이라 지금과 똑같이 welcome 하나로 시작한다.
+  Future<void> _restore() async {
+    try {
+      final stored = await _repo.fetchHistory();
+      if (stored.isEmpty || !mounted) return;
+      // 복원한 대화가 있으면 welcome 대신 그것을 보여준다 — 이어 하는 대화에
+      // 매번 인사가 끼어들면 맥락이 끊긴다.
+      state = state.copyWith(messages: stored);
+    } catch (_) {
+      // 무시: welcome 메시지 상태 유지
+    }
+  }
 
   Future<void> send(String text) async {
     final message = text.trim();

--- a/frontend/flutter/lib/features/ai_coach/presentation/pages/ai_coach_page.dart
+++ b/frontend/flutter/lib/features/ai_coach/presentation/pages/ai_coach_page.dart
@@ -102,7 +102,25 @@ class _AICoachPageState extends ConsumerState<AICoachPage> {
                           ),
                         ),
                       ),
-                      const SizedBox(height: 24),
+                      const SizedBox(height: 12),
+                      // 의료 조언 면책 — 코치는 식단·운동 코칭이지 진료가 아니다.
+                      // 시스템 프롬프트에도 진단 금지 지시가 있지만, 사용자가
+                      // 그걸 볼 수는 없으므로 화면에도 한 줄 남긴다.
+                      Center(
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 24),
+                          child: Text(
+                            l.aicMedicalDisclaimer,
+                            textAlign: TextAlign.center,
+                            style: const TextStyle(
+                              fontSize: 10.5,
+                              height: 1.4,
+                              color: FigmaColors.textMuted,
+                            ),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 20),
                       for (final ChatMessage m in chat.messages) ...<Widget>[
                         _bubble(m),
                         const SizedBox(height: 16),

--- a/frontend/flutter/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations.dart
@@ -2402,6 +2402,12 @@ abstract class AppLocalizations {
   /// **'Today'**
   String get aicDatePillToday;
 
+  /// No description provided for @aicMedicalDisclaimer.
+  ///
+  /// In en, this message translates to:
+  /// **'The AI coach is a reference for diet and exercise habits, not a diagnosis or prescription. Please consult a doctor about symptoms.'**
+  String get aicMedicalDisclaimer;
+
   /// No description provided for @aicInputHint.
   ///
   /// In en, this message translates to:

--- a/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
@@ -1267,6 +1267,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get aicDatePillToday => 'Today';
 
   @override
+  String get aicMedicalDisclaimer =>
+      'The AI coach is a reference for diet and exercise habits, not a diagnosis or prescription. Please consult a doctor about symptoms.';
+
+  @override
   String get aicInputHint => 'Ask the AI anything';
 
   @override

--- a/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
@@ -1252,6 +1252,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get aicDatePillToday => '오늘';
 
   @override
+  String get aicMedicalDisclaimer =>
+      'AI 코치는 식단·운동 관리를 돕는 참고용이에요. 진단·처방이 아니니 증상이 있으면 전문의와 상담해 주세요.';
+
+  @override
   String get aicInputHint => 'AI에게 무엇이든 물어보세요';
 
   @override

--- a/frontend/flutter/lib/l10n/app_en.arb
+++ b/frontend/flutter/lib/l10n/app_en.arb
@@ -683,6 +683,7 @@
   "navExerciseOptionSub": "Log the type and duration",
   "aicHeaderSubtitle": "Ask me anytime",
   "aicDatePillToday": "Today",
+  "aicMedicalDisclaimer": "The AI coach is a reference for diet and exercise habits, not a diagnosis or prescription. Please consult a doctor about symptoms.",
   "aicInputHint": "Ask the AI anything",
   "aicQuickRepliesLabel": "Try asking",
   "aicQuickReply1": "Recommend a dinner menu for today",

--- a/frontend/flutter/lib/l10n/app_ko.arb
+++ b/frontend/flutter/lib/l10n/app_ko.arb
@@ -428,6 +428,7 @@
   "navExerciseOptionSub": "종류와 시간 기록",
   "aicHeaderSubtitle": "언제든 물어보세요",
   "aicDatePillToday": "오늘",
+  "aicMedicalDisclaimer": "AI 코치는 식단·운동 관리를 돕는 참고용이에요. 진단·처방이 아니니 증상이 있으면 전문의와 상담해 주세요.",
   "aicInputHint": "AI에게 무엇이든 물어보세요",
   "aicQuickRepliesLabel": "이런 걸 물어보세요",
   "aicQuickReply1": "오늘 저녁 메뉴 추천해줘",

--- a/frontend/flutter/test/features/ai_coach/chat_controller_test.dart
+++ b/frontend/flutter/test/features/ai_coach/chat_controller_test.dart
@@ -8,9 +8,23 @@ import 'package:oncare/features/ai_coach/presentation/controllers/ai_coach_contr
 import 'package:oncare/features/ai_coach/presentation/controllers/chat_controller.dart';
 
 class _FakeCoachRepo implements AiCoachRepository {
+  _FakeCoachRepo({this.stored = const <ChatMessage>[], this.historyFails = false});
+
+  /// 서버에 저장돼 있다고 가정할 이전 대화.
+  final List<ChatMessage> stored;
+
+  /// true 면 히스토리 조회가 실패한다(복원 실패해도 채팅은 살아 있어야 한다).
+  final bool historyFails;
+
   @override
   Future<AiCoachState> fetchState() async =>
       const AiCoachState(greeting: '', suggestions: <AiSuggestion>[]);
+
+  @override
+  Future<List<ChatMessage>> fetchHistory() async {
+    if (historyFails) throw Exception('history unavailable');
+    return stored;
+  }
 
   @override
   Future<ChatMessage> sendMessage({
@@ -59,5 +73,75 @@ void main() {
     expect(state.messages.last.sources, contains('나트륨 줄이기'));
     // 진행 중 표시(pending)는 응답 후 남아있지 않아야 한다.
     expect(state.messages.any((ChatMessage m) => m.pending), isFalse);
+  });
+
+  // ── 대화 복원(#274) ──────────────────────────────────────────────────────
+
+  test('저장된 대화가 있으면 welcome 대신 그 대화를 보여준다', () async {
+    final container = ProviderContainer(
+      overrides: <Override>[
+        aiCoachRepositoryProvider.overrideWithValue(
+          _FakeCoachRepo(
+            stored: const <ChatMessage>[
+              ChatMessage(role: ChatRole.user, content: '어제 물어본 것'),
+              ChatMessage(
+                role: ChatRole.coach,
+                content: '어제 답변',
+                sources: <String>['나트륨 줄이기'],
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    container.read(chatControllerProvider); // 컨트롤러 생성 → 복원 시작
+    await Future<void>.delayed(Duration.zero);
+
+    final state = container.read(chatControllerProvider);
+    expect(state.messages.length, 2);
+    expect(state.messages.first.content, '어제 물어본 것');
+    // 근거도 함께 복원돼야 왜 그렇게 답했는지 되짚을 수 있다.
+    expect(state.messages.last.sources, contains('나트륨 줄이기'));
+  });
+
+  test('저장된 대화가 없으면 지금처럼 welcome 하나로 시작한다', () async {
+    // 목업/데모 모드가 이 경로다 — 화면이 이전과 같아야 한다.
+    final container = ProviderContainer(
+      overrides: <Override>[
+        aiCoachRepositoryProvider.overrideWithValue(_FakeCoachRepo()),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    container.read(chatControllerProvider);
+    await Future<void>.delayed(Duration.zero);
+
+    final state = container.read(chatControllerProvider);
+    expect(state.messages.length, 1);
+    expect(state.messages.single.role, ChatRole.coach);
+  });
+
+  test('히스토리 조회가 실패해도 채팅은 그대로 쓸 수 있다', () async {
+    final container = ProviderContainer(
+      overrides: <Override>[
+        aiCoachRepositoryProvider.overrideWithValue(
+          _FakeCoachRepo(historyFails: true),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    container.read(chatControllerProvider);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(container.read(chatControllerProvider).messages.length, 1);
+
+    // 복원이 실패했어도 전송은 정상 동작한다.
+    await container.read(chatControllerProvider.notifier).send('질문');
+    final state = container.read(chatControllerProvider);
+    expect(state.messages.last.role, ChatRole.coach);
+    expect(state.sending, isFalse);
   });
 }

--- a/frontend/flutter/test/features/ai_coach/dio_ai_coach_repository_test.dart
+++ b/frontend/flutter/test/features/ai_coach/dio_ai_coach_repository_test.dart
@@ -1,0 +1,95 @@
+/// AI 코치 REST 계약 — 백엔드 실응답 형태를 그대로 넣어 필드명 어긋남을 잡는다.
+library;
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/ai_coach/data/repositories/dio_ai_coach_repository.dart';
+import 'package:oncare/features/ai_coach/domain/entities/chat_message.dart';
+
+class _StubAdapter implements HttpClientAdapter {
+  _StubAdapter(this.body);
+
+  final String body;
+  RequestOptions? lastRequest;
+
+  @override
+  Future<ResponseBody> fetch(RequestOptions options, _, _) async {
+    lastRequest = options;
+    return ResponseBody.fromString(
+      body,
+      200,
+      headers: <String, List<String>>{
+        Headers.contentTypeHeader: <String>[Headers.jsonContentType],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+Dio _dioWith(_StubAdapter adapter) {
+  // 전역 기본값을 앱과 같게 둔다 — 채팅만 더 긴 타임아웃을 쓰는지 확인해야 하므로.
+  final dio = Dio(
+    BaseOptions(receiveTimeout: const Duration(seconds: 15)),
+  )..httpClientAdapter = adapter;
+  return dio;
+}
+
+void main() {
+  test('저장된 대화를 role/content/sources 로 복원한다', () async {
+    final adapter = _StubAdapter(
+      '{"messages":['
+      '{"role":"user","content":"나트륨 줄이는 법","sources":[],'
+      '"created_at":"2026-08-08T10:00:00Z"},'
+      '{"role":"coach","content":"국물을 남겨보세요","sources":["나트륨 줄이기"],'
+      '"created_at":"2026-08-08T10:00:01Z"}]}',
+    );
+    final repo = DioAiCoachRepository(_dioWith(adapter));
+
+    final history = await repo.fetchHistory();
+
+    expect(history.length, 2);
+    expect(history.first.isUser, isTrue);
+    expect(history.first.content, '나트륨 줄이는 법');
+    expect(history.last.role, ChatRole.coach);
+    expect(history.last.sources, <String>['나트륨 줄이기']);
+    expect(adapter.lastRequest?.path, '/ai-coach/messages');
+  });
+
+  test('빈 히스토리도 정상 처리한다', () async {
+    final repo = DioAiCoachRepository(_dioWith(_StubAdapter('{"messages":[]}')));
+    expect(await repo.fetchHistory(), isEmpty);
+  });
+
+  test('채팅은 전역 15초가 아니라 더 긴 타임아웃을 쓴다', () async {
+    // 코치 답변은 RAG + Gemini 라 실측 7.6~12.8초였다. 15초면 배포 후 정기적으로
+    // 넘고, 서버는 답변을 저장하므로 사용자는 실패를 본 뒤 다음에 열었을 때
+    // 본 적 없는 답변을 발견하게 된다.
+    final adapter = _StubAdapter('{"reply":"네","sources":[]}');
+    final repo = DioAiCoachRepository(_dioWith(adapter));
+
+    await repo.sendMessage(message: '안녕', history: const <ChatMessage>[]);
+
+    final timeout = adapter.lastRequest?.receiveTimeout;
+    expect(timeout, isNotNull);
+    expect(timeout! > const Duration(seconds: 15), isTrue);
+  });
+
+  test('코치 답변의 근거를 그대로 싣는다', () async {
+    final adapter = _StubAdapter(
+      '{"reply":"국물을 남겨보세요","sources":["나트륨 줄이기","DASH 식단 개요"]}',
+    );
+    final repo = DioAiCoachRepository(_dioWith(adapter));
+
+    final reply = await repo.sendMessage(
+      message: '나트륨',
+      history: const <ChatMessage>[],
+    );
+
+    expect(reply.role, ChatRole.coach);
+    expect(reply.content, '국물을 남겨보세요');
+    expect(reply.sources, contains('DASH 식단 개요'));
+  });
+}


### PR DESCRIPTION
Closes #274

## Summary

AI 코치 채팅을 프로덕션에서 쓸 수 있는 상태로 마감합니다. 백엔드는 이미 RAG 검색 →
Gemini 생성 → 폴백까지 구현돼 있었으나 **무상태**여서 히스토리를 클라가 매번 실어
보내야 했고, 재접속·다기기에서 대화가 사라졌습니다.

대화를 서버에 저장·복원하고, 개인화가 실제로 동작하는지 고정하고, 실 서비스에서
터질 지점(타임아웃·비용·면책)을 막았습니다.

## Changes

**대화 영속화**
- `ai_conversations` / `ai_messages` 테이블 + 마이그레이션 0022(downgrade 검증)
- `GET /ai-coach/messages` 신설, `POST /ai-coach/chat` 이 질문·답변을 한 커밋으로 저장
- 채팅은 서버 저장분을 맥락으로 사용 — 클라가 `history` 를 안 보내도 대화가 이어짐
- 앱: 채팅 진입 시 복원. 저장분이 있으면 welcome 대신 그 대화를 표시

**개인화 검증**
- `POST /diet/analyze → 개인 RAG 문서 → retrieve → 채팅 프롬프트` 사슬을 테스트로 고정
- 남의 개인 기록이 내 프롬프트에 섞이지 않는 것도 함께 고정

**하드닝**
- 채팅 응답 타임아웃 15초 → 60초 분리
- 채팅 전용 rate limit(`COACH_CHAT_PER_MINUTE`, 기본 20) — LLM 비용 가드
- 의료 조언 면책 문구를 채팅 화면에 노출(ko/en) + 시스템 지시 유지를 테스트로 고정

## Notes

**메시지 순서를 `created_at` 으로 잡으면 안 됩니다.** PostgreSQL 의 `now()` 는 트랜잭션
시각이라 같은 커밋에 저장되는 질문과 답변이 **동일한 `created_at`** 을 갖습니다.
처음에 `(created_at, id)` 로 정렬했더니 id 가 uuid 라 실제로 **답변이 질문보다 먼저**
나왔고, `flush()` 로도 해결되지 않아 `seq` 순번 컬럼을 뒀습니다.

**타임아웃은 단순 실패가 아니라 더 나쁜 상태를 만듭니다.** 실측 7.6~12.8초인데 앱
전역 타임아웃이 15초였습니다. 서버는 답변을 저장하므로 앱만 타임아웃되면 사용자는
에러를 본 뒤 다음에 열었을 때 **본 적 없는 답변**을 발견하게 됩니다.

**개인화는 모델 말투가 아니라 프롬프트 내용으로 검증합니다.** "답변에 '비빔밥'이
나오는지"로 확인하면 LLM 이 그 단어를 안 쓰기만 해도 깨지는, 실패를 신뢰할 수 없는
테스트가 됩니다.

조회 경로(`GET /ai-coach/messages`)는 스레드를 만들지 않습니다 — 채팅만 열고 아무 말도
안 한 사용자에게 빈 대화 레코드를 남기지 않기 위해서입니다. 앱에 대화 목록 UI 가
없어 **사용자당 활성 스레드 1개**를 get-or-create 하며, 나중에 목록이 필요해지면
`archived_at` 을 채우는 것으로 확장됩니다.

### 검증

실 Gemini 다기기 복원 — 두 번째 클라이언트가 로컬 히스토리 없이 서버 저장분만으로
맥락을 이어받습니다:

```
[기기 A] "저는 저녁에 라면을 자주 먹어요. 괜찮을까요?"
      → 라면 스프와 국물에는 나트륨이 많이 들어 있어서…  (근거: 나트륨 줄이기 외)
[기기 B] 복원된 대화 2건 — [user, coach]
         "제가 방금 뭘 자주 먹는다고 했죠?"
      → 방금 저녁에 **라면**을 자주 드신다고 말씀해 주셨어요!
```

개인화 — 기록한 식단이 답변 근거로 인용됩니다:

```
[식단 기록] 짬뽕, 단무지 / 750kcal, 나트륨 3,200mg
[질문] "오늘 제가 먹은 걸 보고 저녁을 추천해 주세요"
[답변] 오늘 드신 짬뽕과 단무지는 나트륨 함량(3,200mg)이 높아 …
       저녁은 나트륨을 대폭 줄인 식단이 필요해요.
```

테스트: 백엔드 386개, Flutter 312개 전부 통과(신규 백엔드 13개 · 앱 7개 포함).
백엔드 대화 테스트는 LLM 을 실패시켜 검색 기반 폴백 경로로 고정했습니다 — 폴백에서도
저장이 되어야 한다는 것 자체가 검증 대상입니다.

### 범위 밖

- **스트리밍** — #274 에서도 선택 항목이라 뺐습니다
- **앱의 실 백엔드 전환**(`USE_MOCK_API=false`) — 전역 플래그라 채팅만 따로 켤 수 없고
  #330(소셜 로그인)·#338(채팅 실연동) 과 함께 다뤄야 합니다
