### PR TITLE
fix(gym): 트레이너 디렉터리에 상담 가능 소속 조건 적용

### DIFF
--- a/backend/app/services/gym_service.py
+++ b/backend/app/services/gym_service.py
@@ -161,10 +161,34 @@ def _to_trainer(user: User, profile: TrainerProfile) -> TrainerOut:
 
 
 def _trainer_query():
+    """디렉터리에 노출할 트레이너 — 상담 대상 조건과 같아야 한다. (#451)
+
+    `consultation_service._validate_target` 은 상담 요청 시 트레이너의 소속을
+    `places`(category='fitness') 에서 검증한다. 여기서 role·active 만 보면
+    소속이 없는 트레이너가 목록·상세에 뜨고, 회원은 상담 신청 단계에서야 404 를
+    받는다. 두 곳이 같은 조건을 쓰도록 `places` 를 inner 조인한다.
+
+    따라서 다음 트레이너는 목록·추천·상세 어디에도 나오지 않는다(상세는 404):
+
+    - `gym_id` 가 NULL — 아직 소속이 백필되지 않았거나 해제된 경우.
+      `TrainerProfile.gym_id` 는 `places.id` 를 ondelete='SET NULL' 로 참조하므로,
+      헬스장이 지워지면 소속은 NULL 이 되고 여기서 함께 빠진다(가리키는 Place 가
+      없는 gym_id 는 FK 가 막아 준다).
+    - 소속 Place 의 category 가 'fitness' 가 아님 — 병원·약국 같은 다른 장소.
+
+    소속이 빠진 트레이너를 숨기는 쪽을 골랐다. 상담을 걸 수 없는 트레이너를 목록에
+    남기면 회원은 고를 수 있는데 마지막 단계에서만 막히고, 트레이너 앱이 소속을
+    채우면(#452) 그대로 다시 노출된다.
+    """
     return (
         select(User, TrainerProfile)
         .join(TrainerProfile, TrainerProfile.trainer_id == User.id)
-        .where(User.role == "trainer", User.is_active.is_(True))
+        .join(Place, Place.id == TrainerProfile.gym_id)
+        .where(
+            User.role == "trainer",
+            User.is_active.is_(True),
+            Place.category == "fitness",
+        )
     )
 
 

--- a/backend/tests/test_gyms.py
+++ b/backend/tests/test_gyms.py
@@ -196,6 +196,134 @@ def test_trainer_fields_match_app_contract(client):
     assert isinstance(trainer["certifications"], list)
 
 
