### PR TITLE
fix(ui): 회원앱 부분창 하단 여백 및 전체 화면 전환 개선

### DIFF
--- a/frontend/flutter/lib/app/router/app_router.dart
+++ b/frontend/flutter/lib/app/router/app_router.dart
@@ -15,6 +15,7 @@ import 'package:oncare/features/auth/presentation/pages/sign_in_page.dart';
 import 'package:oncare/features/auth/presentation/pages/sign_up_page.dart';
 import 'package:oncare/features/dashboard/presentation/pages/dashboard_page.dart';
 import 'package:oncare/features/diet/presentation/pages/diet_record_page.dart';
+import 'package:oncare/features/diet/presentation/widgets/diet_flows.dart';
 import 'package:oncare/features/exercise/domain/entities/consultation_request.dart';
 import 'package:oncare/features/exercise/presentation/pages/consultation_complete_page.dart';
 import 'package:oncare/features/exercise/presentation/pages/consultation_request_page.dart';
@@ -24,6 +25,7 @@ import 'package:oncare/features/exercise/presentation/pages/gym_list_page.dart';
 import 'package:oncare/features/exercise/presentation/pages/trainer_detail_page.dart';
 import 'package:oncare/features/exercise/presentation/pages/trainer_list_page.dart';
 import 'package:oncare/features/my_health/presentation/pages/my_health_page.dart';
+import 'package:oncare/features/my_health/presentation/widgets/my_flows.dart';
 import 'package:oncare/features/notification/presentation/pages/notification_page.dart';
 import 'package:oncare/features/place/presentation/pages/place_page.dart';
 
