### PR TITLE
test(flutter): integration smoke test를 현재 인증 흐름에 맞게 갱신

### DIFF
--- a/frontend/flutter/integration_test/app_smoke_test.dart
+++ b/frontend/flutter/integration_test/app_smoke_test.dart
@@ -5,51 +5,100 @@ import 'package:integration_test/integration_test.dart';
 import 'package:logger/logger.dart';
 
 import 'package:oncare/app/app.dart';
+import 'package:oncare/app/router/main_shell.dart';
 import 'package:oncare/app/session_feature_reset.dart';
 import 'package:oncare/core/config/app_config.dart';
 import 'package:oncare/core/logging/app_logger.dart';
+import 'package:oncare/features/auth/presentation/pages/sign_in_page.dart';
+import 'package:oncare/features/dashboard/presentation/pages/dashboard_page.dart';
+import 'package:oncare/features/diet/presentation/pages/diet_record_page.dart';
+import 'package:oncare/features/exercise/presentation/pages/exercise_page.dart';
+import 'package:oncare/features/my_health/presentation/pages/my_health_page.dart';
 import 'package:oncare/shared/services/locale_provider.dart';
 
-/// Run on a device/emulator with:
-///   flutter test integration_test/app_smoke_test.dart
+/// End-to-end smoke: the app boots into sign-in, demo entry reaches the main
+/// shell, and every bottom-nav destination renders its branch page.
+///
+/// Run headless on the host:
+///   flutter test integration_test/app_smoke_test.dart -d flutter-tester
+/// or on a device/emulator:
+///   flutter test integration_test/app_smoke_test.dart -d `<device>`
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('app boots into Dashboard and tabs are reachable', (
-    tester,
-  ) async {
-    const config = AppConfig(
-      environment: Environment.dev,
-      apiBaseUrl: 'https://dev.api.test',
-      useMockApi: true,
-    );
+  const config = AppConfig(
+    environment: Environment.dev,
+    apiBaseUrl: 'https://dev.api.test',
+    useMockApi: true,
+  );
+
+  Future<void> pumpApp(WidgetTester tester) async {
     await tester.pumpWidget(
       ProviderScope(
         overrides: <Override>[
           appConfigProvider.overrideWithValue(config),
           appLoggerProvider.overrideWithValue(Logger(level: Level.off)),
+          // Production wiring — the session reset registry is what clears
+          // account-specific state on sign-in/out, so the smoke test must
+          // exercise the same override the app installs.
           sessionFeatureResetOverride(),
+          // Pin the locale so a different host locale cannot change which
+          // strings render. Assertions below go through widget types rather
+          // than text, so this only keeps the run deterministic.
           localeProvider.overrideWith((ref) => const Locale('en')),
         ],
         child: const OncareApp(),
       ),
     );
     await tester.pumpAndSettle();
+  }
 
-    // Boot into Dashboard.
-    expect(find.widgetWithText(AppBar, 'Dashboard'), findsOneWidget);
-    expect(find.byType(NavigationBar), findsOneWidget);
+  /// Taps a bottom-nav destination by its (unselected) icon so the tap does
+  /// not depend on the localised label.
+  Future<void> tapDestination(WidgetTester tester, IconData icon) async {
+    await tester.tap(
+      find.ancestor(of: find.byIcon(icon), matching: find.byType(InkWell)),
+    );
+    await tester.pumpAndSettle();
+  }
 
-    // Tap each non-Dashboard tab and verify the title changes.
-    for (final ({String label, String title}) tab
-        in const <({String label, String title})>[
-          (label: 'Diet', title: 'Diet Record'),
-          (label: 'Exercise', title: 'Exercise'),
-          (label: 'My Health', title: 'My Health'),
-        ]) {
-      await tester.tap(find.text(tab.label).first);
-      await tester.pumpAndSettle();
-      expect(find.widgetWithText(AppBar, tab.title), findsOneWidget);
-    }
+  testWidgets('demo entry reaches the main shell and every tab renders', (
+    tester,
+  ) async {
+    await pumpApp(tester);
+
+    // The app starts at sign-in — not at a tab.
+    expect(find.byType(SignInPage), findsOneWidget);
+    expect(find.byType(MainShell), findsNothing);
+
+    // Enter demo mode. The button sits below the fold on the test surface,
+    // and the Key keeps the finder locale-independent.
+    final Finder demoButton = find.byKey(const Key('demoEnterButton'));
+    await tester.ensureVisible(demoButton);
+    await tester.pumpAndSettle();
+    await tester.tap(demoButton);
+    await tester.pumpAndSettle();
+
+    // Home is the first branch of the shell's StatefulShellRoute.
+    expect(find.byType(MainShell), findsOneWidget);
+    expect(find.byType(DashboardPage), findsOneWidget);
+
+    // Each destination swaps the branch page. The nav has a fifth slot (the
+    // floating "+"), which is not a destination and is skipped here.
+    await tapDestination(tester, Icons.restaurant_outlined);
+    expect(find.byType(DietRecordPage), findsOneWidget);
+
+    await tapDestination(tester, Icons.fitness_center_outlined);
+    expect(find.byType(ExercisePage), findsOneWidget);
+
+    await tapDestination(tester, Icons.person_outline);
+    expect(find.byType(MyHealthPage), findsOneWidget);
+
+    // Back to Home — the shell keeps its branches alive, so returning must
+    // still render the dashboard.
+    await tapDestination(tester, Icons.home_outlined);
+    expect(find.byType(DashboardPage), findsOneWidget);
+
+    expect(tester.takeException(), isNull);
   });
 }


### PR DESCRIPTION
Closes #454

## Summary

`integration_test/app_smoke_test.dart` 가 앱의 현재 구조와 어긋나 있었습니다. 앱은 로그인 화면으로 부팅하는데 테스트는 예전 `Dashboard` AppBar 가 곧바로 뜬다고 기대했고, 실제로는 지금 화면에 `AppBar` 도 `NavigationBar` 도 없습니다 — `MainShell` 이 커스텀 하단 내비를 그리고 각 탭은 `StatefulShellRoute` 의 브랜치입니다.

일반 `test/widget_test.dart` 는 `demoEnterButton` 을 눌러 인증 흐름을 통과하는데 통합 smoke 테스트에는 그 단계가 없었습니다.

## Changes

테스트를 현재 흐름대로 다시 썼습니다.

1. 부팅 직후 `SignInPage` 가 뜨고 `MainShell` 은 없음을 확인합니다 — 인증 게이트가 사라지면 여기서 걸립니다.
2. `demoEnterButton` 을 `ensureVisible` 후 눌러 데모로 진입합니다(테스트 화면에서는 버튼이 접힘 아래에 있습니다).
3. `MainShell` 과 첫 브랜치 `DashboardPage` 를 확인합니다.
4. 하단 내비의 네 목적지를 차례로 눌러 `DietRecordPage` → `ExercisePage` → `MyHealthPage` → 다시 `DashboardPage` 가 렌더되는지 봅니다.

- 탭은 **아이콘**(`Icons.restaurant_outlined` 등)의 `InkWell` 조상을 눌러 로케일과 무관하게 동작합니다. 페이지 확인도 문구 대신 **위젯 타입**이라 문구가 바뀌어도 깨지지 않습니다.
- `sessionFeatureResetOverride()` 는 프로덕션과 동일하게 유지했습니다. 계정별 상태를 비우는 배선이라 smoke 가 같은 override 를 타야 합니다.
- `localeProvider` 오버라이드는 실행을 결정론적으로 두려고 남겼습니다. 문구로 단정하지 않으므로 이제는 assertion 에 영향을 주지 않습니다.
- 하단 내비 가운데의 플로팅 `+` 버튼은 목적지가 아니라 건너뜁니다.

`useMockApi: true` 면 repository provider 들이 mock 을 고르므로, `widget_test.dart` 처럼 diet/exercise/dashboard repository 를 따로 오버라이드하지 않아도 됩니다.

## Tests

```
flutter test integration_test/app_smoke_test.dart -d flutter-tester
```

로컬(Flutter 3.44.0)에서 통과했습니다. `-d flutter-tester` 는 데스크톱·Chrome 이 붙어 있는 개발 머신에서 호스트 헤드리스로 돌리기 위한 것입니다 — 디바이스가 없는 환경에서는 `-d` 없이 같은 명령으로 실행됩니다. 실행법은 파일 상단 주석에 적어 뒀습니다.

함께 확인:

- `flutter test` — 326건 통과
- `flutter analyze` — 이슈 없음
- `flutter pub run custom_lint` — 이슈 없음

## Notes

- `user-app-ci.yml` 의 테스트 단계는 `flutter test` 라서 `integration_test/` 를 실행하지 않습니다. 이번 불일치가 오래 남아 있었던 이유이기도 한데, CI 에 통합 테스트 단계를 추가하는 것은 이 이슈 범위를 넘어 따로 다루는 편이 좋겠습니다.
- 앱 코드는 건드리지 않았습니다 — 테스트만 현재 구조에 맞췄습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 앱 시작 시 로그인 페이지와 데모 진입 흐름을 검증하도록 스모크 테스트를 개선했습니다.
  * 메인 화면에서 식단, 운동, 마이헬스, 홈 탭 전환 및 각 화면 표시를 확인합니다.
  * 앱 종료 시 예외 발생 여부까지 검증합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->