### PR TITLE
feat(chat): 사용자 트레이너 공용 채팅 실연동

### DIFF
--- a/frontend/flutter/lib/features/exercise/presentation/widgets/gym_tab.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/gym_tab.dart
@@ -9,6 +9,9 @@ import 'package:oncare/features/exercise/domain/entities/gym.dart';
 import 'package:oncare/features/exercise/domain/entities/trainer.dart';
 import 'package:oncare/features/exercise/presentation/controllers/consultation_request_controller.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
+import 'package:oncare/features/member_coach/domain/entities/member_coach.dart';
+import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
+import 'package:oncare/features/member_coach/presentation/widgets/coach_chat_sheet.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 
 class GymTab extends ConsumerWidget {
@@ -33,6 +36,9 @@ class GymTab extends ConsumerWidget {
     final AsyncValue<List<Gym>> knownGymsAsync = ref.watch(
       gymFinderResultsProvider,
     );
+    final MemberCoach? assignedCoach = ref
+        .watch(memberCoachProvider)
+        .valueOrNull;
     final List<ConsultationRequest> requests = ref.watch(
       consultationRequestControllerProvider,
     );
@@ -43,6 +49,11 @@ class GymTab extends ConsumerWidget {
         recentRequest?.status == ConsultationStatus.pending
         ? recentRequest
         : null;
+    final bool showTrainerChat =
+        assignedCoach != null && pendingRequest == null;
+    final int unreadCoachMessages = showTrainerChat
+        ? ref.watch(coachUnreadProvider).valueOrNull ?? 0
+        : 0;
     final GlobalKey recentConsultationKey = GlobalKey();
 
     void showRecentConsultation() {
@@ -73,6 +84,13 @@ class GymTab extends ConsumerWidget {
             onPendingConsultationTap: pendingRequest == null
                 ? null
                 : showRecentConsultation,
+            onTrainerChatTap: showTrainerChat
+                ? () => openTrainerChatPage(
+                    context,
+                    trainerName: assignedCoach.name,
+                  )
+                : null,
+            unreadCoachMessages: unreadCoachMessages,
           ),
           if (recentRequest != null) ...<Widget>[
             const SizedBox(height: 28),
@@ -237,6 +255,8 @@ class _MyGymSection extends StatelessWidget {
     required this.onFind,
     required this.onRetry,
     required this.onPendingConsultationTap,
+    required this.onTrainerChatTap,
+    required this.unreadCoachMessages,
   });
 
   final AsyncValue<Gym?> gymAsync;
@@ -248,6 +268,8 @@ class _MyGymSection extends StatelessWidget {
   final VoidCallback onFind;
   final VoidCallback onRetry;
   final VoidCallback? onPendingConsultationTap;
+  final VoidCallback? onTrainerChatTap;
+  final int unreadCoachMessages;
 
   @override
   Widget build(BuildContext context) {
@@ -263,6 +285,8 @@ class _MyGymSection extends StatelessWidget {
               onSlot: onSlot,
               onGymTap: () => context.push(AppRoutes.gymDetailPath(gym.id)),
               onPendingConsultationTap: onPendingConsultationTap,
+              onTrainerChatTap: onTrainerChatTap,
+              unreadCoachMessages: unreadCoachMessages,
             ),
     );
   }
@@ -276,6 +300,8 @@ class _MyGymCard extends StatelessWidget {
     required this.onSlot,
     required this.onGymTap,
     required this.onPendingConsultationTap,
+    required this.onTrainerChatTap,
+    required this.unreadCoachMessages,
   });
 
   final Gym gym;
@@ -284,6 +310,8 @@ class _MyGymCard extends StatelessWidget {
   final ValueChanged<String> onSlot;
   final VoidCallback onGymTap;
   final VoidCallback? onPendingConsultationTap;
+  final VoidCallback? onTrainerChatTap;
+  final int unreadCoachMessages;
 
   @override
   Widget build(BuildContext context) {
@@ -406,8 +434,67 @@ class _MyGymCard extends StatelessWidget {
                 ),
               ),
             ),
+          ] else if (onTrainerChatTap != null) ...<Widget>[
+            const SizedBox(height: 14),
+            _TrainerChatButton(
+              unread: unreadCoachMessages,
+              onTap: onTrainerChatTap!,
+            ),
           ],
         ],
+      ),
+    );
+  }
+}
+
+class _TrainerChatButton extends StatelessWidget {
+  const _TrainerChatButton({required this.unread, required this.onTap});
+
+  final int unread;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final String unreadLabel = unread > 99 ? '99+' : '$unread';
+
+    return SizedBox(
+      width: double.infinity,
+      child: OutlinedButton.icon(
+        key: const Key('gymTrainerChatButton'),
+        onPressed: onTap,
+        icon: const Icon(Icons.chat_bubble_outline, size: 16),
+        label: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            const Text('트레이너와 채팅'),
+            if (unread > 0) ...<Widget>[
+              const SizedBox(width: 8),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+                decoration: const BoxDecoration(
+                  color: FigmaColors.redDot,
+                  borderRadius: BorderRadius.all(Radius.circular(999)),
+                ),
+                child: Text(
+                  unreadLabel,
+                  style: const TextStyle(
+                    fontSize: 10,
+                    fontWeight: FontWeight.w800,
+                    color: Colors.white,
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
+        style: OutlinedButton.styleFrom(
+          foregroundColor: FigmaColors.primary,
+          minimumSize: const Size(0, 44),
+          side: BorderSide(color: FigmaColors.primaryA(0.25)),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+        ),
       ),
     );
   }
@@ -710,9 +797,8 @@ class _RecommendedTrainerSection extends StatelessWidget {
                   return _TrainerRecommendationCard(
                     trainer: trainer,
                     gymName: gymNames[trainer.gymId] ?? '',
-                    onTap: () => context.push(
-                      AppRoutes.trainerDetailPath(trainer.id),
-                    ),
+                    onTap: () =>
+                        context.push(AppRoutes.trainerDetailPath(trainer.id)),
                   );
                 },
               ),

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/gym_tab.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/gym_tab.dart
@@ -45,10 +45,15 @@ class GymTab extends ConsumerWidget {
     final ConsultationRequest? recentRequest = requests.isEmpty
         ? null
         : requests.first;
-    final ConsultationRequest? pendingRequest =
-        recentRequest?.status == ConsultationStatus.pending
-        ? recentRequest
-        : null;
+    ConsultationRequest? pendingRequest;
+    for (final ConsultationRequest request in requests) {
+      if (request.status == ConsultationStatus.pending) {
+        pendingRequest = request;
+        break;
+      }
+    }
+    final ConsultationRequest? displayedRequest =
+        pendingRequest ?? recentRequest;
     final bool showTrainerChat =
         assignedCoach != null && pendingRequest == null;
     final int unreadCoachMessages = showTrainerChat
@@ -92,11 +97,11 @@ class GymTab extends ConsumerWidget {
                 : null,
             unreadCoachMessages: unreadCoachMessages,
           ),
-          if (recentRequest != null) ...<Widget>[
+          if (displayedRequest != null) ...<Widget>[
             const SizedBox(height: 28),
             _RecentConsultationSection(
               key: recentConsultationKey,
-              request: recentRequest,
+              request: displayedRequest,
             ),
           ],
           const SizedBox(height: 28),
@@ -277,7 +282,21 @@ class _MyGymSection extends StatelessWidget {
       loading: () => const _SectionLoading(height: 180),
       error: (Object _, StackTrace _) => _SectionError(onRetry: onRetry),
       data: (Gym? gym) => gym == null
-          ? _EmptyMyGym(onFind: onFind)
+          ? Column(
+              children: <Widget>[
+                _EmptyMyGym(onFind: onFind),
+                if (onPendingConsultationTap != null) ...<Widget>[
+                  const SizedBox(height: 14),
+                  _PendingConsultationButton(onTap: onPendingConsultationTap!),
+                ] else if (onTrainerChatTap != null) ...<Widget>[
+                  const SizedBox(height: 14),
+                  _TrainerChatButton(
+                    unread: unreadCoachMessages,
+                    onTap: onTrainerChatTap!,
+                  ),
+                ],
+              ],
+            )
           : _MyGymCard(
               gym: gym,
               trainer: trainer,
@@ -414,26 +433,7 @@ class _MyGymCard extends StatelessWidget {
           ],
           if (onPendingConsultationTap != null) ...<Widget>[
             const SizedBox(height: 14),
-            SizedBox(
-              width: double.infinity,
-              child: FilledButton(
-                onPressed: onPendingConsultationTap,
-                style: FilledButton.styleFrom(
-                  backgroundColor: FigmaColors.primary,
-                  minimumSize: const Size(0, 44),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                ),
-                child: Text(
-                  l.exViewConsultationRequest,
-                  style: const TextStyle(
-                    fontSize: 12,
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-              ),
-            ),
+            _PendingConsultationButton(onTap: onPendingConsultationTap!),
           ] else if (onTrainerChatTap != null) ...<Widget>[
             const SizedBox(height: 14),
             _TrainerChatButton(
@@ -442,6 +442,34 @@ class _MyGymCard extends StatelessWidget {
             ),
           ],
         ],
+      ),
+    );
+  }
+}
+
+class _PendingConsultationButton extends StatelessWidget {
+  const _PendingConsultationButton({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations l = AppLocalizations.of(context);
+    return SizedBox(
+      width: double.infinity,
+      child: FilledButton(
+        onPressed: onTap,
+        style: FilledButton.styleFrom(
+          backgroundColor: FigmaColors.primary,
+          minimumSize: const Size(0, 44),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+        ),
+        child: Text(
+          l.exViewConsultationRequest,
+          style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w700),
+        ),
       ),
     );
   }

--- a/frontend/flutter/lib/features/member_coach/data/dtos/member_coach_dtos.dart
+++ b/frontend/flutter/lib/features/member_coach/data/dtos/member_coach_dtos.dart
@@ -27,15 +27,36 @@ CoachRoutine coachRoutineFromJson(Map<String, Object?> json) {
 }
 
 /// `/me/coach/chat` element (ChatMessageOut) → [CoachMessage]. From the
-/// member's viewpoint `sender` is `me` | `trainer`; anything that isn't
-/// `trainer` maps to [CoachSender.me].
+/// member's viewpoint `sender` is `me` | `trainer`.
 CoachMessage coachMessageFromJson(Map<String, Object?> json) {
+  final CoachSender sender = switch (json['sender']) {
+    'me' => CoachSender.me,
+    'trainer' => CoachSender.trainer,
+    _ => throw const FormatException('Invalid member chat sender.'),
+  };
+
   return CoachMessage(
-    id: _str(json['id']),
-    sender: json['sender'] == 'trainer' ? CoachSender.trainer : CoachSender.me,
-    body: _str(json['body']),
-    timeLabel: _str(json['time_label']),
+    id: _requiredString(json, 'id'),
+    sender: sender,
+    body: _requiredString(json, 'body'),
+    timeLabel: _requiredString(json, 'time_label'),
+    createdAt: _requiredDateTime(json, 'created_at'),
   );
 }
 
 String _str(Object? v) => v is String ? v : '';
+
+String _requiredString(Map<String, Object?> json, String key) {
+  final Object? value = json[key];
+  if (value is String) return value;
+  throw FormatException('Invalid member chat $key.');
+}
+
+DateTime _requiredDateTime(Map<String, Object?> json, String key) {
+  final Object? value = json[key];
+  if (value is String) {
+    final DateTime? parsed = DateTime.tryParse(value);
+    if (parsed != null) return parsed;
+  }
+  throw FormatException('Invalid member chat $key.');
+}

--- a/frontend/flutter/lib/features/member_coach/data/repositories/dio_member_coach_repository.dart
+++ b/frontend/flutter/lib/features/member_coach/data/repositories/dio_member_coach_repository.dart
@@ -31,8 +31,18 @@ class DioMemberCoachRepository implements MemberCoachRepository {
       _getList('/me/coach/routines', coachRoutineFromJson);
 
   @override
-  Future<List<CoachMessage>> fetchChat() =>
-      _getList('/me/coach/chat', coachMessageFromJson);
+  Future<List<CoachMessage>> fetchChat() async {
+    final List<CoachMessage> messages = await _getList(
+      '/me/coach/chat',
+      coachMessageFromJson,
+    );
+    messages.sort((CoachMessage first, CoachMessage second) {
+      final int createdAtOrder = first.createdAt.compareTo(second.createdAt);
+      if (createdAtOrder != 0) return createdAtOrder;
+      return first.id.compareTo(second.id);
+    });
+    return messages;
+  }
 
   @override
   Future<void> sendMessage(String text) async {
@@ -77,8 +87,12 @@ class DioMemberCoachRepository implements MemberCoachRepository {
       final res = await _dio.get<List<dynamic>>(path);
       final data = res.data ?? const <dynamic>[];
       return data
-          .whereType<Map<String, Object?>>()
-          .map(fromJson)
+          .map((dynamic item) {
+            if (item is! Map<String, Object?>) {
+              throw const FormatException('Invalid member coach list item.');
+            }
+            return fromJson(item);
+          })
           .toList(growable: false);
     } on DioException catch (e) {
       if (e.response?.statusCode == 404) return <T>[];

--- a/frontend/flutter/lib/features/member_coach/data/repositories/dio_member_coach_repository.dart
+++ b/frontend/flutter/lib/features/member_coach/data/repositories/dio_member_coach_repository.dart
@@ -71,8 +71,11 @@ class DioMemberCoachRepository implements MemberCoachRepository {
   Future<int> unreadCount() async {
     try {
       final res = await _dio.get<Map<String, Object?>>('/me/coach/chat/unread');
-      final v = res.data?['unread'];
-      return v is num ? v.toInt() : 0;
+      final Object? unread = res.data?['unread'];
+      if (unread is! int || unread < 0) {
+        throw const FormatException('Invalid unread message count.');
+      }
+      return unread;
     } on DioException catch (e) {
       if (e.response?.statusCode == 404) return 0;
       throw AppError.fromDio(e);

--- a/frontend/flutter/lib/features/member_coach/data/repositories/mock_member_coach_repository.dart
+++ b/frontend/flutter/lib/features/member_coach/data/repositories/mock_member_coach_repository.dart
@@ -45,11 +45,12 @@ class MockMemberCoachRepository implements MemberCoachRepository {
   ];
 
   final List<CoachMessage> _chat = <CoachMessage>[
-    const CoachMessage(
+    CoachMessage(
       id: 'seed-m1',
       sender: CoachSender.trainer,
       body: '오늘 점심 등록 잘 확인했어요. 나트륨만 조금 신경 써 주세요!',
       timeLabel: '13:20',
+      createdAt: DateTime.utc(2026, 1, 1, 13, 20),
     ),
   ];
 
@@ -79,6 +80,7 @@ class MockMemberCoachRepository implements MemberCoachRepository {
         timeLabel:
             '${now.hour.toString().padLeft(2, '0')}:'
             '${now.minute.toString().padLeft(2, '0')}',
+        createdAt: now,
       ),
     );
   }

--- a/frontend/flutter/lib/features/member_coach/domain/entities/member_coach.dart
+++ b/frontend/flutter/lib/features/member_coach/domain/entities/member_coach.dart
@@ -55,12 +55,14 @@ class CoachMessage {
     required this.sender,
     required this.body,
     required this.timeLabel,
+    required this.createdAt,
   });
 
   final String id;
   final CoachSender sender;
   final String body;
   final String timeLabel;
+  final DateTime createdAt;
 
   bool get fromMe => sender == CoachSender.me;
 }

--- a/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_card.dart
+++ b/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_card.dart
@@ -255,6 +255,8 @@ class _ChatButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final String unreadLabel = unread > 99 ? '99+' : '$unread';
+
     return Material(
       color: FigmaColors.softBlue,
       borderRadius: BorderRadius.circular(12),
@@ -293,7 +295,7 @@ class _ChatButton extends StatelessWidget {
                     borderRadius: BorderRadius.all(Radius.circular(999)),
                   ),
                   child: Text(
-                    '$unread',
+                    unreadLabel,
                     style: const TextStyle(
                       fontSize: 10,
                       fontWeight: FontWeight.w800,

--- a/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_chat_sheet.dart
+++ b/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_chat_sheet.dart
@@ -34,11 +34,20 @@ class _TrainerChatPageState extends ConsumerState<TrainerChatPage> {
   @override
   void initState() {
     super.initState();
-    // Opening the thread clears the unread badge.
     Future<void>.microtask(() async {
-      await ref.read(memberCoachRepositoryProvider).markRead();
-      if (mounted) ref.invalidate(coachUnreadProvider);
+      ref.invalidate(coachChatProvider);
+      await _markRead();
     });
+  }
+
+  Future<void> _markRead() async {
+    try {
+      await ref.read(memberCoachRepositoryProvider).markRead();
+    } catch (_) {
+      // 읽음 처리 실패는 이미 불러오는 대화 표시를 막지 않는다.
+      return;
+    }
+    if (mounted) ref.invalidate(coachUnreadProvider);
   }
 
   @override

--- a/frontend/flutter/test/features/exercise/gym_tab_action_test.dart
+++ b/frontend/flutter/test/features/exercise/gym_tab_action_test.dart
@@ -289,7 +289,7 @@ void main() {
       preferredTimeSlot: PreferredTimeSlot.afternoon,
       message: null,
       status: ConsultationStatus.accepted,
-      createdAt: DateTime(2026, 8, 1),
+      createdAt: DateTime(2026, 8),
     );
     await pumpGymTab(
       tester,

--- a/frontend/flutter/test/features/exercise/gym_tab_action_test.dart
+++ b/frontend/flutter/test/features/exercise/gym_tab_action_test.dart
@@ -79,6 +79,8 @@ void main() {
   Future<void> pumpGymTab(
     WidgetTester tester, {
     ConsultationRequest? consultation,
+    List<ConsultationRequest> additionalConsultations =
+        const <ConsultationRequest>[],
     bool hasMyGym = true,
     Trainer? trainer = _trainer,
     MemberCoach? coach,
@@ -90,6 +92,9 @@ void main() {
     consultationController = newTestConsultationController();
     if (consultation != null) {
       await seedPending(consultationController, consultation);
+    }
+    for (final ConsultationRequest request in additionalConsultations) {
+      await seedPending(consultationController, request);
     }
     router = buildAppRouter(config: _config);
     addTearDown(router.dispose);
@@ -238,6 +243,69 @@ void main() {
 
     expect(find.byType(TrainerChatPage), findsOneWidget);
     expect(find.text(_coach.name), findsOneWidget);
+  });
+
+  testWidgets('connected trainer can open chat without a member gym link', (
+    WidgetTester tester,
+  ) async {
+    await pumpGymTab(tester, hasMyGym: false, coach: _coach);
+
+    expect(find.byKey(const Key('gymTrainerChatButton')), findsOneWidget);
+  });
+
+  testWidgets(
+    'pending consultation keeps its action without a member gym link',
+    (WidgetTester tester) async {
+      await pumpGymTab(
+        tester,
+        hasMyGym: false,
+        consultation: _consultation(ConsultationStatus.pending),
+        coach: _coach,
+      );
+
+      final AppLocalizations l = AppLocalizations.of(
+        tester.element(find.byType(Scaffold).first),
+      );
+      expect(find.text(l.exViewConsultationRequest), findsOneWidget);
+      expect(find.byKey(const Key('gymTrainerChatButton')), findsNothing);
+    },
+  );
+
+  testWidgets('any pending consultation keeps the consultation action', (
+    WidgetTester tester,
+  ) async {
+    final ConsultationRequest recentAcceptedRequest = ConsultationRequest(
+      id: 'consultation-recent-accepted',
+      targetType: ConsultationTargetType.trainer,
+      gymId: _gym.id,
+      gymName: _gym.name,
+      trainerId: 'another-trainer',
+      trainerName: '박최근',
+      trainerRole: '전담 트레이너',
+      exerciseGoal: ExerciseGoal.weightLoss,
+      healthPurposeType: HealthPurposeType.chronic,
+      healthPurposeDetail: null,
+      preferredDate: DateTime(2026, 8),
+      preferredTimeSlot: PreferredTimeSlot.afternoon,
+      message: null,
+      status: ConsultationStatus.accepted,
+      createdAt: DateTime(2026, 8, 1),
+    );
+    await pumpGymTab(
+      tester,
+      consultation: _consultation(ConsultationStatus.pending),
+      additionalConsultations: <ConsultationRequest>[recentAcceptedRequest],
+      coach: _coach,
+    );
+    await scrollToCard(tester);
+
+    final AppLocalizations l = AppLocalizations.of(
+      tester.element(find.byType(Scaffold).first),
+    );
+    expect(find.text(l.exViewConsultationRequest), findsOneWidget);
+    expect(find.byKey(const Key('gymTrainerChatButton')), findsNothing);
+    expect(find.text(l.exConsultPendingStatus), findsOneWidget);
+    expect(find.text('박최근'), findsNothing);
   });
 
   testWidgets('connected trainer shows unread count and caps it at 99+', (

--- a/frontend/flutter/test/features/exercise/gym_tab_action_test.dart
+++ b/frontend/flutter/test/features/exercise/gym_tab_action_test.dart
@@ -12,6 +12,10 @@ import 'package:oncare/features/exercise/domain/entities/gym.dart';
 import 'package:oncare/features/exercise/domain/entities/trainer.dart';
 import 'package:oncare/features/exercise/presentation/controllers/consultation_request_controller.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
+import 'package:oncare/features/member_coach/data/repositories/mock_member_coach_repository.dart';
+import 'package:oncare/features/member_coach/domain/entities/member_coach.dart';
+import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
+import 'package:oncare/features/member_coach/presentation/widgets/coach_chat_sheet.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 
 import '../../support/consultation_test_support.dart';
@@ -32,6 +36,16 @@ const Trainer _trainer = Trainer(
   role: '전담 트레이너',
 );
 
+const MemberCoach _coach = MemberCoach(
+  trainerId: 'trainer-action-test',
+  name: '김액션',
+  specialty: '전담 트레이너',
+  career: '5년',
+  intro: '건강한 운동을 돕습니다.',
+  gymName: '액션 테스트 헬스장',
+  goal: '체력 강화',
+);
+
 const AppConfig _config = AppConfig(
   environment: Environment.dev,
   apiBaseUrl: 'https://dev.api.test',
@@ -49,7 +63,7 @@ ConsultationRequest _consultation(ConsultationStatus status) {
     trainerRole: _trainer.role,
     exerciseGoal: ExerciseGoal.weightLoss,
     healthPurposeType: HealthPurposeType.chronic,
-  healthPurposeDetail: null,
+    healthPurposeDetail: null,
     preferredDate: DateTime(2026, 8),
     preferredTimeSlot: PreferredTimeSlot.afternoon,
     message: null,
@@ -67,6 +81,8 @@ void main() {
     ConsultationRequest? consultation,
     bool hasMyGym = true,
     Trainer? trainer = _trainer,
+    MemberCoach? coach,
+    int unread = 0,
   }) async {
     await tester.binding.setSurfaceSize(const Size(390, 844));
     addTearDown(() => tester.binding.setSurfaceSize(null));
@@ -99,6 +115,11 @@ void main() {
           consultationRequestControllerProvider.overrideWith(
             (ref) => consultationController,
           ),
+          memberCoachRepositoryProvider.overrideWithValue(
+            MockMemberCoachRepository(),
+          ),
+          memberCoachProvider.overrideWith((ref) async => coach),
+          coachUnreadProvider.overrideWith((ref) async => unread),
         ],
         child: MaterialApp.router(
           routerConfig: router,
@@ -141,10 +162,7 @@ void main() {
     expect(find.text(l.exViewConsultationRequest), findsNothing);
     expect(find.text(l.exMyGymSection), findsOneWidget);
     expect(
-      find.descendant(
-        of: myGymCard(),
-        matching: find.text(_trainer.name),
-      ),
+      find.descendant(of: myGymCard(), matching: find.text(_trainer.name)),
       findsNothing,
     );
 
@@ -178,6 +196,7 @@ void main() {
     await pumpGymTab(
       tester,
       consultation: _consultation(ConsultationStatus.pending),
+      coach: _coach,
     );
     await scrollToCard(tester);
 
@@ -187,6 +206,7 @@ void main() {
     expect(find.text(l.exViewConsultationRequest), findsOneWidget);
     expect(find.text(l.exGymInfo), findsNothing);
     expect(find.text(l.exConsultButton), findsNothing);
+    expect(find.byKey(const Key('gymTrainerChatButton')), findsNothing);
 
     final Finder statusSection = find.text(l.exConsultStatusSection);
     final double statusTopBeforeTap = tester.getTopLeft(statusSection).dy;
@@ -198,6 +218,65 @@ void main() {
     expect(tester.getTopLeft(statusSection).dy, lessThan(statusTopBeforeTap));
     expect(consultationController.state, hasLength(requestCountBeforeTap));
     expect(find.byType(BottomSheet), findsNothing);
+  });
+
+  testWidgets('connected trainer shows chat without a zero badge', (
+    WidgetTester tester,
+  ) async {
+    await pumpGymTab(tester, coach: _coach);
+    await scrollToCard(tester);
+
+    final Finder chatButton = find.byKey(const Key('gymTrainerChatButton'));
+    expect(chatButton, findsOneWidget);
+    expect(
+      find.descendant(of: chatButton, matching: find.text('0')),
+      findsNothing,
+    );
+
+    await tester.tap(chatButton);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TrainerChatPage), findsOneWidget);
+    expect(find.text(_coach.name), findsOneWidget);
+  });
+
+  testWidgets('connected trainer shows unread count and caps it at 99+', (
+    WidgetTester tester,
+  ) async {
+    await pumpGymTab(tester, coach: _coach, unread: 100);
+    await scrollToCard(tester);
+
+    final Finder chatButton = find.byKey(const Key('gymTrainerChatButton'));
+    expect(
+      find.descendant(of: chatButton, matching: find.text('99+')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: chatButton, matching: find.text('100')),
+      findsNothing,
+    );
+  });
+
+  testWidgets('connected trainer shows the actual unread count below 100', (
+    WidgetTester tester,
+  ) async {
+    await pumpGymTab(tester, coach: _coach, unread: 7);
+    await scrollToCard(tester);
+
+    final Finder chatButton = find.byKey(const Key('gymTrainerChatButton'));
+    expect(
+      find.descendant(of: chatButton, matching: find.text('7')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('member without an active trainer has no chat action', (
+    WidgetTester tester,
+  ) async {
+    await pumpGymTab(tester);
+    await scrollToCard(tester);
+
+    expect(find.byKey(const Key('gymTrainerChatButton')), findsNothing);
   });
 
   for (final ConsultationStatus status in <ConsultationStatus>[
@@ -231,7 +310,6 @@ void main() {
     );
     await tester.pumpAndSettle();
     expect(find.text(l.exGymDetailTitle), findsOneWidget);
-
   });
 
   testWidgets('담당 트레이너가 없으면 예약 패널을 감춘다', (WidgetTester tester) async {

--- a/frontend/flutter/test/features/member_coach/dio_member_coach_repository_test.dart
+++ b/frontend/flutter/test/features/member_coach/dio_member_coach_repository_test.dart
@@ -148,6 +148,18 @@ void main() {
     expect(await repo.unreadCount(), 3);
   });
 
+  test('unreadCount rejects a malformed unread field', () async {
+    when(
+      () => dio.get<Map<String, Object?>>('/me/coach/chat/unread'),
+    ).thenAnswer(
+      (_) async => _ok<Map<String, Object?>>(<String, Object?>{
+        'unread': '3',
+      }, '/me/coach/chat/unread'),
+    );
+
+    expect(repo.unreadCount(), throwsFormatException);
+  });
+
   test('markRead POSTs the shared thread read endpoint', () async {
     when(
       () => dio.post<Map<String, Object?>>('/me/coach/chat/read'),

--- a/frontend/flutter/test/features/member_coach/dio_member_coach_repository_test.dart
+++ b/frontend/flutter/test/features/member_coach/dio_member_coach_repository_test.dart
@@ -8,19 +8,19 @@ import 'package:oncare/features/member_coach/domain/entities/member_coach.dart';
 class _MockDio extends Mock implements Dio {}
 
 Response<T> _ok<T>(T body, String path) => Response<T>(
-      requestOptions: RequestOptions(path: path),
-      statusCode: 200,
-      data: body,
-    );
+  requestOptions: RequestOptions(path: path),
+  statusCode: 200,
+  data: body,
+);
 
 DioException _httpError(int status, String path) => DioException(
-      requestOptions: RequestOptions(path: path),
-      type: DioExceptionType.badResponse,
-      response: Response<Object?>(
-        requestOptions: RequestOptions(path: path),
-        statusCode: status,
-      ),
-    );
+  requestOptions: RequestOptions(path: path),
+  type: DioExceptionType.badResponse,
+  response: Response<Object?>(
+    requestOptions: RequestOptions(path: path),
+    statusCode: status,
+  ),
+);
 
 void main() {
   late _MockDio dio;
@@ -33,18 +33,19 @@ void main() {
 
   test('fetchCoach returns the coach', () async {
     when(() => dio.get<Map<String, Object?>>('/me/coach')).thenAnswer(
-      (_) async => _ok<Map<String, Object?>>(
-        <String, Object?>{'trainer_id': 't1', 'name': '김트레이너'},
-        '/me/coach',
-      ),
+      (_) async => _ok<Map<String, Object?>>(<String, Object?>{
+        'trainer_id': 't1',
+        'name': '김트레이너',
+      }, '/me/coach'),
     );
     final coach = await repo.fetchCoach();
     expect(coach?.name, '김트레이너');
   });
 
   test('fetchCoach returns null when the member has no coach (404)', () async {
-    when(() => dio.get<Map<String, Object?>>('/me/coach'))
-        .thenThrow(_httpError(404, '/me/coach'));
+    when(
+      () => dio.get<Map<String, Object?>>('/me/coach'),
+    ).thenThrow(_httpError(404, '/me/coach'));
     expect(await repo.fetchCoach(), isNull);
   });
 
@@ -54,7 +55,14 @@ void main() {
         requestOptions: RequestOptions(path: '/me/coach/routines'),
         statusCode: 200,
         data: <dynamic>[
-          <String, Object?>{'id': 'r1', 'name': '저강도 유산소', 'minutes': 20, 'type': '유산소', 'reason': '', 'source': 'ai'},
+          <String, Object?>{
+            'id': 'r1',
+            'name': '저강도 유산소',
+            'minutes': 20,
+            'type': '유산소',
+            'reason': '',
+            'source': 'ai',
+          },
         ],
       ),
     );
@@ -62,45 +70,97 @@ void main() {
     expect(routines.single.name, '저강도 유산소');
   });
 
-  test('fetchChat parses the thread', () async {
+  test('fetchChat parses and sorts the thread oldest first', () async {
     when(() => dio.get<List<dynamic>>('/me/coach/chat')).thenAnswer(
       (_) async => Response<List<dynamic>>(
         requestOptions: RequestOptions(path: '/me/coach/chat'),
         statusCode: 200,
         data: <dynamic>[
-          <String, Object?>{'id': 'm1', 'sender': 'trainer', 'body': '안녕', 'time_label': '13:20'},
+          <String, Object?>{
+            'id': 'm2',
+            'sender': 'me',
+            'body': '반가워요',
+            'time_label': '13:21',
+            'created_at': '2026-08-07T13:21:00Z',
+          },
+          <String, Object?>{
+            'id': 'm1',
+            'sender': 'trainer',
+            'body': '안녕',
+            'time_label': '13:20',
+            'created_at': '2026-08-07T13:20:00Z',
+          },
         ],
       ),
     );
     final chat = await repo.fetchChat();
-    expect(chat.single.sender, CoachSender.trainer);
+    expect(chat.map((CoachMessage message) => message.id), <String>[
+      'm1',
+      'm2',
+    ]);
+    expect(chat.first.sender, CoachSender.trainer);
+  });
+
+  test('fetchChat rejects a malformed list item', () async {
+    when(() => dio.get<List<dynamic>>('/me/coach/chat')).thenAnswer(
+      (_) async => Response<List<dynamic>>(
+        requestOptions: RequestOptions(path: '/me/coach/chat'),
+        statusCode: 200,
+        data: <dynamic>['invalid'],
+      ),
+    );
+
+    expect(repo.fetchChat(), throwsFormatException);
   });
 
   test('sendMessage POSTs the trimmed text; skips blank', () async {
-    when(() => dio.post<Map<String, Object?>>(
-          '/me/coach/chat',
-          data: any(named: 'data'),
-        )).thenAnswer(
-      (_) async => _ok<Map<String, Object?>>(<String, Object?>{'id': 'x'}, '/me/coach/chat'),
+    when(
+      () => dio.post<Map<String, Object?>>(
+        '/me/coach/chat',
+        data: any(named: 'data'),
+      ),
+    ).thenAnswer(
+      (_) async => _ok<Map<String, Object?>>(<String, Object?>{
+        'id': 'x',
+      }, '/me/coach/chat'),
     );
 
     await repo.sendMessage('  좋아요  ');
-    verify(() => dio.post<Map<String, Object?>>(
-          '/me/coach/chat',
-          data: <String, Object?>{'text': '좋아요'},
-        )).called(1);
+    verify(
+      () => dio.post<Map<String, Object?>>(
+        '/me/coach/chat',
+        data: <String, Object?>{'text': '좋아요'},
+      ),
+    ).called(1);
 
     await repo.sendMessage('   ');
     verifyNoMoreInteractions(dio);
   });
 
   test('unreadCount reads the unread field', () async {
-    when(() => dio.get<Map<String, Object?>>('/me/coach/chat/unread')).thenAnswer(
-      (_) async => _ok<Map<String, Object?>>(
-        <String, Object?>{'unread': 3},
-        '/me/coach/chat/unread',
-      ),
+    when(
+      () => dio.get<Map<String, Object?>>('/me/coach/chat/unread'),
+    ).thenAnswer(
+      (_) async => _ok<Map<String, Object?>>(<String, Object?>{
+        'unread': 3,
+      }, '/me/coach/chat/unread'),
     );
     expect(await repo.unreadCount(), 3);
+  });
+
+  test('markRead POSTs the shared thread read endpoint', () async {
+    when(
+      () => dio.post<Map<String, Object?>>('/me/coach/chat/read'),
+    ).thenAnswer(
+      (_) async => _ok<Map<String, Object?>>(<String, Object?>{
+        'marked_read': 1,
+      }, '/me/coach/chat/read'),
+    );
+
+    await repo.markRead();
+
+    verify(
+      () => dio.post<Map<String, Object?>>('/me/coach/chat/read'),
+    ).called(1);
   });
 }

--- a/frontend/flutter/test/features/member_coach/member_coach_dtos_test.dart
+++ b/frontend/flutter/test/features/member_coach/member_coach_dtos_test.dart
@@ -40,20 +40,49 @@ void main() {
         'sender': 'trainer',
         'body': '안녕하세요',
         'time_label': '13:20',
+        'created_at': '2026-08-07T13:20:00Z',
       });
       expect(m.sender, CoachSender.trainer);
       expect(m.fromMe, isFalse);
+      expect(m.createdAt, DateTime.utc(2026, 8, 7, 13, 20));
     });
 
-    test('maps my own message (me / anything else) to me', () {
+    test('maps my own message', () {
       final m = coachMessageFromJson(<String, Object?>{
         'id': 'm2',
         'sender': 'me',
         'body': '좋아요',
         'time_label': '13:21',
+        'created_at': '2026-08-07T13:21:00Z',
       });
       expect(m.sender, CoachSender.me);
       expect(m.fromMe, isTrue);
+    });
+
+    test('rejects an unknown sender', () {
+      expect(
+        () => coachMessageFromJson(<String, Object?>{
+          'id': 'm3',
+          'sender': 'client',
+          'body': '잘못된 발신자',
+          'time_label': '13:22',
+          'created_at': '2026-08-07T13:22:00Z',
+        }),
+        throwsFormatException,
+      );
+    });
+
+    test('rejects an invalid created_at value', () {
+      expect(
+        () => coachMessageFromJson(<String, Object?>{
+          'id': 'm4',
+          'sender': 'trainer',
+          'body': '잘못된 시간',
+          'time_label': '13:23',
+          'created_at': 'not-a-date',
+        }),
+        throwsFormatException,
+      );
     });
   });
 }

--- a/frontend/flutter/test/features/member_coach/recommended_exercise_cards_test.dart
+++ b/frontend/flutter/test/features/member_coach/recommended_exercise_cards_test.dart
@@ -48,6 +48,20 @@ const Trainer _assignedTrainer = Trainer(
   role: '퍼스널 트레이너',
 );
 
+class _ReadFailingMemberCoachRepository extends MockMemberCoachRepository {
+  @override
+  Future<void> markRead() async {
+    throw StateError('읽음 처리 실패');
+  }
+}
+
+class _SendFailingMemberCoachRepository extends MockMemberCoachRepository {
+  @override
+  Future<void> sendMessage(String text) async {
+    throw StateError('메시지 전송 실패');
+  }
+}
+
 void main() {
   Future<void> pumpRecommendationCards(
     WidgetTester tester,
@@ -125,9 +139,7 @@ void main() {
     expect(find.text('현재 추천할 수 있는 AI 맞춤 운동이 없어요'), findsOneWidget);
   });
 
-  testWidgets('담당 트레이너 프로필은 트레이너 상세 경로로 이동한다', (
-    WidgetTester tester,
-  ) async {
+  testWidgets('담당 트레이너 프로필은 트레이너 상세 경로로 이동한다', (WidgetTester tester) async {
     final GoRouter router = GoRouter(
       routes: <RouteBase>[
         GoRoute(
@@ -241,10 +253,9 @@ void main() {
 
     expect(find.text('운동 후 확인할게요'), findsOneWidget);
     expect(find.textContaining('나 ·'), findsNothing);
-    final Finder sentBubble = find.ancestor(
-      of: find.text('운동 후 확인할게요'),
-      matching: find.byType(Container),
-    ).first;
+    final Finder sentBubble = find
+        .ancestor(of: find.text('운동 후 확인할게요'), matching: find.byType(Container))
+        .first;
     final BoxDecoration sentBubbleDecoration =
         tester.widget<Container>(sentBubble).decoration! as BoxDecoration;
     expect(sentBubbleDecoration.color, FigmaColors.primary);
@@ -263,5 +274,44 @@ void main() {
 
     expect(find.byType(TrainerChatPage), findsNothing);
     expect(find.byKey(const Key('underlyingFloatingButton')), findsOneWidget);
+  });
+
+  testWidgets('읽음 처리가 실패해도 대화 목록을 표시한다', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          memberCoachRepositoryProvider.overrideWithValue(
+            _ReadFailingMemberCoachRepository(),
+          ),
+        ],
+        child: const MaterialApp(home: TrainerChatPage(trainerName: '김트레이너')),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('오늘 점심'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('메시지 전송이 실패하면 입력 내용을 유지한다', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          memberCoachRepositoryProvider.overrideWithValue(
+            _SendFailingMemberCoachRepository(),
+          ),
+        ],
+        child: const MaterialApp(home: TrainerChatPage(trainerName: '김트레이너')),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), '다시 보낼 메시지');
+    await tester.tap(find.byIcon(Icons.send));
+    await tester.pumpAndSettle();
+
+    final TextField input = tester.widget<TextField>(find.byType(TextField));
+    expect(input.controller?.text, '다시 보낼 메시지');
+    expect(find.text('메시지 전송에 실패했어요. 다시 시도해 주세요'), findsOneWidget);
   });
 }

--- a/frontend/flutter/test/features/member_coach/recommended_exercise_cards_test.dart
+++ b/frontend/flutter/test/features/member_coach/recommended_exercise_cards_test.dart
@@ -62,6 +62,24 @@ class _SendFailingMemberCoachRepository extends MockMemberCoachRepository {
   }
 }
 
+class _ReadTrackingMemberCoachRepository extends MockMemberCoachRepository {
+  int unreadCalls = 0;
+  int markReadCalls = 0;
+  bool _read = false;
+
+  @override
+  Future<int> unreadCount() async {
+    unreadCalls += 1;
+    return _read ? 0 : 1;
+  }
+
+  @override
+  Future<void> markRead() async {
+    markReadCalls += 1;
+    _read = true;
+  }
+}
+
 void main() {
   Future<void> pumpRecommendationCards(
     WidgetTester tester,
@@ -291,6 +309,40 @@ void main() {
 
     expect(find.textContaining('오늘 점심'), findsOneWidget);
     expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('읽음 처리 후 unread count를 갱신한다', (WidgetTester tester) async {
+    final repository = _ReadTrackingMemberCoachRepository();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          memberCoachRepositoryProvider.overrideWithValue(repository),
+        ],
+        child: MaterialApp(
+          home: Consumer(
+            builder: (BuildContext context, WidgetRef ref, Widget? child) {
+              ref.watch(coachUnreadProvider);
+              return Scaffold(
+                body: ElevatedButton(
+                  onPressed: () =>
+                      openTrainerChatPage(context, trainerName: '김트레이너'),
+                  child: const Text('채팅 열기'),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(repository.unreadCalls, 1);
+
+    await tester.tap(find.text('채팅 열기'));
+    await tester.pumpAndSettle();
+
+    expect(repository.markReadCalls, 1);
+    expect(repository.unreadCalls, 2);
   });
 
   testWidgets('메시지 전송이 실패하면 입력 내용을 유지한다', (WidgetTester tester) async {


### PR DESCRIPTION
## Summary

* 사용자 앱의 헬스장 탭에서 활성 담당 트레이너와의 실제 채팅으로 진입하도록 연결했습니다.
* 기존 회원용 `/me/coach/chat` API와 PR #342의 공용 `(trainer_id, member_id)` 스레드를 그대로 재사용합니다.
* unread 배지, 메시지 응답 검증·정렬, 읽음 처리 실패 분리와 관련 테스트를 보강했습니다.

---

## Changes

### ✨ Features

* 활성 담당 트레이너가 있고 pending 상담 요청이 없을 때 헬스장 카드에 `트레이너와 채팅` 버튼을 표시합니다.
* 채팅 진입 시 실 API 메시지 목록을 다시 조회하고 수신 메시지를 읽음 처리합니다.

### 🔧 Improvements

* `sender` 값과 `created_at` 형식을 검증하고, 생성 시간과 ID로 메시지를 안정적으로 정렬합니다.
* 잘못된 채팅 목록 원소를 조용히 누락하지 않고 잘못된 응답으로 처리합니다.
* 읽음 처리 실패가 대화 목록 표시를 막지 않도록 분리합니다.

### 🎨 UI/UX

* unread가 0이면 배지를 숨기고, 1~99는 실제 숫자, 100 이상은 `99+`로 표시합니다.
* pending 상담 요청이 있으면 기존 `상담 요청 확인` 버튼을 유지하고 채팅 버튼을 표시하지 않습니다.
* 메시지 전송 실패 시 입력 내용을 유지해 다시 시도할 수 있습니다.

### 📝 Docs

* 별도 문서 변경은 없습니다. 기존 백엔드·트레이너 채팅 API 계약을 그대로 사용합니다.

### 🐛 Fixes

* 채팅 재진입 시 캐시된 메시지가 계속 표시될 수 있는 문제를 방지합니다.
* 읽음 처리 실패가 비동기 미처리 예외로 남는 문제를 수정합니다.

---

## Commits

1. `79ab955` feat(chat): 사용자 트레이너 공용 채팅 실연동

---

## Notes

* 백엔드, `frontend/flutter_trainer`, DB, migration은 수정하지 않았습니다.
* 기존 사용자 앱 `MemberCoachRepository`와 PR #342가 사용하는 공용 채팅 스레드를 재사용합니다.
* 열린 이슈 #426이 같은 `gym_tab.dart`의 `_MyGymCard`·`_ReservationPanel`을 변경할 예정이라 파일·위젯 범위가 겹칩니다. #426은 이 PR의 채팅 CTA를 유지한 최신 `main` 기준으로 작업해야 합니다.
* 작업 트리에 있던 iOS 프로젝트 변경 2개는 이 PR에 포함하지 않았습니다.

---

## Screenshots (Optional)

| Before | After |
| ------ | ----- |
| 활성 담당 트레이너가 있어도 헬스장 카드에 채팅 CTA 없음 | 활성 연결 시 채팅 CTA와 unread 배지 표시 |

---

## Test Plan

* [x] 활성·미연결·pending 상태별 채팅 CTA 확인
* [x] unread 0, 1~99, 100 이상 배지 확인
* [x] sender·timestamp·정렬·잘못된 응답 확인
* [x] 전송·읽음 처리 실패 확인
* [x] `dart analyze` 변경 파일 통과
* [x] `flutter test --no-pub` 사용자 앱 전체 통과
* [ ] 웹 빌드는 PR CI에서 확인

### Manual Test Steps

1. `USE_MOCK_API=false`로 활성 담당 트레이너가 있는 회원으로 로그인합니다.
2. `운동 > 헬스장`의 `트레이너와 채팅`을 열고 메시지를 주고받습니다.
3. 채팅 진입 전·후 unread 배지가 백엔드 상태와 일치하는지 확인합니다.
4. 담당 트레이너가 없거나 pending 상담 요청이 있는 회원의 CTA가 요구사항대로 표시되는지 확인합니다.

---

## Related Issues

Closes #338

Related: #426

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] 열린 PR 없음·최신 `main` 기준 Merge 충돌 없음
* [x] Mock 데모 시나리오 회귀 테스트 통과


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 운동 탭에서 연결된 코치의 채팅 진입점과 읽지 않은 메시지 배지를 제공합니다.
  * 보류 중인 상담이 있으면 상담 요청을 우선 표시하고, 상담 중에는 코치 채팅 버튼을 숨깁니다.
  * 읽지 않은 메시지 수는 최대 `99+`로 표시됩니다.

* **버그 수정**
  * 채팅 메시지를 시간순으로 안정적으로 표시합니다.
  * 채팅 진입 시 읽음 상태와 읽지 않은 메시지 수를 갱신합니다.
  * 전송 또는 읽음 처리 실패 시에도 대화 내용과 입력 상태를 안전하게 유지합니다.
  * 잘못된 메시지 데이터는 명확한 오류로 처리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->