+# ---- 디렉터리 소속 조건 (#451) ----
+
+@pytest.fixture
+def directory_trainer(client, db_session):
+    """소속을 지정해 트레이너를 만드는 팩토리. (trainer_id)
+
+    끝나면 지운다 — 디렉터리 인원 수·이름 중복을 세는 테스트가 있어 남겨 두면
+    그쪽이 깨진다.
+    """
+    from uuid import uuid4
+
+    from app.models import models
+
+    created: list[str] = []
+
+    def _make(*, gym_id: str | None) -> str:
+        trainer_id = f"trainer-test-{uuid4().hex[:10]}"
+        db_session.add(models.User(
+            id=trainer_id,
+            email=f"{trainer_id}@oncare.test",
+            name=f"소속테스트 {trainer_id[-6:]}",
+            hashed_password="",
+            role="trainer",
+        ))
+        db_session.flush()
+        db_session.add(models.TrainerProfile(
+            trainer_id=trainer_id,
+            gym_id=gym_id,
+            specialty="퍼스널 트레이너",
+            # 비면 추천 레일에서 사유 조건에 걸려 빠진다 — 소속 조건만 보려고 채운다.
+            recommend_reason="소속 조건 테스트",
+        ))
+        db_session.commit()
+        created.append(trainer_id)
+        return trainer_id
+
+    yield _make
+
+    from app.models import models as _models
+
+    for trainer_id in created:
+        db_session.query(_models.TrainerProfile).filter(
+            _models.TrainerProfile.trainer_id == trainer_id
+        ).delete()
+        db_session.query(_models.User).filter(
+            _models.User.id == trainer_id
+        ).delete()
+    db_session.commit()
+
+
+def test_trainer_with_fitness_gym_is_listed(client, directory_trainer):
+    """소속이 멀쩡하면 그대로 노출된다 — 아래 제외 테스트의 대조군."""
+    trainer_id = directory_trainer(gym_id="gym-oncare-sinchon")
+
+    listed = {t["id"] for t in client.get("/v1/trainers").json()}
+    assert trainer_id in listed
+    assert trainer_id in {t["id"] for t in client.get("/v1/trainers/recommended").json()}
+    assert client.get(f"/v1/trainers/{trainer_id}").status_code == 200
+
+
+def test_trainer_without_gym_is_hidden_from_directory(client, directory_trainer):
+    """소속이 없으면 목록·추천·상세 어디에도 나오지 않는다. (#451)"""
+    trainer_id = directory_trainer(gym_id=None)
+
+    assert trainer_id not in {t["id"] for t in client.get("/v1/trainers").json()}
+    assert trainer_id not in {
+        t["id"] for t in client.get("/v1/trainers/recommended").json()
+    }
+    assert client.get(f"/v1/trainers/{trainer_id}").status_code == 404
+
+
+def test_trainer_at_non_fitness_place_is_hidden(client, directory_trainer):
+    """place-1 은 medical 이다 — 헬스장이 아닌 곳 소속은 디렉터리에 새면 안 된다."""
+    trainer_id = directory_trainer(gym_id="place-1")
+
+    assert trainer_id not in {t["id"] for t in client.get("/v1/trainers").json()}
+    assert trainer_id not in {
+        t["id"] for t in client.get("/v1/trainers/recommended").json()
+    }
+    assert client.get(f"/v1/trainers/{trainer_id}").status_code == 404
+
+
+def test_gym_trainer_list_stays_a_subset_of_the_directory(client):
+    """헬스장 상세의 소속 트레이너는 디렉터리에도 있어야 한다.
+
+    두 경로가 같은 쿼리를 쓰는 한 성립한다 — 한쪽만 조건이 바뀌면 여기서 깨진다.
+    """
+    listed = {t["id"] for t in client.get("/v1/trainers").json()}
+    assert listed
+
+    for gym_id in PARTNER_IDS:
+        scoped = {t["id"] for t in client.get(f"/v1/gyms/{gym_id}/trainers").json()}
+        assert scoped <= listed, f"{gym_id}: {scoped - listed}"
+
+
+def test_listed_trainers_all_have_a_fitness_gym(client):
+    """디렉터리에 뜬 트레이너는 전부 헬스장 상세로 이어져야 한다.
+
+    `gym_id` 가 비어 있으면 앱이 소속 카드를 그릴 수 없고, 그 id 가 헬스장이 아니면
+    `/gyms/{id}` 가 404 를 낸다.
+    """
+    trainers = client.get("/v1/trainers").json()
+    assert trainers
+
+    for trainer in trainers:
+        gym_id = trainer["gym_id"]
+        assert gym_id, f"{trainer['name']} 의 소속이 비어 있다"
+        assert client.get(f"/v1/gyms/{gym_id}").status_code == 200, gym_id
+
+
+def test_hidden_trainer_is_also_rejected_by_consultation(client, directory_trainer):
+    """디렉터리에서 뺀 트레이너는 상담 대상도 아니다 — 두 조건이 같아야 한다(#443).
+
+    반대로 목록에 남겨 두면 회원은 고를 수 있는데 상담 요청에서만 404 를 받는다.
+    """
+    from tests.test_consultations import _auth, _payload, _register_member
+
+    trainer_id = directory_trainer(gym_id=None)
+    _member_id, token = _register_member(client)
+
+    r = client.post(
+        "/v1/consultations",
+        headers=_auth(token),
+        json=_payload(target_type="trainer", trainer_id=trainer_id),
+    )
+    assert r.status_code == 404, r.text
+
+
 def test_my_coach_exposes_gym_id(client, db_session):
     """"내 헬스장" 카드가 헬스장 상세로 이동하려면 id 가 필요하다(#324).
 


### PR DESCRIPTION
Closes #451

## Summary

트레이너 디렉터리(`/v1/trainers`, `/v1/trainers/recommended`, `/v1/trainers/{trainer_id}`)와 상담 대상 검증이 서로 다른 소속 조건을 쓰고 있었습니다. `gym_service._trainer_query()` 는 `role`·`is_active` 만 봐서, 유효한 fitness Place 소속이 없는 트레이너도 목록·상세에 노출됐습니다. 회원은 화면에서 그 트레이너를 고를 수 있는데 상담 요청 단계(#443)에서만 404 를 받습니다.

두 곳이 같은 조건을 쓰도록 맞췄습니다.

## Changes

- `gym_service._trainer_query()` 가 `places` 를 inner 조인하고 `category == "fitness"` 를 확인합니다 — `consultation_service._validate_target` 의 트레이너 검증과 같은 조건입니다.
- 목록·추천·상세(`/gyms/{id}/trainers` 포함)가 같은 쿼리를 공유하므로 한 곳만 고쳐도 네 경로에 함께 적용됩니다.

### 처리 정책

소속이 유효하지 않은 트레이너는 **숨깁니다**. 목록·추천에서 빠지고 상세는 404 입니다.

| 상태 | 처리 |
| --- | --- |
| `gym_id` 가 NULL | 제외 |
| 소속 Place 의 `category` 가 `fitness` 가 아님 | 제외 |
| `gym_id` 가 가리키는 Place 가 없음 | 발생하지 않음 — FK(`places.id`, `ondelete='SET NULL'`)가 막습니다. 헬스장이 지워지면 소속이 NULL 이 되어 위 첫 줄로 흡수됩니다. |

상담을 걸 수 없는 트레이너를 목록에 남기면 회원은 고를 수 있는데 마지막 단계에서만 막힙니다. 소속이 채워지면(#452) 그대로 다시 노출됩니다.

## Tests

`backend/tests/test_gyms.py` 에 소속을 지정해 트레이너를 만드는 `directory_trainer` 픽스처와 케이스를 추가했습니다.

- 정상: fitness 헬스장 소속 트레이너는 목록·추천·상세에 그대로 나옵니다(대조군).
- 예외: `gym_id` 가 NULL 인 트레이너는 목록·추천에서 빠지고 상세가 404 입니다.
- 예외: `place-1`(medical) 소속 트레이너도 마찬가지로 빠집니다.
- 계약: 목록에 뜬 트레이너는 전부 `gym_id` 가 있고 `/v1/gyms/{gym_id}` 가 200 입니다.
- 계약: 헬스장별 소속 트레이너는 항상 디렉터리의 부분집합입니다.
- 정합: 디렉터리에서 뺀 트레이너는 상담 요청도 404 로 거절됩니다.

로컬 Postgres(pgvector)에서 `backend/tests` 전체 418건 통과했습니다. 새 예외 케이스는 수정 전에는 실패하는 것을 확인했습니다.

## Notes

- `TrainerOut` 필드 구성은 그대로입니다. `gym_id` 도 Optional 유지 — 응답에서 실질적으로 항상 채워지지만 스키마는 건드리지 않았습니다.
- 시드 트레이너는 `seed_gyms` 백필로 전부 소속이 이어져 있어 디렉터리 구성은 달라지지 않습니다.
- 시드 외 경로로 `gym_id` 를 채우는 방법은 아직 없습니다 — #452 에서 다룹니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 헬스장에 소속된 트레이너만 트레이너 목록, 추천 및 상세 조회에 표시됩니다.
  * 소속이 없거나 헬스장이 아닌 장소에 소속된 트레이너는 해당 영역에서 제외됩니다.
  * 디렉터리에서 제외된 트레이너에 대한 상담 요청은 처리되지 않습니다.

* **테스트**
  * 트레이너 노출 및 상담 요청 조건에 대한 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->