### PR TITLE
feat(auth): Apple 로그인 verifier 구현 — JWKS 서명 검증

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -28,6 +28,14 @@ KAKAO_REST_API_KEY=
 PLACES_PROVIDER=auto
 KAKAO_TIMEOUT_SECONDS=3.0
 
+# --- 소셜 로그인 ---
+# Apple 로그인에서 허용할 aud(client_id) 목록, 콤마 구분.
+# iOS 앱은 번들 ID, 웹은 Service ID 로 서로 다른 aud 를 받으므로 복수를 넣는다.
+#   예: APPLE_CLIENT_IDS=com.oncare.app,com.oncare.web
+# 비워두면 Apple 로그인은 검증할 수 없어 **거부**된다(조용히 통과시키면 다른 앱용
+# Apple 토큰으로도 로그인이 뚫린다). kakao/google 은 별도 설정이 필요 없다.
+APPLE_CLIENT_IDS=
+
 # 기타
 CORS_ALLOW_ORIGINS=*
 # 운영은 false 권장. true로 켜면 DEMO_LOGIN_PASSWORD를 12자 이상으로 반드시 설정.

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -41,6 +41,13 @@ class Settings(BaseSettings):
     # 토큰 없이 접근 시 데모 사용자로 폴백(개발 편의). 운영(prod)에서는 항상 비활성.
     allow_demo_fallback: bool = True
 
+    # --- 소셜 로그인 ---
+    # Apple 로그인에서 허용할 `aud`(client_id) 목록, 콤마 구분.
+    # iOS 앱은 번들 ID, 웹은 Service ID 로 서로 다른 aud 를 받으므로 복수를 허용한다.
+    # 비어 있으면 Apple 로그인은 검증 불가로 **거부**된다(조용히 통과시키면 다른 앱용
+    # Apple 토큰으로도 로그인이 뚫린다).
+    apple_client_ids: str = ""
+
     # --- 장소(O2O) ---
     # 카카오 Local REST 키. 있으면 실검색, 없으면 시드 폴백(recognizer 팩토리와 같은 철학).
     kakao_rest_api_key: str = ""

--- a/backend/app/services/social/apple.py
+++ b/backend/app/services/social/apple.py
@@ -16,6 +16,7 @@ JWKS 는 `PyJWKClient` 가 캐싱하고 키 회전 시 다시 가져온다. 매 
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 from functools import lru_cache
 
@@ -34,6 +35,11 @@ APPLE_JWKS_URL = "https://appleid.apple.com/auth/keys"
 #: 쓰면 정상 로그인이 실패한다. PyJWKClient 는 캐시에 없는 kid 를 만나면 다시 받아온다.
 _JWKS_CACHE_LIFESPAN = 600
 
+#: JWKS 조회 HTTP 타임아웃(초). 기본값 30 초는 로그인 한 번이 30 초를 기다린다는 뜻이라
+#: 너무 길다. 스레드로 넘겨 이벤트 루프는 막히지 않지만, 그 스레드도 오래 잡혀 있으면
+#: 안 되므로 짧게 끊고 실패시킨다(다른 provider 의 httpx timeout=5.0 과 맞춤).
+_JWKS_TIMEOUT_SEC = 5
+
 
 @lru_cache
 def _jwk_client() -> PyJWKClient:
@@ -45,6 +51,7 @@ def _jwk_client() -> PyJWKClient:
         APPLE_JWKS_URL,
         cache_keys=True,
         lifespan=_JWKS_CACHE_LIFESPAN,
+        timeout=_JWKS_TIMEOUT_SEC,
     )
 
 
@@ -76,7 +83,14 @@ class AppleVerifier(SocialVerifier):
             raise SocialAuthError("APPLE_CLIENT_IDS 미설정")
 
         try:
-            signing_key = _jwk_client().get_signing_key_from_jwt(token)
+            # PyJWKClient 는 urllib 기반이라 **동기 블로킹**이다(다른 provider 는
+            # httpx.AsyncClient 라 이 문제가 없다). 캐시가 비었거나 Apple 이 키를
+            # 회전한 직후에는 여기서 실제 HTTP 요청이 나가는데, async 핸들러에서
+            # 그대로 호출하면 그동안 **이벤트 루프 전체가 멈춰** 무관한 요청까지
+            # 함께 지연된다. 스레드로 넘겨 루프를 놓아 준다.
+            signing_key = await asyncio.to_thread(
+                _jwk_client().get_signing_key_from_jwt, token
+            )
         except Exception as exc:  # noqa: BLE001 — JWKS 조회 실패·kid 불일치 등
             raise SocialAuthError(f"apple 공개키 조회 실패: {exc}") from exc
 

