### PR TITLE
feat(app): 데모에서 기능별 실 백엔드 전환 스위치

### DIFF
--- a/frontend/flutter/README.md
+++ b/frontend/flutter/README.md
@@ -34,6 +34,16 @@ flutter build web --release \
   --dart-define=ENV=prod \
   --dart-define=API_BASE_URL=https://api.oncare.example.com
 
+# 기능별 실 백엔드 전환 (REAL_API)
+# USE_MOCK_API 는 전역이라 끄면 로그인·홈·식단·운동·채팅이 한꺼번에 실서버로 넘어간다.
+# 준비된 기능만 골라 실연동해 보여주고 싶을 때 쓴다. 지정하지 않으면 지금까지의
+# 데모 동작과 완전히 동일하다(기본 꺼짐).
+flutter run -d chrome \
+  --dart-define=API_BASE_URL=http://localhost:8000/v1 \
+  --dart-define=REAL_API=ai-coach       # AI 코치만 실 Gemini, 나머지는 목업
+# 사용 가능한 키: ai-coach(/ai-coach) · auth(/auth) · diet(/diet)
+# 키 → 경로 대응은 lib/core/config/app_config.dart 의 kRealApiFeatures 참고.
+
 # Android
 flutter run -d <android-device>  # debug
 flutter build apk --release      # 또는 build appbundle

--- a/frontend/flutter/lib/core/config/app_config.dart
+++ b/frontend/flutter/lib/core/config/app_config.dart
@@ -2,12 +2,32 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 enum Environment { dev, staging, prod }
 
+/// `REAL_API` 로 켤 수 있는 기능 키 → 실 백엔드로 보낼 경로 접두사.
+///
+/// 목업 인터셉터가 가로채는 경로 중 **어디까지를 실 서버로 넘길지**를 여기 한 곳에서
+/// 정한다. 기능별로 임시 플래그(`REAL_AI_COACH`, `REAL_AUTH` …)를 각각 만들면
+/// `AppConfig` 와 인터셉터라는 같은 파일이 이슈마다 고쳐져 충돌하므로, 키 목록을 받는
+/// 스위치 하나로 통일한다.
+///
+/// 새 기능을 켤 수 있게 하려면 여기에 키와 경로만 추가하면 된다 — 인터셉터는 손대지
+/// 않는다.
+const Map<String, List<String>> kRealApiFeatures = <String, List<String>>{
+  // AI 코치(온이) 대화·피드백. 리포지토리를 교체하지 않고 인터셉터만 가로채는
+  // 구조라, 경로만 흘려보내면 곧바로 실 Gemini 응답이 된다.
+  'ai-coach': <String>['/ai-coach'],
+  // 소셜 로그인 포함 인증. 실 OAuth 토큰을 서버가 검증하게 하려면 필요하다.
+  'auth': <String>['/auth'],
+  // 식단 기록·분석·추천.
+  'diet': <String>['/diet'],
+};
+
 class AppConfig {
   const AppConfig({
     required this.environment,
     required this.apiBaseUrl,
     required this.useMockApi,
     this.sentryDsn,
+    this.realApiFeatures = const <String>{},
   });
 
   final Environment environment;
@@ -18,6 +38,31 @@ class AppConfig {
   /// matching a known path and returns canned data. Used while the
   /// real REST backend (Q1 decision) is being built.
   final bool useMockApi;
+
+  /// 목업 모드에서도 **실 백엔드를 쓸 기능 키** 목록.
+  ///
+  /// `useMockApi` 는 전역 스위치라 끄는 순간 로그인·홈·식단·운동·채팅이 한꺼번에
+  /// 실서버로 넘어간다. 그래서 준비된 기능 하나만 먼저 실연동해 보여줄 수가 없었다.
+  /// 이 목록에 든 키에 해당하는 경로는 목업 인터셉터가 가로채지 않고 실 네트워크로
+  /// 흘려보낸다.
+  ///
+  /// 비어 있으면(기본값) 지금까지의 데모 동작과 **완전히 동일**하다.
+  ///
+  /// 키 → 경로 대응은 [kRealApiFeatures] 참고.
+  /// 예: `--dart-define=REAL_API=ai-coach,auth`
+  final Set<String> realApiFeatures;
+
+  /// 이 경로를 목업이 아니라 실 백엔드로 보내야 하는가.
+  bool isRealApiPath(String path) {
+    if (realApiFeatures.isEmpty) return false;
+    for (final String feature in realApiFeatures) {
+      final List<String> prefixes = kRealApiFeatures[feature] ?? const <String>[];
+      for (final String prefix in prefixes) {
+        if (path.startsWith(prefix)) return true;
+      }
+    }
+    return false;
+  }
 
   bool get isProd => environment == Environment.prod;
   bool get isDev => environment == Environment.dev;
@@ -35,11 +80,19 @@ class AppConfig {
     );
     const sentryDsn = String.fromEnvironment('SENTRY_DSN');
     const useMockApi = bool.fromEnvironment('USE_MOCK_API', defaultValue: true);
+    // 예: --dart-define=REAL_API=ai-coach,auth
+    // 알 수 없는 키는 무시된다(오타가 조용히 전 기능을 실서버로 보내지 않도록,
+    // 매칭되는 경로가 없으면 아무 일도 일어나지 않는다).
+    const realApi = String.fromEnvironment('REAL_API');
     return AppConfig(
       environment: env,
       apiBaseUrl: apiBaseUrl,
       sentryDsn: sentryDsn.isEmpty ? null : sentryDsn,
       useMockApi: useMockApi,
+      realApiFeatures: <String>{
+        for (final String key in realApi.split(','))
+          if (key.trim().isNotEmpty) key.trim(),
+      },
     );
   }
 }

