### PR TITLE
chore(ios): iOS 시뮬레이터 빌드 설정 동기화

### DIFF
--- a/frontend/flutter/ios/Podfile.lock
+++ b/frontend/flutter/ios/Podfile.lock
@@ -2,42 +2,20 @@ PODS:
   - Flutter (1.0.0)
   - flutter_secure_storage (6.0.0):
     - Flutter
-  - Google-Maps-iOS-Utils (5.0.0):
-    - GoogleMaps (~> 8.0)
-  - google_maps_flutter_ios (0.0.1):
-    - Flutter
-    - Google-Maps-iOS-Utils (< 7.0, >= 5.0)
-    - GoogleMaps (< 11.0, >= 8.4)
-  - GoogleMaps (8.4.0):
-    - GoogleMaps/Maps (= 8.4.0)
-  - GoogleMaps/Base (8.4.0)
-  - GoogleMaps/Maps (8.4.0):
-    - GoogleMaps/Base
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
-  - google_maps_flutter_ios (from `.symlinks/plugins/google_maps_flutter_ios/ios`)
-
-SPEC REPOS:
-  trunk:
-    - Google-Maps-iOS-Utils
-    - GoogleMaps
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
   flutter_secure_storage:
     :path: ".symlinks/plugins/flutter_secure_storage/ios"
-  google_maps_flutter_ios:
-    :path: ".symlinks/plugins/google_maps_flutter_ios/ios"
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
-  Google-Maps-iOS-Utils: 66d6de12be1ce6d3742a54661e7a79cb317a9321
-  google_maps_flutter_ios: 17552876e72723da1d41accc22f03b5f7afbde69
-  GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
 
 PODFILE CHECKSUM: e30f02f9d1c72c47bb6344a0a748c9d268180865
 

--- a/frontend/flutter/ios/Runner.xcodeproj/project.pbxproj
+++ b/frontend/flutter/ios/Runner.xcodeproj/project.pbxproj
@@ -203,7 +203,6 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				97C305171A8158E4335A9367 /* [CP] Embed Pods Frameworks */,
-				933754CC7ED7D7B2BB6F413D /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -317,23 +316,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		933754CC7ED7D7B2BB6F413D /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {


### PR DESCRIPTION
## Summary

* Flutter 사용자 앱을 Xcode iOS Simulator에서 빌드·실행할 수 있도록 CocoaPods 상태를 동기화합니다.
* 현재 Flutter 플러그인 구성에 맞게 `Podfile.lock`을 갱신합니다.
* Xcode 프로젝트에서 더 이상 생성되지 않는 CocoaPods 리소스 복사 단계를 정리합니다.

---

## Changes

### ✨ Features

* 기능 추가는 없습니다.

### 🔧 Improvements

* `pod install` 결과와 저장소의 iOS lock 파일을 일치시킵니다.
* `Runner.xcworkspace`를 통한 iOS Simulator 빌드에서 현재 pod 구성만 사용하도록 합니다.

### 🎨 UI/UX

* UI 변경은 없습니다.

### 📝 Docs

* 문서 변경은 없습니다.

### 🐛 Fixes

* `Podfile.lock`과 `Pods/Manifest.lock`이 달라 Xcode 빌드에서 `The sandbox is not in sync with the Podfile.lock` 오류가 발생할 수 있는 상태를 해소합니다.

---

## Commits

1. `eef6eff` chore(ios): iOS 시뮬레이터 빌드 설정 동기화

---

## Notes

* iOS Simulator 빌드 환경 동기화만 다루며 Dart/Flutter 소스 코드는 수정하지 않습니다.
* 새 플러그인이나 런타임 의존성을 추가하지 않습니다.
* 현재 열린 PR #463과 변경 파일이 겹치지 않습니다.

---

## Screenshots (Optional)

| Before | After |
| ------ | ----- |
| CocoaPods lock·Xcode 프로젝트 상태 불일치 | `pod install` 결과와 저장소 설정 일치 |

---

## Test Plan

* [x] `pod install` 성공
* [x] `Podfile.lock`과 `Pods/Manifest.lock` 일치 확인
* [x] `flutter build ios --simulator --no-pub` 성공
* [x] `build/ios/iphonesimulator/Runner.app` 생성 확인

### Manual Test Steps

1. `frontend/flutter/ios` 디렉터리에서 `pod install`을 실행합니다.
2. `Runner.xcworkspace`를 Xcode로 엽니다.
3. iOS Simulator를 대상으로 Runner를 빌드·실행합니다.

---

## Related Issues

없음

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] iOS 시뮬레이터 빌드 확인