--- a/backend/app/services/social/apple.py
+++ b/backend/app/services/social/apple.py
@@ -1,16 +1,110 @@
-"""Apple 로그인 검증 (스텁).
+"""Apple 로그인 검증 — identity_token(JWT) 을 Apple 공개키로 서명 검증.
 
-Apple 은 identity_token(JWT) 을 Apple 공개키(JWKS: https://appleid.apple.com/auth/keys)로
-서명 검증하고 aud/iss 를 확인해야 한다. JWKS 캐싱·키 회전 처리가 필요해
-별도 작업으로 구현한다(스텁 유지 — 호출 시 501 로 응답).
+카카오/구글과 달리 Apple 은 토큰을 확인해 주는 조회 엔드포인트가 없다. 클라이언트가
+받은 identity_token 자체가 JWT 이고, 서버는 이걸 Apple 의 공개키(JWKS)로 **직접
+검증**해야 한다. 그래서 이 파일만 다른 provider 와 구조가 다르다.
+
+검증 항목(하나라도 빠지면 우회가 생긴다):
+- 서명: JWKS 의 공개키로. `kid` 로 키를 고르고, Apple 이 키를 회전해도 따라가야 한다.
+- `iss`: 반드시 https://appleid.apple.com
+- `aud`: **우리 앱의 client_id**. 이걸 확인하지 않으면 다른 앱용으로 발급된 유효한
+  Apple 토큰으로도 로그인이 뚫린다.
+- `exp`: 만료. PyJWT 가 기본으로 검사한다.
+
+JWKS 는 `PyJWKClient` 가 캐싱하고 키 회전 시 다시 가져온다. 매 로그인마다 Apple 에
+네트워크 요청을 보내지 않도록 클라이언트를 모듈 수준에서 재사용한다.
 """
 from __future__ import annotations
 
-from app.services.social.base import SocialIdentity, SocialVerifier
+import logging
+from functools import lru_cache
+
+import jwt
+from jwt import PyJWKClient
+
+from app.core.config import get_settings
+from app.services.social.base import SocialAuthError, SocialIdentity, SocialVerifier
+
+logger = logging.getLogger(__name__)
+
+APPLE_ISSUER = "https://appleid.apple.com"
+APPLE_JWKS_URL = "https://appleid.apple.com/auth/keys"
+
+#: JWKS 캐시 수명(초). Apple 은 키를 자주 바꾸지 않지만, 회전 후에도 낡은 키를 계속
+#: 쓰면 정상 로그인이 실패한다. PyJWKClient 는 캐시에 없는 kid 를 만나면 다시 받아온다.
+_JWKS_CACHE_LIFESPAN = 600
+
+
+@lru_cache
+def _jwk_client() -> PyJWKClient:
+    """JWKS 클라이언트(프로세스당 1개).
+
+    매 로그인마다 새로 만들면 캐시가 의미를 잃고 Apple 에 매번 요청이 나간다.
+    """
+    return PyJWKClient(
+        APPLE_JWKS_URL,
+        cache_keys=True,
+        lifespan=_JWKS_CACHE_LIFESPAN,
+    )
+
+
+def _allowed_audiences() -> list[str]:
+    """허용할 `aud` 목록.
+
+    iOS 앱은 번들 ID, 웹은 Service ID 로 서로 다른 aud 를 받기 때문에 복수를 허용한다.
+    """
+    raw = get_settings().apple_client_ids or ""
+    return [v.strip() for v in raw.split(",") if v.strip()]
 
 
 class AppleVerifier(SocialVerifier):
     provider = "apple"
 
     async def verify(self, token: str) -> SocialIdentity:
-        raise NotImplementedError("Apple 로그인 검증은 이후 구현 예정입니다.")
+        audiences = _allowed_audiences()
+        if not audiences:
+            # 설정이 없다고 검증을 건너뛰면 안 된다. aud 를 확인하지 않는 순간 다른
+            # 앱용 Apple 토큰으로도 로그인이 뚫리므로, 조용히 통과시키는 대신 막는다.
+            # (다른 provider 는 키가 없으면 폴백하지만, 인증은 폴백 대상이 아니다.)
+            #
+            # 클라이언트에는 라우터가 일반화된 401 을 주므로, 운영자가 원인을 알 수
+            # 있도록 여기서 설정 문제임을 로그로 남긴다 — 안 그러면 "토큰이 잘못됐나"
+            # 를 한참 들여다보게 된다.
+            logger.error(
+                "APPLE_CLIENT_IDS 미설정 — Apple 로그인을 검증할 수 없어 거부합니다."
+            )
+            raise SocialAuthError("APPLE_CLIENT_IDS 미설정")
+
+        try:
+            signing_key = _jwk_client().get_signing_key_from_jwt(token)
+        except Exception as exc:  # noqa: BLE001 — JWKS 조회 실패·kid 불일치 등
+            raise SocialAuthError(f"apple 공개키 조회 실패: {exc}") from exc
+
+        try:
+            claims = jwt.decode(
+                token,
+                signing_key.key,
+                algorithms=["RS256"],
+                audience=audiences,
+                issuer=APPLE_ISSUER,
+                options={"require": ["exp", "iss", "aud", "sub"]},
+            )
+        except jwt.InvalidTokenError as exc:
+            # 만료·aud 불일치·서명 위조 모두 여기로 온다. 원인은 로그로만 남기고
+            # 클라이언트에는 라우터가 일반화된 401 을 준다.
+            raise SocialAuthError(f"apple 토큰 검증 실패: {exc}") from exc
+
+        uid = str(claims.get("sub") or "")
+        if not uid:
+            raise SocialAuthError("apple 사용자 id(sub) 없음")
+
+        # Apple 은 이름을 토큰에 담지 않는다. 최초 로그인 때 클라이언트가 별도로 한 번만
+        # 받으므로, 서버는 이름을 비워 두고 이메일만 취한다.
+        # `email_verified`/`is_private_email` 은 문자열("true")로 오는 경우가 있어
+        # 값 비교 대신 존재 여부만 쓴다.
+        return SocialIdentity(
+            provider="apple",
+            provider_user_id=uid,
+            email=str(claims.get("email") or ""),
+            name="",
+        )

--- a/backend/tests/test_social_apple.py
+++ b/backend/tests/test_social_apple.py
@@ -1,0 +1,193 @@
+"""Apple 로그인 검증 (#330).
+
+Apple 은 토큰을 확인해 주는 조회 엔드포인트가 없어 서버가 JWT 를 직접 검증한다.
+검증이 한 군데라도 비면 우회가 생기므로, **뚫리는 경우가 실제로 막히는지**를 본다:
+만료·aud 불일치·iss 위조·서명 위조·alg 강등(none).
+
+테스트용 RSA 키쌍을 만들어 JWKS 를 대신하므로 네트워크가 필요 없다(CI 에 Apple
+자격증명이 없고, 있더라도 실제 Apple 토큰은 재현할 수 없다).
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from app.services.social import apple as apple_mod
+from app.services.social.apple import AppleVerifier
+from app.services.social.base import SocialAuthError
+
+_KID = "test-key-1"
+
+
+@pytest.fixture(scope="module")
+def keypair():
+    """서명용 개인키와 검증용 공개키."""
+    private = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return private, private.public_key()
+
+
+@pytest.fixture(autouse=True)
+def _apple_client_ids(monkeypatch):
+    """허용 aud 를 고정한다(설정 파일·환경에 의존하지 않도록)."""
+    monkeypatch.setattr(
+        apple_mod, "_allowed_audiences", lambda: ["com.oncare.app", "com.oncare.web"]
+    )
+
+
+@pytest.fixture(autouse=True)
+def _stub_jwks(monkeypatch, keypair):
+    """JWKS 조회를 테스트 공개키로 대체 — 네트워크를 타지 않는다."""
+    _, public = keypair
+
+    class _Key:
+        key = public
+
+    class _Client:
+        def get_signing_key_from_jwt(self, token):  # noqa: ANN001
+            return _Key()
+
+    monkeypatch.setattr(apple_mod, "_jwk_client", lambda: _Client())
+
+
+def _token(keypair, **overrides) -> str:
+    private, _ = keypair
+    now = datetime.now(tz=timezone.utc)
+    claims = {
+        "iss": apple_mod.APPLE_ISSUER,
+        "aud": "com.oncare.app",
+        "sub": "001234.abcdef.5678",
+        "email": "user@privaterelay.appleid.com",
+        "iat": now,
+        "exp": now + timedelta(minutes=10),
+    }
+    claims.update(overrides)
+    return jwt.encode(claims, private, algorithm="RS256", headers={"kid": _KID})
+
+
+def _verify(token: str):
+    """검증 실행.
+
+    이 저장소엔 pytest-asyncio 가 없고 async 테스트도 이것뿐이라, 의존성을 늘리는
+    대신 코루틴을 직접 돌린다.
+    """
+    return asyncio.run(AppleVerifier().verify(token))
+
+
+def test_valid_token_returns_identity(keypair):
+    identity = _verify(_token(keypair))
+
+    assert identity.provider == "apple"
+    assert identity.provider_user_id == "001234.abcdef.5678"
+    assert identity.email == "user@privaterelay.appleid.com"
+    # Apple 은 이름을 토큰에 담지 않는다(최초 로그인 때 클라이언트가 따로 받는다).
+    assert identity.name == ""
+
+
+def test_web_audience_is_also_accepted(keypair):
+    """iOS 는 번들 ID, 웹은 Service ID 로 서로 다른 aud 를 받는다."""
+    identity = _verify(_token(keypair, aud="com.oncare.web"))
+    assert identity.provider_user_id
+
+
+def test_token_for_another_app_is_rejected(keypair):
+    """aud 를 확인하지 않으면 **다른 앱용 유효한 Apple 토큰**으로 로그인이 뚫린다."""
+    with pytest.raises(SocialAuthError):
+        _verify(_token(keypair, aud="com.someone-else.app"))
+
+
+def test_expired_token_is_rejected(keypair):
+    past = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+    with pytest.raises(SocialAuthError):
+        _verify(_token(keypair, exp=past, iat=past - timedelta(minutes=10)))
+
+
+def test_forged_issuer_is_rejected(keypair):
+    with pytest.raises(SocialAuthError):
+        _verify(_token(keypair, iss="https://evil.example.com"))
+
+
+def test_token_signed_by_another_key_is_rejected(keypair):
+    """서명 검증이 실제로 도는지 — 남의 키로 서명한 토큰은 통과하면 안 된다."""
+    attacker = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    now = datetime.now(tz=timezone.utc)
+    forged = jwt.encode(
+        {
+            "iss": apple_mod.APPLE_ISSUER,
+            "aud": "com.oncare.app",
+            "sub": "001234.abcdef.5678",
+            "iat": now,
+            "exp": now + timedelta(minutes=10),
+        },
+        attacker,
+        algorithm="RS256",
+        headers={"kid": _KID},
+    )
+    with pytest.raises(SocialAuthError):
+        _verify(forged)
+
+
+def test_unsigned_token_is_rejected(keypair):
+    """alg=none 강등 — 서명 없는 토큰을 받아 주면 아무나 로그인할 수 있다."""
+    now = datetime.now(tz=timezone.utc)
+    unsigned = jwt.encode(
+        {
+            "iss": apple_mod.APPLE_ISSUER,
+            "aud": "com.oncare.app",
+            "sub": "001234.abcdef.5678",
+            "iat": now,
+            "exp": now + timedelta(minutes=10),
+        },
+        key="",
+        algorithm="none",
+    )
+    with pytest.raises(SocialAuthError):
+        _verify(unsigned)
+
+
+def test_token_without_sub_is_rejected(keypair):
+    with pytest.raises(SocialAuthError):
+        _verify(_token(keypair, sub=""))
+
+
+def test_missing_client_id_config_refuses_instead_of_skipping(
+    monkeypatch, keypair
+):
+    """설정이 없으면 **검증을 건너뛰지 않고 거부**한다.
+
+    다른 provider 는 키가 없으면 폴백하지만 인증은 폴백 대상이 아니다. aud 확인을
+    생략하는 순간 다른 앱용 토큰으로 로그인이 뚫린다.
+    """
+    monkeypatch.setattr(apple_mod, "_allowed_audiences", list)
+
+    with pytest.raises(SocialAuthError):
+        _verify(_token(keypair))
+
+
+# ───────────────────────────────────────────────────────── 엔드포인트(DB) ──
+
+
+def test_endpoint_no_longer_returns_501(client):
+    """`POST /auth/social/apple` 이 더 이상 "미지원(501)"이 아니다.
+
+    이 이슈의 출발점이 501 이었다. 이제 검증을 실제로 수행하므로, 잘못된 토큰은
+    다른 provider 와 똑같이 401 로 거절돼야 한다(구현 여부가 응답으로 드러나면
+    안 된다).
+    """
+    res = client.post("/v1/auth/social/apple", json={"token": "not-a-real-token"})
+
+    assert res.status_code != 501
+    assert res.status_code == 401
+
+
+def test_endpoint_rejection_matches_other_providers(client):
+    """apple 이 kakao/google 과 같은 형태로 거절되는지 — 응답만 보고 어떤 provider 가
+    구현됐는지 알 수 없어야 한다."""
+    apple = client.post("/v1/auth/social/apple", json={"token": "bad"})
+    google = client.post("/v1/auth/social/google", json={"token": "bad"})
+
+    assert apple.status_code == google.status_code == 401
+    assert apple.json()["detail"] == google.json()["detail"]

--- a/backend/tests/test_social_apple.py
+++ b/backend/tests/test_social_apple.py
@@ -10,6 +10,7 @@ Apple 은 토큰을 확인해 주는 조회 엔드포인트가 없어 서버가 
 from __future__ import annotations
 
 import asyncio
+import threading
 from datetime import datetime, timedelta, timezone
 
 import jwt
@@ -40,17 +41,26 @@ def _apple_client_ids(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def _stub_jwks(monkeypatch, keypair):
-    """JWKS 조회를 테스트 공개키로 대체 — 네트워크를 타지 않는다."""
+    """JWKS 조회를 테스트 공개키로 대체 — 네트워크를 타지 않는다.
+
+    조회가 **어느 스레드에서 실행됐는지**도 기록한다. 이벤트 루프를 막지 않는지
+    검증하는 데 쓴다.
+    """
     _, public = keypair
 
     class _Key:
         key = public
 
     class _Client:
+        called_on: list[int] = []
+
         def get_signing_key_from_jwt(self, token):  # noqa: ANN001
+            _Client.called_on.append(threading.get_ident())
             return _Key()
 
+    _Client.called_on = []
     monkeypatch.setattr(apple_mod, "_jwk_client", lambda: _Client())
+    return _Client
 
 
 def _token(keypair, **overrides) -> str:
@@ -191,3 +201,24 @@ def test_endpoint_rejection_matches_other_providers(client):
 
     assert apple.status_code == google.status_code == 401
     assert apple.json()["detail"] == google.json()["detail"]
+
+
+def test_jwks_lookup_runs_off_the_event_loop(keypair, _stub_jwks):
+    """JWKS 조회는 이벤트 루프 밖(다른 스레드)에서 실행돼야 한다.
+
+    PyJWKClient 는 urllib 기반이라 동기 블로킹이다. 캐시가 비었거나 Apple 이 키를
+    회전한 직후에는 실제 HTTP 요청이 나가는데, async 핸들러에서 그대로 호출하면
+    그동안 이벤트 루프가 멈춰 **무관한 요청까지 함께 지연된다.**
+    """
+    main_thread = threading.get_ident()
+
+    async def _run():
+        await AppleVerifier().verify(_token(keypair))
+        return threading.get_ident()
+
+    loop_thread = asyncio.run(_run())
+
+    assert _stub_jwks.called_on, "JWKS 조회가 호출되지 않았다"
+    # 코루틴이 도는 스레드와 JWKS 조회가 실행된 스레드가 달라야 한다.
+    assert _stub_jwks.called_on[0] != loop_thread
+    assert _stub_jwks.called_on[0] != main_thread


### PR DESCRIPTION
Part of #330

## Summary

`POST /auth/social/apple` 이 501(미지원)을 반환하고 있었습니다. Apple identity_token 을
Apple 공개키로 직접 검증하도록 구현해 #330 의 백엔드 항목을 채웁니다.

Apple 은 카카오/구글과 달리 **토큰을 확인해 주는 조회 엔드포인트가 없습니다.**
클라이언트가 받은 identity_token 자체가 JWT 이고 서버가 서명을 직접 검증해야 해서,
이 verifier 만 다른 provider 와 구조가 다릅니다.

## Changes

- `AppleVerifier` 구현 — `PyJWKClient` 로 Apple 공개키를 캐싱하며 가져오고(키 회전
  자동 추적) 서명 · `iss` · `aud` · `exp` 를 검증
- `APPLE_CLIENT_IDS` 설정 추가(콤마 구분) + `.env.example` 문서화
- 검증 테스트 11개

기존 의존성만 씁니다(PyJWT + cryptography). 새 패키지 없음.

## Notes

**`aud` 확인이 이 구현의 핵심입니다.** 서명만 보고 `aud` 를 확인하지 않으면 **다른
앱용으로 발급된 유효한 Apple 토큰**으로도 우리 서비스에 로그인이 됩니다. iOS 는 번들
ID, 웹은 Service ID 로 서로 다른 `aud` 를 받으므로 목록으로 받습니다.

**설정이 비어 있으면 검증을 건너뛰지 않고 거부합니다.** 이 저장소의 다른 통합은 키가
없으면 폴백하지만(카카오 → 시드 데이터, 임베더 → 해시), 인증은 폴백 대상이 아닙니다.
다만 클라이언트에는 라우터가 일반화된 401 을 주므로, 운영자가 "토큰이 잘못됐나" 를
들여다보지 않도록 설정 문제임을 서버 로그에 남깁니다.

테스트는 **통과 경로보다 뚫리는 경로**에 무게를 뒀습니다. RSA 키쌍을 만들어 JWKS 를
대신하므로 네트워크가 필요 없습니다(CI 에 Apple 자격증명이 없고, 있더라도 실제 Apple
토큰은 재현 불가):

| 막아야 하는 것 | 테스트 |
| --- | --- |
| 다른 앱용 토큰 | `test_token_for_another_app_is_rejected` |
| 만료 토큰 | `test_expired_token_is_rejected` |
| iss 위조 | `test_forged_issuer_is_rejected` |
| 남의 키로 서명 | `test_token_signed_by_another_key_is_rejected` |
| `alg=none` 강등 | `test_unsigned_token_is_rejected` |
| 설정 누락 시 무검증 통과 | `test_missing_client_id_config_refuses_instead_of_skipping` |

엔드포인트가 더는 501 이 아니고, **다른 provider 와 동일한 401** 로 거절하는 것도
고정했습니다 — 응답만 보고 어떤 provider 가 구현됐는지 알 수 없어야 합니다.

## Apple 도입 계획은 없습니다 — 그럼에도 구현하는 이유

Apple 로그인은 유료 개발자 계정이 필요해 **현재 도입 계획이 없습니다.** 그럼에도
스텁을 구현으로 바꾸는 이유는 두 가지입니다.

1. **501 스텁은 그 자체로 정보를 흘립니다.** 응답만 보고 어떤 provider 가 미구현인지
   알 수 있습니다. 이제 다른 provider 와 동일한 401 로 거절합니다.
2. **도입하지 않아도 비용이 없습니다.** `APPLE_CLIENT_IDS` 를 비워 두면 Apple 경로는
   깨끗하게 거부되고 카카오·구글에는 아무 영향이 없습니다. 나중에 계정이 생기면
   설정 한 줄만 넣으면 됩니다.

## 범위 밖 — #330 은 열어 둡니다

#330 은 항목이 셋인데 이 PR 은 그중 백엔드 하나만 처리합니다. 애플을 도입하지 않더라도
나머지 둘은 그대로 남으므로 `Closes` 가 아니라 `Part of` 입니다.

- [x] 백엔드: Apple verifier 구현(현재 501) ← **이 PR**
- [ ] 프론트: Kakao/Google 네이티브 SDK 로 실제 토큰 획득 후 전송
- [ ] 실패/취소 UX, 신규 사용자 온보딩 연결

프론트 연동(`sign_in_page.dart:72` 의 `demo-<provider>-token`)은 Kakao 네이티브 앱 키 ·
Google OAuth 클라이언트 ID · URL 스킴 등록 같은 플랫폼 설정과 실기기 검증이 필요해
별도로 진행합니다. 전역 `USE_MOCK_API` 구조상 소셜 로그인만 실서버로 켜려면 #457 이
함께 있어야 데모를 깨지 않고 시연할 수 있습니다.

테스트: 백엔드 전체 통과(신규 12개 — 검증 우회 시나리오 6종 + 이벤트 루프 차단 방지).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - Apple 소셜 로그인의 JWT 토큰 검증을 지원합니다.
  - iOS 번들 ID와 웹 Service ID 등 여러 Apple 클라이언트 ID를 허용 목록으로 설정할 수 있습니다.
  - 서명, 발급자, 대상, 만료 기간 및 사용자 식별자를 확인해 안전한 로그인을 제공합니다.
- **버그 수정**
  - 유효하지 않거나 만료된 Apple 토큰은 일관된 인증 오류로 처리됩니다.
  - Apple 로그인 미설정 및 사용자 정보 누락 상황을 적절히 거부합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
