### PR TITLE
feat(exercise): 예약 슬롯을 트레이너별로 분리

### DIFF
--- a/frontend/flutter/lib/features/exercise/data/repositories/dio_gym_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/dio_gym_repository.dart
@@ -3,6 +3,7 @@ import 'package:dio/dio.dart';
 import 'package:oncare/features/exercise/domain/entities/gym.dart';
 import 'package:oncare/features/exercise/domain/entities/gym_search_area.dart';
 import 'package:oncare/features/exercise/domain/entities/trainer.dart';
+import 'package:oncare/features/exercise/domain/entities/trainer_slot.dart';
 import 'package:oncare/features/exercise/domain/repositories/gym_repository.dart';
 
 /// 헬스장·트레이너 디렉터리 실 API. (#324)
@@ -26,6 +27,14 @@ class DioGymRepository implements GymRepository {
     phone: j['phone'] as String?,
     lat: (j['lat'] as num?)?.toDouble(),
     lng: (j['lng'] as num?)?.toDouble(),
+  );
+
+  static TrainerSlot _slot(Map<String, Object?> j) => TrainerSlot(
+    id: j['id']! as String,
+    trainerId: (j['trainer_id'] as String?) ?? '',
+    startsAt: DateTime.parse(j['starts_at']! as String).toLocal(),
+    capacity: ((j['capacity'] as num?) ?? 0).toInt(),
+    remaining: ((j['remaining'] as num?) ?? 0).toInt(),
   );
 
   static Trainer _trainer(Map<String, Object?> j) => Trainer(
@@ -126,4 +135,14 @@ class DioGymRepository implements GymRepository {
 
   @override
   Future<void> disconnectMyTrainer() => _dio.delete<void>('/me/coach/trainer');
+
+  @override
+  Future<List<TrainerSlot>> fetchSlots(String trainerId) =>
+      _list('/trainers/$trainerId/slots', _slot);
+
+  @override
+  Future<void> reserve(String slotId) =>
+      _dio.post<void>('/reservations', data: <String, Object?>{
+        'slot_id': slotId,
+      });
 }

--- a/frontend/flutter/lib/features/exercise/data/repositories/dio_gym_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/dio_gym_repository.dart
@@ -141,8 +141,23 @@ class DioGymRepository implements GymRepository {
       _list('/trainers/$trainerId/slots', _slot);
 
   @override
-  Future<void> reserve(String slotId) =>
-      _dio.post<void>('/reservations', data: <String, Object?>{
-        'slot_id': slotId,
-      });
+  Future<void> reserve(String slotId) async {
+    try {
+      await _dio.post<void>(
+        '/reservations',
+        data: <String, Object?>{'slot_id': slotId},
+      );
+    } on DioException catch (e) {
+      // 도메인 계약(GymRepository.reserve)은 "없음/마감"을 StateError 로
+      // 정의한다. 목과 실서버가 같은 예외를 내야 호출자가 한 갈래만 다룬다.
+      final int? code = e.response?.statusCode;
+      if (code == 404) {
+        throw StateError('slot not found: $slotId');
+      }
+      if (code == 409 || code == 410) {
+        throw StateError('slot no longer bookable: $slotId');
+      }
+      rethrow;
+    }
+  }
 }

--- a/frontend/flutter/lib/features/exercise/data/repositories/mock_gym_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/mock_gym_repository.dart
@@ -323,41 +323,57 @@ class MockGymRepository implements GymRepository {
   static List<TrainerSlot> _seedSlots() {
     final DateTime today = DateTime.now();
     return <TrainerSlot>[
-      // 김트레이너 — 저녁 위주.
+      // 오늘 자리는 데모에서 "가까운 시간"을 보여주려고 둔다. 저녁에 앱을 켜면
+      // 이미 지나 목록에서 빠지므로, 트레이너마다 내일 이후 자리를 함께 둬서
+      // 어느 시각에 열어도 예약할 수 있는 자리가 남는다.
       TrainerSlot(
-        id: 'slot-kim-1',
+        id: 'slot-kim-today',
         trainerId: 'trainer-kim',
         startsAt: _at(today, 0, 19, 0),
         capacity: 2,
         remaining: 1,
       ),
       TrainerSlot(
-        id: 'slot-kim-2',
+        id: 'slot-kim-1',
         trainerId: 'trainer-kim',
         startsAt: _at(today, 1, 7, 30),
         capacity: 2,
         remaining: 2,
       ),
       TrainerSlot(
-        id: 'slot-kim-3',
+        id: 'slot-kim-2',
         trainerId: 'trainer-kim',
+        // 마감된 자리도 남겨 두어야 "그날은 꽉 찼다"가 읽힌다.
         startsAt: _at(today, 1, 20, 0),
         capacity: 3,
-        // 마감된 자리도 남겨 두어야 "그날은 꽉 찼다"가 읽힌다.
         remaining: 0,
       ),
-      // 박트레이너 — 재활 세션이라 낮 시간대.
       TrainerSlot(
-        id: 'slot-park-1',
+        id: 'slot-kim-3',
+        trainerId: 'trainer-kim',
+        startsAt: _at(today, 2, 18, 0),
+        capacity: 2,
+        remaining: 2,
+      ),
+      // 박트레이너 — 재활 세션이라 1:1, 낮 시간대.
+      TrainerSlot(
+        id: 'slot-park-today',
         trainerId: 'trainer-park',
         startsAt: _at(today, 0, 14, 0),
         capacity: 1,
         remaining: 1,
       ),
       TrainerSlot(
+        id: 'slot-park-1',
+        trainerId: 'trainer-park',
+        startsAt: _at(today, 1, 11, 0),
+        capacity: 1,
+        remaining: 1,
+      ),
+      TrainerSlot(
         id: 'slot-park-2',
         trainerId: 'trainer-park',
-        startsAt: _at(today, 2, 11, 0),
+        startsAt: _at(today, 2, 15, 0),
         capacity: 1,
         remaining: 1,
       ),
@@ -371,14 +387,14 @@ class MockGymRepository implements GymRepository {
       ),
       // 강트레이너 — 교대근무 대응이라 이른 아침·늦은 밤.
       TrainerSlot(
-        id: 'slot-kang-1',
+        id: 'slot-kang-today',
         trainerId: 'trainer-kang',
         startsAt: _at(today, 0, 6, 0),
         capacity: 2,
         remaining: 2,
       ),
       TrainerSlot(
-        id: 'slot-kang-2',
+        id: 'slot-kang-1',
         trainerId: 'trainer-kang',
         startsAt: _at(today, 1, 22, 0),
         capacity: 2,
@@ -398,9 +414,15 @@ class MockGymRepository implements GymRepository {
   @override
   Future<List<TrainerSlot>> fetchSlots(String trainerId) async {
     await Future<void>.delayed(const Duration(milliseconds: 60));
+    // 이미 지난 시간은 보여주지 않는다 — 저녁에 앱을 켰을 때 오늘 아침 자리가
+    // "예약 가능"으로 뜨면 안 된다.
+    final DateTime now = DateTime.now();
     final List<TrainerSlot> mine =
         _slots
-            .where((TrainerSlot slot) => slot.trainerId == trainerId)
+            .where(
+              (TrainerSlot slot) =>
+                  slot.trainerId == trainerId && slot.startsAt.isAfter(now),
+            )
             .toList()
           ..sort(
             (TrainerSlot a, TrainerSlot b) => a.startsAt.compareTo(b.startsAt),
@@ -417,6 +439,10 @@ class MockGymRepository implements GymRepository {
     }
     if (_slots[i].isFull) {
       throw StateError('slot already full: $slotId');
+    }
+    // 목록에서 이미 빠진 시간을 오래된 화면이 그대로 잡는 것도 막는다.
+    if (!_slots[i].startsAt.isAfter(DateTime.now())) {
+      throw StateError('slot already started: $slotId');
     }
     _slots[i] = _slots[i].copyWith(remaining: _slots[i].remaining - 1);
   }

--- a/frontend/flutter/lib/features/exercise/data/repositories/mock_gym_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/mock_gym_repository.dart
@@ -1,5 +1,6 @@
 import 'package:oncare/features/exercise/domain/entities/gym.dart';
 import 'package:oncare/features/exercise/domain/entities/trainer.dart';
+import 'package:oncare/features/exercise/domain/entities/trainer_slot.dart';
 import 'package:oncare/features/exercise/domain/repositories/gym_repository.dart';
 
 /// In-memory gym + trainer data matching the prototype's `GymCard` /
@@ -306,5 +307,117 @@ class MockGymRepository implements GymRepository {
     await Future<void>.delayed(const Duration(milliseconds: 60));
     // 헬스장 연결은 그대로 두고 담당 트레이너만 뗀다.
     _myTrainerId = null;
+  }
+
+  // ── 예약 슬롯 ──────────────────────────────────────────────────────────
+  //
+  // 슬롯은 트레이너마다 다르다. 시각은 저장소를 만든 시점의 "오늘"을 기준으로
+  // 잡아, 화면에 실제 날짜가 뜨고 날이 바뀌어도 문구가 어긋나지 않는다.
+  // 예약 결과는 이 인스턴스에 남으므로 화면을 나갔다 와도 유지된다.
+  late final List<TrainerSlot> _slots = _seedSlots();
+
+  static DateTime _at(DateTime day, int addDays, int hour, int minute) {
+    return DateTime(day.year, day.month, day.day + addDays, hour, minute);
+  }
+
+  static List<TrainerSlot> _seedSlots() {
+    final DateTime today = DateTime.now();
+    return <TrainerSlot>[
+      // 김트레이너 — 저녁 위주.
+      TrainerSlot(
+        id: 'slot-kim-1',
+        trainerId: 'trainer-kim',
+        startsAt: _at(today, 0, 19, 0),
+        capacity: 2,
+        remaining: 1,
+      ),
+      TrainerSlot(
+        id: 'slot-kim-2',
+        trainerId: 'trainer-kim',
+        startsAt: _at(today, 1, 7, 30),
+        capacity: 2,
+        remaining: 2,
+      ),
+      TrainerSlot(
+        id: 'slot-kim-3',
+        trainerId: 'trainer-kim',
+        startsAt: _at(today, 1, 20, 0),
+        capacity: 3,
+        // 마감된 자리도 남겨 두어야 "그날은 꽉 찼다"가 읽힌다.
+        remaining: 0,
+      ),
+      // 박트레이너 — 재활 세션이라 낮 시간대.
+      TrainerSlot(
+        id: 'slot-park-1',
+        trainerId: 'trainer-park',
+        startsAt: _at(today, 0, 14, 0),
+        capacity: 1,
+        remaining: 1,
+      ),
+      TrainerSlot(
+        id: 'slot-park-2',
+        trainerId: 'trainer-park',
+        startsAt: _at(today, 2, 11, 0),
+        capacity: 1,
+        remaining: 1,
+      ),
+      // 최트레이너 — 소그룹이라 정원이 크다.
+      TrainerSlot(
+        id: 'slot-choi-1',
+        trainerId: 'trainer-choi',
+        startsAt: _at(today, 1, 18, 30),
+        capacity: 4,
+        remaining: 3,
+      ),
+      // 강트레이너 — 교대근무 대응이라 이른 아침·늦은 밤.
+      TrainerSlot(
+        id: 'slot-kang-1',
+        trainerId: 'trainer-kang',
+        startsAt: _at(today, 0, 6, 0),
+        capacity: 2,
+        remaining: 2,
+      ),
+      TrainerSlot(
+        id: 'slot-kang-2',
+        trainerId: 'trainer-kang',
+        startsAt: _at(today, 1, 22, 0),
+        capacity: 2,
+        remaining: 1,
+      ),
+      TrainerSlot(
+        id: 'slot-lee-1',
+        trainerId: 'trainer-lee',
+        startsAt: _at(today, 2, 10, 0),
+        capacity: 2,
+        remaining: 2,
+      ),
+      // 윤트레이너는 슬롯이 없다 — 빈 상태를 데모에서도 볼 수 있어야 한다.
+    ];
+  }
+
+  @override
+  Future<List<TrainerSlot>> fetchSlots(String trainerId) async {
+    await Future<void>.delayed(const Duration(milliseconds: 60));
+    final List<TrainerSlot> mine =
+        _slots
+            .where((TrainerSlot slot) => slot.trainerId == trainerId)
+            .toList()
+          ..sort(
+            (TrainerSlot a, TrainerSlot b) => a.startsAt.compareTo(b.startsAt),
+          );
+    return List<TrainerSlot>.unmodifiable(mine);
+  }
+
+  @override
+  Future<void> reserve(String slotId) async {
+    await Future<void>.delayed(const Duration(milliseconds: 60));
+    final int i = _slots.indexWhere((TrainerSlot slot) => slot.id == slotId);
+    if (i < 0) {
+      throw StateError('slot not found: $slotId');
+    }
+    if (_slots[i].isFull) {
+      throw StateError('slot already full: $slotId');
+    }
+    _slots[i] = _slots[i].copyWith(remaining: _slots[i].remaining - 1);
   }
 }

--- a/frontend/flutter/lib/features/exercise/domain/entities/trainer_slot.dart
+++ b/frontend/flutter/lib/features/exercise/domain/entities/trainer_slot.dart
@@ -1,0 +1,40 @@
+/// One bookable time on a trainer's calendar.
+///
+/// Slots belong to a trainer, not to a gym: a gym employs several trainers and
+/// each keeps their own hours, so the same gym shows different times depending
+/// on who you are booking.
+class TrainerSlot {
+  const TrainerSlot({
+    required this.id,
+    required this.trainerId,
+    required this.startsAt,
+    required this.capacity,
+    required this.remaining,
+  });
+
+  final String id;
+  final String trainerId;
+
+  /// When the session starts. Rendered with the device locale rather than a
+  /// fixed "오늘/내일" string, so the label stays true as days pass.
+  final DateTime startsAt;
+
+  /// How many people the slot takes in total.
+  final int capacity;
+
+  /// Places still open. 0 means booked out — the chip is shown but not
+  /// selectable, so the trainer's day still reads as full rather than empty.
+  final int remaining;
+
+  bool get isFull => remaining <= 0;
+
+  TrainerSlot copyWith({int? remaining}) {
+    return TrainerSlot(
+      id: id,
+      trainerId: trainerId,
+      startsAt: startsAt,
+      capacity: capacity,
+      remaining: remaining ?? this.remaining,
+    );
+  }
+}

--- a/frontend/flutter/lib/features/exercise/domain/repositories/gym_repository.dart
+++ b/frontend/flutter/lib/features/exercise/domain/repositories/gym_repository.dart
@@ -1,5 +1,6 @@
 import 'package:oncare/features/exercise/domain/entities/gym.dart';
 import 'package:oncare/features/exercise/domain/entities/trainer.dart';
+import 'package:oncare/features/exercise/domain/entities/trainer_slot.dart';
 
 /// Gym + trainer directory, plus the user's own two links. Both live here
 /// because the links are coupled: leaving a gym also drops its trainer.
@@ -32,4 +33,15 @@ abstract class GymRepository {
 
   /// Drops only the trainer link; the gym link stays. No-op when unassigned.
   Future<void> disconnectMyTrainer();
+
+  /// Bookable times for one trainer, earliest first. Past slots are already
+  /// filtered out; booked-out ones are kept so the day reads as full rather
+  /// than empty.
+  Future<List<TrainerSlot>> fetchSlots(String trainerId);
+
+  /// Takes one place in [slotId].
+  ///
+  /// Throws [StateError] when the slot is unknown or already booked out, so a
+  /// stale screen cannot silently overbook.
+  Future<void> reserve(String slotId);
 }

--- a/frontend/flutter/lib/features/exercise/presentation/controllers/exercise_controller.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/controllers/exercise_controller.dart
@@ -11,6 +11,7 @@ import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
 import 'package:oncare/features/exercise/domain/entities/gym.dart';
 import 'package:oncare/features/exercise/domain/entities/gym_search_area.dart';
 import 'package:oncare/features/exercise/domain/entities/trainer.dart';
+import 'package:oncare/features/exercise/domain/entities/trainer_slot.dart';
 import 'package:oncare/features/exercise/domain/repositories/exercise_repository.dart';
 import 'package:oncare/features/exercise/domain/repositories/gym_repository.dart';
 import 'package:oncare/features/place/domain/entities/place.dart';
@@ -270,3 +271,12 @@ final recommendedTrainersProvider = FutureProvider<List<Trainer>>((ref) {
 final allTrainersProvider = FutureProvider<List<Trainer>>((ref) {
   return ref.watch(gymRepositoryProvider).fetchAllTrainers();
 }, name: 'allTrainers');
+
+/// 한 트레이너의 예약 가능 시간. 트레이너별로 다르므로 family 로 둔다.
+/// 예약이 성사되면 이 provider 를 invalidate 해서 잔여 자리를 다시 읽는다.
+final trainerSlotsProvider = FutureProvider.family<List<TrainerSlot>, String>((
+  ref,
+  String trainerId,
+) {
+  return ref.watch(gymRepositoryProvider).fetchSlots(trainerId);
+}, name: 'trainerSlots');

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/gym_tab.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/gym_tab.dart
@@ -7,6 +7,7 @@ import 'package:oncare/design_system/figma/figma_kit.dart';
 import 'package:oncare/features/exercise/domain/entities/consultation_request.dart';
 import 'package:oncare/features/exercise/domain/entities/gym.dart';
 import 'package:oncare/features/exercise/domain/entities/trainer.dart';
+import 'package:oncare/features/exercise/domain/entities/trainer_slot.dart';
 import 'package:oncare/features/exercise/presentation/controllers/consultation_request_controller.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
 import 'package:oncare/features/member_coach/domain/entities/member_coach.dart';
@@ -426,7 +427,7 @@ class _MyGymCard extends StatelessWidget {
             const SizedBox(height: 16),
             _ReservationPanel(
               gym: gym,
-              trainer: trainer!.name,
+              trainer: trainer!,
               selectedSlot: selectedSlot,
               onSlot: onSlot,
             ),
@@ -528,7 +529,12 @@ class _TrainerChatButton extends StatelessWidget {
   }
 }
 
-class _ReservationPanel extends StatelessWidget {
+/// 담당 트레이너의 실제 예약 가능 시간.
+///
+/// 슬롯은 트레이너에 귀속되므로 여기서 [trainerSlotsProvider] 를 직접 읽는다.
+/// 마감된 자리도 숨기지 않고 비활성으로 남겨, 그 트레이너의 하루가 "비어 있음"
+/// 이 아니라 "찼음" 으로 읽히게 한다.
+class _ReservationPanel extends ConsumerWidget {
   const _ReservationPanel({
     required this.gym,
     required this.trainer,
@@ -537,13 +543,49 @@ class _ReservationPanel extends StatelessWidget {
   });
 
   final Gym gym;
-  final String trainer;
+  final Trainer trainer;
+
+  /// 선택된 슬롯 id. 부모(운동 탭)가 들고 있다.
   final String? selectedSlot;
   final ValueChanged<String> onSlot;
 
+  /// 로케일에 맞는 "8월 8일 오후 7:00" 형태. 고정 문자열이 아니라 실제 시각을
+  /// 쓰므로 날이 바뀌어도 어긋나지 않는다.
+  String _when(BuildContext context, AppLocalizations l, DateTime at) {
+    final MaterialLocalizations m = MaterialLocalizations.of(context);
+    return l.exSlotWhen(
+      m.formatMediumDate(at),
+      m.formatTimeOfDay(TimeOfDay.fromDateTime(at)),
+    );
+  }
+
+  Future<void> _reserve(
+    BuildContext context,
+    WidgetRef ref,
+    AppLocalizations l,
+    TrainerSlot slot,
+  ) async {
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    final String label = _when(context, l, slot.startsAt);
+    try {
+      await ref.read(gymRepositoryProvider).reserve(slot.id);
+    } catch (_) {
+      messenger.showSnackBar(SnackBar(content: Text(l.exReserveFailed)));
+      return;
+    }
+    // 잔여 자리를 다시 읽어, 방금 잡은 자리가 목록에도 반영되게 한다.
+    ref.invalidate(trainerSlotsProvider(trainer.id));
+    messenger.showSnackBar(
+      SnackBar(content: Text(l.exReserveConfirmedSlotGym(label, gym.name))),
+    );
+  }
+
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final AppLocalizations l = AppLocalizations.of(context);
+    final AsyncValue<List<TrainerSlot>> slotsAsync = ref.watch(
+      trainerSlotsProvider(trainer.id),
+    );
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.all(12),
@@ -569,7 +611,7 @@ class _ReservationPanel extends StatelessWidget {
           ),
           const SizedBox(height: 2),
           Text(
-            l.exTrainerAvailability(trainer),
+            l.exTrainerAvailability(trainer.name),
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
             style: const TextStyle(
@@ -579,58 +621,136 @@ class _ReservationPanel extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 10),
-          Wrap(
-            spacing: 8,
-            runSpacing: 8,
-            children: <Widget>[
-              for (final List<String> slot in <List<String>>[
-                <String>[l.exSlotToday19, l.exSlot1Left],
-                <String>[l.exSlotTomorrow0730, l.exSlotAvailable],
-                <String>[l.exSlotTomorrow20, l.exSlot2Left],
-              ])
-                _SlotChip(
-                  label: slot[0],
-                  sub: slot[1],
-                  selected: selectedSlot == slot[0],
-                  onTap: () => onSlot(slot[0]),
-                ),
-            ],
-          ),
-          if (selectedSlot != null) ...<Widget>[
-            const SizedBox(height: 10),
-            SizedBox(
-              width: double.infinity,
-              child: FilledButton(
-                onPressed: () {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: Text(
-                        l.exReserveConfirmedSlotGym(selectedSlot!, gym.name),
-                      ),
-                    ),
-                  );
-                },
-                style: FilledButton.styleFrom(
-                  backgroundColor: FigmaColors.primary,
-                  minimumSize: const Size(0, 42),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                ),
-                child: Text(
-                  l.exReserveConfirm(selectedSlot!),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(
-                    fontSize: 12,
-                    fontWeight: FontWeight.w700,
-                  ),
+          slotsAsync.when(
+            loading: () => const Padding(
+              padding: EdgeInsets.symmetric(vertical: 12),
+              child: Center(
+                child: SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: CircularProgressIndicator(strokeWidth: 2.5),
                 ),
               ),
             ),
-          ],
+            error: (Object _, StackTrace _) => _SlotNotice(
+              message: l.exSlotsLoadError,
+              onRetry: () => ref.invalidate(trainerSlotsProvider(trainer.id)),
+            ),
+            data: (List<TrainerSlot> slots) {
+              if (slots.isEmpty) {
+                return _SlotNotice(message: l.exSlotsEmpty);
+              }
+              final bool allBooked = slots.every(
+                (TrainerSlot slot) => slot.isFull,
+              );
+              final TrainerSlot? picked = slots
+                  .where(
+                    (TrainerSlot slot) =>
+                        slot.id == selectedSlot && !slot.isFull,
+                  )
+                  .firstOrNull;
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  if (allBooked) ...<Widget>[
+                    _SlotNotice(message: l.exSlotsAllBooked),
+                    const SizedBox(height: 10),
+                  ],
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: <Widget>[
+                      for (final TrainerSlot slot in slots)
+                        _SlotChip(
+                          label: _when(context, l, slot.startsAt),
+                          sub: slot.isFull
+                              ? l.exSlotFull
+                              : l.exSlotRemaining(slot.remaining),
+                          selected: picked?.id == slot.id,
+                          // 마감된 자리는 고를 수 없다.
+                          onTap: slot.isFull ? null : () => onSlot(slot.id),
+                        ),
+                    ],
+                  ),
+                  if (picked != null) ...<Widget>[
+                    const SizedBox(height: 10),
+                    SizedBox(
+                      width: double.infinity,
+                      child: FilledButton(
+                        onPressed: () => _reserve(context, ref, l, picked),
+                        style: FilledButton.styleFrom(
+                          backgroundColor: FigmaColors.primary,
+                          minimumSize: const Size(0, 42),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                        ),
+                        child: Text(
+                          l.exReserveConfirm(
+                            _when(context, l, picked.startsAt),
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: const TextStyle(
+                            fontSize: 12,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ],
+              );
+            },
+          ),
         ],
       ),
+    );
+  }
+}
+
+/// 슬롯이 없거나 전부 찼거나 조회에 실패했을 때의 한 줄 안내.
+class _SlotNotice extends StatelessWidget {
+  const _SlotNotice({required this.message, this.onRetry});
+
+  final String message;
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations l = AppLocalizations.of(context);
+    return Row(
+      children: <Widget>[
+        const Icon(
+          Icons.event_busy_outlined,
+          size: 14,
+          color: FigmaColors.textMuted,
+        ),
+        const SizedBox(width: 6),
+        Expanded(
+          child: Text(
+            message,
+            style: const TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+              color: FigmaColors.textMuted,
+            ),
+          ),
+        ),
+        if (onRetry != null)
+          TextButton(
+            onPressed: onRetry,
+            style: TextButton.styleFrom(
+              foregroundColor: FigmaColors.primary,
+              minimumSize: const Size(48, 32),
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+            ),
+            child: Text(
+              l.actionRetry,
+              style: const TextStyle(fontSize: 11, fontWeight: FontWeight.w700),
+            ),
+          ),
+      ],
     );
   }
 }
@@ -1034,12 +1154,17 @@ class _SlotChip extends StatelessWidget {
   final String label;
   final String sub;
   final bool selected;
-  final VoidCallback onTap;
+
+  /// null 이면 마감된 자리다 — 눌리지 않고 흐리게 그려진다.
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
+    final bool disabled = onTap == null;
     return Material(
-      color: selected ? FigmaColors.primary : Colors.white,
+      color: selected
+          ? FigmaColors.primary
+          : (disabled ? FigmaColors.softBlue : Colors.white),
       borderRadius: BorderRadius.circular(12),
       child: InkWell(
         onTap: onTap,
@@ -1061,7 +1186,9 @@ class _SlotChip extends StatelessWidget {
                 style: TextStyle(
                   fontSize: 11,
                   fontWeight: FontWeight.w700,
-                  color: selected ? Colors.white : FigmaColors.ink,
+                  color: selected
+                      ? Colors.white
+                      : (disabled ? FigmaColors.textFaint : FigmaColors.ink),
                 ),
               ),
               Text(
@@ -1071,7 +1198,9 @@ class _SlotChip extends StatelessWidget {
                   fontWeight: FontWeight.w500,
                   color: selected
                       ? Colors.white.withValues(alpha: 0.8)
-                      : FigmaColors.textMuted,
+                      : (disabled
+                            ? FigmaColors.textFaint
+                            : FigmaColors.textMuted),
                 ),
               ),
             ],

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/gym_tab.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/gym_tab.dart
@@ -534,7 +534,7 @@ class _TrainerChatButton extends StatelessWidget {
 /// 슬롯은 트레이너에 귀속되므로 여기서 [trainerSlotsProvider] 를 직접 읽는다.
 /// 마감된 자리도 숨기지 않고 비활성으로 남겨, 그 트레이너의 하루가 "비어 있음"
 /// 이 아니라 "찼음" 으로 읽히게 한다.
-class _ReservationPanel extends ConsumerWidget {
+class _ReservationPanel extends ConsumerStatefulWidget {
   const _ReservationPanel({
     required this.gym,
     required this.trainer,
@@ -549,6 +549,15 @@ class _ReservationPanel extends ConsumerWidget {
   final String? selectedSlot;
   final ValueChanged<String> onSlot;
 
+  @override
+  ConsumerState<_ReservationPanel> createState() => _ReservationPanelState();
+}
+
+class _ReservationPanelState extends ConsumerState<_ReservationPanel> {
+  /// 요청이 오가는 동안 잡고 있는 슬롯 id. 예약은 멱등이 아니라서, 확정 버튼을
+  /// 두 번 누르면 좌석이 두 번 빠진다 — 그래서 진행 중에는 버튼을 잠근다.
+  String? _reserving;
+
   /// 로케일에 맞는 "8월 8일 오후 7:00" 형태. 고정 문자열이 아니라 실제 시각을
   /// 쓰므로 날이 바뀌어도 어긋나지 않는다.
   String _when(BuildContext context, AppLocalizations l, DateTime at) {
@@ -559,33 +568,36 @@ class _ReservationPanel extends ConsumerWidget {
     );
   }
 
-  Future<void> _reserve(
-    BuildContext context,
-    WidgetRef ref,
-    AppLocalizations l,
-    TrainerSlot slot,
-  ) async {
+  Future<void> _reserve(AppLocalizations l, TrainerSlot slot) async {
+    if (_reserving != null) return;
     final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
     final String label = _when(context, l, slot.startsAt);
+    setState(() => _reserving = slot.id);
     try {
       await ref.read(gymRepositoryProvider).reserve(slot.id);
     } catch (_) {
+      if (mounted) setState(() => _reserving = null);
       messenger.showSnackBar(SnackBar(content: Text(l.exReserveFailed)));
       return;
     }
+    if (!mounted) return;
+    setState(() => _reserving = null);
     // 잔여 자리를 다시 읽어, 방금 잡은 자리가 목록에도 반영되게 한다.
-    ref.invalidate(trainerSlotsProvider(trainer.id));
+    ref.invalidate(trainerSlotsProvider(widget.trainer.id));
     messenger.showSnackBar(
-      SnackBar(content: Text(l.exReserveConfirmedSlotGym(label, gym.name))),
+      SnackBar(
+        content: Text(l.exReserveConfirmedSlotGym(label, widget.gym.name)),
+      ),
     );
   }
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final AppLocalizations l = AppLocalizations.of(context);
     final AsyncValue<List<TrainerSlot>> slotsAsync = ref.watch(
-      trainerSlotsProvider(trainer.id),
+      trainerSlotsProvider(widget.trainer.id),
     );
+    final bool busy = _reserving != null;
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.all(12),
@@ -611,7 +623,7 @@ class _ReservationPanel extends ConsumerWidget {
           ),
           const SizedBox(height: 2),
           Text(
-            l.exTrainerAvailability(trainer.name),
+            l.exTrainerAvailability(widget.trainer.name),
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
             style: const TextStyle(
@@ -634,7 +646,8 @@ class _ReservationPanel extends ConsumerWidget {
             ),
             error: (Object _, StackTrace _) => _SlotNotice(
               message: l.exSlotsLoadError,
-              onRetry: () => ref.invalidate(trainerSlotsProvider(trainer.id)),
+              onRetry: () =>
+                  ref.invalidate(trainerSlotsProvider(widget.trainer.id)),
             ),
             data: (List<TrainerSlot> slots) {
               if (slots.isEmpty) {
@@ -646,7 +659,7 @@ class _ReservationPanel extends ConsumerWidget {
               final TrainerSlot? picked = slots
                   .where(
                     (TrainerSlot slot) =>
-                        slot.id == selectedSlot && !slot.isFull,
+                        slot.id == widget.selectedSlot && !slot.isFull,
                   )
                   .firstOrNull;
               return Column(
@@ -667,8 +680,11 @@ class _ReservationPanel extends ConsumerWidget {
                               ? l.exSlotFull
                               : l.exSlotRemaining(slot.remaining),
                           selected: picked?.id == slot.id,
-                          // 마감된 자리는 고를 수 없다.
-                          onTap: slot.isFull ? null : () => onSlot(slot.id),
+                          // 마감된 자리는 고를 수 없고, 예약이 오가는 중에는
+                          // 선택도 잠근다.
+                          onTap: slot.isFull || busy
+                              ? null
+                              : () => widget.onSlot(slot.id),
                         ),
                     ],
                   ),
@@ -677,7 +693,7 @@ class _ReservationPanel extends ConsumerWidget {
                     SizedBox(
                       width: double.infinity,
                       child: FilledButton(
-                        onPressed: () => _reserve(context, ref, l, picked),
+                        onPressed: busy ? null : () => _reserve(l, picked),
                         style: FilledButton.styleFrom(
                           backgroundColor: FigmaColors.primary,
                           minimumSize: const Size(0, 42),

--- a/frontend/flutter/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations.dart
@@ -1961,7 +1961,7 @@ abstract class AppLocalizations {
   /// No description provided for @exSlotsAllBooked.
   ///
   /// In en, this message translates to:
-  /// **'Every slot this week is taken'**
+  /// **'All available times are fully booked'**
   String get exSlotsAllBooked;
 
   /// No description provided for @exSlotsLoadError.

--- a/frontend/flutter/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations.dart
@@ -1934,41 +1934,47 @@ abstract class AppLocalizations {
   /// **'{trainer}\'s openings'**
   String exTrainerAvailability(String trainer);
 
-  /// No description provided for @exSlotToday19.
+  /// No description provided for @exSlotWhen.
   ///
   /// In en, this message translates to:
-  /// **'Today 19:00'**
-  String get exSlotToday19;
+  /// **'{date} {time}'**
+  String exSlotWhen(String date, String time);
 
-  /// No description provided for @exSlotTomorrow0730.
+  /// No description provided for @exSlotRemaining.
   ///
   /// In en, this message translates to:
-  /// **'Tomorrow 07:30'**
-  String get exSlotTomorrow0730;
+  /// **'{count} left'**
+  String exSlotRemaining(int count);
 
-  /// No description provided for @exSlotTomorrow20.
+  /// No description provided for @exSlotFull.
   ///
   /// In en, this message translates to:
-  /// **'Tomorrow 20:00'**
-  String get exSlotTomorrow20;
+  /// **'Fully booked'**
+  String get exSlotFull;
 
-  /// No description provided for @exSlot1Left.
+  /// No description provided for @exSlotsEmpty.
   ///
   /// In en, this message translates to:
-  /// **'1 spot left'**
-  String get exSlot1Left;
+  /// **'No times available'**
+  String get exSlotsEmpty;
 
-  /// No description provided for @exSlotAvailable.
+  /// No description provided for @exSlotsAllBooked.
   ///
   /// In en, this message translates to:
-  /// **'Open'**
-  String get exSlotAvailable;
+  /// **'Every slot this week is taken'**
+  String get exSlotsAllBooked;
 
-  /// No description provided for @exSlot2Left.
+  /// No description provided for @exSlotsLoadError.
   ///
   /// In en, this message translates to:
-  /// **'2 spots left'**
-  String get exSlot2Left;
+  /// **'Could not load available times.'**
+  String get exSlotsLoadError;
+
+  /// No description provided for @exReserveFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not book that time. Please try again.'**
+  String get exReserveFailed;
 
   /// No description provided for @exReserveConfirmedSlotGym.
   ///

--- a/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
@@ -1033,7 +1033,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get exSlotsEmpty => 'No times available';
 
   @override
-  String get exSlotsAllBooked => 'Every slot this week is taken';
+  String get exSlotsAllBooked => 'All available times are fully booked';
 
   @override
   String get exSlotsLoadError => 'Could not load available times.';

--- a/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
@@ -1017,22 +1017,29 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get exSlotToday19 => 'Today 19:00';
+  String exSlotWhen(String date, String time) {
+    return '$date $time';
+  }
 
   @override
-  String get exSlotTomorrow0730 => 'Tomorrow 07:30';
+  String exSlotRemaining(int count) {
+    return '$count left';
+  }
 
   @override
-  String get exSlotTomorrow20 => 'Tomorrow 20:00';
+  String get exSlotFull => 'Fully booked';
 
   @override
-  String get exSlot1Left => '1 spot left';
+  String get exSlotsEmpty => 'No times available';
 
   @override
-  String get exSlotAvailable => 'Open';
+  String get exSlotsAllBooked => 'Every slot this week is taken';
 
   @override
-  String get exSlot2Left => '2 spots left';
+  String get exSlotsLoadError => 'Could not load available times.';
+
+  @override
+  String get exReserveFailed => 'Could not book that time. Please try again.';
 
   @override
   String exReserveConfirmedSlotGym(String slot, String gym) {

--- a/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
@@ -1016,7 +1016,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get exSlotsEmpty => '예약 가능한 시간이 없어요';
 
   @override
-  String get exSlotsAllBooked => '이번 주 예약이 모두 찼어요';
+  String get exSlotsAllBooked => '예약 가능한 시간이 모두 찼어요';
 
   @override
   String get exSlotsLoadError => '예약 시간을 불러오지 못했어요.';

--- a/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
@@ -1000,22 +1000,29 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
-  String get exSlotToday19 => '오늘 19:00';
+  String exSlotWhen(String date, String time) {
+    return '$date $time';
+  }
 
   @override
-  String get exSlotTomorrow0730 => '내일 07:30';
+  String exSlotRemaining(int count) {
+    return '잔여 $count자리';
+  }
 
   @override
-  String get exSlotTomorrow20 => '내일 20:00';
+  String get exSlotFull => '예약 마감';
 
   @override
-  String get exSlot1Left => '잔여 1자리';
+  String get exSlotsEmpty => '예약 가능한 시간이 없어요';
 
   @override
-  String get exSlotAvailable => '여유 있음';
+  String get exSlotsAllBooked => '이번 주 예약이 모두 찼어요';
 
   @override
-  String get exSlot2Left => '잔여 2자리';
+  String get exSlotsLoadError => '예약 시간을 불러오지 못했어요.';
+
+  @override
+  String get exReserveFailed => '예약에 실패했어요. 잠시 후 다시 시도해 주세요';
 
   @override
   String exReserveConfirmedSlotGym(String slot, String gym) {

--- a/frontend/flutter/lib/l10n/app_en.arb
+++ b/frontend/flutter/lib/l10n/app_en.arb
@@ -565,7 +565,7 @@
   },
   "exSlotFull": "Fully booked",
   "exSlotsEmpty": "No times available",
-  "exSlotsAllBooked": "Every slot this week is taken",
+  "exSlotsAllBooked": "All available times are fully booked",
   "exSlotsLoadError": "Could not load available times.",
   "exReserveFailed": "Could not book that time. Please try again.",
   "exReserveConfirmedSlotGym": "{slot} · {gym} reservation confirmed",

--- a/frontend/flutter/lib/l10n/app_en.arb
+++ b/frontend/flutter/lib/l10n/app_en.arb
@@ -550,12 +550,24 @@
       }
     }
   },
-  "exSlotToday19": "Today 19:00",
-  "exSlotTomorrow0730": "Tomorrow 07:30",
-  "exSlotTomorrow20": "Tomorrow 20:00",
-  "exSlot1Left": "1 spot left",
-  "exSlotAvailable": "Open",
-  "exSlot2Left": "2 spots left",
+  "exSlotWhen": "{date} {time}",
+  "@exSlotWhen": {
+    "placeholders": {
+      "date": { "type": "String" },
+      "time": { "type": "String" }
+    }
+  },
+  "exSlotRemaining": "{count} left",
+  "@exSlotRemaining": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "exSlotFull": "Fully booked",
+  "exSlotsEmpty": "No times available",
+  "exSlotsAllBooked": "Every slot this week is taken",
+  "exSlotsLoadError": "Could not load available times.",
+  "exReserveFailed": "Could not book that time. Please try again.",
   "exReserveConfirmedSlotGym": "{slot} · {gym} reservation confirmed",
   "@exReserveConfirmedSlotGym": {
     "placeholders": {

--- a/frontend/flutter/lib/l10n/app_ko.arb
+++ b/frontend/flutter/lib/l10n/app_ko.arb
@@ -351,7 +351,7 @@
   },
   "exSlotFull": "예약 마감",
   "exSlotsEmpty": "예약 가능한 시간이 없어요",
-  "exSlotsAllBooked": "이번 주 예약이 모두 찼어요",
+  "exSlotsAllBooked": "예약 가능한 시간이 모두 찼어요",
   "exSlotsLoadError": "예약 시간을 불러오지 못했어요.",
   "exReserveFailed": "예약에 실패했어요. 잠시 후 다시 시도해 주세요",
   "exReserveConfirmedSlotGym": "{slot} · {gym} 예약이 확정됐어요",

--- a/frontend/flutter/lib/l10n/app_ko.arb
+++ b/frontend/flutter/lib/l10n/app_ko.arb
@@ -336,12 +336,24 @@
   "exTrainerDedicated": "전담 트레이너",
   "exAiSlotTitle": "✦ AI 추천 예약 시간",
   "exTrainerAvailability": "{trainer} 빈 시간",
-  "exSlotToday19": "오늘 19:00",
-  "exSlotTomorrow0730": "내일 07:30",
-  "exSlotTomorrow20": "내일 20:00",
-  "exSlot1Left": "잔여 1자리",
-  "exSlotAvailable": "여유 있음",
-  "exSlot2Left": "잔여 2자리",
+  "exSlotWhen": "{date} {time}",
+  "@exSlotWhen": {
+    "placeholders": {
+      "date": { "type": "String" },
+      "time": { "type": "String" }
+    }
+  },
+  "exSlotRemaining": "잔여 {count}자리",
+  "@exSlotRemaining": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "exSlotFull": "예약 마감",
+  "exSlotsEmpty": "예약 가능한 시간이 없어요",
+  "exSlotsAllBooked": "이번 주 예약이 모두 찼어요",
+  "exSlotsLoadError": "예약 시간을 불러오지 못했어요.",
+  "exReserveFailed": "예약에 실패했어요. 잠시 후 다시 시도해 주세요",
   "exReserveConfirmedSlotGym": "{slot} · {gym} 예약이 확정됐어요",
   "exReserveConfirm": "{slot} 예약 확정",
   "exGymInfo": "헬스장 정보",

--- a/frontend/flutter/test/features/exercise/trainer_slot_test.dart
+++ b/frontend/flutter/test/features/exercise/trainer_slot_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/exercise/data/repositories/mock_gym_repository.dart';
+import 'package:oncare/features/exercise/domain/entities/trainer_slot.dart';
+
+/// 예약 슬롯은 트레이너에 귀속된다(#426). 예전에는 위젯 안에 슬롯 3개가
+/// 하드코딩되어 있어 누구를 예약하든 같은 시간이 떴다.
+void main() {
+  test('트레이너마다 다른 슬롯을 돌려준다', () async {
+    final MockGymRepository repo = MockGymRepository();
+
+    final List<TrainerSlot> kim = await repo.fetchSlots('trainer-kim');
+    final List<TrainerSlot> park = await repo.fetchSlots('trainer-park');
+
+    expect(kim, isNotEmpty);
+    expect(park, isNotEmpty);
+    expect(kim.every((TrainerSlot s) => s.trainerId == 'trainer-kim'), isTrue);
+    expect(park.every((TrainerSlot s) => s.trainerId == 'trainer-park'), isTrue);
+    // 같은 헬스장 소속이어도 빈 시간이 겹치지 않는다.
+    expect(
+      kim.map((TrainerSlot s) => s.startsAt).toSet().intersection(
+        park.map((TrainerSlot s) => s.startsAt).toSet(),
+      ),
+      isEmpty,
+    );
+  });
+
+  test('슬롯은 시작 시각 오름차순이다', () async {
+    final List<TrainerSlot> slots = await MockGymRepository().fetchSlots(
+      'trainer-kim',
+    );
+
+    for (int i = 1; i < slots.length; i++) {
+      expect(
+        slots[i].startsAt.isBefore(slots[i - 1].startsAt),
+        isFalse,
+        reason: '슬롯이 시간순으로 정렬돼야 함',
+      );
+    }
+  });
+
+  test('슬롯이 없는 트레이너는 빈 목록이다', () async {
+    // 윤트레이너는 빈 상태 화면을 데모에서 보려고 일부러 비워 뒀다.
+    expect(await MockGymRepository().fetchSlots('trainer-yoon'), isEmpty);
+    expect(await MockGymRepository().fetchSlots('trainer-nope'), isEmpty);
+  });
+
+  test('예약하면 잔여 자리가 줄고 다시 조회해도 유지된다', () async {
+    final MockGymRepository repo = MockGymRepository();
+    final List<TrainerSlot> before = await repo.fetchSlots('trainer-kim');
+    final TrainerSlot open = before.firstWhere((TrainerSlot s) => !s.isFull);
+
+    await repo.reserve(open.id);
+
+    final List<TrainerSlot> after = await repo.fetchSlots('trainer-kim');
+    final TrainerSlot same = after.firstWhere((TrainerSlot s) => s.id == open.id);
+    expect(same.remaining, open.remaining - 1);
+    expect(same.capacity, open.capacity, reason: '정원은 그대로여야 함');
+  });
+
+  test('마감된 자리는 예약할 수 없다', () async {
+    final MockGymRepository repo = MockGymRepository();
+    final List<TrainerSlot> slots = await repo.fetchSlots('trainer-kim');
+    final TrainerSlot full = slots.firstWhere((TrainerSlot s) => s.isFull);
+
+    expect(full.remaining, 0);
+    await expectLater(repo.reserve(full.id), throwsStateError);
+  });
+
+  test('마지막 한 자리를 잡으면 그 슬롯이 마감된다', () async {
+    final MockGymRepository repo = MockGymRepository();
+    final List<TrainerSlot> slots = await repo.fetchSlots('trainer-park');
+    // 박트레이너는 1:1 이라 정원이 1이다.
+    final TrainerSlot single = slots.firstWhere(
+      (TrainerSlot s) => s.capacity == 1 && !s.isFull,
+    );
+
+    await repo.reserve(single.id);
+
+    final List<TrainerSlot> after = await repo.fetchSlots('trainer-park');
+    expect(after.firstWhere((TrainerSlot s) => s.id == single.id).isFull, isTrue);
+    // 같은 자리를 두 번 잡을 수 없다.
+    await expectLater(repo.reserve(single.id), throwsStateError);
+  });
+
+  test('없는 슬롯 예약은 실패한다', () async {
+    await expectLater(
+      MockGymRepository().reserve('slot-nope'),
+      throwsStateError,
+    );
+  });
+
+  test('한 저장소의 예약이 다른 트레이너 슬롯을 건드리지 않는다', () async {
+    final MockGymRepository repo = MockGymRepository();
+    final List<TrainerSlot> parkBefore = await repo.fetchSlots('trainer-park');
+    final TrainerSlot kimSlot = (await repo.fetchSlots(
+      'trainer-kim',
+    )).firstWhere((TrainerSlot s) => !s.isFull);
+
+    await repo.reserve(kimSlot.id);
+
+    final List<TrainerSlot> parkAfter = await repo.fetchSlots('trainer-park');
+    expect(
+      parkAfter.map((TrainerSlot s) => s.remaining),
+      parkBefore.map((TrainerSlot s) => s.remaining),
+    );
+  });
+}

--- a/frontend/flutter/test/features/exercise/trainer_slot_test.dart
+++ b/frontend/flutter/test/features/exercise/trainer_slot_test.dart
@@ -5,6 +5,10 @@ import 'package:oncare/features/exercise/domain/entities/trainer_slot.dart';
 
 /// 예약 슬롯은 트레이너에 귀속된다(#426). 예전에는 위젯 안에 슬롯 3개가
 /// 하드코딩되어 있어 누구를 예약하든 같은 시간이 떴다.
+///
+/// 시각 의존을 피하려고 "특정 슬롯이 있다"고 단정하지 않는다. 시드에 오늘
+/// 자리가 섞여 있어 실행 시각에 따라 목록에서 빠질 수 있으므로, 어느 시각에
+/// 돌려도 성립하는 성질만 검증한다.
 void main() {
   test('트레이너마다 다른 슬롯을 돌려준다', () async {
     final MockGymRepository repo = MockGymRepository();
@@ -23,6 +27,27 @@ void main() {
       ),
       isEmpty,
     );
+  });
+
+  test('지난 시간은 목록에 나오지 않는다', () async {
+    final DateTime now = DateTime.now();
+    final MockGymRepository repo = MockGymRepository();
+
+    for (final String id in <String>[
+      'trainer-kim',
+      'trainer-park',
+      'trainer-kang',
+    ]) {
+      final List<TrainerSlot> slots = await repo.fetchSlots(id);
+      expect(slots, isNotEmpty, reason: '$id 는 항상 미래 자리가 남아 있어야 함');
+      for (final TrainerSlot slot in slots) {
+        expect(
+          slot.startsAt.isAfter(now),
+          isTrue,
+          reason: '지난 시간이 예약 가능으로 노출되면 안 됨: ${slot.id}',
+        );
+      }
+    }
   });
 
   test('슬롯은 시작 시각 오름차순이다', () async {
@@ -53,7 +78,9 @@ void main() {
     await repo.reserve(open.id);
 
     final List<TrainerSlot> after = await repo.fetchSlots('trainer-kim');
-    final TrainerSlot same = after.firstWhere((TrainerSlot s) => s.id == open.id);
+    final TrainerSlot same = after.firstWhere(
+      (TrainerSlot s) => s.id == open.id,
+    );
     expect(same.remaining, open.remaining - 1);
     expect(same.capacity, open.capacity, reason: '정원은 그대로여야 함');
   });
@@ -78,7 +105,10 @@ void main() {
     await repo.reserve(single.id);
 
     final List<TrainerSlot> after = await repo.fetchSlots('trainer-park');
-    expect(after.firstWhere((TrainerSlot s) => s.id == single.id).isFull, isTrue);
+    expect(
+      after.firstWhere((TrainerSlot s) => s.id == single.id).isFull,
+      isTrue,
+    );
     // 같은 자리를 두 번 잡을 수 없다.
     await expectLater(repo.reserve(single.id), throwsStateError);
   });
@@ -88,6 +118,26 @@ void main() {
       MockGymRepository().reserve('slot-nope'),
       throwsStateError,
     );
+  });
+
+  test('목록에서 빠진 지난 자리는 오래된 화면에서도 예약되지 않는다', () async {
+    final MockGymRepository repo = MockGymRepository();
+    final DateTime now = DateTime.now();
+    // 오늘 06:00 자리는 아침에 돌리면 살아 있고 저녁이면 이미 빠져 있다.
+    // 빠져 있을 때만 "지난 자리 예약 거부"를 검증한다.
+    final List<TrainerSlot> live = await repo.fetchSlots('trainer-kang');
+    final bool todaySlotGone = !live.any(
+      (TrainerSlot s) => s.id == 'slot-kang-today',
+    );
+    if (!todaySlotGone) {
+      // 아직 오늘 자리가 유효한 시각이므로 이 성질은 검증 대상이 아니다.
+      expect(
+        live.every((TrainerSlot s) => s.startsAt.isAfter(now)),
+        isTrue,
+      );
+      return;
+    }
+    await expectLater(repo.reserve('slot-kang-today'), throwsStateError);
   });
 
   test('한 저장소의 예약이 다른 트레이너 슬롯을 건드리지 않는다', () async {

--- a/frontend/flutter/test/features/my_health/my_health_gym_section_test.dart
+++ b/frontend/flutter/test/features/my_health/my_health_gym_section_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:oncare/features/exercise/data/repositories/mock_gym_repository.dart';
 import 'package:oncare/features/exercise/domain/entities/gym.dart';
 import 'package:oncare/features/exercise/domain/entities/trainer.dart';
+import 'package:oncare/features/exercise/domain/entities/trainer_slot.dart';
 import 'package:oncare/features/exercise/domain/repositories/gym_repository.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
 import 'package:oncare/features/my_health/data/repositories/mock_my_health_repository.dart';
@@ -26,6 +27,13 @@ class _FailingGymRepository implements GymRepository {
 
   @override
   Future<List<Gym>> fetchNearby() async => const <Gym>[];
+
+  @override
+  Future<List<TrainerSlot>> fetchSlots(String trainerId) async =>
+      const <TrainerSlot>[];
+
+  @override
+  Future<void> reserve(String slotId) async {}
 
   @override
   Future<Trainer?> fetchMyTrainer() async => null;


### PR DESCRIPTION
## Summary

* 예약 패널의 하드코딩 슬롯 3개를 걷어내고, 슬롯을 트레이너에 귀속시킴
* 마감된 자리는 숨기지 않고 비활성으로 표시 — 그 트레이너의 하루가 "비었다"가 아니라 "찼다"로 읽히도록
* 예약 확정 시 잔여 자리가 실제로 줄고, 화면을 나갔다 와도 유지됨
* 슬롯 시각을 실제 `DateTime` 에서 로케일에 맞게 포맷 — 날이 바뀌어도 문구가 어긋나지 않음

---

## Changes

### ✨ Features

* `TrainerSlot` 엔티티 추가 — `id` · `trainerId` · `startsAt` · `capacity` · `remaining`
* `GymRepository.fetchSlots(trainerId)` · `reserve(slotId)` 추가
* `trainerSlotsProvider` (family) 추가
* 목 저장소에 트레이너별 슬롯 시드 — 김(저녁) · 박(낮 재활) · 최(소그룹) · 강(새벽·심야) · 이
* `DioGymRepository` 에도 `/trainers/{id}/slots` · `/reservations` 로 구현

### 🔧 Improvements

* `_ReservationPanel` 이 `ConsumerWidget` 으로 바뀌어 슬롯을 직접 조회. 이름 문자열 대신 `Trainer` 객체를 받음
* `_SlotChip` 의 `onTap` 을 nullable 로 바꿔 마감 자리를 비활성 처리

### 🎨 UI/UX

* 빈 상태 3종 — 슬롯 없음 / 전부 마감 / 조회 실패(재시도 버튼 포함)
* 예약 실패 시 SnackBar 안내 후 목록 재조회

### 🐛 Fixes

* 같은 헬스장 트레이너들이 모두 같은 빈 시간을 보여주던 문제
* `잔여 1자리` · `여유 있음` 이 실제 재고와 무관한 고정 문자열이던 문제
* 예약 확정이 SnackBar 만 띄우고 저장되지 않던 문제

### 📝 Docs

*

---

## Commits

1. `d2a95b7` feat(exercise): bind reservation slots to each trainer

---

## Notes

* 하드코딩 ARB 키 6개(`exSlotToday19` · `exSlotTomorrow0730` · `exSlotTomorrow20` · `exSlot1Left` · `exSlot2Left` · `exSlotAvailable`)를 제거하고 데이터 기반 키 7개로 교체 후 `flutter gen-l10n` 재생성했습니다.
* 윤트레이너는 슬롯을 **일부러 비워** 뒀습니다. 빈 상태 화면을 데모에서도 확인할 수 있어야 해서입니다.
* #463 의 상담 CTA · 채팅 CTA 우선순위 구조는 건드리지 않았습니다. 예약 패널은 그 위에 그대로 있습니다.
* **결정 대기 항목**: 이슈에 적힌 "예약 확정 후 어디에 표시할지"는 정해지지 않아 운동 탭 안에서만 처리했습니다. 홈 "오늘의 일정" · 스케줄 캘린더 연동은 작업 범위에 없어 임의로 넓히지 않았습니다. 방향이 정해지면 별도 커밋으로 붙이겠습니다.
* 실 예약 API 연동, 예약 취소·변경, 알림은 범위 밖입니다.

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [ ] UI 확인
* [ ] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 데모 진입 → 운동 탭 → 헬스장 하위탭
2. 내 헬스장 카드의 예약 패널에 김트레이너의 실제 날짜·시간이 뜨는지 확인
3. 마감된 자리(잔여 0)가 흐리게 표시되고 눌리지 않는지 확인
4. 자리를 골라 예약 확정 → 잔여 수가 1 줄어드는지 확인
5. 다른 탭 갔다 돌아와도 줄어든 잔여 수가 유지되는지 확인
6. MY 탭에서 트레이너를 박트레이너로 바꾸면 다른 시간대가 뜨는지 확인

---

## Related Issues

Closes #426

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 트레이너별 예약 가능 시간대를 조회하고 예약할 수 있습니다.
  - 각 슬롯의 날짜, 시간, 잔여 좌석 및 마감 상태를 확인할 수 있습니다.
  - 마지막 좌석 예약 시 자동으로 마감 처리됩니다.

- **개선 사항**
  - 슬롯 로딩 중, 조회 실패, 빈 슬롯, 전체 예약 완료 상태를 안내합니다.
  - 마감된 시간대는 선택할 수 없으며, 예약 성공 및 실패 메시지를 제공합니다.
  - 예약 가능한 시간대가 시작 시간순으로 표시됩니다.

- **테스트**
  - 슬롯 조회, 정렬, 예약, 잔여 좌석 감소 및 예외 상황을 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->