@@ -62,6 +64,7 @@ GoRouter buildAppRouter({
   SessionStatus Function()? readStatus,
   Listenable? refresh,
 }) {
+  GoRouter.optionURLReflectsImperativeAPIs = true;
   return GoRouter(
     initialLocation: AppRoutes.signIn,
     debugLogDiagnostics: !config.isProd,
@@ -123,6 +126,32 @@ GoRouter buildAppRouter({
       GoRoute(
         path: AppRoutes.notification,
         builder: (context, state) => const NotificationPage(),
+      ),
+      GoRoute(
+        path: AppRoutes.dietEntryDetail,
+        builder: (context, state) => DietMealDetailPage(
+          entryId: state.pathParameters['entryId'] ?? '',
+          initialMeal: state.extra is DietMeal
+              ? state.extra! as DietMeal
+              : null,
+        ),
+      ),
+      GoRoute(
+        path: AppRoutes.myPoints,
+        builder: (context, state) => PointsBenefitsPage(
+          points: state.extra is int ? state.extra! as int : null,
+        ),
+      ),
+      GoRoute(
+        path: AppRoutes.mySettings,
+        builder: (context, state) => switch (state.pathParameters['section']) {
+          'profile' => const ProfileSettingsPage(),
+          'goals' => const HealthGoalsPage(),
+          'notifications' => const NotificationSettingsPage(),
+          'terms' => const LegalDocumentPage(document: 'terms'),
+          'privacy' => const LegalDocumentPage(document: 'privacy'),
+          _ => const SupportPage(),
+        },
       ),
       GoRoute(
         path: AppRoutes.place,

--- a/frontend/flutter/lib/app/router/main_shell.dart
+++ b/frontend/flutter/lib/app/router/main_shell.dart
@@ -40,7 +40,10 @@ class MainShell extends StatelessWidget {
       // showing a separate white strip above the navigation bar.
       extendBody: true,
       body: navigationShell,
-      floatingActionButton: OniFab(onTap: () => showCoachingSheet(context)),
+      floatingActionButton: OniFab(
+        key: const Key('coachingFab'),
+        onTap: () => showCoachingSheet(context),
+      ),
       bottomNavigationBar: SizedBox(
         height: barHeight + lift + effectiveBottomPadding,
         child: Center(

--- a/frontend/flutter/lib/app/router/main_shell.dart
+++ b/frontend/flutter/lib/app/router/main_shell.dart
@@ -183,6 +183,7 @@ class _NavAddButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
+      key: const Key('recordAddButton'),
       onTap: onTap,
       behavior: HitTestBehavior.opaque,
       child: Container(
@@ -228,18 +229,19 @@ class _RecordAddSheet extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
-    return SafeArea(
-      top: false,
-      child: ConstrainedBox(
-        // Match the main content width so the sheet scales with the viewport
-        // like the tab pages. The theme lifts the modal route cap to this
-        // width too (see AppTheme._bottomSheetTheme); this centres the child.
-        constraints: const BoxConstraints(maxWidth: AppBreakpoints.contentMaxWidth),
-        child: Container(
-          decoration: const BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
-          ),
+    return ConstrainedBox(
+      // Match the main content width so the sheet scales with the viewport
+      // like the tab pages. The theme lifts the modal route cap to this
+      // width too (see AppTheme._bottomSheetTheme); this centres the child.
+      constraints: const BoxConstraints(maxWidth: AppBreakpoints.contentMaxWidth),
+      child: Container(
+        key: const Key('recordAddSheet'),
+        decoration: const BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+        ),
+        child: SafeArea(
+          top: false,
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
@@ -285,7 +287,8 @@ class _RecordAddSheet extends StatelessWidget {
                 ),
               ),
               Padding(
-                padding: const EdgeInsets.fromLTRB(20, 12, 20, 24),
+                key: const Key('recordOptions'),
+                padding: const EdgeInsets.fromLTRB(20, 12, 20, 0),
                 child: Row(
                   children: <Widget>[
                     Expanded(

--- a/frontend/flutter/lib/app/router/routes.dart
+++ b/frontend/flutter/lib/app/router/routes.dart
@@ -12,6 +12,9 @@ class AppRoutes {
   // Modal-ish routes (pushed from any tab)
   static const String aiCoach = '/ai-coach';
   static const String notification = '/notification';
+  static const String dietEntryDetail = '/diet/entries/:entryId';
+  static const String myPoints = '/my-health/points';
+  static const String mySettings = '/my-health/settings/:section';
   static const String place = '/place';
   static const String gyms = '/gyms';
   static const String trainers = '/trainers';
@@ -26,6 +29,12 @@ class AppRoutes {
 
   static String trainerDetailPath(String trainerId) =>
       '$trainers/${Uri.encodeComponent(trainerId)}';
+
+  static String dietEntryDetailPath(String entryId) =>
+      '$diet/entries/${Uri.encodeComponent(entryId)}';
+
+  static String mySettingsPath(String section) =>
+      '/my-health/settings/${Uri.encodeComponent(section)}';
 
   /// [trainerId] is required for trainer-target consultations — a gym has
   /// several trainers, so the gym id alone cannot identify one.

--- a/frontend/flutter/lib/features/dashboard/presentation/pages/dashboard_page.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/pages/dashboard_page.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
+import 'package:oncare/app/router/routes.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
 import 'package:oncare/features/dashboard/presentation/widgets/dashboard_content.dart';
-import 'package:oncare/features/notification/presentation/widgets/notification_panel.dart';
-import 'package:oncare/shared/widgets/modals/right_slide_panel.dart';
 import 'package:oncare/shared/widgets/modals/schedule_calendar_sheet.dart';
 
 /// Home tab. The header now scrolls with the content (per the Figma redesign),
@@ -19,10 +19,7 @@ class DashboardPage extends StatelessWidget {
       body: SafeArea(
         bottom: false,
         child: DashboardContent(
-          onNotificationTap: () => showRightSlidePanel<void>(
-            context,
-            content: const NotificationPanelBody(),
-          ),
+          onNotificationTap: () => context.push(AppRoutes.notification),
           onCalendarTap: () => showScheduleCalendarSheet(context),
         ),
       ),

--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -1,20 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
+import 'package:oncare/app/router/routes.dart';
 import 'package:oncare/design_system/figma/figma_kit.dart';
 import 'package:oncare/features/diet/domain/entities/diet_day.dart';
 import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
 import 'package:oncare/features/diet/presentation/widgets/diet_flows.dart';
 import 'package:oncare/features/member_coach/presentation/widgets/trainer_chat_header_button.dart';
-import 'package:oncare/features/notification/presentation/widgets/notification_panel.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
-import 'package:oncare/shared/widgets/modals/right_slide_panel.dart';
 import 'package:oncare/shared/widgets/modals/schedule_calendar_sheet.dart';
 
 /// 식단 tab, rebuilt to match the On-Care Figma redesign. The weekly date
 /// strip is centred on today (per the product request); the nutrition summary /
 /// AI feedback / meal log are driven by [dietTodayProvider], and the "식단 추가"
-/// and meal-edit flows open as bottom sheets wired to the diet repository.
+/// and meal-detail flows open as full pages wired to the diet repository.
 ///
 /// The backend currently exposes only "today", so a non-today selection shows
 /// an empty state until the per-date query lands (tracked as a follow-up).
@@ -150,10 +150,7 @@ class _DietRecordPageState extends ConsumerState<DietRecordPage> {
                 FigmaTabHeader(
                   title: l.dietTitle,
                   trailingAction: const TrainerChatHeaderButton(),
-                  onBell: () => showRightSlidePanel<void>(
-                    context,
-                    content: const NotificationPanelBody(),
-                  ),
+                  onBell: () => context.push(AppRoutes.notification),
                   onCalendar: () => showScheduleCalendarSheet(context),
                 ),
                 _DateStrip(
@@ -194,7 +191,7 @@ class _DietRecordPageState extends ConsumerState<DietRecordPage> {
                           entries: day.entries,
                           onAdd: () => showDietAddSheet(context),
                           onEditMeal: (DietMeal m) =>
-                              showMealEditSheet(context, m),
+                              openMealDetailPage(context, m),
                         ),
                       ],
                     ),

--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -1236,6 +1236,7 @@ class _MealCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final AppLocalizations l = AppLocalizations.of(context);
     return Container(
+      key: meal.id == null ? null : Key('mealCard-${meal.id}'),
       decoration: BoxDecoration(
         color: Colors.white,
         borderRadius: BorderRadius.circular(20),

--- a/frontend/flutter/lib/features/diet/presentation/widgets/diet_flows.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/diet_flows.dart
@@ -2,8 +2,10 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:image_picker/image_picker.dart';
 
+import 'package:oncare/app/router/routes.dart';
 import 'package:oncare/design_system/figma/figma_kit.dart';
 import 'package:oncare/design_system/tokens/breakpoints.dart';
 import 'package:oncare/features/diet/domain/entities/diet_analysis.dart';
@@ -150,7 +152,9 @@ Future<void> _pickAndAnalyze(
     // Permission denied / platform error / unreadable file — don't crash.
     if (sheetContext.mounted) {
       ScaffoldMessenger.of(sheetContext).showSnackBar(
-        SnackBar(content: Text(AppLocalizations.of(sheetContext).dietPhotoLoadError)),
+        SnackBar(
+          content: Text(AppLocalizations.of(sheetContext).dietPhotoLoadError),
+        ),
       );
     }
     return;
@@ -467,7 +471,10 @@ class _ResultSheetState extends ConsumerState<_ResultSheet> {
             const SizedBox(height: 14),
             Text(
               l.dietAnalyzingBody,
-              style: const TextStyle(fontSize: 13, color: FigmaColors.textMuted),
+              style: const TextStyle(
+                fontSize: 13,
+                color: FigmaColors.textMuted,
+              ),
             ),
           ],
         ),
@@ -480,7 +487,10 @@ class _ResultSheetState extends ConsumerState<_ResultSheet> {
           children: <Widget>[
             Text(
               l.dietAnalysisFailedBody,
-              style: const TextStyle(fontSize: 13, color: FigmaColors.textMuted),
+              style: const TextStyle(
+                fontSize: 13,
+                color: FigmaColors.textMuted,
+              ),
             ),
             const SizedBox(height: 16),
             SizedBox(
@@ -509,7 +519,9 @@ class _ResultSheetState extends ConsumerState<_ResultSheet> {
     }
 
     final DietAnalysisResult r = _result!;
-    final String recognized = r.foods.map((RecognizedFood f) => f.name).join(' · ');
+    final String recognized = r.foods
+        .map((RecognizedFood f) => f.name)
+        .join(' · ');
     return Column(
       children: <Widget>[
         Container(
@@ -598,9 +610,9 @@ class _ResultSheetState extends ConsumerState<_ResultSheet> {
           child: FilledButton.icon(
             onPressed: () {
               Navigator.of(context).pop();
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(content: Text(l.dietSaved)),
-              );
+              ScaffoldMessenger.of(
+                context,
+              ).showSnackBar(SnackBar(content: Text(l.dietSaved)));
             },
             style: FilledButton.styleFrom(
               backgroundColor: FigmaColors.primary,
@@ -622,7 +634,11 @@ class _ResultSheetState extends ConsumerState<_ResultSheet> {
 }
 
 class _ResultRow extends StatelessWidget {
-  const _ResultRow({required this.label, required this.value, required this.unit});
+  const _ResultRow({
+    required this.label,
+    required this.value,
+    required this.unit,
+  });
   final String label;
   final String value;
   final String unit;
@@ -669,9 +685,87 @@ class _ResultRow extends StatelessWidget {
 
 /// Opens meal details as a full page above the member tab shell.
 Future<void> openMealDetailPage(BuildContext context, DietMeal meal) {
-  return Navigator.of(context, rootNavigator: true).push<void>(
-    MaterialPageRoute<void>(builder: (_) => _MealEditSheet(meal: meal)),
+  final String? id = meal.id;
+  if (id == null) return Future<void>.value();
+  return context.push<void>(AppRoutes.dietEntryDetailPath(id), extra: meal);
+}
+
+/// Full-page meal editor. [initialMeal] makes the first transition immediate;
+/// when a web URL is refreshed, the same meal is restored from today's data.
+class DietMealDetailPage extends ConsumerWidget {
+  const DietMealDetailPage({
+    super.key,
+    required this.entryId,
+    this.initialMeal,
+  });
+
+  final String entryId;
+  final DietMeal? initialMeal;
+
+  DietMeal _fromEntry(DietEntry entry) => DietMeal(
+    id: entry.id,
+    mealType: entry.mealType,
+    time: entry.timeLabel,
+    total: entry.totalCalories,
+    emoji: '',
+    thumbBg: Colors.white,
+    photoAsset: entry.photoAsset,
+    aiComment: entry.aiComment,
+    items: <DietFood>[
+      for (final FoodItem food in entry.foods)
+        DietFood(
+          food.name,
+          food.calories,
+          sodiumMg: food.sodiumMg,
+          sugarG: food.sugarG,
+        ),
+    ],
+    tags: const <DietTag>[],
+    sodium: entry.sodiumMg,
+    sugar: entry.sugarG,
   );
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final DietMeal? supplied = initialMeal;
+    if (supplied != null && supplied.id == entryId) {
+      return _MealEditSheet(meal: supplied);
+    }
+
+    final AppLocalizations l = AppLocalizations.of(context);
+    return ref
+        .watch(dietTodayProvider)
+        .when(
+          data: (DietDay day) {
+            for (final DietEntry entry in day.entries) {
+              if (entry.id == entryId) {
+                return _MealEditSheet(meal: _fromEntry(entry));
+              }
+            }
+            return _MealDetailUnavailable(message: l.dietLoadError);
+          },
+          loading: () => const Scaffold(
+            backgroundColor: Colors.white,
+            body: Center(child: CircularProgressIndicator()),
+          ),
+          error: (_, _) => _MealDetailUnavailable(message: l.dietLoadError),
+        );
+  }
+}
+
+class _MealDetailUnavailable extends StatelessWidget {
+  const _MealDetailUnavailable({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(backgroundColor: Colors.white),
+      body: Center(child: Text(message)),
+    );
+  }
 }
 
 class _MealEditSheet extends ConsumerStatefulWidget {
@@ -723,14 +817,10 @@ class _MealEditSheetState extends ConsumerState<_MealEditSheet> {
       if (!mounted) return;
       ref.invalidate(dietTodayProvider);
       navigator.pop();
-      messenger.showSnackBar(
-        SnackBar(content: Text(l.dietSaved)),
-      );
+      messenger.showSnackBar(SnackBar(content: Text(l.dietSaved)));
     } catch (_) {
       if (mounted) setState(() => _busy = false);
-      messenger.showSnackBar(
-        SnackBar(content: Text(l.dietSaveFailed)),
-      );
+      messenger.showSnackBar(SnackBar(content: Text(l.dietSaveFailed)));
     }
   }
 
@@ -774,14 +864,10 @@ class _MealEditSheetState extends ConsumerState<_MealEditSheet> {
       if (!mounted) return;
       ref.invalidate(dietTodayProvider);
       navigator.pop();
-      messenger.showSnackBar(
-        SnackBar(content: Text(l.dietDeleted)),
-      );
+      messenger.showSnackBar(SnackBar(content: Text(l.dietDeleted)));
     } catch (_) {
       if (mounted) setState(() => _busy = false);
-      messenger.showSnackBar(
-        SnackBar(content: Text(l.dietDeleteFailed)),
-      );
+      messenger.showSnackBar(SnackBar(content: Text(l.dietDeleteFailed)));
     }
   }
 
@@ -945,8 +1031,9 @@ class _MealEditSheetState extends ConsumerState<_MealEditSheet> {
                     _FoodRow(
                       index: i + 1,
                       food: _foods[i],
-                      onDelete: () =>
-                          setState(() => _foods = <DietFood>[..._foods]..removeAt(i)),
+                      onDelete: () => setState(
+                        () => _foods = <DietFood>[..._foods]..removeAt(i),
+                      ),
                     ),
                     const SizedBox(height: 8),
                   ],
@@ -1039,7 +1126,10 @@ class _MealEditSheetState extends ConsumerState<_MealEditSheet> {
       color: FigmaColors.statBg,
       borderRadius: BorderRadius.circular(16),
     ),
-    child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: children),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: children,
+    ),
   );
 }
 
@@ -1123,11 +1213,7 @@ class _FoodRow extends StatelessWidget {
           const SizedBox(width: 8),
           GestureDetector(
             onTap: onDelete,
-            child: const Icon(
-              Icons.cancel,
-              size: 18,
-              color: Color(0xFFFFB4A8),
-            ),
+            child: const Icon(Icons.cancel, size: 18, color: Color(0xFFFFB4A8)),
           ),
         ],
       ),

--- a/frontend/flutter/lib/features/diet/presentation/widgets/diet_flows.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/diet_flows.dart
@@ -82,23 +82,38 @@ String _currentMealType() {
   return 'snack';
 }
 
-Widget _sheetShell(BuildContext context, Widget child) {
-  return SafeArea(
-    top: false,
-    child: ConstrainedBox(
-      constraints: BoxConstraints(
-        maxHeight: MediaQuery.of(context).size.height * 0.9,
-        // Match the main content width so the sheet scales with the viewport
-        // like the tab pages. The theme lifts the modal route cap to this
-        // width too (see AppTheme._bottomSheetTheme); this centres the child.
-        maxWidth: AppBreakpoints.contentMaxWidth,
+Widget _sheetShell(BuildContext context, Widget child, {Key? key}) {
+  return ConstrainedBox(
+    constraints: BoxConstraints(
+      maxHeight: MediaQuery.of(context).size.height * 0.9,
+      // Match the main content width so the sheet scales with the viewport
+      // like the tab pages. The theme lifts the modal route cap to this
+      // width too (see AppTheme._bottomSheetTheme); this centres the child.
+      maxWidth: AppBreakpoints.contentMaxWidth,
+    ),
+    child: Container(
+      key: key,
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
       ),
-      child: Container(
-        decoration: const BoxDecoration(
-          color: Colors.white,
-          borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+      child: SafeArea(top: false, child: child),
+    ),
+  );
+}
+
+Widget _pageShell(Widget child) {
+  return Scaffold(
+    key: const Key('mealDetailPage'),
+    backgroundColor: Colors.white,
+    body: SafeArea(
+      child: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(
+            maxWidth: AppBreakpoints.contentMaxWidth,
+          ),
+          child: SizedBox.expand(child: child),
         ),
-        child: child,
       ),
     ),
   );
@@ -120,9 +135,9 @@ Widget _sheetHandle() => Container(
 /// Silently returns if the user cancels the picker.
 Future<void> _pickAndAnalyze(
   BuildContext sheetContext,
-  BuildContext pageContext,
   ImageSource source,
 ) async {
+  final NavigatorState navigator = Navigator.of(sheetContext);
   final Uint8List bytes;
   try {
     final XFile? file = await ImagePicker().pickImage(
@@ -140,15 +155,18 @@ Future<void> _pickAndAnalyze(
     }
     return;
   }
-  if (sheetContext.mounted) Navigator.of(sheetContext).pop();
-  if (!pageContext.mounted) return;
-  await showDietResultSheet(pageContext, bytes, _currentMealType());
+  if (!sheetContext.mounted) return;
+  navigator.pop();
+  await showDietResultSheet(navigator.context, bytes, _currentMealType());
 }
 
-/// "식단 추가하기" — pick a photo source, then show the AI analysis result.
+/// Opens the short photo-source choice as a content-sized bottom sheet.
 Future<void> showDietAddSheet(BuildContext context) {
   return showModalBottomSheet<void>(
     context: context,
+    // Keep the sheet above the main shell's floating buttons even when it is
+    // opened from a tab page that has its own nested Navigator.
+    useRootNavigator: true,
     isScrollControlled: true,
     backgroundColor: Colors.transparent,
     barrierColor: FigmaColors.sheetScrim,
@@ -162,13 +180,13 @@ Future<void> showDietAddSheet(BuildContext context) {
             Center(child: _sheetHandle()),
             Padding(
               padding: const EdgeInsets.fromLTRB(20, 8, 20, 4),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
+              child: Row(
                 children: <Widget>[
-                  Row(
-                    children: <Widget>[
-                      Expanded(
-                        child: Text(
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Text(
                           l.dietAddSheetTitle,
                           style: const TextStyle(
                             fontSize: 18,
@@ -176,23 +194,24 @@ Future<void> showDietAddSheet(BuildContext context) {
                             color: FigmaColors.ink,
                           ),
                         ),
-                      ),
-                      _CircleClose(onTap: () => Navigator.of(ctx).pop()),
-                    ],
-                  ),
-                  const SizedBox(height: 2),
-                  Text(
-                    l.dietAddSheetSubtitle,
-                    style: const TextStyle(
-                      fontSize: 12,
-                      color: FigmaColors.textMuted,
+                        const SizedBox(height: 2),
+                        Text(
+                          l.dietAddSheetSubtitle,
+                          style: const TextStyle(
+                            fontSize: 12,
+                            color: FigmaColors.textMuted,
+                          ),
+                        ),
+                      ],
                     ),
                   ),
+                  _CircleClose(onTap: () => Navigator.of(ctx).pop()),
                 ],
               ),
             ),
             Padding(
-              padding: const EdgeInsets.fromLTRB(20, 12, 20, 24),
+              key: const Key('dietAddOptions'),
+              padding: const EdgeInsets.fromLTRB(20, 12, 20, 0),
               child: Column(
                 children: <Widget>[
                   _SourceOption(
@@ -201,8 +220,7 @@ Future<void> showDietAddSheet(BuildContext context) {
                     iconColor: FigmaColors.primary,
                     title: l.dietPickPhoto,
                     subtitle: l.dietPickPhotoSub,
-                    onTap: () =>
-                        _pickAndAnalyze(ctx, context, ImageSource.gallery),
+                    onTap: () => _pickAndAnalyze(ctx, ImageSource.gallery),
                   ),
                   const SizedBox(height: 12),
                   _SourceOption(
@@ -211,14 +229,14 @@ Future<void> showDietAddSheet(BuildContext context) {
                     iconColor: FigmaColors.greenText,
                     title: l.dietTakePhoto,
                     subtitle: l.dietTakePhotoSub,
-                    onTap: () =>
-                        _pickAndAnalyze(ctx, context, ImageSource.camera),
+                    onTap: () => _pickAndAnalyze(ctx, ImageSource.camera),
                   ),
                 ],
               ),
             ),
           ],
         ),
+        key: const Key('dietAddSheet'),
       );
     },
   );
@@ -426,7 +444,7 @@ class _ResultSheetState extends ConsumerState<_ResultSheet> {
             ),
           ),
           Padding(
-            padding: const EdgeInsets.fromLTRB(20, 4, 20, 24),
+            padding: const EdgeInsets.fromLTRB(20, 4, 20, 0),
             child: _body(),
           ),
         ],
@@ -649,14 +667,10 @@ class _ResultRow extends StatelessWidget {
 
 // ─────────────────────────────────────────────────── 식사 수정 ──
 
-/// Meal-edit sheet: meal type, time, editable food list + nutrient values.
-Future<void> showMealEditSheet(BuildContext context, DietMeal meal) {
-  return showModalBottomSheet<void>(
-    context: context,
-    isScrollControlled: true,
-    backgroundColor: Colors.transparent,
-    barrierColor: FigmaColors.sheetScrim,
-    builder: (BuildContext ctx) => _MealEditSheet(meal: meal),
+/// Opens meal details as a full page above the member tab shell.
+Future<void> openMealDetailPage(BuildContext context, DietMeal meal) {
+  return Navigator.of(context, rootNavigator: true).push<void>(
+    MaterialPageRoute<void>(builder: (_) => _MealEditSheet(meal: meal)),
   );
 }
 
@@ -775,12 +789,9 @@ class _MealEditSheetState extends ConsumerState<_MealEditSheet> {
   Widget build(BuildContext context) {
     final AppLocalizations l = AppLocalizations.of(context);
     // Block back/drag dismiss while a save/delete request is in flight.
-    final Widget sheet = _sheetShell(
-      context,
+    final Widget page = _pageShell(
       Column(
-        mainAxisSize: MainAxisSize.min,
         children: <Widget>[
-          Center(child: _sheetHandle()),
           Padding(
             padding: const EdgeInsets.fromLTRB(20, 8, 20, 8),
             child: Row(
@@ -1019,7 +1030,7 @@ class _MealEditSheetState extends ConsumerState<_MealEditSheet> {
         ],
       ),
     );
-    return PopScope(canPop: !_busy, child: sheet);
+    return PopScope(canPop: !_busy, child: page);
   }
 
   Widget _card(List<Widget> children) => Container(

--- a/frontend/flutter/lib/features/diet/presentation/widgets/diet_flows.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/diet_flows.dart
@@ -155,7 +155,7 @@ Future<void> _pickAndAnalyze(
     }
     return;
   }
-  if (!sheetContext.mounted) return;
+  if (!navigator.mounted) return;
   navigator.pop();
   await showDietResultSheet(navigator.context, bytes, _currentMealType());
 }

--- a/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
@@ -3,11 +3,10 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-
-import 'package:oncare/app/router/routes.dart';
 // NumberFormat 만 가져온다 — intl 의 TextDirection 이 dart:ui 것과 충돌한다.
 import 'package:intl/intl.dart' show NumberFormat;
 
+import 'package:oncare/app/router/routes.dart';
 import 'package:oncare/design_system/figma/figma_kit.dart';
 import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';

--- a/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
@@ -2,6 +2,9 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:oncare/app/router/routes.dart';
 // NumberFormat 만 가져온다 — intl 의 TextDirection 이 dart:ui 것과 충돌한다.
 import 'package:intl/intl.dart' show NumberFormat;
 
@@ -12,10 +15,8 @@ import 'package:oncare/features/exercise/presentation/widgets/exercise_flows.dar
 import 'package:oncare/features/exercise/presentation/widgets/gym_tab.dart';
 import 'package:oncare/features/member_coach/presentation/widgets/coach_card.dart';
 import 'package:oncare/features/member_coach/presentation/widgets/trainer_chat_header_button.dart';
-import 'package:oncare/features/notification/presentation/widgets/notification_panel.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 import 'package:oncare/shared/services/exercise_burn_goal_provider.dart';
-import 'package:oncare/shared/widgets/modals/right_slide_panel.dart';
 import 'package:oncare/shared/widgets/modals/schedule_calendar_sheet.dart';
 
 /// 운동 tab, rebuilt to the On-Care Figma redesign — a 운동 기록 / 헬스장
@@ -58,10 +59,7 @@ class _ExercisePageState extends State<ExercisePage> {
                 FigmaTabHeader(
                   title: l.pageExerciseTitle,
                   trailingAction: const TrainerChatHeaderButton(),
-                  onBell: () => showRightSlidePanel<void>(
-                    context,
-                    content: const NotificationPanelBody(),
-                  ),
+                  onBell: () => context.push(AppRoutes.notification),
                   onCalendar: () => showScheduleCalendarSheet(context),
                 ),
                 _SubTabs(

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/exercise_flows.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/exercise_flows.dart
@@ -73,23 +73,20 @@ int _estimateCalories(ExerciseType type, int minutes, int level) {
   return (perMin * minutes * factor).round();
 }
 
-Widget _shell(BuildContext context, Widget child) => SafeArea(
-  top: false,
-  child: ConstrainedBox(
-    constraints: BoxConstraints(
-      maxHeight: MediaQuery.of(context).size.height * 0.9,
-      // Match the main content width so the sheet scales with the viewport
-      // like the tab pages. The theme lifts the modal route cap to this
-      // width too (see AppTheme._bottomSheetTheme); this centres the child.
-      maxWidth: AppBreakpoints.contentMaxWidth,
+Widget _shell(BuildContext context, Widget child) => ConstrainedBox(
+  constraints: BoxConstraints(
+    maxHeight: MediaQuery.of(context).size.height * 0.9,
+    // Match the main content width so the sheet scales with the viewport
+    // like the tab pages. The theme lifts the modal route cap to this
+    // width too (see AppTheme._bottomSheetTheme); this centres the child.
+    maxWidth: AppBreakpoints.contentMaxWidth,
+  ),
+  child: Container(
+    decoration: const BoxDecoration(
+      color: Colors.white,
+      borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
     ),
-    child: Container(
-      decoration: const BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
-      ),
-      child: child,
-    ),
+    child: SafeArea(top: false, child: child),
   ),
 );
 
@@ -251,7 +248,7 @@ class _ExerciseAddSheetState extends ConsumerState<_ExerciseAddSheet> {
           Flexible(
             child: ListView(
               shrinkWrap: true,
-              padding: const EdgeInsets.fromLTRB(20, 4, 20, 28),
+              padding: const EdgeInsets.fromLTRB(20, 4, 20, 0),
               children: <Widget>[
                 _Label(l.exExerciseType),
                 const SizedBox(height: 10),

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/exercise_flows.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/exercise_flows.dart
@@ -82,6 +82,7 @@ Widget _shell(BuildContext context, Widget child) => ConstrainedBox(
     maxWidth: AppBreakpoints.contentMaxWidth,
   ),
   child: Container(
+    key: const Key('exerciseAddSheet'),
     decoration: const BoxDecoration(
       color: Colors.white,
       borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
@@ -247,6 +248,7 @@ class _ExerciseAddSheetState extends ConsumerState<_ExerciseAddSheet> {
           ),
           Flexible(
             child: ListView(
+              key: const Key('exerciseAddContent'),
               shrinkWrap: true,
               padding: const EdgeInsets.fromLTRB(20, 4, 20, 0),
               children: <Widget>[

--- a/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
@@ -13,9 +13,7 @@ import 'package:oncare/features/member_coach/presentation/widgets/trainer_chat_h
 import 'package:oncare/features/my_health/domain/entities/health_history.dart';
 import 'package:oncare/features/my_health/presentation/controllers/my_health_controller.dart';
 import 'package:oncare/features/my_health/presentation/widgets/my_flows.dart';
-import 'package:oncare/features/notification/presentation/widgets/notification_panel.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
-import 'package:oncare/shared/widgets/modals/right_slide_panel.dart';
 import 'package:oncare/shared/widgets/modals/schedule_calendar_sheet.dart';
 
 /// MY tab, rebuilt to the On-Care Figma redesign: profile, role toggle
@@ -31,13 +29,13 @@ class MyHealthPage extends ConsumerWidget {
   void _openSetting(BuildContext context, _MySetting id) {
     switch (id) {
       case _MySetting.profile:
-        showProfileSheet(context);
+        openProfilePage(context);
       case _MySetting.goals:
-        showGoalsSheet(context);
+        openGoalsPage(context);
       case _MySetting.notif:
-        showNotifSheet(context);
+        openNotificationSettingsPage(context);
       case _MySetting.support:
-        showSupportSheet(context);
+        openSupportPage(context);
     }
   }
 
@@ -58,10 +56,7 @@ class MyHealthPage extends ConsumerWidget {
                 FigmaTabHeader(
                   title: l.myTabTitle,
                   trailingAction: const TrainerChatHeaderButton(),
-                  onBell: () => showRightSlidePanel<void>(
-                    context,
-                    content: const NotificationPanelBody(),
-                  ),
+                  onBell: () => context.push(AppRoutes.notification),
                   onCalendar: () => showScheduleCalendarSheet(context),
                 ),
                 const SizedBox(height: 4),
@@ -214,7 +209,7 @@ class _PointsBanner extends StatelessWidget {
   Widget build(BuildContext context) {
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
-      onTap: () => _showPointsBenefitsSheet(context, points),
+      onTap: () => _openPointsBenefitsPage(context, points),
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
         decoration: BoxDecoration(
@@ -263,15 +258,12 @@ class _PointsBanner extends StatelessWidget {
   }
 }
 
-/// Opens the "포인트 사용처" sheet — a new modal window (not an inline
-/// expansion) listing what points can be redeemed for.
-Future<void> _showPointsBenefitsSheet(BuildContext context, int? points) {
-  return showModalBottomSheet<void>(
-    context: context,
-    isScrollControlled: true,
-    backgroundColor: Colors.transparent,
-    barrierColor: FigmaColors.sheetScrim,
-    builder: (BuildContext ctx) => _PointsBenefitsSheet(points: points),
+/// Opens point benefits as a full page above the member tab shell.
+Future<void> _openPointsBenefitsPage(BuildContext context, int? points) {
+  return Navigator.of(context, rootNavigator: true).push<void>(
+    MaterialPageRoute<void>(
+      builder: (_) => _PointsBenefitsPage(points: points),
+    ),
   );
 }
 
@@ -310,107 +302,52 @@ const List<_PointBenefit> _pointBenefits = <_PointBenefit>[
   ),
 ];
 
-/// Bottom-sheet window listing the point redemption options.
-class _PointsBenefitsSheet extends StatelessWidget {
-  const _PointsBenefitsSheet({required this.points});
+class _PointsBenefitsPage extends StatelessWidget {
+  const _PointsBenefitsPage({required this.points});
 
   final int? points;
 
   @override
   Widget build(BuildContext context) {
-    return SafeArea(
-      top: false,
-      child: ConstrainedBox(
-        constraints: BoxConstraints(
-          maxHeight: MediaQuery.of(context).size.height * 0.9,
-          maxWidth: 480,
-        ),
-        child: Container(
-          decoration: const BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
+    return Scaffold(
+      key: const Key('pointsBenefitsPage'),
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        centerTitle: true,
+        backgroundColor: Colors.white,
+        scrolledUnderElevation: 0,
+        title: const Text(
+          '포인트 사용처',
+          style: TextStyle(
+            fontSize: 17,
+            fontWeight: FontWeight.w800,
+            color: FigmaColors.ink,
           ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              const SizedBox(height: 12),
-              Container(
-                width: 40,
-                height: 4,
-                decoration: BoxDecoration(
-                  color: const Color(0xFFE3E8EE),
-                  borderRadius: BorderRadius.circular(999),
+        ),
+      ),
+      body: SafeArea(
+        top: false,
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 720),
+            child: ListView(
+              padding: const EdgeInsets.fromLTRB(20, 18, 20, 28),
+              children: <Widget>[
+                Text(
+                  points != null ? '보유 ${points}P' : '포인트로 받을 수 있는 혜택',
+                  style: const TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w700,
+                    color: FigmaColors.primary,
+                  ),
                 ),
-              ),
-              Padding(
-                padding: const EdgeInsets.fromLTRB(20, 16, 16, 10),
-                child: Row(
-                  children: <Widget>[
-                    Container(
-                      width: 40,
-                      height: 40,
-                      alignment: Alignment.center,
-                      decoration: BoxDecoration(
-                        gradient: const LinearGradient(
-                          begin: Alignment.topLeft,
-                          end: Alignment.bottomRight,
-                          colors: <Color>[
-                            FigmaColors.primary,
-                            FigmaColors.primaryDeep,
-                          ],
-                        ),
-                        borderRadius: BorderRadius.circular(12),
-                      ),
-                      child: const Icon(
-                        Icons.star_rounded,
-                        color: Colors.white,
-                        size: 22,
-                      ),
-                    ),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: <Widget>[
-                          const Text(
-                            '포인트 사용처',
-                            style: TextStyle(
-                              fontSize: 16,
-                              fontWeight: FontWeight.w800,
-                              color: FigmaColors.ink,
-                            ),
-                          ),
-                          const SizedBox(height: 2),
-                          Text(
-                            points != null
-                                ? '보유 ${points}P'
-                                : '포인트로 받을 수 있는 혜택',
-                            style: const TextStyle(
-                              fontSize: 12.5,
-                              fontWeight: FontWeight.w600,
-                              color: FigmaColors.primary,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                    _SheetCloseButton(onTap: () => Navigator.of(context).pop()),
-                  ],
-                ),
-              ),
-              Flexible(
-                child: ListView.separated(
-                  shrinkWrap: true,
-                  padding: const EdgeInsets.fromLTRB(20, 6, 20, 6),
-                  itemCount: _pointBenefits.length,
-                  separatorBuilder: (_, _) => const SizedBox(height: 12),
-                  itemBuilder: (_, int i) =>
-                      _PointBenefitCard(benefit: _pointBenefits[i]),
-                ),
-              ),
-              const Padding(
-                padding: EdgeInsets.fromLTRB(20, 6, 20, 18),
-                child: Row(
+                const SizedBox(height: 16),
+                for (int i = 0; i < _pointBenefits.length; i++) ...<Widget>[
+                  _PointBenefitCard(benefit: _pointBenefits[i]),
+                  if (i < _pointBenefits.length - 1) const SizedBox(height: 12),
+                ],
+                const SizedBox(height: 16),
+                const Row(
                   children: <Widget>[
                     Icon(
                       Icons.info_outline_rounded,
@@ -430,8 +367,8 @@ class _PointsBenefitsSheet extends StatelessWidget {
                     ),
                   ],
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),
@@ -520,56 +457,6 @@ class _PointBenefitCard extends StatelessWidget {
             ),
           ),
         ],
-      ),
-    );
-  }
-}
-
-class _SheetCloseButton extends StatelessWidget {
-  const _SheetCloseButton({required this.onTap});
-
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    // 로케일에 맞는 "닫기"/"Close" 레이블(추가 ARB 키 없이 프레임워크 제공).
-    final String label = MaterialLocalizations.of(context).closeButtonTooltip;
-    return Tooltip(
-      message: label,
-      child: Semantics(
-        button: true,
-        label: label,
-        child: Material(
-          color: Colors.transparent,
-          shape: const CircleBorder(),
-          clipBehavior: Clip.antiAlias,
-          child: InkWell(
-            onTap: onTap,
-            customBorder: const CircleBorder(),
-            // 시각적 원은 32 유지, 탭 영역은 접근성 최소 48×48 보장.
-            child: const SizedBox(
-              width: 48,
-              height: 48,
-              child: Center(
-                child: DecoratedBox(
-                  decoration: BoxDecoration(
-                    color: Color(0xFFF4F6F8),
-                    shape: BoxShape.circle,
-                  ),
-                  child: SizedBox(
-                    width: 32,
-                    height: 32,
-                    child: Icon(
-                      Icons.close_rounded,
-                      size: 17,
-                      color: FigmaColors.textSub,
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ),
       ),
     );
   }

--- a/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
@@ -208,6 +208,7 @@ class _PointsBanner extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
+      key: const Key('pointsBanner'),
       behavior: HitTestBehavior.opaque,
       onTap: () => _openPointsBenefitsPage(context, points),
       child: Container(
@@ -260,11 +261,7 @@ class _PointsBanner extends StatelessWidget {
 
 /// Opens point benefits as a full page above the member tab shell.
 Future<void> _openPointsBenefitsPage(BuildContext context, int? points) {
-  return Navigator.of(context, rootNavigator: true).push<void>(
-    MaterialPageRoute<void>(
-      builder: (_) => _PointsBenefitsPage(points: points),
-    ),
-  );
+  return context.push<void>(AppRoutes.myPoints, extra: points);
 }
 
 /// A point redemption option shown in the benefits sheet.
@@ -281,34 +278,36 @@ class _PointBenefit {
   final String cost;
 }
 
-const List<_PointBenefit> _pointBenefits = <_PointBenefit>[
+List<_PointBenefit> _pointBenefitsOf(AppLocalizations l) => <_PointBenefit>[
   _PointBenefit(
     icon: Icons.savings_rounded,
-    title: '포인트 차감 현금성 할인',
-    desc: '1:1 코칭권·PT 결제 시 보유 포인트를 최대 10%까지 현금처럼 차감해요.',
-    cost: '최대 10%',
+    title: l.myPointsDiscountTitle,
+    desc: l.myPointsDiscountDescription,
+    cost: l.myPointsDiscountCost,
   ),
   _PointBenefit(
     icon: Icons.lock_open_rounded,
-    title: '혈당·혈압 예측 리포트 잠금 해제',
-    desc: '주간·월간 건강 데이터 종합 리포트를 열람할 수 있어요.',
-    cost: '500P',
+    title: l.myPointsReportTitle,
+    desc: l.myPointsReportDescription,
+    cost: l.myPointsReportCost,
   ),
   _PointBenefit(
     icon: Icons.menu_book_rounded,
-    title: '맞춤형 건강 식단 레시피 패키지',
-    desc: '건강 목표(당뇨 예방·체중 감량 등)에 맞춘 식단 가이드를 PDF·인터랙티브로 받아요.',
-    cost: '500P',
+    title: l.myPointsRecipeTitle,
+    desc: l.myPointsRecipeDescription,
+    cost: l.myPointsRecipeCost,
   ),
 ];
 
-class _PointsBenefitsPage extends StatelessWidget {
-  const _PointsBenefitsPage({required this.points});
+class PointsBenefitsPage extends StatelessWidget {
+  const PointsBenefitsPage({super.key, required this.points});
 
   final int? points;
 
   @override
   Widget build(BuildContext context) {
+    final AppLocalizations l = AppLocalizations.of(context);
+    final List<_PointBenefit> benefits = _pointBenefitsOf(l);
     return Scaffold(
       key: const Key('pointsBenefitsPage'),
       backgroundColor: Colors.white,
@@ -316,9 +315,9 @@ class _PointsBenefitsPage extends StatelessWidget {
         centerTitle: true,
         backgroundColor: Colors.white,
         scrolledUnderElevation: 0,
-        title: const Text(
-          '포인트 사용처',
-          style: TextStyle(
+        title: Text(
+          l.myPointsBenefitsTitle,
+          style: const TextStyle(
             fontSize: 17,
             fontWeight: FontWeight.w800,
             color: FigmaColors.ink,
@@ -334,7 +333,9 @@ class _PointsBenefitsPage extends StatelessWidget {
               padding: const EdgeInsets.fromLTRB(20, 18, 20, 28),
               children: <Widget>[
                 Text(
-                  points != null ? '보유 ${points}P' : '포인트로 받을 수 있는 혜택',
+                  points != null
+                      ? l.myPointsBalance(points!)
+                      : l.myPointsBenefitsSubtitle,
                   style: const TextStyle(
                     fontSize: 14,
                     fontWeight: FontWeight.w700,
@@ -342,23 +343,23 @@ class _PointsBenefitsPage extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(height: 16),
-                for (int i = 0; i < _pointBenefits.length; i++) ...<Widget>[
-                  _PointBenefitCard(benefit: _pointBenefits[i]),
-                  if (i < _pointBenefits.length - 1) const SizedBox(height: 12),
+                for (int i = 0; i < benefits.length; i++) ...<Widget>[
+                  _PointBenefitCard(benefit: benefits[i]),
+                  if (i < benefits.length - 1) const SizedBox(height: 12),
                 ],
                 const SizedBox(height: 16),
-                const Row(
+                Row(
                   children: <Widget>[
-                    Icon(
+                    const Icon(
                       Icons.info_outline_rounded,
                       size: 14,
                       color: FigmaColors.textMuted,
                     ),
-                    SizedBox(width: 6),
+                    const SizedBox(width: 6),
                     Expanded(
                       child: Text(
-                        '기록을 꾸준히 남기면 포인트가 쌓이고, 위 혜택에 사용할 수 있어요.',
-                        style: TextStyle(
+                        l.myPointsBenefitsHint,
+                        style: const TextStyle(
                           fontSize: 11.5,
                           color: FigmaColors.textMuted,
                           height: 1.35,

--- a/frontend/flutter/lib/features/my_health/presentation/widgets/my_flows.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/widgets/my_flows.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:oncare/app/router/routes.dart';
 import 'package:oncare/core/storage/prefs_store.dart';
 import 'package:oncare/design_system/figma/figma_kit.dart';
 import 'package:oncare/design_system/tokens/breakpoints.dart';
@@ -53,14 +55,6 @@ Widget _shell(
     ),
   );
   return PopScope(canPop: !saving, child: page);
-}
-
-Future<void> _open(BuildContext context, String title, List<Widget> body) {
-  return Navigator.of(context, rootNavigator: true).push<void>(
-    MaterialPageRoute<void>(
-      builder: (BuildContext ctx) => _shell(ctx, title, body),
-    ),
-  );
 }
 
 Widget _card(List<Widget> children) => Container(
@@ -258,14 +252,11 @@ Widget _saveRow({
 /// Profile editor — pre-fills from `profileProvider` and persists via
 /// `AccountRepository.updateProfile`.
 Future<void> openProfilePage(BuildContext context) {
-  return Navigator.of(
-    context,
-    rootNavigator: true,
-  ).push<void>(MaterialPageRoute<void>(builder: (_) => const _ProfileSheet()));
+  return context.push<void>(AppRoutes.mySettingsPath('profile'));
 }
 
-class _ProfileSheet extends ConsumerWidget {
-  const _ProfileSheet();
+class ProfileSettingsPage extends ConsumerWidget {
+  const ProfileSettingsPage({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -380,14 +371,11 @@ class _ProfileFormState extends ConsumerState<_ProfileForm> {
 /// 건강 목표 시트 — 식단 일일 목표(6종) + 주간 운동 목표(3종)를 수정한다.
 /// 체중/혈압/혈당(vitals) 목표는 다루지 않는다.
 Future<void> openGoalsPage(BuildContext context) {
-  return Navigator.of(
-    context,
-    rootNavigator: true,
-  ).push<void>(MaterialPageRoute<void>(builder: (_) => const _GoalsSheet()));
+  return context.push<void>(AppRoutes.mySettingsPath('goals'));
 }
 
-class _GoalsSheet extends ConsumerWidget {
-  const _GoalsSheet();
+class HealthGoalsPage extends ConsumerWidget {
+  const HealthGoalsPage({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -636,20 +624,19 @@ String _notifLabel(AppLocalizations l, String prefKey) {
 /// Notification preferences — toggles load from and persist to
 /// SharedPreferences so they survive a reload.
 Future<void> openNotificationSettingsPage(BuildContext context) {
-  return Navigator.of(
-    context,
-    rootNavigator: true,
-  ).push<void>(MaterialPageRoute<void>(builder: (_) => const _NotifSheet()));
+  return context.push<void>(AppRoutes.mySettingsPath('notifications'));
 }
 
-class _NotifSheet extends ConsumerStatefulWidget {
-  const _NotifSheet();
+class NotificationSettingsPage extends ConsumerStatefulWidget {
+  const NotificationSettingsPage({super.key});
 
   @override
-  ConsumerState<_NotifSheet> createState() => _NotifSheetState();
+  ConsumerState<NotificationSettingsPage> createState() =>
+      _NotificationSettingsPageState();
 }
 
-class _NotifSheetState extends ConsumerState<_NotifSheet> {
+class _NotificationSettingsPageState
+    extends ConsumerState<NotificationSettingsPage> {
   late final SharedPreferences _prefs;
   final Map<String, bool> _on = <String, bool>{};
 
@@ -704,36 +691,45 @@ class _NotifSheetState extends ConsumerState<_NotifSheet> {
 
 /// Customer support entries.
 Future<void> openSupportPage(BuildContext context) {
-  final AppLocalizations l = AppLocalizations.of(context);
-  return _open(context, l.mySupportTitle, <Widget>[
-    _supportRow(
-      Icons.help_outline,
-      l.mySupportFaq,
-      () => _comingSoon(context, l.mySupportFaq),
-    ),
-    _supportRow(
-      Icons.chat_bubble_outline,
-      l.mySupportInquiry,
-      () => _comingSoon(context, l.mySupportInquiry),
-    ),
-    _supportRow(
-      Icons.description_outlined,
-      l.myLegalTermsTitle,
-      () => _openLegal(context, _LegalDoc.terms),
-    ),
-    _supportRow(
-      Icons.privacy_tip_outlined,
-      l.myLegalPrivacyTitle,
-      () => _openLegal(context, _LegalDoc.privacy),
-    ),
-    const SizedBox(height: 12),
-    Center(
-      child: Text(
-        l.myAppVersion,
-        style: const TextStyle(fontSize: 12, color: FigmaColors.textFaint),
+  return context.push<void>(AppRoutes.mySettingsPath('support'));
+}
+
+class SupportPage extends StatelessWidget {
+  const SupportPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations l = AppLocalizations.of(context);
+    return _shell(context, l.mySupportTitle, <Widget>[
+      _supportRow(
+        Icons.help_outline,
+        l.mySupportFaq,
+        () => _comingSoon(context, l.mySupportFaq),
       ),
-    ),
-  ]);
+      _supportRow(
+        Icons.chat_bubble_outline,
+        l.mySupportInquiry,
+        () => _comingSoon(context, l.mySupportInquiry),
+      ),
+      _supportRow(
+        Icons.description_outlined,
+        l.myLegalTermsTitle,
+        () => _openLegal(context, _LegalDoc.terms),
+      ),
+      _supportRow(
+        Icons.privacy_tip_outlined,
+        l.myLegalPrivacyTitle,
+        () => _openLegal(context, _LegalDoc.privacy),
+      ),
+      const SizedBox(height: 12),
+      Center(
+        child: Text(
+          l.myAppVersion,
+          style: const TextStyle(fontSize: 12, color: FigmaColors.textFaint),
+        ),
+      ),
+    ]);
+  }
 }
 
 void _comingSoon(BuildContext context, String label) {
@@ -744,9 +740,7 @@ void _comingSoon(BuildContext context, String label) {
 }
 
 void _openLegal(BuildContext context, _LegalDoc doc) {
-  Navigator.of(context, rootNavigator: true).push<void>(
-    MaterialPageRoute<void>(builder: (_) => _LegalDocSheet(doc: doc)),
-  );
+  context.push<void>(AppRoutes.mySettingsPath(doc.name));
 }
 
 Widget _supportRow(IconData icon, String label, VoidCallback onTap) {
@@ -791,19 +785,17 @@ Widget _supportRow(IconData icon, String label, VoidCallback onTap) {
 /// bodies are resolved from localizations via [_LegalDocSheet].
 enum _LegalDoc { terms, privacy }
 
-class _LegalDocSheet extends StatelessWidget {
-  const _LegalDocSheet({required this.doc});
-  final _LegalDoc doc;
+class LegalDocumentPage extends StatelessWidget {
+  const LegalDocumentPage({super.key, required this.document});
+
+  final String document;
 
   @override
   Widget build(BuildContext context) {
     final AppLocalizations l = AppLocalizations.of(context);
-    final String title = doc == _LegalDoc.terms
-        ? l.myLegalTermsTitle
-        : l.myLegalPrivacyTitle;
-    final String body = doc == _LegalDoc.terms
-        ? l.myLegalTermsBody
-        : l.myLegalPrivacyBody;
+    final bool isTerms = document == _LegalDoc.terms.name;
+    final String title = isTerms ? l.myLegalTermsTitle : l.myLegalPrivacyTitle;
+    final String body = isTerms ? l.myLegalTermsBody : l.myLegalPrivacyBody;
     return _shell(context, title, <Widget>[
       _card(<Widget>[
         Text(

--- a/frontend/flutter/lib/features/my_health/presentation/widgets/my_flows.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/widgets/my_flows.dart
@@ -21,90 +21,45 @@ Widget _shell(
   List<Widget> children, {
   bool saving = false,
 }) {
-  final Widget sheet = SafeArea(
-    top: false,
-    child: ConstrainedBox(
-      constraints: BoxConstraints(
-        maxHeight: MediaQuery.of(context).size.height * 0.9,
-        // Match the main content width so the sheet scales with the viewport
-        // like the tab pages. The theme lifts the modal route cap to this
-        // width too (see AppTheme._bottomSheetTheme); this centres the child.
-        maxWidth: AppBreakpoints.contentMaxWidth,
-      ),
-      child: Container(
-        decoration: const BoxDecoration(
-          color: Colors.white,
-          borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+  final Widget page = Scaffold(
+    key: const Key('mySettingsPage'),
+    backgroundColor: Colors.white,
+    appBar: AppBar(
+      centerTitle: true,
+      backgroundColor: Colors.white,
+      scrolledUnderElevation: 0,
+      title: Text(
+        title,
+        style: const TextStyle(
+          fontSize: 17,
+          fontWeight: FontWeight.w800,
+          color: FigmaColors.ink,
         ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
-            Container(
-              margin: const EdgeInsets.only(top: 12, bottom: 4),
-              width: 36,
-              height: 4,
-              decoration: BoxDecoration(
-                color: const Color(0xFFDDE3EA),
-                borderRadius: BorderRadius.circular(999),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.fromLTRB(20, 8, 20, 8),
-              child: Row(
-                children: <Widget>[
-                  Expanded(
-                    child: Text(
-                      title,
-                      style: const TextStyle(
-                        fontSize: 18,
-                        fontWeight: FontWeight.w800,
-                        color: FigmaColors.ink,
-                      ),
-                    ),
-                  ),
-                  Material(
-                    color: const Color(0xFFF4F6F8),
-                    shape: const CircleBorder(),
-                    clipBehavior: Clip.antiAlias,
-                    child: InkWell(
-                      // Disabled while a save is in flight (blocks dismiss).
-                      onTap: saving ? null : () => Navigator.of(context).pop(),
-                      child: const SizedBox(
-                        width: 32,
-                        height: 32,
-                        child: Icon(
-                          Icons.close,
-                          size: 16,
-                          color: FigmaColors.textSub,
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            Flexible(
-              child: ListView(
-                shrinkWrap: true,
-                padding: const EdgeInsets.fromLTRB(20, 4, 20, 28),
-                children: children,
-              ),
-            ),
-          ],
+      ),
+    ),
+    body: SafeArea(
+      top: false,
+      child: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(
+            maxWidth: AppBreakpoints.contentMaxWidth,
+          ),
+          child: ListView(
+            padding: const EdgeInsets.fromLTRB(20, 16, 20, 28),
+            children: children,
+          ),
         ),
       ),
     ),
   );
-  return PopScope(canPop: !saving, child: sheet);
+  return PopScope(canPop: !saving, child: page);
 }
 
 Future<void> _open(BuildContext context, String title, List<Widget> body) {
-  return showModalBottomSheet<void>(
-    context: context,
-    isScrollControlled: true,
-    backgroundColor: Colors.transparent,
-    barrierColor: FigmaColors.sheetScrim,
-    builder: (BuildContext ctx) => _shell(ctx, title, body),
+  return Navigator.of(context, rootNavigator: true).push<void>(
+    MaterialPageRoute<void>(
+      builder: (BuildContext ctx) => _shell(ctx, title, body),
+    ),
   );
 }
 
@@ -302,14 +257,11 @@ Widget _saveRow({
 
 /// Profile editor — pre-fills from `profileProvider` and persists via
 /// `AccountRepository.updateProfile`.
-Future<void> showProfileSheet(BuildContext context) {
-  return showModalBottomSheet<void>(
-    context: context,
-    isScrollControlled: true,
-    backgroundColor: Colors.transparent,
-    barrierColor: FigmaColors.sheetScrim,
-    builder: (BuildContext ctx) => const _ProfileSheet(),
-  );
+Future<void> openProfilePage(BuildContext context) {
+  return Navigator.of(
+    context,
+    rootNavigator: true,
+  ).push<void>(MaterialPageRoute<void>(builder: (_) => const _ProfileSheet()));
 }
 
 class _ProfileSheet extends ConsumerWidget {
@@ -427,14 +379,11 @@ class _ProfileFormState extends ConsumerState<_ProfileForm> {
 
 /// 건강 목표 시트 — 식단 일일 목표(6종) + 주간 운동 목표(3종)를 수정한다.
 /// 체중/혈압/혈당(vitals) 목표는 다루지 않는다.
-Future<void> showGoalsSheet(BuildContext context) {
-  return showModalBottomSheet<void>(
-    context: context,
-    isScrollControlled: true,
-    backgroundColor: Colors.transparent,
-    barrierColor: FigmaColors.sheetScrim,
-    builder: (BuildContext ctx) => const _GoalsSheet(),
-  );
+Future<void> openGoalsPage(BuildContext context) {
+  return Navigator.of(
+    context,
+    rootNavigator: true,
+  ).push<void>(MaterialPageRoute<void>(builder: (_) => const _GoalsSheet()));
 }
 
 class _GoalsSheet extends ConsumerWidget {
@@ -686,14 +635,11 @@ String _notifLabel(AppLocalizations l, String prefKey) {
 
 /// Notification preferences — toggles load from and persist to
 /// SharedPreferences so they survive a reload.
-Future<void> showNotifSheet(BuildContext context) {
-  return showModalBottomSheet<void>(
-    context: context,
-    isScrollControlled: true,
-    backgroundColor: Colors.transparent,
-    barrierColor: FigmaColors.sheetScrim,
-    builder: (BuildContext ctx) => const _NotifSheet(),
-  );
+Future<void> openNotificationSettingsPage(BuildContext context) {
+  return Navigator.of(
+    context,
+    rootNavigator: true,
+  ).push<void>(MaterialPageRoute<void>(builder: (_) => const _NotifSheet()));
 }
 
 class _NotifSheet extends ConsumerStatefulWidget {
@@ -757,7 +703,7 @@ class _NotifSheetState extends ConsumerState<_NotifSheet> {
 // ───────────────────────────────────────────────────────── 고객 지원 ──
 
 /// Customer support entries.
-Future<void> showSupportSheet(BuildContext context) {
+Future<void> openSupportPage(BuildContext context) {
   final AppLocalizations l = AppLocalizations.of(context);
   return _open(context, l.mySupportTitle, <Widget>[
     _supportRow(
@@ -798,12 +744,8 @@ void _comingSoon(BuildContext context, String label) {
 }
 
 void _openLegal(BuildContext context, _LegalDoc doc) {
-  showModalBottomSheet<void>(
-    context: context,
-    isScrollControlled: true,
-    backgroundColor: Colors.transparent,
-    barrierColor: FigmaColors.sheetScrim,
-    builder: (BuildContext ctx) => _LegalDocSheet(doc: doc),
+  Navigator.of(context, rootNavigator: true).push<void>(
+    MaterialPageRoute<void>(builder: (_) => _LegalDocSheet(doc: doc)),
   );
 }
 

--- a/frontend/flutter/lib/features/notification/presentation/pages/notification_page.dart
+++ b/frontend/flutter/lib/features/notification/presentation/pages/notification_page.dart
@@ -29,6 +29,7 @@ class NotificationPage extends ConsumerWidget {
     final notifier = ref.read(notificationControllerProvider.notifier);
 
     return Scaffold(
+      key: const Key('notificationPage'),
       appBar: AppBar(
         title: Text(l.pageNotificationTitle),
         actions: <Widget>[

--- a/frontend/flutter/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations.dart
@@ -2084,6 +2084,84 @@ abstract class AppLocalizations {
   /// **'Customer Support'**
   String get mySupportTitle;
 
+  /// No description provided for @myPointsBenefitsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Use Points'**
+  String get myPointsBenefitsTitle;
+
+  /// No description provided for @myPointsBalance.
+  ///
+  /// In en, this message translates to:
+  /// **'Balance: {points}P'**
+  String myPointsBalance(int points);
+
+  /// No description provided for @myPointsBenefitsSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Benefits available with points'**
+  String get myPointsBenefitsSubtitle;
+
+  /// No description provided for @myPointsBenefitsHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Keep logging your activity to earn points and use the benefits above.'**
+  String get myPointsBenefitsHint;
+
+  /// No description provided for @myPointsDiscountTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Cash discount with points'**
+  String get myPointsDiscountTitle;
+
+  /// No description provided for @myPointsDiscountDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Use points like cash for up to 10% off 1:1 coaching and personal training.'**
+  String get myPointsDiscountDescription;
+
+  /// No description provided for @myPointsDiscountCost.
+  ///
+  /// In en, this message translates to:
+  /// **'Up to 10%'**
+  String get myPointsDiscountCost;
+
+  /// No description provided for @myPointsReportTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Unlock glucose and blood pressure reports'**
+  String get myPointsReportTitle;
+
+  /// No description provided for @myPointsReportDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'View comprehensive weekly and monthly health-data reports.'**
+  String get myPointsReportDescription;
+
+  /// No description provided for @myPointsReportCost.
+  ///
+  /// In en, this message translates to:
+  /// **'500P'**
+  String get myPointsReportCost;
+
+  /// No description provided for @myPointsRecipeTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Personalized healthy recipe package'**
+  String get myPointsRecipeTitle;
+
+  /// No description provided for @myPointsRecipeDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Get PDF and interactive meal guides tailored to goals such as diabetes prevention or weight loss.'**
+  String get myPointsRecipeDescription;
+
+  /// No description provided for @myPointsRecipeCost.
+  ///
+  /// In en, this message translates to:
+  /// **'500P'**
+  String get myPointsRecipeCost;
+
   /// No description provided for @myLogout.
   ///
   /// In en, this message translates to:

--- a/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
@@ -1098,6 +1098,51 @@ class AppLocalizationsEn extends AppLocalizations {
   String get mySupportTitle => 'Customer Support';
 
   @override
+  String get myPointsBenefitsTitle => 'Use Points';
+
+  @override
+  String myPointsBalance(int points) {
+    return 'Balance: ${points}P';
+  }
+
+  @override
+  String get myPointsBenefitsSubtitle => 'Benefits available with points';
+
+  @override
+  String get myPointsBenefitsHint =>
+      'Keep logging your activity to earn points and use the benefits above.';
+
+  @override
+  String get myPointsDiscountTitle => 'Cash discount with points';
+
+  @override
+  String get myPointsDiscountDescription =>
+      'Use points like cash for up to 10% off 1:1 coaching and personal training.';
+
+  @override
+  String get myPointsDiscountCost => 'Up to 10%';
+
+  @override
+  String get myPointsReportTitle => 'Unlock glucose and blood pressure reports';
+
+  @override
+  String get myPointsReportDescription =>
+      'View comprehensive weekly and monthly health-data reports.';
+
+  @override
+  String get myPointsReportCost => '500P';
+
+  @override
+  String get myPointsRecipeTitle => 'Personalized healthy recipe package';
+
+  @override
+  String get myPointsRecipeDescription =>
+      'Get PDF and interactive meal guides tailored to goals such as diabetes prevention or weight loss.';
+
+  @override
+  String get myPointsRecipeCost => '500P';
+
+  @override
   String get myLogout => 'Log out';
 
   @override

--- a/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
@@ -1081,6 +1081,49 @@ class AppLocalizationsKo extends AppLocalizations {
   String get mySupportTitle => '고객 지원';
 
   @override
+  String get myPointsBenefitsTitle => '포인트 사용처';
+
+  @override
+  String myPointsBalance(int points) {
+    return '보유 ${points}P';
+  }
+
+  @override
+  String get myPointsBenefitsSubtitle => '포인트로 받을 수 있는 혜택';
+
+  @override
+  String get myPointsBenefitsHint => '기록을 꾸준히 남기면 포인트가 쌓이고, 위 혜택에 사용할 수 있어요.';
+
+  @override
+  String get myPointsDiscountTitle => '포인트 차감 현금성 할인';
+
+  @override
+  String get myPointsDiscountDescription =>
+      '1:1 코칭권·PT 결제 시 보유 포인트를 최대 10%까지 현금처럼 차감해요.';
+
+  @override
+  String get myPointsDiscountCost => '최대 10%';
+
+  @override
+  String get myPointsReportTitle => '혈당·혈압 예측 리포트 잠금 해제';
+
+  @override
+  String get myPointsReportDescription => '주간·월간 건강 데이터 종합 리포트를 열람할 수 있어요.';
+
+  @override
+  String get myPointsReportCost => '500P';
+
+  @override
+  String get myPointsRecipeTitle => '맞춤형 건강 식단 레시피 패키지';
+
+  @override
+  String get myPointsRecipeDescription =>
+      '건강 목표(당뇨 예방·체중 감량 등)에 맞춘 식단 가이드를 PDF·인터랙티브로 받아요.';
+
+  @override
+  String get myPointsRecipeCost => '500P';
+
+  @override
   String get myLogout => '로그아웃';
 
   @override

--- a/frontend/flutter/lib/l10n/app_en.arb
+++ b/frontend/flutter/lib/l10n/app_en.arb
@@ -599,6 +599,24 @@
   "myProfileTitle": "My Profile",
   "myNotifTitle": "Notification Settings",
   "mySupportTitle": "Customer Support",
+  "myPointsBenefitsTitle": "Use Points",
+  "myPointsBalance": "Balance: {points}P",
+  "@myPointsBalance": {
+    "placeholders": {
+      "points": {"type": "int"}
+    }
+  },
+  "myPointsBenefitsSubtitle": "Benefits available with points",
+  "myPointsBenefitsHint": "Keep logging your activity to earn points and use the benefits above.",
+  "myPointsDiscountTitle": "Cash discount with points",
+  "myPointsDiscountDescription": "Use points like cash for up to 10% off 1:1 coaching and personal training.",
+  "myPointsDiscountCost": "Up to 10%",
+  "myPointsReportTitle": "Unlock glucose and blood pressure reports",
+  "myPointsReportDescription": "View comprehensive weekly and monthly health-data reports.",
+  "myPointsReportCost": "500P",
+  "myPointsRecipeTitle": "Personalized healthy recipe package",
+  "myPointsRecipeDescription": "Get PDF and interactive meal guides tailored to goals such as diabetes prevention or weight loss.",
+  "myPointsRecipeCost": "500P",
   "myLogout": "Log out",
   "myLogoutConfirm": "Log out of your account?",
   "myCancel": "Cancel",

--- a/frontend/flutter/lib/l10n/app_ko.arb
+++ b/frontend/flutter/lib/l10n/app_ko.arb
@@ -361,6 +361,24 @@
   "myProfileTitle": "내 프로필",
   "myNotifTitle": "알림 설정",
   "mySupportTitle": "고객 지원",
+  "myPointsBenefitsTitle": "포인트 사용처",
+  "myPointsBalance": "보유 {points}P",
+  "@myPointsBalance": {
+    "placeholders": {
+      "points": {"type": "int"}
+    }
+  },
+  "myPointsBenefitsSubtitle": "포인트로 받을 수 있는 혜택",
+  "myPointsBenefitsHint": "기록을 꾸준히 남기면 포인트가 쌓이고, 위 혜택에 사용할 수 있어요.",
+  "myPointsDiscountTitle": "포인트 차감 현금성 할인",
+  "myPointsDiscountDescription": "1:1 코칭권·PT 결제 시 보유 포인트를 최대 10%까지 현금처럼 차감해요.",
+  "myPointsDiscountCost": "최대 10%",
+  "myPointsReportTitle": "혈당·혈압 예측 리포트 잠금 해제",
+  "myPointsReportDescription": "주간·월간 건강 데이터 종합 리포트를 열람할 수 있어요.",
+  "myPointsReportCost": "500P",
+  "myPointsRecipeTitle": "맞춤형 건강 식단 레시피 패키지",
+  "myPointsRecipeDescription": "건강 목표(당뇨 예방·체중 감량 등)에 맞춘 식단 가이드를 PDF·인터랙티브로 받아요.",
+  "myPointsRecipeCost": "500P",
   "myLogout": "로그아웃",
   "myLogoutConfirm": "로그아웃 하시겠어요?",
   "myCancel": "취소",

--- a/frontend/flutter/lib/shared/widgets/coaching_sheet.dart
+++ b/frontend/flutter/lib/shared/widgets/coaching_sheet.dart
@@ -104,6 +104,7 @@ class _CoachingSheet extends ConsumerWidget {
         maxWidth: 480,
       ),
       child: Container(
+        key: const Key('coachingSheet'),
         decoration: const BoxDecoration(
           color: Colors.white,
           borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
@@ -166,6 +167,7 @@ class _CoachingSheet extends ConsumerWidget {
                 ),
               ),
               Padding(
+                key: const Key('coachingSheetCta'),
                 padding: const EdgeInsets.fromLTRB(20, 12, 20, 0),
                 child: SizedBox(
                   width: double.infinity,

--- a/frontend/flutter/lib/shared/widgets/coaching_sheet.dart
+++ b/frontend/flutter/lib/shared/widgets/coaching_sheet.dart
@@ -98,18 +98,18 @@ class _CoachingSheet extends ConsumerWidget {
           : live.map(_cardFromSuggestion).toList();
     }
 
-    return SafeArea(
-      top: false,
-      child: ConstrainedBox(
-        constraints: BoxConstraints(
-          maxHeight: MediaQuery.of(context).size.height * 0.88,
-          maxWidth: 480,
+    return ConstrainedBox(
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.88,
+        maxWidth: 480,
+      ),
+      child: Container(
+        decoration: const BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
         ),
-        child: Container(
-          decoration: const BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
-          ),
+        child: SafeArea(
+          top: false,
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
@@ -166,7 +166,7 @@ class _CoachingSheet extends ConsumerWidget {
                 ),
               ),
               Padding(
-                padding: const EdgeInsets.fromLTRB(20, 12, 20, 20),
+                padding: const EdgeInsets.fromLTRB(20, 12, 20, 0),
                 child: SizedBox(
                   width: double.infinity,
                   child: FilledButton.icon(

--- a/frontend/flutter/test/widget_test.dart
+++ b/frontend/flutter/test/widget_test.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:logger/logger.dart';
 
 import 'package:oncare/app/app.dart';
+import 'package:oncare/app/router/app_router.dart';
+import 'package:oncare/app/router/routes.dart';
 import 'package:oncare/app/session_feature_reset.dart';
 import 'package:oncare/core/config/app_config.dart';
 import 'package:oncare/core/logging/app_logger.dart';
@@ -45,7 +48,8 @@ void main() {
           // 9.8); the smoke test only inspects the nav, so the mock is
           // plenty.
           dashboardRepositoryProvider.overrideWithValue(
-            MockDashboardRepository(MockDietRepository()) as DashboardRepository,
+            MockDashboardRepository(MockDietRepository())
+                as DashboardRepository,
           ),
           sessionFeatureResetOverride(),
           if (locale != null) localeProvider.overrideWith((ref) => locale),
@@ -64,6 +68,12 @@ void main() {
     await tester.pumpAndSettle();
   }
 
+  GoRouter appRouter(WidgetTester tester) {
+    return ProviderScope.containerOf(
+      tester.element(find.byType(OncareApp)),
+    ).read(appRouterProvider);
+  }
+
   Future<double> openRecordSheetAndMeasureBottomSpacing(
     WidgetTester tester,
   ) async {
@@ -78,6 +88,26 @@ void main() {
     expect(tester.getBottomRight(sheet).dy, logicalHeight);
 
     return tester.getBottomRight(sheet).dy - tester.getBottomRight(options).dy;
+  }
+
+  double bottomSpacingBetween(
+    WidgetTester tester,
+    String surfaceKey,
+    String contentKey,
+  ) {
+    return tester.getBottomRight(find.byKey(Key(surfaceKey))).dy -
+        tester.getBottomRight(find.byKey(Key(contentKey))).dy;
+  }
+
+  Future<void> openExerciseAddSheet(WidgetTester tester) async {
+    await tester.tap(find.byKey(const Key('recordAddButton')));
+    await tester.pumpAndSettle();
+    final exerciseOption = find.descendant(
+      of: find.byKey(const Key('recordOptions')),
+      matching: find.text('운동'),
+    );
+    await tester.tap(exerciseOption);
+    await tester.pumpAndSettle();
   }
 
   testWidgets('Enters the Home tab in English after demo', (tester) async {
@@ -149,6 +179,80 @@ void main() {
     expect(find.byKey(const Key('recordAddSheet')), findsNothing);
   });
 
+  testWidgets('exercise add has no fixed bottom gap without a system inset', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await pumpApp(tester, locale: const Locale('ko'));
+    await openExerciseAddSheet(tester);
+
+    expect(
+      bottomSpacingBetween(tester, 'exerciseAddSheet', 'exerciseAddContent'),
+      0,
+    );
+  });
+
+  testWidgets('exercise add keeps only the required system inset', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    tester.view.padding = const FakeViewPadding(bottom: 34);
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPadding);
+
+    await pumpApp(tester, locale: const Locale('ko'));
+    await openExerciseAddSheet(tester);
+
+    expect(
+      bottomSpacingBetween(tester, 'exerciseAddSheet', 'exerciseAddContent'),
+      34,
+    );
+  });
+
+  testWidgets('coaching sheet has no fixed bottom gap without a system inset', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await pumpApp(tester, locale: const Locale('ko'));
+    await tester.tap(find.byKey(const Key('coachingFab')));
+    await tester.pumpAndSettle();
+
+    expect(
+      bottomSpacingBetween(tester, 'coachingSheet', 'coachingSheetCta'),
+      0,
+    );
+  });
+
+  testWidgets('coaching sheet keeps only the required system inset', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    tester.view.padding = const FakeViewPadding(bottom: 34);
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPadding);
+
+    await pumpApp(tester, locale: const Locale('ko'));
+    await tester.tap(find.byKey(const Key('coachingFab')));
+    await tester.pumpAndSettle();
+
+    expect(
+      bottomSpacingBetween(tester, 'coachingSheet', 'coachingSheetCta'),
+      34,
+    );
+  });
+
   testWidgets('header notification opens the existing full page', (
     tester,
   ) async {
@@ -160,6 +264,50 @@ void main() {
     final page = find.byKey(const Key('notificationPage'));
     expect(page, findsOneWidget);
     expect(tester.getTopLeft(page).dy, 0);
+  });
+
+  testWidgets('point benefits use a full-page URL route', (tester) async {
+    await pumpApp(tester, locale: const Locale('ko'));
+    await tester.tap(find.text('MY').first);
+    await tester.pumpAndSettle();
+
+    final banner = find.byKey(const Key('pointsBanner'));
+    await tester.ensureVisible(banner);
+    await tester.tap(banner);
+    await tester.pumpAndSettle();
+
+    final page = find.byKey(const Key('pointsBenefitsPage'));
+    expect(page, findsOneWidget);
+    expect(
+      appRouter(tester).routeInformationProvider.value.uri.path,
+      AppRoutes.myPoints,
+    );
+  });
+
+  testWidgets('MY settings use full-page URL routes', (tester) async {
+    await pumpApp(tester, locale: const Locale('ko'));
+    appRouter(tester).go(AppRoutes.mySettingsPath('support'));
+    await tester.pumpAndSettle();
+
+    final page = find.byKey(const Key('mySettingsPage'));
+    expect(page, findsOneWidget);
+    expect(
+      appRouter(tester).routeInformationProvider.value.uri.path,
+      AppRoutes.mySettingsPath('support'),
+    );
+  });
+
+  testWidgets('diet detail URL restores the full-page editor', (tester) async {
+    await pumpApp(tester, locale: const Locale('ko'));
+    appRouter(tester).go(AppRoutes.dietEntryDetailPath('mock-breakfast'));
+    await tester.pumpAndSettle();
+
+    final page = find.byKey(const Key('mealDetailPage'));
+    expect(page, findsOneWidget);
+    expect(
+      appRouter(tester).routeInformationProvider.value.uri.path,
+      AppRoutes.dietEntryDetailPath('mock-breakfast'),
+    );
   });
 
   testWidgets('Tapping a bottom-nav destination switches branch', (
@@ -232,25 +380,28 @@ void main() {
     expect(find.text('나트륨 초과'), findsNothing);
   });
 
-  test('coaching/advice strings are localised — en English, ko Korean (리뷰 #292)', () {
-    final AppLocalizations en = lookupAppLocalizations(const Locale('en'));
-    final AppLocalizations ko = lookupAppLocalizations(const Locale('ko'));
-    final RegExp hangul = RegExp('[가-힣]');
+  test(
+    'coaching/advice strings are localised — en English, ko Korean (리뷰 #292)',
+    () {
+      final AppLocalizations en = lookupAppLocalizations(const Locale('en'));
+      final AppLocalizations ko = lookupAppLocalizations(const Locale('ko'));
+      final RegExp hangul = RegExp('[가-힣]');
 
-    // 코드에 하드코딩돼 있던 문구들이 이제 로케일별 ARB 로 분리됐다.
-    expect(en.coachCardDietTitle, 'Great breakfast — watch lunch sodium');
-    expect(ko.coachCardDietTitle, '아침 식단 훌륭, 점심 나트륨 주의');
-    expect(en.coachCardExerciseTitle, 'Upper-body PT session 12 done');
-    expect(en.homeAiAdviceTitle, "Today's combined AI advice");
-    expect(ko.homeAiAdviceTitle, '오늘의 AI 통합 조언');
-    expect(en.homeSodiumExceededBadge, 'Sodium over');
-    expect(ko.homeSodiumExceededBadge, '나트륨 초과');
+      // 코드에 하드코딩돼 있던 문구들이 이제 로케일별 ARB 로 분리됐다.
+      expect(en.coachCardDietTitle, 'Great breakfast — watch lunch sodium');
+      expect(ko.coachCardDietTitle, '아침 식단 훌륭, 점심 나트륨 주의');
+      expect(en.coachCardExerciseTitle, 'Upper-body PT session 12 done');
+      expect(en.homeAiAdviceTitle, "Today's combined AI advice");
+      expect(ko.homeAiAdviceTitle, '오늘의 AI 통합 조언');
+      expect(en.homeSodiumExceededBadge, 'Sodium over');
+      expect(ko.homeSodiumExceededBadge, '나트륨 초과');
 
-    // 영어 리소스에 한글이 남아 있지 않아야 한다.
-    expect(hangul.hasMatch(en.coachCardDietBody), isFalse);
-    expect(hangul.hasMatch(en.coachCardExerciseBody), isFalse);
-    expect(hangul.hasMatch(en.homeAiAdviceBody), isFalse);
-  });
+      // 영어 리소스에 한글이 남아 있지 않아야 한다.
+      expect(hangul.hasMatch(en.coachCardDietBody), isFalse);
+      expect(hangul.hasMatch(en.coachCardExerciseBody), isFalse);
+      expect(hangul.hasMatch(en.homeAiAdviceBody), isFalse);
+    },
+  );
 
   test('운동 탭 기간 토글·도넛 라벨이 로케일을 따른다 (#297)', () {
     final AppLocalizations en = lookupAppLocalizations(const Locale('en'));
@@ -261,7 +412,11 @@ void main() {
     // 이번 달" 처럼 한 토글 안에 두 언어가 섞였다.
     expect(en.exThisMonth, 'This month');
     expect(ko.exThisMonth, '이번 달');
-    for (final String s in <String>[en.exToday, en.exThisWeek, en.exThisMonth]) {
+    for (final String s in <String>[
+      en.exToday,
+      en.exThisWeek,
+      en.exThisMonth,
+    ]) {
       expect(hangul.hasMatch(s), isFalse);
     }
 
@@ -289,7 +444,10 @@ void main() {
       ko.otherDateEmpty(ko.pageDietTitle).split('\n').first,
       ko.otherDateEmpty(ko.pageExerciseTitle).split('\n').first,
     );
-    expect(RegExp('[가-힣]').hasMatch(en.otherDateEmpty(en.pageDietTitle)), isFalse);
+    expect(
+      RegExp('[가-힣]').hasMatch(en.otherDateEmpty(en.pageDietTitle)),
+      isFalse,
+    );
   });
 
   test('운동 탭 UI 골격 문구가 로케일을 따른다 (#367)', () {

--- a/frontend/flutter/test/widget_test.dart
+++ b/frontend/flutter/test/widget_test.dart
@@ -64,6 +64,22 @@ void main() {
     await tester.pumpAndSettle();
   }
 
+  Future<double> openRecordSheetAndMeasureBottomSpacing(
+    WidgetTester tester,
+  ) async {
+    await tester.tap(find.byKey(const Key('recordAddButton')));
+    await tester.pumpAndSettle();
+
+    final sheet = find.byKey(const Key('recordAddSheet'));
+    final options = find.byKey(const Key('recordOptions'));
+
+    final logicalHeight =
+        tester.view.physicalSize.height / tester.view.devicePixelRatio;
+    expect(tester.getBottomRight(sheet).dy, logicalHeight);
+
+    return tester.getBottomRight(sheet).dy - tester.getBottomRight(options).dy;
+  }
+
   testWidgets('Enters the Home tab in English after demo', (tester) async {
     await pumpApp(tester, locale: const Locale('en'));
     // Bottom-nav labels match the React original.
@@ -71,6 +87,79 @@ void main() {
     expect(find.text('Diet'), findsAtLeastNWidgets(1));
     expect(find.text('Exercise'), findsAtLeastNWidgets(1));
     expect(find.text('MY'), findsAtLeastNWidgets(1));
+  });
+
+  testWidgets('record sheet has no fixed bottom gap without a system inset', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await pumpApp(tester, locale: const Locale('ko'));
+
+    final bottomSpacing = await openRecordSheetAndMeasureBottomSpacing(tester);
+
+    expect(bottomSpacing, 0);
+  });
+
+  testWidgets('record sheet keeps only the required system inset', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    tester.view.padding = const FakeViewPadding(bottom: 34);
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPadding);
+
+    await pumpApp(tester, locale: const Locale('ko'));
+
+    final bottomSpacing = await openRecordSheetAndMeasureBottomSpacing(tester);
+
+    expect(bottomSpacing, 34);
+  });
+
+  testWidgets('diet add opens as a content-sized sheet without a bottom gap', (
+    tester,
+  ) async {
+    await pumpApp(tester, locale: const Locale('ko'));
+    await tester.tap(find.byKey(const Key('recordAddButton')));
+    await tester.pumpAndSettle();
+
+    final dietOption = find.descendant(
+      of: find.byKey(const Key('recordOptions')),
+      matching: find.text('식단'),
+    );
+    await tester.tap(dietOption);
+    await tester.pumpAndSettle();
+
+    final sheet = find.byKey(const Key('dietAddSheet'));
+    final options = find.byKey(const Key('dietAddOptions'));
+    expect(sheet, findsOneWidget);
+    expect(tester.getTopLeft(sheet).dy, greaterThan(0));
+    final logicalHeight =
+        tester.view.physicalSize.height / tester.view.devicePixelRatio;
+    expect(tester.getBottomRight(sheet).dy, logicalHeight);
+    expect(
+      tester.getBottomRight(sheet).dy - tester.getBottomRight(options).dy,
+      0,
+    );
+    expect(find.byKey(const Key('recordAddSheet')), findsNothing);
+  });
+
+  testWidgets('header notification opens the existing full page', (
+    tester,
+  ) async {
+    await pumpApp(tester, locale: const Locale('ko'));
+
+    await tester.tap(find.byIcon(Icons.notifications_none_rounded).first);
+    await tester.pumpAndSettle();
+
+    final page = find.byKey(const Key('notificationPage'));
+    expect(page, findsOneWidget);
+    expect(tester.getTopLeft(page).dy, 0);
   });
 
   testWidgets('Tapping a bottom-nav destination switches branch', (


### PR DESCRIPTION
## Summary

* 회원 앱의 짧은 Bottom Sheet에서 SafeArea와 고정 bottom padding이 중복되던 문제를 제거했습니다.
* 식단 추가는 콘텐츠 높이의 부분창으로 유지하면서 루트 Navigator에서 열어 플로팅 버튼보다 위에 표시합니다.
* 알림, 등록 식단 상세, 포인트 및 MY 설정 화면은 전체 화면으로 전환했습니다.

---

## Changes

### ✨ Features

* 등록된 식단 상세·수정 화면을 전체 화면으로 제공합니다.
* 포인트 사용처와 MY 설정·지원·약관 화면을 전체 화면으로 제공합니다.

### 🔧 Improvements

* 식단 추가 부분창이 루트 Navigator를 사용해 공통 플로팅 버튼보다 앞에 표시됩니다.
* 회원 앱과 웹에서 동일한 화면 전환 구조를 사용합니다.

### 🎨 UI/UX

* 새 기록 추가, 식단 분석, 운동 추가·수정, AI 건강 도우미의 중복 하단 여백을 제거했습니다.
* 헤더 알림 버튼이 우측 부분 패널 대신 기존 알림 전체 화면으로 이동합니다.
* 콘텐츠가 짧은 식단 추가 창은 콘텐츠 높이만 차지하고 필요한 SafeArea만 유지합니다.

### 📝 Docs

* 해당 없음

### 🐛 Fixes

* SafeArea 바깥에 시트 배경이 남아 하단에 큰 흰 공간처럼 보이던 레이아웃을 수정했습니다.
* 고정 bottom padding과 시스템 inset이 합산되던 문제를 수정했습니다.

---

## Commits

1. `4419ddd` fix(ui): 회원앱 부분창 여백과 화면 전환 개선
2. `fcba8d4` fix(ci): 회원앱 분석 경고 수정

---

## Notes

* 열린 PR은 없어 파일 충돌 범위가 없습니다.
* 열린 이슈 #467은 회원 앱을 범위에서 제외하고, #426은 `gym_tab.dart`의 예약 슬롯만 다루므로 이번 변경과 중복되지 않습니다. 중복 이슈가 없어 별도 이슈 댓글은 남기지 않았습니다.
* Flutter SDK 내부 Dart 분석(`dart analyze --fatal-infos`) 결과 `No issues found`이며, 전체 테스트와 웹 빌드도 통과했습니다.
* #466 조사 이후 요청된 전체 화면 전환(알림·등록 식단·포인트·MY 설정)도 함께 반영했습니다.

---

## Screenshots (Optional)

| Before | After |
| ------ | ----- |
| 첨부 없음 | 첨부 없음 |

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [ ] 실기기 UI 확인
* [x] 웹 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 하단 중앙 추가 버튼에서 새 기록 추가 창을 열고 콘텐츠 아래 고정 여백이 없는지 확인합니다.
2. 식단 추가 창이 콘텐츠 높이로 열리고 플로팅 버튼보다 앞에 표시되는지 확인합니다.
3. 헤더 알림, 등록 식단, 포인트 및 MY 설정 항목이 전체 화면으로 이동하는지 확인합니다.

---

## Related Issues

Closes #466

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인