--- a/frontend/flutter/lib/core/network/dio_client.dart
+++ b/frontend/flutter/lib/core/network/dio_client.dart
@@ -34,9 +34,18 @@ final dioProvider = Provider<Dio>((ref) {
   // Order matters: LocalApi (drift-backed) and the legacy in-memory
   // MockApi both short-circuit before auth/logging fire.
   if (config.useMockApi) {
+    // REAL_API 로 켠 기능의 경로는 두 목업 인터셉터 모두 가로채지 않고 실 네트워크로
+    // 흘려보낸다 — 준비된 기능만 골라 실연동해 보여줄 수 있게(전역 USE_MOCK_API 는
+    // 끄는 순간 전 기능이 함께 넘어간다).
     dio.interceptors
-      ..add(LocalApiInterceptor(ref.watch(appDatabaseProvider), logger))
-      ..add(MockApiInterceptor(logger));
+      ..add(
+        LocalApiInterceptor(
+          ref.watch(appDatabaseProvider),
+          logger,
+          isRealApiPath: config.isRealApiPath,
+        ),
+      )
+      ..add(MockApiInterceptor(logger, isRealApiPath: config.isRealApiPath));
   }
   dio.interceptors.add(AuthInterceptor(ref));
   if (!config.isProd) {

--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -21,10 +21,16 @@ import 'package:oncare/core/storage/app_database.dart';
 /// `core/network/case_mapper.dart` so the contract matches the real
 /// server's Pydantic models.
 class LocalApiInterceptor extends Interceptor {
-  LocalApiInterceptor(this._db, this._logger);
+  LocalApiInterceptor(this._db, this._logger, {this.isRealApiPath});
 
   final AppDatabase _db;
   final Logger _logger;
+
+  /// 이 경로를 목업이 아니라 실 백엔드로 보내야 하는지 판정한다(`AppConfig.isRealApiPath`).
+  ///
+  /// 주입받는 이유는 이 인터셉터가 설정에 직접 의존하지 않게 하기 위해서다 —
+  /// 테스트에서 설정 전체를 세우지 않고 이 함수만 넘기면 된다.
+  final bool Function(String path)? isRealApiPath;
 
   // Path-pattern → handler map. Static paths get O(1) dispatch;
   // path-with-id endpoints (`/diet/entries/{id}`) fall to the regex
@@ -74,6 +80,13 @@ class LocalApiInterceptor extends Interceptor {
     final method = options.method.toUpperCase();
     final path = options.path;
     final key = '$method $path';
+
+    // REAL_API 로 켠 기능은 목업이 가로채지 않고 실 백엔드로 흘려보낸다.
+    // (null 을 돌려주면 다음 인터셉터를 거쳐 실 네트워크로 나간다.)
+    if (isRealApiPath != null && isRealApiPath!(path)) {
+      _logger.d('[local-api] $key → 실 백엔드(REAL_API)');
+      return null;
+    }
 
     try {
       // Static dispatch first.

--- a/frontend/flutter/lib/core/network/interceptors/mock_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/mock_api_interceptor.dart
@@ -5,8 +5,12 @@ import 'package:logger/logger.dart';
 /// before the real REST backend exists. Toggle via
 /// `--dart-define=USE_MOCK_API=false`.
 class MockApiInterceptor extends Interceptor {
-  MockApiInterceptor(this._logger);
+  MockApiInterceptor(this._logger, {this.isRealApiPath});
   final Logger _logger;
+
+  /// 이 경로를 목업이 아니라 실 백엔드로 보내야 하는지 판정한다
+  /// (`AppConfig.isRealApiPath`). LocalApiInterceptor 와 같은 규칙을 쓴다.
+  final bool Function(String path)? isRealApiPath;
 
   // Path → JSON map. Add new mock endpoints here as features need them.
   static const Map<String, Map<String, Object?>> _routes =
@@ -21,6 +25,11 @@ class MockApiInterceptor extends Interceptor {
 
   @override
   void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    // REAL_API 로 켠 기능은 목업이 가로채지 않고 실 백엔드로 흘려보낸다.
+    if (isRealApiPath != null && isRealApiPath!(options.path)) {
+      handler.next(options);
+      return;
+    }
     final key = '${options.method.toUpperCase()} ${options.path}';
     final body = _routes[key];
     if (body == null) {

--- a/frontend/flutter/test/core/real_api_switch_test.dart
+++ b/frontend/flutter/test/core/real_api_switch_test.dart
@@ -1,0 +1,125 @@
+/// 기능별 실 백엔드 전환 스위치(`REAL_API`) — #457.
+///
+/// `USE_MOCK_API` 는 전역이라 끄는 순간 로그인·홈·식단·운동·채팅이 한꺼번에 실서버로
+/// 넘어간다. 이 스위치는 준비된 기능만 골라 실연동할 수 있게 한다.
+///
+/// **가장 중요한 계약은 "키를 주지 않으면 지금과 완전히 같다"**이다. 배포된 데모가
+/// 조용히 실서버를 치기 시작하면 안 된다.
+library;
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
+
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/core/network/interceptors/mock_api_interceptor.dart';
+
+AppConfig _config({Set<String> realApi = const <String>{}}) => AppConfig(
+  environment: Environment.dev,
+  apiBaseUrl: 'https://example.test/v1',
+  useMockApi: true,
+  realApiFeatures: realApi,
+);
+
+void main() {
+  group('AppConfig.isRealApiPath', () {
+    test('키를 주지 않으면 어떤 경로도 실 백엔드로 가지 않는다', () {
+      final AppConfig config = _config();
+
+      // 데모 배포가 이 경로다 — 하나라도 true 면 조용히 실서버를 치기 시작한다.
+      for (final String path in <String>[
+        '/ai-coach/chat',
+        '/ai-coach/messages',
+        '/auth/login',
+        '/auth/social/kakao',
+        '/diet/days/today',
+        '/dashboard/summary',
+      ]) {
+        expect(config.isRealApiPath(path), isFalse, reason: path);
+      }
+    });
+
+    test('켠 기능의 경로만 실 백엔드로 간다', () {
+      final AppConfig config = _config(realApi: <String>{'ai-coach'});
+
+      expect(config.isRealApiPath('/ai-coach/chat'), isTrue);
+      expect(config.isRealApiPath('/ai-coach/messages'), isTrue);
+      // 켜지 않은 기능은 그대로 목업
+      expect(config.isRealApiPath('/auth/login'), isFalse);
+      expect(config.isRealApiPath('/diet/days/today'), isFalse);
+      expect(config.isRealApiPath('/dashboard/summary'), isFalse);
+    });
+
+    test('여러 기능을 함께 켤 수 있다', () {
+      final AppConfig config = _config(realApi: <String>{'ai-coach', 'auth'});
+
+      expect(config.isRealApiPath('/ai-coach/chat'), isTrue);
+      expect(config.isRealApiPath('/auth/social/google'), isTrue);
+      expect(config.isRealApiPath('/diet/days/today'), isFalse);
+    });
+
+    test('알 수 없는 키는 아무 경로도 열지 않는다', () {
+      // 오타가 조용히 전 기능을 실서버로 보내면 최악이다.
+      final AppConfig config = _config(realApi: <String>{'ai_coach', 'typo'});
+
+      expect(config.isRealApiPath('/ai-coach/chat'), isFalse);
+      expect(config.isRealApiPath('/auth/login'), isFalse);
+    });
+
+    test('등록된 기능 키는 모두 경로가 정의돼 있다', () {
+      for (final MapEntry<String, List<String>> entry
+          in kRealApiFeatures.entries) {
+        expect(entry.value, isNotEmpty, reason: '${entry.key} 에 경로가 없다');
+        for (final String prefix in entry.value) {
+          expect(prefix.startsWith('/'), isTrue, reason: prefix);
+        }
+      }
+    });
+  });
+
+  group('MockApiInterceptor', () {
+    late Logger logger;
+
+    setUp(() => logger = Logger(level: Level.off));
+
+    /// 인터셉터가 목업 응답으로 가로챘는지(resolve), 흘려보냈는지(next) 판정.
+    Future<bool> intercepted(
+      MockApiInterceptor interceptor,
+      String path,
+    ) async {
+      final options = RequestOptions(path: path, method: 'GET');
+      bool resolved = false;
+      final handler = _RecordingHandler(onResolve: () => resolved = true);
+      interceptor.onRequest(options, handler);
+      return resolved;
+    }
+
+    test('스위치가 꺼져 있으면 알려진 경로를 그대로 가로챈다', () async {
+      final interceptor = MockApiInterceptor(logger);
+      expect(await intercepted(interceptor, '/ping'), isTrue);
+    });
+
+    test('스위치가 켜진 경로는 가로채지 않고 흘려보낸다', () async {
+      final interceptor = MockApiInterceptor(
+        logger,
+        isRealApiPath: (String path) => path.startsWith('/ping'),
+      );
+      expect(await intercepted(interceptor, '/ping'), isFalse);
+    });
+  });
+}
+
+/// resolve/next 중 무엇이 불렸는지만 기록하는 핸들러.
+class _RecordingHandler extends RequestInterceptorHandler {
+  _RecordingHandler({required this.onResolve});
+
+  final void Function() onResolve;
+
+  @override
+  void resolve(Response<dynamic> response, [bool callFollowingResponseInterceptor = false]) {
+    onResolve();
+  }
+
+  @override
+  void next(RequestOptions requestOptions) {}
+}


### PR DESCRIPTION
Closes #457

## Summary

`USE_MOCK_API` 가 전역 단일 플래그라, 끄는 순간 로그인·홈·식단·운동·채팅이 **한꺼번에**
실 백엔드로 넘어갑니다. 그래서 준비된 기능 하나만 먼저 실연동해 보여줄 수가 없었습니다.

`--dart-define=REAL_API=ai-coach,auth` 처럼 기능 키 목록을 받아, 해당 경로만 목업
인터셉터가 가로채지 않고 실 네트워크로 흘려보냅니다.

**기본값은 꺼짐이라 지정하지 않으면 지금까지의 데모와 완전히 동일합니다.**

## Changes

- `AppConfig.realApiFeatures` + `isRealApiPath()` — `REAL_API` dart-define 파싱
- `kRealApiFeatures` — 기능 키 → 경로 접두사 표 (`ai-coach` / `auth` / `diet`)
- `LocalApiInterceptor` · `MockApiInterceptor` 가 해당 경로를 흘려보냄
- README 에 사용법·키 목록 문서화
- 테스트 7개

## Notes

**기능별로 임시 플래그를 각각 만들지 않았습니다.** `REAL_AI_COACH` · `REAL_AUTH` 식으로
늘리면 `AppConfig` 와 인터셉터라는 **같은 두 파일**을 이슈마다 고치게 돼 PR 끼리
충돌합니다. 키 → 경로 대응을 `kRealApiFeatures` 한 곳에 모아, 새 기능을 켤 때 그 표에만
줄을 추가하면 되게 했습니다 — 인터셉터는 손대지 않습니다.

**가장 나쁜 실패는 배포된 데모가 조용히 실서버를 치기 시작하는 것**이라, 키를 주지
않았을 때 어떤 경로도 열리지 않는 것을 테스트로 고정했습니다. 오타로 넣은 키
(`ai_coach` 등)도 매칭되는 경로가 없어 아무 것도 열지 않습니다.

판정 함수는 인터셉터에 주입합니다. 인터셉터가 설정에 직접 의존하지 않아, 테스트에서
설정 전체를 세우지 않고 함수 하나만 넘기면 됩니다.

### 검증

`--dart-define` 이 `AppConfig` 까지 실제로 도달하는지 빌드로 확인했습니다:

```
=== REAL_API 미지정 (현재 데모 상태) ===
  realApiFeatures = {}
  /ai-coach/chat   → false
  /diet/days/today → false
  /auth/login      → false

=== REAL_API=ai-coach 지정 ===
  realApiFeatures = {ai-coach}
  /ai-coach/chat   → true
  /diet/days/today → false
  /auth/login      → false
```

로컬 백엔드를 띄워 `/ai-coach/chat` 이 실 Gemini 응답을 주는 것도 확인했습니다:

```
오늘 기록해 주신 식단의 나트륨이 1,200mg으로 나타나, DASH 식단 기준인
하루 1,500~2,300mg 이하 목표를 위해 관리가 필요해요...
```

테스트: Flutter 326개 전부 통과(신규 7개 포함).

## 활용

이제 #274 로 만든 실 Gemini 대화를 데모를 깨지 않고 시연할 수 있습니다:

```bash
flutter run -d chrome \
  --dart-define=API_BASE_URL=http://localhost:8000/v1 \
  --dart-define=REAL_API=ai-coach
```

#330 의 Kakao/Google SDK 연동이 끝나면 `REAL_API=auth` 로 소셜 로그인만 따로 켤 수
있습니다.
