### PR TITLE
feat(trainer): 소속 헬스장 gym_id 런타임 설정 경로 추가

### DIFF
--- a/backend/app/api/v1/trainer.py
+++ b/backend/app/api/v1/trainer.py
@@ -28,8 +28,9 @@ from app.schemas.trainer_api import (
     ReportSendRequest, RoutineAssignRequest, RoutineOut, RoutineHistoryOut,
     RoutineOptionsOut, RoutineOptionsRequest,
     ScheduleCompleteRequest, ScheduleCreateRequest, ScheduleSessionOut, ScheduleUpdateRequest,
-    TrainerClientOut, TrainerMe, TrainerMeUpdate, TrainerNotificationSettings,
-    TrainerNotificationSettingsUpdate, TrainerPasswordChange, WeeklyReportOut,
+    TrainerClientOut, TrainerGymAffiliation, TrainerMe, TrainerMeUpdate,
+    TrainerNotificationSettings, TrainerNotificationSettingsUpdate,
+    TrainerPasswordChange, WeeklyReportOut,
 )
 from app.services import trainer_routine_options_service, trainer_service
 from app.services.coach.chat import answer as coach_answer
@@ -94,7 +95,47 @@ def trainer_update_me(
     if not fields:
         # 빈 PATCH 를 성공으로 처리하면 클라이언트가 저장됐다고 오해한다.
         raise HTTPException(status_code=400, detail="수정할 항목이 없습니다.")
-    return trainer_service.update_trainer_profile(db, trainer, profile, fields)
+    try:
+        return trainer_service.update_trainer_profile(db, trainer, profile, fields)
+    except trainer_service.GymTextLockedByAffiliation as e:
+        # 값이 틀린 게 아니라 소속이 설정된 상태와 충돌하는 것이라 422 가 아니라 409.
+        raise HTTPException(
+            status_code=409,
+            detail="소속 헬스장이 설정돼 있어 헬스장 정보를 직접 수정할 수 없습니다. "
+                   "PUT /trainer/me/gym 으로 소속을 바꾸세요.",
+        ) from e
+
+
+@router.put("/trainer/me/gym", response_model=TrainerMe)
+def trainer_set_gym(
+    payload: TrainerGymAffiliation,
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> TrainerMe:
+    """소속 헬스장 설정·변경. (#452)
+
+    시드(`seed_gyms`)의 이름 매칭 백필 말고는 `gym_id` 를 채울 길이 없었다. 자기
+    프로필만 바꿀 수 있고(`RequireTrainer` 가 토큰의 트레이너로 고정), 실재하는
+    fitness Place 가 아니면 404 다.
+    """
+    profile = _require_profile(db, trainer.id)
+    me = trainer_service.set_trainer_gym(db, trainer, profile, payload.gym_id)
+    if me is None:
+        raise HTTPException(status_code=404, detail="헬스장을 찾을 수 없습니다.")
+    return me
+
+
+@router.delete("/trainer/me/gym", response_model=TrainerMe)
+def trainer_clear_gym(
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> TrainerMe:
+    """소속 해제. 원래 소속이 없어도 200 — 해제는 두 번 눌러도 오류가 아니다.
+
+    갱신된 프로필을 그대로 돌려주므로 클라이언트가 다시 GET 하지 않아도 된다.
+    """
+    profile = _require_profile(db, trainer.id)
+    return trainer_service.clear_trainer_gym(db, trainer, profile)
 
 
 @router.post("/trainer/me/password", status_code=200)

--- a/backend/app/schemas/trainer_api.py
+++ b/backend/app/schemas/trainer_api.py
@@ -315,6 +315,16 @@ class TrainerMeUpdate(BaseModel):
         return self
 
 
+class TrainerGymAffiliation(BaseModel):
+    """PUT /trainer/me/gym — 소속 헬스장 설정·변경. (#452)
+
+    위 `gym_*` 문자열과 달리 실재하는 `places` 행을 가리킨다. 해제는 값 대신
+    DELETE 로 표현한다 — 이 필드에 null 을 허용하면 "안 보냈다"와 "지워라"가
+    같은 요청으로 섞인다.
+    """
+    gym_id: str = Field(min_length=1, max_length=64)
+
+
 # ---- 트레이너용 AI 코칭 (회원 데이터 기반) ----
 
 class ClientCoachRequest(BaseModel):

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -16,8 +16,8 @@ from sqlalchemy import func, or_, select, tuple_, update
 from sqlalchemy.orm import Session
 
 from app.models.models import (
-    ChatMessage, DietEntry, RoutineHistory, TrainerClient, TrainerProfile,
-    TrainerRoutine, TrainerSchedule, User,
+    ChatMessage, DietEntry, GymProfile, Place, RoutineHistory, TrainerClient,
+    TrainerProfile, TrainerRoutine, TrainerSchedule, User,
 )
 from app.schemas.trainer_api import (
     ChatMessageOut, ClientDietEntryOut, MemberCoachOut, ProgramItem, RoutineHistoryOut,
@@ -924,19 +924,93 @@ def build_trainer_me(trainer: User, profile: TrainerProfile) -> TrainerMe:
     )
 
 
+#: `TrainerMeUpdate` 가 받는 호환용 헬스장 문자열. 소속(`gym_id`)이 설정돼 있으면
+#: 이 값들은 Place/GymProfile 에서 파생되므로 직접 수정할 수 없다(#452).
+GYM_TEXT_FIELDS = ("gym_name", "gym_address", "gym_hours", "gym_phone")
+
+
+class GymTextLockedByAffiliation(Exception):
+    """소속이 설정된 프로필에서 호환 문자열만 따로 바꾸려 한 경우. (#452)"""
+
+
 def update_trainer_profile(
     db: Session, trainer: User, profile: TrainerProfile, fields: dict
 ) -> TrainerMe:
-    """보낸 필드만 반영한다. 자격증은 통째로 교체(부분 병합은 순서가 모호하다)."""
+    """보낸 필드만 반영한다. 자격증은 통째로 교체(부분 병합은 순서가 모호하다).
+
+    `gym_id` 가 있으면 호환 문자열은 소속에서 파생된 값이라 여기서 못 고친다 —
+    문자열만 바꾸면 소속과 화면이 어긋난다. `GymTextLockedByAffiliation` 을 올리고
+    라우터가 409 로 돌려준다. 소속이 없는(레거시·해제) 프로필은 예전처럼 직접 적는다.
+    """
+    if profile.gym_id is not None and any(f in fields for f in GYM_TEXT_FIELDS):
+        raise GymTextLockedByAffiliation
+
     if "certifications" in fields:
         certs = [c.strip() for c in (fields["certifications"] or []) if c.strip()]
         profile.certifications_json = json.dumps(certs, ensure_ascii=False)
-    for column in (
-        "phone", "specialty", "career_years", "intro",
-        "gym_name", "gym_address", "gym_hours", "gym_phone",
-    ):
+    for column in ("phone", "specialty", "career_years", "intro", *GYM_TEXT_FIELDS):
         if column in fields:
             setattr(profile, column, fields[column])
+    db.commit()
+    db.refresh(profile)
+    return build_trainer_me(trainer, profile)
+
+
+# ---- 소속 헬스장 (#452) ----
+
+def _apply_gym_texts(profile: TrainerProfile, place: Place | None, gym: GymProfile | None) -> None:
+    """호환 문자열을 소속에서 파생시킨다 — 소속이 진실이고 문자열은 그 사본이다.
+
+    트레이너 앱은 아직 `gym.{name,address,hours,phone}` 만 읽으므로, 소속을 바꿔도
+    문자열이 그대로면 화면에는 예전 헬스장이 남는다. 해제(place=None)면 비운다 —
+    떠난 헬스장의 이름을 남겨 두면 회원 쪽 코치 카드가 그 값으로 폴백한다
+    (`_member_gym_out`).
+    """
+    if place is None:
+        profile.gym_name = ""
+        profile.gym_address = ""
+        profile.gym_hours = ""
+        profile.gym_phone = ""
+        return
+    # places.name(200) 이 trainer_profiles.gym_name(100) 보다 길다 — 넘치면 DB 가 막는다.
+    profile.gym_name = place.name[:100]
+    profile.gym_address = place.address[:300]
+    # 영업시간·전화는 헬스장 부가 정보(GymProfile)에만 있다. 카카오에서 발견한
+    # 헬스장은 부가 정보가 없어 빈 값이 정상이다.
+    profile.gym_hours = (gym.weekday_hours if gym else "")[:50]
+    profile.gym_phone = (gym.phone if gym else "")[:20]
+
+
+def set_trainer_gym(
+    db: Session, trainer: User, profile: TrainerProfile, gym_id: str
+) -> TrainerMe | None:
+    """소속 헬스장을 설정·변경한다. 유효한 헬스장이 아니면 None(라우터 404).
+
+    `places` 에 있고 category 가 'fitness' 인 곳만 받는다 — 상담 대상 검증
+    (`consultation_service._validate_target`)·헬스장 디렉터리와 같은 조건이라야
+    소속을 설정한 트레이너가 회원 화면에 제대로 뜬다(#451, #443).
+    """
+    place = db.scalar(
+        select(Place).where(Place.id == gym_id, Place.category == "fitness")
+    )
+    if place is None:
+        return None
+
+    profile.gym_id = place.id
+    _apply_gym_texts(profile, place, db.get(GymProfile, place.id))
+    db.commit()
+    db.refresh(profile)
+    return build_trainer_me(trainer, profile)
+
+
+def clear_trainer_gym(db: Session, trainer: User, profile: TrainerProfile) -> TrainerMe:
+    """소속 해제. 원래 없었어도 성공한다 — 해제는 두 번 눌러도 오류가 아니다.
+
+    회원↔헬스장 링크(`member_gyms`)는 건드리지 않는다. 회원이 직접 연결한 헬스장은
+    트레이너가 이적해도 회원의 선택으로 남는다(#444).
+    """
+    profile.gym_id = None
+    _apply_gym_texts(profile, None, None)
     db.commit()
     db.refresh(profile)
     return build_trainer_me(trainer, profile)

--- a/backend/docs/TRAINER_DOMAIN.md
+++ b/backend/docs/TRAINER_DOMAIN.md
@@ -69,9 +69,14 @@
 - 관계 판단의 기준은 `gym_id`다. 기존 `gym_name`, `gym_address`, `gym_hours`,
   `gym_phone`은 트레이너 웹의 `gym {name, address, hours, phone}` 계약을
   유지하기 위한 호환 필드로 당분간 남겨 둔다.
-- 현재 `gym_id`를 채우는 경로는 `seed_gyms.py`의 `gym_name` 이름 매칭
-  백필뿐이다. 설정 API는 아직 없고, 트레이너 앱의 프로필 수정은
-  호환용 `gym_*` 문자열만 바꾼다(후속 과제).
+- `gym_id`는 `PUT /trainer/me/gym`으로 설정·변경하고 `DELETE /trainer/me/gym`으로
+  해제한다(#452). 시드(`seed_gyms.py`의 `gym_name` 이름 매칭 백필)는 기존 데이터를
+  이어 주는 용도로 남는다.
+- **호환 문자열 동기화 기준**: `gym_id`가 있으면 `gym_name`·`gym_address`·
+  `gym_hours`·`gym_phone`은 소속 `Place`/`GymProfile`에서 파생된 사본이다. 소속을
+  설정·변경하면 서버가 덮어쓰고, 해제하면 비운다. 그 동안 `PUT /trainer/me`로
+  문자열만 따로 바꾸는 요청은 **409**다 — 소속과 화면이 어긋나기 때문이다.
+  `gym_id`가 없는(레거시·해제 상태) 프로필에서는 예전처럼 직접 입력한다.
 
 ## 4. 트레이너 API (`/v1/trainer/*`, RequireTrainer)
 
@@ -79,6 +84,8 @@
 |---|---|---|
 | GET | `/trainer/me` | 내 트레이너 프로필 |
 | PUT | `/trainer/me` | 프로필 부분 수정(보낸 필드만; 이름/이메일은 계정 소관) |
+| PUT | `/trainer/me/gym` | 소속 헬스장 설정·변경(fitness `Place`만; 없으면 404) |
+| DELETE | `/trainer/me/gym` | 소속 해제(원래 없어도 200) |
 | POST | `/trainer/me/password` | 비밀번호 변경(현재 비밀번호 확인) |
 | GET | `/trainer/me/settings` | 알림 수신 설정 |
 | PUT | `/trainer/me/settings` | 알림 수신 설정 부분 수정 |

--- a/backend/tests/test_trainer_gym.py
+++ b/backend/tests/test_trainer_gym.py
@@ -1,0 +1,318 @@
+"""트레이너 소속 헬스장 설정·변경·해제 (`/trainer/me/gym`). (#452)
+
+시드(`seed_gyms`)의 이름 매칭 백필 말고 운영 중에 `TrainerProfile.gym_id` 를 바꾸는
+유일한 경로다. 데모 트레이너(trainer-demo)는 다른 테스트가 소속을 전제하므로 건드리지
+않고, 테스트마다 자기 트레이너를 만들어 쓴다.
+"""
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+#: 시드 제휴 헬스장 — `_PARTNER_GYMS` 와 같은 값(부가 정보까지 있다).
+HEALTHMATE = {
+    "id": "gym-healthmate",
+    "name": "헬스메이트 신촌점",
+    "address": "서울 서대문구 신촌로 83",
+    "hours": "05:30 - 24:00",
+    "phone": "02-2345-6789",
+}
+ONCARE = {"id": "gym-oncare-sinchon", "name": "온케어짐 신촌점"}
+#: 카카오에서 발견한 실재 헬스장 — 부가 정보(GymProfile)가 없다.
+DISCOVERED_GYM_ID = "328969863"
+#: 시드 데모의 medical 장소 — 헬스장이 아니다.
+MEDICAL_PLACE_ID = "place-1"
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def trainer(client, db_session):
+    """소속이 없는 트레이너 계정 하나. (token, trainer_id)
+
+    데모 트레이너를 재사용하면 소속을 바꾸는 순간 `/trainer/me`·코치 카드·헬스장별
+    트레이너 목록을 검증하는 다른 테스트가 함께 흔들린다.
+    """
+    from app.core.security import hash_password
+    from app.models import models
+
+    trainer_id = f"trainer-gym-{uuid4().hex[:10]}"
+    email = f"{trainer_id}@oncare.test"
+    db_session.add(models.User(
+        id=trainer_id,
+        email=email,
+        name=f"소속테스트 {trainer_id[-6:]}",
+        hashed_password=hash_password("pw!"),
+        role="trainer",
+    ))
+    db_session.flush()
+    db_session.add(models.TrainerProfile(
+        trainer_id=trainer_id,
+        specialty="퍼스널 트레이너",
+        career_years=3,
+    ))
+    db_session.commit()
+
+    token = client.post(
+        "/v1/auth/login", data={"username": email, "password": "pw!"}
+    ).json()["access_token"]
+
+    yield token, trainer_id
+
+    db_session.query(models.TrainerProfile).filter(
+        models.TrainerProfile.trainer_id == trainer_id
+    ).delete()
+    db_session.query(models.User).filter(models.User.id == trainer_id).delete()
+    db_session.commit()
+
+
+# ---- 설정 · 변경 ----
+
+def test_set_gym_links_the_place_and_syncs_the_texts(client, trainer):
+    token, _trainer_id = trainer
+    before = client.get("/v1/trainer/me", headers=_auth(token)).json()
+    assert before["gym"]["id"] is None, "픽스처 트레이너는 소속이 없어야 한다"
+
+    r = client.put(
+        "/v1/trainer/me/gym", json={"gym_id": HEALTHMATE["id"]}, headers=_auth(token)
+    )
+    assert r.status_code == 200, r.text
+    gym = r.json()["gym"]
+
+    assert gym["id"] == HEALTHMATE["id"]
+    # 호환 문자열은 소속에서 파생된다 — 트레이너 웹이 아직 이 값들만 읽는다.
+    assert gym["name"] == HEALTHMATE["name"]
+    assert gym["address"] == HEALTHMATE["address"]
+    assert gym["hours"] == HEALTHMATE["hours"]
+    assert gym["phone"] == HEALTHMATE["phone"]
+
+
+def test_set_gym_persists(client, trainer):
+    """응답만 맞고 저장이 안 되면 새로고침에서 되돌아간다."""
+    token, _trainer_id = trainer
+    client.put(
+        "/v1/trainer/me/gym", json={"gym_id": HEALTHMATE["id"]}, headers=_auth(token)
+    )
+
+    gym = client.get("/v1/trainer/me", headers=_auth(token)).json()["gym"]
+    assert gym["id"] == HEALTHMATE["id"]
+    assert gym["name"] == HEALTHMATE["name"]
+
+
+def test_changing_gym_replaces_the_previous_one(client, trainer):
+    """이적 — 소속은 한 곳이므로 이전 값이 남으면 안 된다."""
+    token, _trainer_id = trainer
+    client.put(
+        "/v1/trainer/me/gym", json={"gym_id": HEALTHMATE["id"]}, headers=_auth(token)
+    )
+
+    r = client.put(
+        "/v1/trainer/me/gym", json={"gym_id": ONCARE["id"]}, headers=_auth(token)
+    )
+    assert r.status_code == 200, r.text
+    gym = r.json()["gym"]
+    assert gym["id"] == ONCARE["id"]
+    assert gym["name"] == ONCARE["name"]
+
+
+def test_set_gym_copies_only_what_the_gym_actually_has(client, trainer):
+    """카카오 발견 헬스장은 영업시간을 모른다 — 지어내지 않고 비워 둔다."""
+    token, _trainer_id = trainer
+    r = client.put(
+        "/v1/trainer/me/gym", json={"gym_id": DISCOVERED_GYM_ID}, headers=_auth(token)
+    )
+    assert r.status_code == 200, r.text
+    gym = r.json()["gym"]
+
+    assert gym["id"] == DISCOVERED_GYM_ID
+    assert gym["name"] == "빌드업짐 PT 신촌점"
+    assert gym["phone"] == "0502-5552-4212"  # 카카오 실데이터는 그대로 싣는다
+    assert gym["hours"] == ""
+
+
+# ---- 해제 ----
+
+def test_clear_gym_releases_the_affiliation(client, trainer):
+    token, _trainer_id = trainer
+    client.put(
+        "/v1/trainer/me/gym", json={"gym_id": HEALTHMATE["id"]}, headers=_auth(token)
+    )
+
+    r = client.delete("/v1/trainer/me/gym", headers=_auth(token))
+    assert r.status_code == 200, r.text
+    gym = r.json()["gym"]
+
+    assert gym["id"] is None
+    # 떠난 헬스장 이름을 남겨 두면 회원 쪽 코치 카드가 그 값으로 폴백한다.
+    assert gym["name"] == ""
+    assert gym["address"] == ""
+    assert gym["hours"] == ""
+    assert gym["phone"] == ""
+
+
+def test_clear_gym_is_idempotent(client, trainer):
+    """소속이 없어도 오류가 아니다 — 두 번 눌러도 오류 화면이 뜨면 안 된다."""
+    token, _trainer_id = trainer
+    assert client.delete("/v1/trainer/me/gym", headers=_auth(token)).status_code == 200
+    assert client.delete("/v1/trainer/me/gym", headers=_auth(token)).status_code == 200
+
+
+# ---- 유효하지 않은 관계 ----
+
+def test_unknown_gym_is_rejected(client, trainer):
+    token, _trainer_id = trainer
+    r = client.put(
+        "/v1/trainer/me/gym", json={"gym_id": "no-such-gym"}, headers=_auth(token)
+    )
+    assert r.status_code == 404, r.text
+
+
+def test_non_fitness_place_is_rejected(client, trainer):
+    """place-1 은 medical 이다 — FK 만으로는 카테고리를 막을 수 없다."""
+    token, _trainer_id = trainer
+    r = client.put(
+        "/v1/trainer/me/gym", json={"gym_id": MEDICAL_PLACE_ID}, headers=_auth(token)
+    )
+    assert r.status_code == 404, r.text
+
+
+def test_rejected_change_keeps_the_current_affiliation(client, trainer):
+    """실패한 변경이 기존 소속까지 날리면 트레이너가 회원 화면에서 사라진다."""
+    token, _trainer_id = trainer
+    client.put(
+        "/v1/trainer/me/gym", json={"gym_id": HEALTHMATE["id"]}, headers=_auth(token)
+    )
+
+    client.put(
+        "/v1/trainer/me/gym", json={"gym_id": MEDICAL_PLACE_ID}, headers=_auth(token)
+    )
+
+    gym = client.get("/v1/trainer/me", headers=_auth(token)).json()["gym"]
+    assert gym["id"] == HEALTHMATE["id"]
+    assert gym["name"] == HEALTHMATE["name"]
+
+
+def test_blank_gym_id_is_rejected(client, trainer):
+    """빈 문자열을 해제로 해석하면 '안 보냈다'와 '지워라'가 섞인다 — 해제는 DELETE."""
+    token, _trainer_id = trainer
+    r = client.put("/v1/trainer/me/gym", json={"gym_id": ""}, headers=_auth(token))
+    assert r.status_code == 422, r.text
+
+
+# ---- 권한 ----
+
+def test_member_cannot_set_a_gym(client):
+    email = f"member-{uuid4().hex[:8]}@oncare.com"
+    client.post("/v1/auth/register", json={"email": email, "password": "pw!", "name": "u"})
+    token = client.post(
+        "/v1/auth/login", data={"username": email, "password": "pw!"}
+    ).json()["access_token"]
+
+    r = client.put(
+        "/v1/trainer/me/gym", json={"gym_id": HEALTHMATE["id"]}, headers=_auth(token)
+    )
+    assert r.status_code == 403, r.text
+    assert client.delete("/v1/trainer/me/gym", headers=_auth(token)).status_code == 403
+
+
+def test_unauthenticated_is_rejected(client):
+    assert client.put(
+        "/v1/trainer/me/gym", json={"gym_id": HEALTHMATE["id"]}
+    ).status_code == 401
+    assert client.delete("/v1/trainer/me/gym").status_code == 401
+
+
+# ---- 호환 문자열 동기화 기준 ----
+
+def test_gym_texts_are_locked_while_affiliated(client, trainer):
+    """소속이 있으면 문자열만 따로 못 바꾼다 — 소속과 화면이 어긋난다."""
+    token, _trainer_id = trainer
+    client.put(
+        "/v1/trainer/me/gym", json={"gym_id": HEALTHMATE["id"]}, headers=_auth(token)
+    )
+
+    r = client.put(
+        "/v1/trainer/me", json={"gym_name": "직접 적은 헬스장"}, headers=_auth(token)
+    )
+    assert r.status_code == 409, r.text
+    # 거절된 요청이 다른 필드를 흘려보내면 안 된다.
+    assert client.get(
+        "/v1/trainer/me", headers=_auth(token)
+    ).json()["gym"]["name"] == HEALTHMATE["name"]
+
+
+def test_other_profile_fields_are_still_editable_while_affiliated(client, trainer):
+    token, _trainer_id = trainer
+    client.put(
+        "/v1/trainer/me/gym", json={"gym_id": HEALTHMATE["id"]}, headers=_auth(token)
+    )
+
+    r = client.put(
+        "/v1/trainer/me", json={"phone": "010-1111-2222"}, headers=_auth(token)
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["phone"] == "010-1111-2222"
+
+
+def test_gym_texts_stay_editable_without_an_affiliation(client, trainer):
+    """소속이 없는(레거시·해제) 프로필은 예전처럼 직접 적는다 — 기존 경로 유지."""
+    token, _trainer_id = trainer
+    r = client.put(
+        "/v1/trainer/me",
+        json={"gym_name": "직접 적은 헬스장", "gym_phone": "02-0000-0000"},
+        headers=_auth(token),
+    )
+    assert r.status_code == 200, r.text
+    gym = r.json()["gym"]
+    assert gym["id"] is None
+    assert gym["name"] == "직접 적은 헬스장"
+    assert gym["phone"] == "02-0000-0000"
+
+
+# ---- 회원 쪽에서 본 결과 ----
+
+def test_trainer_me_response_contract_is_unchanged(client, trainer):
+    token, _trainer_id = trainer
+    client.put(
+        "/v1/trainer/me/gym", json={"gym_id": HEALTHMATE["id"]}, headers=_auth(token)
+    )
+
+    body = client.get("/v1/trainer/me", headers=_auth(token)).json()
+    assert set(body) == {
+        "id", "name", "email", "phone", "specialty", "career", "intro",
+        "certifications", "gym",
+    }
+    # 트레이너 웹의 gym 계약 — 필드가 사라지면 화면이 빈다.
+    assert set(body["gym"]) == {"id", "name", "address", "hours", "phone"}
+
+
+def test_affiliated_trainer_shows_up_under_that_gym(client, trainer):
+    """소속을 설정하면 회원앱의 헬스장 상세 '소속 트레이너'에 나온다."""
+    token, trainer_id = trainer
+    client.put(
+        "/v1/trainer/me/gym", json={"gym_id": HEALTHMATE["id"]}, headers=_auth(token)
+    )
+
+    listed = client.get(f"/v1/gyms/{HEALTHMATE['id']}/trainers").json()
+    assert trainer_id in {t["id"] for t in listed}
+
+
+def test_setting_a_gym_makes_the_trainer_consultable(client, trainer):
+    """소속이 없으면 상담 대상이 아니다(#443). 설정하면 그때부터 받는다."""
+    from tests.test_consultations import _payload, _register_member
+
+    token, trainer_id = trainer
+    _member_id, member_token = _register_member(client)
+    payload = _payload(target_type="trainer", trainer_id=trainer_id)
+
+    before = client.post("/v1/consultations", headers=_auth(member_token), json=payload)
+    assert before.status_code == 404, before.text
+
+    client.put(
+        "/v1/trainer/me/gym", json={"gym_id": HEALTHMATE["id"]}, headers=_auth(token)
+    )
+    after = client.post("/v1/consultations", headers=_auth(member_token), json=payload)
+    assert after.status_code == 201, after.text


### PR DESCRIPTION
Closes #452

## Summary

`TrainerProfile.gym_id` 를 채우는 경로가 `seed_gyms.py` 의 `gym_name` 이름 매칭 백필뿐이라, 운영 중에 트레이너의 실제 소속을 새로 설정하거나 바꿀 수 없었습니다. `PUT /trainer/me` 는 호환용 `gym_*` 문자열만 바꿉니다.

소속을 설정·변경·해제하는 최소 경로를 트레이너 앱 라우터에 추가했습니다.

## Changes

| Method | Path | 동작 |
| --- | --- | --- |
| `PUT` | `/v1/trainer/me/gym` | 소속 설정·변경. 본문 `{"gym_id": "..."}`, 응답은 `TrainerMe` |
| `DELETE` | `/v1/trainer/me/gym` | 소속 해제. 원래 없어도 200, 응답은 `TrainerMe` |

- **검증**: `places` 에 있고 `category == "fitness"` 인 곳만 받습니다. 아니면 404 이고 기존 소속은 그대로 둡니다. 상담 대상 검증(`consultation_service._validate_target`)·헬스장 디렉터리와 같은 조건이라야 소속을 설정한 트레이너가 회원 화면에 제대로 뜹니다.
- **권한**: `RequireTrainer` — 토큰의 트레이너 본인 프로필만 바꿉니다. 회원 토큰은 403, 미인증은 401. 관리자 경로는 두지 않았습니다(단일 소속이라 본인이 바꾸면 충분).
- **해제 표현**: `gym_id` 에 null 을 허용하지 않고 DELETE 로 분리했습니다. null 을 받으면 "안 보냈다"와 "지워라"가 같은 요청이 됩니다. 빈 문자열은 422 입니다.
- 회원↔헬스장 링크(`member_gyms`)는 건드리지 않습니다. 회원이 직접 연결한 헬스장은 트레이너가 이적해도 회원의 선택으로 남습니다(#444).

### gym_id 와 호환 문자열의 동기화 기준

`gym_id` 가 **진실**이고 `gym_name`·`gym_address`·`gym_hours`·`gym_phone` 은 그 사본입니다.

- 소속을 설정·변경하면 서버가 소속 `Place`/`GymProfile` 값으로 네 문자열을 덮어씁니다. 트레이너 웹이 아직 `gym.{name,address,hours,phone}` 만 읽으므로, 문자열이 그대로면 소속을 바꿔도 화면에는 예전 헬스장이 남습니다.
- 해제하면 네 문자열을 비웁니다. 떠난 헬스장 이름을 남겨 두면 회원 쪽 코치 카드가 그 값으로 폴백합니다(`_member_gym_out`).
- 소속이 있는 동안 `PUT /trainer/me` 로 `gym_*` 만 바꾸는 요청은 **409** 입니다. 값이 틀린 게 아니라 소속이 설정된 상태와 충돌하는 것이라 422 가 아닙니다.
- 소속이 없는(레거시·해제 상태) 프로필에서는 예전처럼 `gym_*` 를 직접 입력합니다 — 기존 경로가 그대로 살아 있습니다.
- `places.name` 은 200자, `trainer_profiles.gym_name` 은 100자라 복사할 때 잘라 넣습니다.

## Tests

`backend/tests/test_trainer_gym.py` 신설(18건). 데모 트레이너는 다른 테스트가 소속을 전제하므로 건드리지 않고, 픽스처가 소속 없는 트레이너를 만들고 끝나면 지웁니다.

- 정상: 설정 시 `gym_id` 연결 + 문자열 동기화, 재조회에도 유지, 변경 시 이전 값 소멸, 부가 정보가 없는 헬스장은 영업시간을 비운 채 복사.
- 정상: 해제 시 `gym_id` null + 문자열 비움, 두 번 해제해도 200.
- 예외: 없는 헬스장 404, medical 장소(`place-1`) 404, 실패한 변경이 기존 소속을 유지, 빈 `gym_id` 422.
- 권한: 회원 토큰 403, 미인증 401.
- 동기화: 소속 중 `gym_*` 수정 409(다른 필드는 정상 수정), 소속 없을 때는 기존처럼 수정 가능.
- 계약: `GET /trainer/me` 응답 키와 `gym` 하위 키가 그대로.
- 연동: 소속 설정 후 `/v1/gyms/{id}/trainers` 에 노출되고, 상담 요청이 404 → 201 로 바뀝니다.

로컬 Postgres(pgvector)에서 `backend/tests` 전체 430건 통과했습니다.

## Notes

- 마이그레이션은 없습니다 — `gym_id` 컬럼은 `0020_gym_profiles_trainer_fk` 에 이미 있습니다.
- `backend/docs/TRAINER_DOMAIN.md` 의 소속 정책·엔드포인트 표를 갱신했습니다.
- #451(디렉터리 소속 조건)과 파일이 겹치지 않아 서로 독립입니다 — 병합 순서에 제약이 없습니다.
- 소속 변경 이력은 여전히 남기지 않습니다(프로필의 `gym_id` 를 교체). 이력·복수 소속이 필요해지면 별도 관계 테이블로 확장합니다.