### PR TITLE
feat(consultation): 상담 승인·거절과 회원↔트레이너 연결 성립

### DIFF
--- a/backend/app/api/v1/trainer.py
+++ b/backend/app/api/v1/trainer.py
@@ -23,6 +23,11 @@ from app.api.deps import RequireTrainer
 from app.core.security import hash_password, verify_password
 from app.db.session import get_db
 from app.models.models import TrainerClient, TrainerProfile
+from app.schemas.consultation_api import (
+    ConsultationDecision,
+    ConsultationStatusFilter,
+    TrainerConsultationOut,
+)
 from app.schemas.trainer_api import (
     ChatMessageOut, ChatSendRequest, ClientCoachOut, ClientCoachRequest, ClientDietEntryOut,
     ReportSendRequest, RoutineAssignRequest, RoutineOut, RoutineHistoryOut,
@@ -32,7 +37,11 @@ from app.schemas.trainer_api import (
     TrainerNotificationSettings, TrainerNotificationSettingsUpdate,
     TrainerPasswordChange, WeeklyReportOut,
 )
-from app.services import trainer_routine_options_service, trainer_service
+from app.services import (
+    consultation_service,
+    trainer_routine_options_service,
+    trainer_service,
+)
 from app.services.coach.chat import answer as coach_answer
 
 router = APIRouter(tags=["trainer"])
@@ -72,6 +81,28 @@ def _require_client(db: Session, trainer_id: str, member_id: str) -> TrainerClie
     if link is None:
         raise HTTPException(status_code=404, detail="담당 고객을 찾을 수 없습니다.")
     return link
+
+
+def _decide(
+    action,
+    db: Session,
+    trainer_id: str,
+    consultation_id: str,
+    payload: ConsultationDecision,
+) -> TrainerConsultationOut:
+    """승인·거절 공통 예외 매핑. 두 라우트가 같은 실패 모드를 갖는다. (#467)
+
+    남의 헬스장 요청을 404 로 돌리는 것은 의도다 — 403 은 그 id 의 요청이 존재한다는
+    사실을 알려 주어 id 를 훑는 것만으로 남의 상담 건수를 셀 수 있다.
+    """
+    try:
+        return action(db, trainer_id, consultation_id, payload.note)
+    except consultation_service.ConsultationNotFound as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except consultation_service.ConsultationAlreadyDecided as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except consultation_service.MemberAlreadyCoached as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 
 @router.get("/trainer/me", response_model=TrainerMe)
@@ -544,3 +575,59 @@ def trainer_send_report(
         )
         text = report.message
     return trainer_service.send_message(db, trainer.id, member_id, "trainer", text)
+
+
+# ---------------------------------------------------------------------------
+# 상담 인박스 — 회원↔트레이너 관계가 성립하는 지점. (#467)
+#
+# 회원이 보낸 상담 요청(POST /consultations)은 지금까지 pending 으로 저장된 뒤
+# 아무도 볼 수 없었다. 승인이 곧 담당 링크(trainer_clients) 생성이고, 그 링크 위에서
+# 고객 목록·루틴·리포트·채팅이 동작한다.
+# ---------------------------------------------------------------------------
+
+
+@router.get("/trainer/consultations", response_model=list[TrainerConsultationOut])
+def trainer_consultations(
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+    status: Annotated[ConsultationStatusFilter, Query()] = "pending",
+) -> list[TrainerConsultationOut]:
+    """나를 지정한 요청 + 내 소속 헬스장으로 온 요청. 기본은 미처리만."""
+    return consultation_service.list_for_trainer(db, trainer.id, status)
+
+
+@router.get("/trainer/consultations/pending-count", response_model=dict[str, int])
+def trainer_consultations_pending_count(
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> dict[str, int]:
+    """인박스 배지용 미처리 건수."""
+    return {"count": consultation_service.pending_count_for_trainer(db, trainer.id)}
+
+
+@router.post(
+    "/trainer/consultations/{consultation_id}/accept",
+    response_model=TrainerConsultationOut,
+)
+def trainer_accept_consultation(
+    consultation_id: str,
+    payload: ConsultationDecision,
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> TrainerConsultationOut:
+    """상담을 승인하고 회원을 담당 고객으로 편입한다."""
+    return _decide(consultation_service.accept, db, trainer.id, consultation_id, payload)
+
+
+@router.post(
+    "/trainer/consultations/{consultation_id}/reject",
+    response_model=TrainerConsultationOut,
+)
+def trainer_reject_consultation(
+    consultation_id: str,
+    payload: ConsultationDecision,
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> TrainerConsultationOut:
+    """상담을 거절한다. 사유는 회원 알림 본문에 그대로 실린다."""
+    return _decide(consultation_service.reject, db, trainer.id, consultation_id, payload)

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -329,6 +329,17 @@ class ConsultationRequest(Base):
     status: Mapped[str] = mapped_column(
         String(20), default="pending", server_default="pending"
     )
+    #: 처리한 트레이너. 헬스장으로 온 요청(target_type='gym')은 소속 트레이너 누구나
+    #: 받을 수 있어 요청 대상(trainer_id)과 다른 값이므로 별도 컬럼이다. (#467)
+    decided_by: Mapped[str | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    #: 승인·거절 시각. updated_at 은 어떤 수정으로도 갱신되어 근거가 못 된다.
+    decided_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    #: 거절 사유. 승인 시에는 비어 있다.
+    decision_note: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )
@@ -356,6 +367,11 @@ class ConsultationRequest(Base):
             "member_id",
             "created_at",
         ),
+        # 트레이너 인박스의 두 경로 — 내 앞으로 온 것 / 내 헬스장으로 온 것. (#467)
+        Index(
+            "ix_consultation_requests_trainer_status", "trainer_id", "status"
+        ),
+        Index("ix_consultation_requests_gym_status", "gym_id", "status"),
     )
 
 

--- a/backend/app/schemas/consultation_api.py
+++ b/backend/app/schemas/consultation_api.py
@@ -60,6 +60,24 @@ class ConsultationCreate(BaseModel):
         return self
 
 
+#: 트레이너 인박스가 걸 수 있는 상태 필터. `all` 은 처리 이력까지 함께 본다.
+ConsultationStatusFilter = Literal["pending", "accepted", "rejected", "all"]
+
+
+class ConsultationDecision(BaseModel):
+    """승인·거절 본문. 거절 사유는 회원 알림 본문에 그대로 실린다."""
+
+    note: str | None = Field(default=None, max_length=500)
+
+    @field_validator("note", mode="before")
+    @classmethod
+    def _normalize_note(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            value = value.strip()
+            return value or None
+        return value
+
+
 class ConsultationOut(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
@@ -81,3 +99,22 @@ class ConsultationOut(BaseModel):
     status: str
     created_at: datetime
     updated_at: datetime
+
+
+class TrainerConsultationOut(ConsultationOut):
+    """트레이너 인박스 카드. 회원용 [ConsultationOut] 에 처리 정보를 더한다.
+
+    회원 응답과 스키마를 나누는 이유: 회원에게는 **누가 처리했는지**가 필요 없고,
+    트레이너에게는 요청자 이름이 반드시 필요하다(회원 id 만으로는 카드를 못 그린다).
+    한 스키마에 다 담으면 회원 응답에도 처리자 id 가 실린다.
+    """
+
+    #: 요청한 회원 이름. 대상 이름과 같은 이유로 id 대신 함께 내려준다.
+    member_name: str | None = None
+    #: 이 요청이 내 앞으로 온 것(False)인지, 내 소속 헬스장으로 온 것(True)인지.
+    #: 카드가 "헬스장 문의" 배지를 다는 근거이며, 트레이너 지정 요청과 섞이면
+    #: 누구를 향한 요청인지 화면에서 구분할 수 없다.
+    via_gym: bool = False
+    decided_by: str | None = None
+    decided_at: datetime | None = None
+    decision_note: str | None = None

--- a/backend/app/services/consultation_service.py
+++ b/backend/app/services/consultation_service.py
@@ -310,17 +310,39 @@ def pending_count_for_trainer(db: Session, trainer_id: str) -> int:
 
 
 def _require_inbox_row(
-    db: Session, trainer_id: str, consultation_id: str
+    db: Session, trainer_id: str, consultation_id: str, *, lock: bool = False
 ) -> ConsultationRequest:
-    row = db.scalar(
-        select(ConsultationRequest).where(
-            ConsultationRequest.id == consultation_id,
-            _inbox_scope(trainer_id, trainer_gym_id(db, trainer_id)),
-        )
+    """인박스 범위 안의 상담 행. 없거나 남의 것이면 [ConsultationNotFound].
+
+    [lock] 은 결정 경로 전용이다. 헬스장으로 온 요청은 같은 헬스장 트레이너 누구나
+    받을 수 있어 두 사람이 같은 순간에 승인할 수 있고, 잠금이 없으면 둘 다 `pending`
+    검사를 통과한 뒤 링크 삽입에서 제약에 걸린다(리뷰). 행을 잠가 직렬화한다.
+    """
+    query = select(ConsultationRequest).where(
+        ConsultationRequest.id == consultation_id,
+        _inbox_scope(trainer_id, trainer_gym_id(db, trainer_id)),
     )
+    if lock:
+        query = query.with_for_update()
+    row = db.scalar(query)
     if row is None:
         raise ConsultationNotFound("상담 요청을 찾을 수 없습니다.")
     return row
+
+
+def _commit_decision(db: Session) -> None:
+    """결정을 커밋한다. 경합으로 제약에 걸리면 '이미 처리됨'으로 수렴시킨다.
+
+    행 잠금이 같은 상담의 동시 처리는 막지만, 회원이 **다른 상담 경로로** 동시에
+    담당이 되는 경우까지는 막지 못한다 — 그때는 `uq_trainer_client_active_member`
+    가 잡는다. IntegrityError 를 그대로 두면 앱에는 500 으로 보이고, 앱은 409 본문의
+    문구를 보여 주도록 만들어져 있어 이유가 사라진다.
+    """
+    try:
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        raise ConsultationAlreadyDecided("이미 처리된 상담 요청입니다.") from exc
 
 
 def _notify(db: Session, *, user_id: str, title: str, body: str) -> None:
@@ -368,7 +390,7 @@ def accept(
     상태 전이·링크 생성·헬스장 연결·알림을 **한 트랜잭션**으로 커밋한다. 나눠 커밋하면
     승인 표시만 남고 담당은 안 생긴 반쪽 상태가 생긴다.
     """
-    row = _require_inbox_row(db, trainer_id, consultation_id)
+    row = _require_inbox_row(db, trainer_id, consultation_id, lock=True)
     if row.status != "pending":
         raise ConsultationAlreadyDecided("이미 처리된 상담 요청입니다.")
 
@@ -408,7 +430,10 @@ def accept(
                     sort_order=(last_order or 0) + 1,
                 )
             )
-        _link_member_gym(db, row.member_id, trainer_gym_id(db, trainer_id))
+    # 링크 생성 여부와는 별개 조건이다 — 이미 이 트레이너의 담당인 회원이 헬스장
+    # 상담을 새로 넣고 승인받는 경우에도 헬스장 연결은 이뤄져야 한다(리뷰).
+    # 이미 연결된 회원에게는 no-op 이라 중복 호출이 무해하다.
+    _link_member_gym(db, row.member_id, trainer_gym_id(db, trainer_id))
 
     row.status = "accepted"
     row.decided_by = trainer_id
@@ -426,7 +451,7 @@ def accept(
             else f"{trainer_name or '트레이너'} 트레이너가 담당으로 연결되었어요. {note}"
         ),
     )
-    db.commit()
+    _commit_decision(db)
     db.refresh(row)
     return _to_trainer_out(db, [row])[0]
 
@@ -450,6 +475,6 @@ def reject(
         title="상담 요청이 반려되었어요",
         body=note or "다른 트레이너에게 상담을 요청해 보세요.",
     )
-    db.commit()
+    _commit_decision(db)
     db.refresh(row)
     return _to_trainer_out(db, [row])[0]

--- a/backend/app/services/consultation_service.py
+++ b/backend/app/services/consultation_service.py
@@ -1,14 +1,27 @@
 from __future__ import annotations
 
 import uuid
-from datetime import date
+from datetime import date, datetime, timezone
 
-from sqlalchemy import select
+from sqlalchemy import func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from app.models.models import ConsultationRequest, Place, TrainerProfile, User
-from app.schemas.consultation_api import ConsultationCreate, ConsultationOut
+from app.models.models import (
+    ConsultationRequest,
+    MemberGym,
+    Notification,
+    Place,
+    TrainerClient,
+    TrainerProfile,
+    User,
+)
+from app.schemas.consultation_api import (
+    ConsultationCreate,
+    ConsultationOut,
+    ConsultationStatusFilter,
+    TrainerConsultationOut,
+)
 
 
 class InvalidConsultationRequest(Exception):
@@ -21,6 +34,27 @@ class ConsultationTargetNotFound(Exception):
 
 class DuplicatePendingConsultation(Exception):
     pass
+
+
+class ConsultationNotFound(Exception):
+    """내 앞으로 온 요청이 아니거나 존재하지 않음 — 라우터가 404 로 옮긴다.
+
+    남의 헬스장 요청을 403 이 아니라 404 로 돌리는 이유: 403 은 "그 id 의 요청이
+    존재한다"를 알려 주어, id 를 훑는 것만으로 다른 헬스장의 상담 건수를 셀 수 있다.
+    """
+
+
+class ConsultationAlreadyDecided(Exception):
+    """이미 승인·거절된 요청을 다시 처리하려 함 — 409."""
+
+
+class MemberAlreadyCoached(Exception):
+    """회원에게 이미 다른 트레이너의 활성 담당이 있음 — 409.
+
+    `uq_trainer_client_active_member` partial unique index 가 DB 차원에서 막지만,
+    그때는 IntegrityError 라 트레이너에게 보여 줄 말이 없다. 먼저 확인해서 이유를
+    돌려준다.
+    """
 
 
 def _pending_query(member_id: str, payload: ConsultationCreate):
@@ -161,3 +195,261 @@ def get_my_consultation(
     if row is None:
         return None
     return attach_target_names(db, [row])[0]
+
+
+# ---------------------------------------------------------------------------
+# 트레이너 측 — 인박스 조회와 승인·거절. (#467)
+#
+# 여기가 회원↔트레이너 관계가 성립하는 유일한 지점이다. 이전에는 `TrainerClient`
+# 링크를 만드는 코드가 시드 스크립트뿐이어서, 실서비스에서 신규 회원이 트레이너를
+# 가질 방법이 없었다.
+# ---------------------------------------------------------------------------
+
+#: 요청의 운동 목표 → 담당 링크의 초기 코칭 목표 문구. 트레이너가 나중에 고쳐 쓰는
+#: 출발점이며, 비워 두면 로스터 카드의 목표 줄이 빈칸으로 뜬다.
+_GOAL_LABELS: dict[str, str] = {
+    "weight_loss": "체중 감량",
+    "strength": "근력 향상",
+    "fitness": "체력 증진",
+    "posture": "자세 교정",
+    "health": "건강 관리",
+    "other": "상담 후 설정",
+}
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def trainer_gym_id(db: Session, trainer_id: str) -> str | None:
+    """트레이너의 소속 헬스장 id. 소속이 없으면 None."""
+    return db.scalar(
+        select(TrainerProfile.gym_id).where(
+            TrainerProfile.trainer_id == trainer_id
+        )
+    )
+
+
+def _inbox_scope(trainer_id: str, gym_id: str | None):
+    """트레이너가 볼 수 있는 요청의 범위.
+
+    두 갈래다 — 나를 지정한 요청(`target_type='trainer'`)과 내 소속 헬스장으로 온
+    요청(`target_type='gym'`). 소속이 없는 트레이너는 헬스장 갈래가 통째로 빠진다
+    (gym_id 가 None 인 조건을 걸면 대상 헬스장이 지워진 남의 요청까지 걸린다).
+    """
+    mine = (ConsultationRequest.target_type == "trainer") & (
+        ConsultationRequest.trainer_id == trainer_id
+    )
+    if gym_id is None:
+        return mine
+    via_gym = (ConsultationRequest.target_type == "gym") & (
+        ConsultationRequest.gym_id == gym_id
+    )
+    return or_(mine, via_gym)
+
+
+def _to_trainer_out(
+    db: Session, rows: list[ConsultationRequest]
+) -> list[TrainerConsultationOut]:
+    """대상 이름 + 요청한 회원 이름을 붙여 인박스 카드 형태로 만든다.
+
+    이름은 대상별로 한 번씩 모아 읽는다([attach_target_names] 와 같은 이유) — 카드마다
+    회원을 다시 조회하면 목록 길이만큼 쿼리가 늘어난다.
+    """
+    if not rows:
+        return []
+    base = {item.id: item for item in attach_target_names(db, rows)}
+    member_ids = {r.member_id for r in rows}
+    member_names = {
+        u.id: u.name
+        for u in db.scalars(select(User).where(User.id.in_(member_ids))).all()
+    }
+    out: list[TrainerConsultationOut] = []
+    for row in rows:
+        item = TrainerConsultationOut(
+            **base[row.id].model_dump(),
+            member_name=member_names.get(row.member_id),
+            via_gym=row.target_type == "gym",
+            decided_by=row.decided_by,
+            decided_at=row.decided_at,
+            decision_note=row.decision_note,
+        )
+        out.append(item)
+    return out
+
+
+def list_for_trainer(
+    db: Session, trainer_id: str, status: ConsultationStatusFilter = "pending"
+) -> list[TrainerConsultationOut]:
+    """트레이너 인박스. 기본은 미처리(`pending`)만, 최신 요청이 위로 온다."""
+    query = select(ConsultationRequest).where(
+        _inbox_scope(trainer_id, trainer_gym_id(db, trainer_id))
+    )
+    if status != "all":
+        query = query.where(ConsultationRequest.status == status)
+    rows = list(
+        db.scalars(
+            query.order_by(
+                ConsultationRequest.created_at.desc(),
+                ConsultationRequest.id.desc(),
+            )
+        ).all()
+    )
+    return _to_trainer_out(db, rows)
+
+
+def pending_count_for_trainer(db: Session, trainer_id: str) -> int:
+    """미처리 요청 수 — 인박스 배지용. 목록 전체를 만들지 않는다."""
+    rows = db.scalars(
+        select(ConsultationRequest.id).where(
+            _inbox_scope(trainer_id, trainer_gym_id(db, trainer_id)),
+            ConsultationRequest.status == "pending",
+        )
+    ).all()
+    return len(rows)
+
+
+def _require_inbox_row(
+    db: Session, trainer_id: str, consultation_id: str
+) -> ConsultationRequest:
+    row = db.scalar(
+        select(ConsultationRequest).where(
+            ConsultationRequest.id == consultation_id,
+            _inbox_scope(trainer_id, trainer_gym_id(db, trainer_id)),
+        )
+    )
+    if row is None:
+        raise ConsultationNotFound("상담 요청을 찾을 수 없습니다.")
+    return row
+
+
+def _notify(db: Session, *, user_id: str, title: str, body: str) -> None:
+    """회원에게 처리 결과 알림을 남긴다(커밋은 호출자가 한다).
+
+    승인·거절은 회원이 앱을 열어 보기 전에는 알 수 없는 변화라 알림이 결과 전달의
+    유일한 경로다. 푸시 발송은 이번 범위 밖이며 여기서는 행만 남긴다.
+    """
+    db.add(
+        Notification(
+            id=f"noti-{uuid.uuid4().hex[:12]}",
+            user_id=user_id,
+            title=title,
+            body=body,
+            category="system",
+            read=False,
+        )
+    )
+
+
+def _link_member_gym(db: Session, member_id: str, gym_id: str | None) -> None:
+    """담당이 생긴 회원을 트레이너의 헬스장에 연결한다(커밋 없음).
+
+    이미 다른 헬스장에 연결돼 있으면 **건드리지 않는다** — 회원이 직접 고른 '내
+    헬스장'을 승인이 말없이 옮기면 MY 탭이 이유 없이 바뀐다.
+    """
+    if gym_id is None:
+        return
+    if db.get(MemberGym, member_id) is not None:
+        return
+    if db.scalar(select(Place.id).where(Place.id == gym_id)) is None:
+        return
+    db.add(MemberGym(member_id=member_id, gym_id=gym_id))
+
+
+def accept(
+    db: Session, trainer_id: str, consultation_id: str, note: str | None = None
+) -> TrainerConsultationOut:
+    """상담을 승인하고 담당 링크를 만든다.
+
+    `pending` 에서만 진행한다. 회원에게 이미 다른 트레이너의 활성 담당이 있으면
+    [MemberAlreadyCoached] — 회원당 활성 담당은 1명이라는 불변식
+    (`uq_trainer_client_active_member`)을 IntegrityError 로 만나기 전에 막는다.
+
+    상태 전이·링크 생성·헬스장 연결·알림을 **한 트랜잭션**으로 커밋한다. 나눠 커밋하면
+    승인 표시만 남고 담당은 안 생긴 반쪽 상태가 생긴다.
+    """
+    row = _require_inbox_row(db, trainer_id, consultation_id)
+    if row.status != "pending":
+        raise ConsultationAlreadyDecided("이미 처리된 상담 요청입니다.")
+
+    existing = db.scalar(
+        select(TrainerClient).where(
+            TrainerClient.member_id == row.member_id,
+            TrainerClient.active.is_(True),
+        )
+    )
+    if existing is not None and existing.trainer_id != trainer_id:
+        raise MemberAlreadyCoached("이미 다른 트레이너가 담당 중인 회원입니다.")
+
+    if existing is None:
+        # 과거에 담당했다가 휴면으로 내려간 링크가 있으면 되살린다 — 새 행을 넣으면
+        # (trainer, member) 유일 제약에 걸리고, 지난 루틴·채팅 이력도 갈라진다.
+        dormant = db.scalar(
+            select(TrainerClient).where(
+                TrainerClient.trainer_id == trainer_id,
+                TrainerClient.member_id == row.member_id,
+            )
+        )
+        if dormant is not None:
+            dormant.active = True
+        else:
+            last_order = db.scalar(
+                select(func.max(TrainerClient.sort_order)).where(
+                    TrainerClient.trainer_id == trainer_id
+                )
+            )
+            db.add(
+                TrainerClient(
+                    id=f"tc-{uuid.uuid4().hex[:12]}",
+                    trainer_id=trainer_id,
+                    member_id=row.member_id,
+                    goal=_GOAL_LABELS.get(row.exercise_goal, ""),
+                    active=True,
+                    sort_order=(last_order or 0) + 1,
+                )
+            )
+        _link_member_gym(db, row.member_id, trainer_gym_id(db, trainer_id))
+
+    row.status = "accepted"
+    row.decided_by = trainer_id
+    row.decided_at = _now()
+    row.decision_note = note
+
+    trainer_name = db.scalar(select(User.name).where(User.id == trainer_id))
+    _notify(
+        db,
+        user_id=row.member_id,
+        title="상담 요청이 승인되었어요",
+        body=(
+            f"{trainer_name or '트레이너'} 트레이너가 담당으로 연결되었어요."
+            if note is None
+            else f"{trainer_name or '트레이너'} 트레이너가 담당으로 연결되었어요. {note}"
+        ),
+    )
+    db.commit()
+    db.refresh(row)
+    return _to_trainer_out(db, [row])[0]
+
+
+def reject(
+    db: Session, trainer_id: str, consultation_id: str, note: str | None = None
+) -> TrainerConsultationOut:
+    """상담을 거절한다. 담당 링크는 만들지 않고 사유만 남긴다."""
+    row = _require_inbox_row(db, trainer_id, consultation_id)
+    if row.status != "pending":
+        raise ConsultationAlreadyDecided("이미 처리된 상담 요청입니다.")
+
+    row.status = "rejected"
+    row.decided_by = trainer_id
+    row.decided_at = _now()
+    row.decision_note = note
+
+    _notify(
+        db,
+        user_id=row.member_id,
+        title="상담 요청이 반려되었어요",
+        body=note or "다른 트레이너에게 상담을 요청해 보세요.",
+    )
+    db.commit()
+    db.refresh(row)
+    return _to_trainer_out(db, [row])[0]

--- a/backend/migrations/versions/0023_consultation_decision.py
+++ b/backend/migrations/versions/0023_consultation_decision.py
@@ -1,0 +1,89 @@
+"""상담 요청 승인·거절 처리 기록
+
+상담 요청은 `pending` 으로 저장된 뒤 상태가 바뀔 길이 없었다 — 트레이너가 요청을
+조회할 엔드포인트도, 승인해서 담당 링크(trainer_clients)를 만들 경로도 없었기
+때문이다. 그래서 실서비스에서 신규 회원이 트레이너를 가질 수 없었다. (#467)
+
+여기서는 **처리 흔적을 남길 컬럼만** 더한다. 상태값 자체(`pending`/`accepted`/
+`rejected`)는 기존 `status` 문자열을 그대로 쓴다 — CHECK 제약을 새로 걸면 기존
+행과 시드까지 검증 대상이 되어 마이그레이션이 데이터에 의존하게 된다.
+
+- `decided_by`  처리한 트레이너. 헬스장으로 온 요청은 소속 트레이너 중 누가
+                받았는지가 남아야 하므로 `trainer_id`(요청 대상)와 별개 컬럼이다.
+- `decided_at`  처리 시각. `updated_at` 은 어떤 수정으로도 갱신되므로 승인 시점의
+                근거로 쓸 수 없다.
+- `decision_note` 거절 사유. 승인 시에는 비어 있다.
+
+셋 다 nullable 이고 백필하지 않는다. 기존 `pending` 행은 그대로 미처리 상태이며,
+응답 스키마도 기존 필드를 바꾸지 않으므로 이미 배포된 앱 화면은 영향받지 않는다.
+
+Revision ID: 0023_consultation_decision
+Revises: 0022_ai_conversations
+Create Date: 2026-08-08
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0023_consultation_decision"
+down_revision: str | Sequence[str] | None = "0022_ai_conversations"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "consultation_requests",
+        sa.Column("decided_by", sa.String(length=64), nullable=True),
+    )
+    op.add_column(
+        "consultation_requests",
+        sa.Column("decided_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "consultation_requests",
+        sa.Column("decision_note", sa.Text(), nullable=True),
+    )
+    # 트레이너 계정이 지워져도 요청 이력은 남아야 한다 — 처리자만 비운다.
+    op.create_foreign_key(
+        "fk_consultation_requests_decided_by",
+        "consultation_requests",
+        "users",
+        ["decided_by"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    # 트레이너 인박스는 "내 앞으로 온 것"(trainer_id) 과 "내 헬스장으로 온 것"(gym_id)을
+    # 각각 status 로 좁혀 읽는다. 두 경로 모두 인덱스 없이는 전건 스캔이 된다.
+    op.create_index(
+        "ix_consultation_requests_trainer_status",
+        "consultation_requests",
+        ["trainer_id", "status"],
+    )
+    op.create_index(
+        "ix_consultation_requests_gym_status",
+        "consultation_requests",
+        ["gym_id", "status"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_consultation_requests_gym_status",
+        table_name="consultation_requests",
+    )
+    op.drop_index(
+        "ix_consultation_requests_trainer_status",
+        table_name="consultation_requests",
+    )
+    op.drop_constraint(
+        "fk_consultation_requests_decided_by",
+        "consultation_requests",
+        type_="foreignkey",
+    )
+    op.drop_column("consultation_requests", "decision_note")
+    op.drop_column("consultation_requests", "decided_at")
+    op.drop_column("consultation_requests", "decided_by")

--- a/backend/tests/test_consultation_decision.py
+++ b/backend/tests/test_consultation_decision.py
@@ -14,6 +14,8 @@ from uuid import uuid4
 
 import pytest
 
+from sqlalchemy.exc import IntegrityError
+
 from app.core.security import hash_password
 from app.models.models import (
     ConsultationRequest,
@@ -24,6 +26,7 @@ from app.models.models import (
     TrainerProfile,
     User,
 )
+from app.services import consultation_service
 
 EMAIL_PREFIX = "decide-test-"
 PLACE_PREFIX = "decide-place-"
@@ -295,7 +298,7 @@ def test_accept_links_member_into_roster(client, db_session):
 
 def test_accept_notifies_the_member(client, db_session):
     trainer, trainer_token = _trainer(client, db_session)
-    member_id, member_token = _member(client)
+    _, member_token = _member(client)
     consultation_id = _request_consultation(
         client, member_token, trainer_id=trainer.id
     )
@@ -376,6 +379,103 @@ def test_accept_rejects_member_already_coached(client, db_session):
 
     assert accepted.status_code == 200, accepted.text
     assert blocked.status_code == 409, blocked.text
+
+
+def test_commit_decision_maps_a_constraint_race_to_already_decided():
+    """경합으로 제약에 걸린 커밋은 500 이 아니라 '이미 처리됨'(409)이 된다.
+
+    아래의 두 트레이너 테스트는 TestClient 가 동기라 **진짜 경합을 재현하지 못한다**
+    — 늦은 요청은 잠금이 없어도 `status != pending` 에서 걸린다. 실제 경합에서만
+    도달하는 것은 커밋의 IntegrityError 경로이므로, 그 매핑을 여기서 직접 덮는다.
+    """
+
+    class _RacingSession:
+        """커밋이 제약 위반으로 실패하는 세션. 롤백 여부까지 확인한다."""
+
+        def __init__(self) -> None:
+            self.rolled_back = False
+
+        def commit(self) -> None:
+            raise IntegrityError("INSERT", {}, Exception("unique violation"))
+
+        def rollback(self) -> None:
+            self.rolled_back = True
+
+    session = _RacingSession()
+
+    with pytest.raises(consultation_service.ConsultationAlreadyDecided):
+        consultation_service._commit_decision(session)
+
+    # 롤백하지 않으면 세션이 실패한 트랜잭션에 갇혀 이후 쿼리가 전부 죽는다.
+    assert session.rolled_back is True
+
+
+def test_two_gym_trainers_both_see_the_request_and_only_one_wins(
+    client, db_session
+):
+    """헬스장 문의는 소속 트레이너 누구나 받는다 — 늦은 쪽은 409 여야 한다.
+
+    순차 호출이라 경합 자체는 재현하지 못하고(위 단위 테스트가 그 경로를 덮는다),
+    여기서는 인박스 공유 범위와 '한 명만 승인된다'는 결과 계약을 확인한다.
+    """
+    gym = _gym(db_session)
+    first_trainer, first_token = _trainer(client, db_session, gym=gym)
+    second_trainer, second_token = _trainer(client, db_session, gym=gym)
+    _, member_token = _member(client)
+    consultation_id = _request_consultation(client, member_token, gym_id=gym.id)
+
+    # 같은 요청이 두 트레이너의 인박스에 모두 보인다.
+    assert first_trainer.id != second_trainer.id
+    for token in (first_token, second_token):
+        inbox = client.get("/v1/trainer/consultations", headers=_auth(token))
+        assert consultation_id in {item["id"] for item in inbox.json()}
+
+    won = client.post(
+        f"/v1/trainer/consultations/{consultation_id}/accept",
+        headers=_auth(first_token),
+        json={},
+    )
+    lost = client.post(
+        f"/v1/trainer/consultations/{consultation_id}/accept",
+        headers=_auth(second_token),
+        json={},
+    )
+
+    assert won.status_code == 200, won.text
+    assert lost.status_code == 409, lost.text
+
+
+def test_accept_links_the_gym_for_an_existing_client(client, db_session):
+    """이미 담당 중인 회원이 헬스장 상담을 넣어도 헬스장 연결은 이뤄진다.
+
+    링크 생성과 헬스장 연결은 별개 조건이다 — 헬스장 연결을 '새 링크를 만든 경우'
+    안에 두면 기존 고객은 영영 연결되지 않는다(리뷰).
+    """
+    gym = _gym(db_session)
+    trainer, trainer_token = _trainer(client, db_session, gym=gym)
+    member_id, member_token = _member(client)
+
+    first = _request_consultation(client, member_token, trainer_id=trainer.id)
+    client.post(
+        f"/v1/trainer/consultations/{first}/accept",
+        headers=_auth(trainer_token),
+        json={},
+    )
+    # 담당은 이미 이 트레이너다. 헬스장 링크만 지운 뒤 헬스장 상담을 새로 넣는다.
+    db_session.query(MemberGym).filter(
+        MemberGym.member_id == member_id
+    ).delete(synchronize_session=False)
+    db_session.commit()
+
+    second = _request_consultation(client, member_token, gym_id=gym.id)
+    accepted = client.post(
+        f"/v1/trainer/consultations/{second}/accept",
+        headers=_auth(trainer_token),
+        json={},
+    )
+
+    assert accepted.status_code == 200, accepted.text
+    assert db_session.get(MemberGym, member_id).gym_id == gym.id
 
 
 def test_accept_foreign_request_is_not_found(client, db_session):

--- a/backend/tests/test_consultation_decision.py
+++ b/backend/tests/test_consultation_decision.py
@@ -1,0 +1,489 @@
+"""상담 승인·거절과 담당 링크 생성. (#467)
+
+여기가 회원↔트레이너 관계가 성립하는 유일한 경로다 — 이전에는 `TrainerClient` 를
+만드는 코드가 시드 스크립트뿐이라 실서비스에서 신규 회원이 트레이너를 가질 수
+없었다. 그래서 "승인하면 로스터에 실제로 나타나는가"를 링크 행이 아니라
+`GET /trainer/clients` 응답으로 확인한다.
+
+DB 가 필요하므로 로컬에서는 skip 되고 CI(Postgres) 에서 실행된다.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from uuid import uuid4
+
+import pytest
+
+from app.core.security import hash_password
+from app.models.models import (
+    ConsultationRequest,
+    MemberGym,
+    Notification,
+    Place,
+    TrainerClient,
+    TrainerProfile,
+    User,
+)
+
+EMAIL_PREFIX = "decide-test-"
+PLACE_PREFIX = "decide-place-"
+PASSWORD = "decide-pw-1234"
+
+
+@pytest.fixture(autouse=True)
+def _cleanup(db_session):
+    yield
+    db_session.rollback()
+    user_ids = [
+        row[0]
+        for row in db_session.query(User.id)
+        .filter(User.email.like(f"{EMAIL_PREFIX}%"))
+        .all()
+    ]
+    if user_ids:
+        db_session.query(ConsultationRequest).filter(
+            (ConsultationRequest.member_id.in_(user_ids))
+            | (ConsultationRequest.trainer_id.in_(user_ids))
+            | (ConsultationRequest.decided_by.in_(user_ids))
+        ).delete(synchronize_session=False)
+        db_session.query(TrainerClient).filter(
+            (TrainerClient.trainer_id.in_(user_ids))
+            | (TrainerClient.member_id.in_(user_ids))
+        ).delete(synchronize_session=False)
+        db_session.query(Notification).filter(
+            Notification.user_id.in_(user_ids)
+        ).delete(synchronize_session=False)
+        db_session.query(MemberGym).filter(
+            MemberGym.member_id.in_(user_ids)
+        ).delete(synchronize_session=False)
+        db_session.query(TrainerProfile).filter(
+            TrainerProfile.trainer_id.in_(user_ids)
+        ).delete(synchronize_session=False)
+        db_session.query(User).filter(User.id.in_(user_ids)).delete(
+            synchronize_session=False
+        )
+    db_session.query(ConsultationRequest).filter(
+        ConsultationRequest.gym_id.like(f"{PLACE_PREFIX}%")
+    ).delete(synchronize_session=False)
+    db_session.query(MemberGym).filter(
+        MemberGym.gym_id.like(f"{PLACE_PREFIX}%")
+    ).delete(synchronize_session=False)
+    db_session.query(Place).filter(Place.id.like(f"{PLACE_PREFIX}%")).delete(
+        synchronize_session=False
+    )
+    db_session.commit()
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _login(client, email: str) -> str:
+    response = client.post(
+        "/v1/auth/login", data={"username": email, "password": PASSWORD}
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["access_token"]
+
+
+def _member(client) -> tuple[str, str]:
+    """회원 계정 하나. (id, token)"""
+    email = f"{EMAIL_PREFIX}member-{uuid4().hex[:10]}@oncare.com"
+    response = client.post(
+        "/v1/auth/register",
+        json={"email": email, "password": PASSWORD, "name": "상담 회원"},
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["id"], _login(client, email)
+
+
+def _gym(db_session) -> Place:
+    place = Place(
+        id=f"{PLACE_PREFIX}{uuid4().hex[:10]}",
+        name="승인 테스트 헬스장",
+        category="fitness",
+        address="서울",
+    )
+    db_session.add(place)
+    db_session.commit()
+    return place
+
+
+def _trainer(client, db_session, *, gym: Place | None = None) -> tuple[User, str]:
+    """로그인 가능한 트레이너. 소속 헬스장은 주어지면 그것, 아니면 새로 만든다."""
+    suffix = uuid4().hex[:10]
+    email = f"{EMAIL_PREFIX}trainer-{suffix}@oncare.com"
+    trainer = User(
+        id=f"decide-trainer-{suffix}",
+        email=email,
+        name="승인 테스트 트레이너",
+        hashed_password=hash_password(PASSWORD),
+        role="trainer",
+        is_active=True,
+    )
+    db_session.add(trainer)
+    db_session.flush()
+    db_session.add(
+        TrainerProfile(
+            trainer_id=trainer.id,
+            gym_id=(gym or _gym(db_session)).id,
+        )
+    )
+    db_session.commit()
+    return trainer, _login(client, email)
+
+
+def _gym_id_of(db_session, trainer: User) -> str:
+    """트레이너의 소속 헬스장 id. TrainerProfile 의 PK 는 trainer_id 가 아니다."""
+    return (
+        db_session.query(TrainerProfile.gym_id)
+        .filter(TrainerProfile.trainer_id == trainer.id)
+        .scalar()
+    )
+
+
+def _request_consultation(
+    client,
+    token: str,
+    *,
+    gym_id: str | None = None,
+    trainer_id: str | None = None,
+) -> str:
+    payload = {
+        "target_type": "gym" if gym_id else "trainer",
+        "gym_id": gym_id,
+        "trainer_id": trainer_id,
+        "exercise_goal": "weight_loss",
+        "health_purpose_type": "general",
+        "health_purpose_detail": None,
+        "preferred_date": (date.today() + timedelta(days=1)).isoformat(),
+        "preferred_time_slot": "evening",
+        "message": "상담 부탁드립니다.",
+    }
+    response = client.post("/v1/consultations", headers=_auth(token), json=payload)
+    assert response.status_code == 201, response.text
+    return response.json()["id"]
+
+
+# --- 인박스 조회 -----------------------------------------------------------
+
+
+def test_inbox_shows_direct_and_gym_requests(client, db_session):
+    """나를 지정한 요청과 내 소속 헬스장으로 온 요청이 함께 보인다."""
+    trainer, trainer_token = _trainer(client, db_session)
+    gym_id = _gym_id_of(db_session, trainer)
+    _, direct_member_token = _member(client)
+    _, gym_member_token = _member(client)
+
+    direct_id = _request_consultation(
+        client, direct_member_token, trainer_id=trainer.id
+    )
+    gym_id_request = _request_consultation(client, gym_member_token, gym_id=gym_id)
+
+    response = client.get("/v1/trainer/consultations", headers=_auth(trainer_token))
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    by_id = {item["id"]: item for item in body}
+    assert direct_id in by_id
+    assert gym_id_request in by_id
+    assert by_id[direct_id]["via_gym"] is False
+    assert by_id[gym_id_request]["via_gym"] is True
+    # 카드가 회원 이름을 렌더하므로 id 만 오면 안 된다.
+    assert by_id[direct_id]["member_name"] == "상담 회원"
+
+
+def test_inbox_excludes_other_trainers_requests(client, db_session):
+    """다른 헬스장으로 간 요청은 보이지 않는다."""
+    _, mine_token = _trainer(client, db_session)
+    other_trainer, _ = _trainer(client, db_session)
+    _, member_token = _member(client)
+
+    foreign_id = _request_consultation(
+        client, member_token, trainer_id=other_trainer.id
+    )
+
+    response = client.get("/v1/trainer/consultations", headers=_auth(mine_token))
+
+    assert response.status_code == 200, response.text
+    assert foreign_id not in {item["id"] for item in response.json()}
+
+
+def test_inbox_defaults_to_pending_only(client, db_session):
+    """기본 필터는 미처리. 처리한 건은 status=all 로만 보인다."""
+    trainer, trainer_token = _trainer(client, db_session)
+    _, member_token = _member(client)
+    consultation_id = _request_consultation(
+        client, member_token, trainer_id=trainer.id
+    )
+    client.post(
+        f"/v1/trainer/consultations/{consultation_id}/reject",
+        headers=_auth(trainer_token),
+        json={"note": "일정이 어려워요"},
+    )
+
+    pending = client.get(
+        "/v1/trainer/consultations", headers=_auth(trainer_token)
+    ).json()
+    every = client.get(
+        "/v1/trainer/consultations?status=all", headers=_auth(trainer_token)
+    ).json()
+
+    assert consultation_id not in {item["id"] for item in pending}
+    assert consultation_id in {item["id"] for item in every}
+
+
+def test_pending_count_matches_inbox(client, db_session):
+    trainer, trainer_token = _trainer(client, db_session)
+    _, member_token = _member(client)
+    _request_consultation(client, member_token, trainer_id=trainer.id)
+
+    count = client.get(
+        "/v1/trainer/consultations/pending-count", headers=_auth(trainer_token)
+    )
+    inbox = client.get("/v1/trainer/consultations", headers=_auth(trainer_token))
+
+    assert count.status_code == 200, count.text
+    assert count.json()["count"] == len(inbox.json()) == 1
+
+
+def test_member_cannot_read_trainer_inbox(client):
+    _, member_token = _member(client)
+    response = client.get("/v1/trainer/consultations", headers=_auth(member_token))
+    assert response.status_code == 403
+
+
+# --- 승인 -------------------------------------------------------------------
+
+
+def test_accept_links_member_into_roster(client, db_session):
+    """승인하면 회원이 실제 담당 고객으로 편입된다 — 로스터 응답으로 확인."""
+    trainer, trainer_token = _trainer(client, db_session)
+    member_id, member_token = _member(client)
+    consultation_id = _request_consultation(
+        client, member_token, trainer_id=trainer.id
+    )
+
+    response = client.post(
+        f"/v1/trainer/consultations/{consultation_id}/accept",
+        headers=_auth(trainer_token),
+        json={},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["status"] == "accepted"
+    assert body["decided_by"] == trainer.id
+    assert body["decided_at"]
+
+    roster = client.get("/v1/trainer/clients", headers=_auth(trainer_token))
+    assert roster.status_code == 200, roster.text
+    assert member_id in {c["id"] for c in roster.json()}
+
+    link = (
+        db_session.query(TrainerClient)
+        .filter(
+            TrainerClient.trainer_id == trainer.id,
+            TrainerClient.member_id == member_id,
+        )
+        .one()
+    )
+    assert link.active is True
+    # 요청의 운동 목표가 코칭 목표의 출발점이 된다(빈 목표 줄 방지).
+    assert link.goal == "체중 감량"
+
+
+def test_accept_notifies_the_member(client, db_session):
+    trainer, trainer_token = _trainer(client, db_session)
+    member_id, member_token = _member(client)
+    consultation_id = _request_consultation(
+        client, member_token, trainer_id=trainer.id
+    )
+
+    client.post(
+        f"/v1/trainer/consultations/{consultation_id}/accept",
+        headers=_auth(trainer_token),
+        json={},
+    )
+
+    alerts = client.get("/v1/notifications", headers=_auth(member_token))
+    assert alerts.status_code == 200, alerts.text
+    titles = [a["title"] for a in alerts.json()]
+    assert "상담 요청이 승인되었어요" in titles
+
+
+def test_accept_links_member_to_the_trainers_gym(client, db_session):
+    """담당이 생긴 회원은 트레이너의 헬스장에도 연결된다."""
+    trainer, trainer_token = _trainer(client, db_session)
+    member_id, member_token = _member(client)
+    gym_id = _gym_id_of(db_session, trainer)
+    consultation_id = _request_consultation(client, member_token, gym_id=gym_id)
+
+    client.post(
+        f"/v1/trainer/consultations/{consultation_id}/accept",
+        headers=_auth(trainer_token),
+        json={},
+    )
+
+    assert db_session.get(MemberGym, member_id).gym_id == gym_id
+
+
+def test_accept_twice_conflicts(client, db_session):
+    trainer, trainer_token = _trainer(client, db_session)
+    _, member_token = _member(client)
+    consultation_id = _request_consultation(
+        client, member_token, trainer_id=trainer.id
+    )
+
+    first = client.post(
+        f"/v1/trainer/consultations/{consultation_id}/accept",
+        headers=_auth(trainer_token),
+        json={},
+    )
+    second = client.post(
+        f"/v1/trainer/consultations/{consultation_id}/accept",
+        headers=_auth(trainer_token),
+        json={},
+    )
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 409, second.text
+
+
+def test_accept_rejects_member_already_coached(client, db_session):
+    """회원당 활성 담당은 1명 — 다른 트레이너가 담당 중이면 승인되지 않는다."""
+    first_trainer, first_token = _trainer(client, db_session)
+    second_trainer, second_token = _trainer(client, db_session)
+    _, member_token = _member(client)
+
+    first_request = _request_consultation(
+        client, member_token, trainer_id=first_trainer.id
+    )
+    second_request = _request_consultation(
+        client, member_token, trainer_id=second_trainer.id
+    )
+
+    accepted = client.post(
+        f"/v1/trainer/consultations/{first_request}/accept",
+        headers=_auth(first_token),
+        json={},
+    )
+    blocked = client.post(
+        f"/v1/trainer/consultations/{second_request}/accept",
+        headers=_auth(second_token),
+        json={},
+    )
+
+    assert accepted.status_code == 200, accepted.text
+    assert blocked.status_code == 409, blocked.text
+
+
+def test_accept_foreign_request_is_not_found(client, db_session):
+    """남의 요청은 403 이 아니라 404 — id 존재 여부를 알려 주지 않는다."""
+    _, outsider_token = _trainer(client, db_session)
+    target_trainer, _ = _trainer(client, db_session)
+    _, member_token = _member(client)
+    consultation_id = _request_consultation(
+        client, member_token, trainer_id=target_trainer.id
+    )
+
+    response = client.post(
+        f"/v1/trainer/consultations/{consultation_id}/accept",
+        headers=_auth(outsider_token),
+        json={},
+    )
+
+    assert response.status_code == 404, response.text
+
+
+def test_accept_reactivates_a_dormant_link(client, db_session):
+    """다시 찾아온 회원은 예전 링크를 되살린다 — 이력이 갈라지지 않는다."""
+    trainer, trainer_token = _trainer(client, db_session)
+    member_id, member_token = _member(client)
+    first_request = _request_consultation(
+        client, member_token, trainer_id=trainer.id
+    )
+    client.post(
+        f"/v1/trainer/consultations/{first_request}/accept",
+        headers=_auth(trainer_token),
+        json={},
+    )
+    # 회원이 담당을 해제 → 링크는 휴면으로 남는다.
+    assert (
+        client.delete("/v1/me/coach", headers=_auth(member_token)).status_code == 204
+    )
+
+    second_request = _request_consultation(
+        client, member_token, trainer_id=trainer.id
+    )
+    again = client.post(
+        f"/v1/trainer/consultations/{second_request}/accept",
+        headers=_auth(trainer_token),
+        json={},
+    )
+
+    assert again.status_code == 200, again.text
+    links = (
+        db_session.query(TrainerClient)
+        .filter(
+            TrainerClient.trainer_id == trainer.id,
+            TrainerClient.member_id == member_id,
+        )
+        .all()
+    )
+    assert len(links) == 1
+    db_session.refresh(links[0])
+    assert links[0].active is True
+
+
+# --- 거절 -------------------------------------------------------------------
+
+
+def test_reject_records_the_reason_and_creates_no_link(client, db_session):
+    trainer, trainer_token = _trainer(client, db_session)
+    member_id, member_token = _member(client)
+    consultation_id = _request_consultation(
+        client, member_token, trainer_id=trainer.id
+    )
+
+    response = client.post(
+        f"/v1/trainer/consultations/{consultation_id}/reject",
+        headers=_auth(trainer_token),
+        json={"note": "  이번 달은 정원이 찼어요  "},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["status"] == "rejected"
+    assert body["decision_note"] == "이번 달은 정원이 찼어요"
+
+    assert (
+        db_session.query(TrainerClient)
+        .filter(TrainerClient.member_id == member_id)
+        .count()
+        == 0
+    )
+    alerts = client.get("/v1/notifications", headers=_auth(member_token)).json()
+    rejected = [a for a in alerts if a["title"] == "상담 요청이 반려되었어요"]
+    assert rejected and rejected[0]["body"] == "이번 달은 정원이 찼어요"
+
+
+def test_reject_after_accept_conflicts(client, db_session):
+    trainer, trainer_token = _trainer(client, db_session)
+    _, member_token = _member(client)
+    consultation_id = _request_consultation(
+        client, member_token, trainer_id=trainer.id
+    )
+    client.post(
+        f"/v1/trainer/consultations/{consultation_id}/accept",
+        headers=_auth(trainer_token),
+        json={},
+    )
+
+    response = client.post(
+        f"/v1/trainer/consultations/{consultation_id}/reject",
+        headers=_auth(trainer_token),
+        json={"note": "취소"},
+    )
+
+    assert response.status_code == 409, response.text

--- a/frontend/flutter_trainer/lib/app/router/app_router.dart
+++ b/frontend/flutter_trainer/lib/app/router/app_router.dart
@@ -10,6 +10,7 @@ import 'package:oncare_trainer/features/auth/presentation/pages/trainer_sign_in_
 import 'package:oncare_trainer/features/auth/presentation/pages/trainer_sign_up_page.dart';
 import 'package:oncare_trainer/features/clients/presentation/pages/clients_page.dart';
 import 'package:oncare_trainer/features/coaching/presentation/pages/coaching_page.dart';
+import 'package:oncare_trainer/features/consultations/presentation/pages/consultations_page.dart';
 import 'package:oncare_trainer/features/dashboard/presentation/pages/dashboard_page.dart';
 import 'package:oncare_trainer/features/my/presentation/pages/my_page.dart';
 import 'package:oncare_trainer/features/reports/presentation/pages/reports_page.dart';
@@ -42,12 +43,13 @@ String? sessionRedirect(SessionStatus status, String location) {
 String? clientSectionRedirect(String? id) =>
     id == null ? null : AppRoutes.clientDetail(id);
 
-/// Builds the trainer routing tree: a six-branch [StatefulShellRoute]
+/// Builds the trainer routing tree: a seven-branch [StatefulShellRoute]
 /// behind an auth gate, plus the auth routes.
 ///
 /// Branches 0–4 are the sidebar destinations (대시보드 / 고객 / 스케줄 /
 /// AI 코칭 / 리포트) in [navDestinations] order; branch 5 is 내 정보 —
-/// reachable from the sidebar footer but not a nav row.
+/// reachable from the sidebar footer but not a nav row; branch 6 is
+/// 상담 요청, whose nav row appears only against the real API.
 ///
 /// [readStatus] drives [sessionRedirect]; [refresh] should fire whenever
 /// the session changes so the guard re-evaluates without rebuilding the
@@ -137,6 +139,17 @@ GoRouter buildAppRouter({
                 path: AppRoutes.my,
                 builder: (context, state) =>
                     MyPage(tab: state.uri.queryParameters['t']),
+              ),
+            ],
+          ),
+          // 상담 요청 is appended AFTER 내 정보 on purpose: `myBranchIndex`
+          // is `navDestinations.length`, so inserting here instead would
+          // shift 내 정보 and silently break the footer's selection. (#467)
+          StatefulShellBranch(
+            routes: <RouteBase>[
+              GoRoute(
+                path: AppRoutes.consultations,
+                builder: (context, state) => const ConsultationsPage(),
               ),
             ],
           ),

--- a/frontend/flutter_trainer/lib/app/router/routes.dart
+++ b/frontend/flutter_trainer/lib/app/router/routes.dart
@@ -35,6 +35,14 @@ class AppRoutes {
   /// 내 정보 / 설정 — reached from the sidebar footer, not the nav list.
   static const String my = '/my';
 
+  /// 상담 요청 — the inbox where a member becomes a client. (#467)
+  ///
+  /// Its nav row only exists against the real API: the demo has no member
+  /// backend to receive requests from, so showing the row there would add
+  /// a permanently empty destination to a screen that must stay as it is.
+  /// The route itself is always registered so a deep link still resolves.
+  static const String consultations = '/consultations';
+
   // --- Client detail ---
 
   /// Every addressable sub-section of a client's detail panel.

--- a/frontend/flutter_trainer/lib/app/shell/app_shell.dart
+++ b/frontend/flutter_trainer/lib/app/shell/app_shell.dart
@@ -32,6 +32,10 @@ class AppShell extends StatelessWidget {
   /// a nav destination.
   static int get myBranchIndex => navDestinations.length;
 
+  /// Branch index of 상담 요청. Sits after [myBranchIndex] so adding it
+  /// could not shift any existing branch. (#467)
+  static int get consultationsBranchIndex => myBranchIndex + 1;
+
   void _goBranch(int index) {
     // Tapping the active destination resets it to its branch root (e.g.
     // 고객 상세에서 '고객'을 다시 누르면 목록으로) — the standard console

--- a/frontend/flutter_trainer/lib/app/shell/app_sidebar.dart
+++ b/frontend/flutter_trainer/lib/app/shell/app_sidebar.dart
@@ -3,12 +3,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:oncare_trainer/app/router/routes.dart';
+import 'package:oncare_trainer/app/shell/app_shell.dart';
 import 'package:oncare_trainer/app/shell/nav_destinations.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/design_system/tokens/layout.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/features/auth/presentation/controllers/session_controller.dart';
+import 'package:oncare_trainer/features/consultations/data/repositories/consultation_repository.dart';
 import 'package:oncare_trainer/shared/models/trainer_profile.dart';
 import 'package:oncare_trainer/shared/services/chat_repository.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
@@ -64,6 +66,13 @@ class AppSidebar extends ConsumerWidget {
         .fold<int>(0, (sum, n) => sum + n);
     final reservations = ref.watch(todayReservationCountProvider).valueOrNull;
     final profile = ref.watch(sessionControllerProvider).profile;
+    // 상담 요청 only exists against the real API — the demo has no member
+    // backend to receive requests from, so the row is not built at all
+    // there and the demo sidebar stays exactly as it was. (#467)
+    final inbox = ref.watch(consultationInboxEnabledProvider);
+    final pendingConsultations = inbox
+        ? ref.watch(consultationPendingCountProvider).valueOrNull
+        : null;
 
     return Container(
       width: expanded ? AppLayout.sidebarWidth : AppLayout.sidebarRailWidth,
@@ -92,10 +101,26 @@ class AppSidebar extends ConsumerWidget {
                       badgeCount: switch (navDestinations[i].badge) {
                         NavBadge.unreadMessages => unread,
                         NavBadge.todayReservations => reservations,
+                        // Not reachable from this loop — 상담 요청 is not in
+                        // navDestinations and is rendered below with its
+                        // count passed in directly.
+                        NavBadge.pendingConsultations => null,
                         NavBadge.none => null,
                       },
                       onTap: () {
                         onSelect(i);
+                        onNavigate?.call();
+                      },
+                    ),
+                  if (inbox)
+                    _NavTile(
+                      destination: consultationsDestination,
+                      selected:
+                          currentIndex == AppShell.consultationsBranchIndex,
+                      expanded: expanded,
+                      badgeCount: pendingConsultations,
+                      onTap: () {
+                        onSelect(AppShell.consultationsBranchIndex);
                         onNavigate?.call();
                       },
                     ),

--- a/frontend/flutter_trainer/lib/app/shell/nav_destinations.dart
+++ b/frontend/flutter_trainer/lib/app/shell/nav_destinations.dart
@@ -12,6 +12,11 @@ enum NavBadge {
 
   /// Today's booked session count.
   todayReservations,
+
+  /// Undecided consultation requests. Supplied by the sidebar directly
+  /// rather than looked up from [navDestinations] — this destination is
+  /// conditional, so it is not in that list. (#467)
+  pendingConsultations,
 }
 
 /// One entry in the sidebar. The order of [navDestinations] is the tab
@@ -82,3 +87,18 @@ const List<NavDestination> navDestinations = <NavDestination>[
     route: AppRoutes.reports,
   ),
 ];
+
+/// 상담 요청 — deliberately NOT in [navDestinations]. (#467)
+///
+/// That list defines branch order (index N here is branch N there), and the
+/// row is only shown against the real API. A conditional entry would make
+/// the list's length depend on build config, which is exactly what
+/// `AppShell.myBranchIndex` reads. Keeping it separate lets the sidebar
+/// render it with an explicit branch index and leaves the demo untouched.
+const NavDestination consultationsDestination = NavDestination(
+  label: '상담 요청',
+  icon: Icons.mark_email_unread_outlined,
+  activeIcon: Icons.mark_email_unread,
+  route: AppRoutes.consultations,
+  badge: NavBadge.pendingConsultations,
+);

--- a/frontend/flutter_trainer/lib/features/consultations/data/dtos/consultation_dtos.dart
+++ b/frontend/flutter_trainer/lib/features/consultations/data/dtos/consultation_dtos.dart
@@ -1,0 +1,81 @@
+import 'package:oncare_trainer/features/consultations/domain/entities/consultation_request.dart';
+
+/// Maps the `TrainerConsultationOut` JSON into [ConsultationRequest].
+///
+/// Kept out of the Dio repository so the mapping is unit-testable on its
+/// own — the enum→한국어 tables below are the part most likely to drift
+/// from the backend's `Literal` types.
+
+/// 운동 목표 코드 → 화면 문구. The backend stores the code so the label can
+/// change without a migration; the mapping has to live on one side and the
+/// trainer console is the only place it is read.
+const Map<String, String> kExerciseGoalLabels = <String, String>{
+  'weight_loss': '체중 감량',
+  'strength': '근력 향상',
+  'fitness': '체력 증진',
+  'posture': '자세 교정',
+  'health': '건강 관리',
+  'other': '기타',
+};
+
+/// 건강관리 목적 코드 → 화면 문구.
+const Map<String, String> kHealthPurposeLabels = <String, String>{
+  'weight': '체중 관리',
+  'chronic': '만성질환 관리',
+  'rehab': '재활',
+  'general': '전반적 건강',
+  'none': '해당 없음',
+  'other': '기타',
+};
+
+/// 희망 시간대 코드 → 화면 문구.
+const Map<String, String> kPreferredTimeLabels = <String, String>{
+  'morning': '오전',
+  'afternoon': '오후',
+  'evening': '저녁',
+  'flexible': '조율 가능',
+};
+
+/// `GET /v1/trainer/consultations` element → [ConsultationRequest].
+///
+/// Unknown enum codes fall back to the raw code rather than an empty
+/// string: a backend that adds `sports_rehab` should show something the
+/// trainer can act on, not a blank line.
+ConsultationRequest consultationRequestFromJson(Map<String, Object?> json) {
+  return ConsultationRequest(
+    id: _str(json['id']),
+    memberId: _str(json['member_id']),
+    memberName: _nullable(json['member_name']) ?? '알 수 없는 회원',
+    goalLabel: _label(kExerciseGoalLabels, json['exercise_goal']),
+    purposeLabel: _label(kHealthPurposeLabels, json['health_purpose_type']),
+    purposeDetail: _nullable(json['health_purpose_detail']),
+    preferredDate: _date(json['preferred_date']),
+    preferredTimeLabel: _label(kPreferredTimeLabels, json['preferred_time_slot']),
+    message: _nullable(json['message']),
+    status: _str(json['status']),
+    viaGym: json['via_gym'] == true,
+    gymName: _nullable(json['gym_name']),
+    decisionNote: _nullable(json['decision_note']),
+  );
+}
+
+String _str(Object? value) => value is String ? value : '';
+
+/// Trims and collapses empty strings to null — the API sends `null` for an
+/// omitted note, but a whitespace-only note would otherwise render an
+/// empty bubble.
+String? _nullable(Object? value) {
+  if (value is! String) return null;
+  final trimmed = value.trim();
+  return trimmed.isEmpty ? null : trimmed;
+}
+
+String _label(Map<String, String> table, Object? code) {
+  final raw = _str(code);
+  return table[raw] ?? (raw.isEmpty ? '-' : raw);
+}
+
+/// `YYYY-MM-DD` → [DateTime]. An unparseable value yields the epoch rather
+/// than throwing: one malformed row must not blank the whole inbox.
+DateTime _date(Object? value) =>
+    DateTime.tryParse(_str(value)) ?? DateTime.fromMillisecondsSinceEpoch(0);

--- a/frontend/flutter_trainer/lib/features/consultations/data/repositories/consultation_repository.dart
+++ b/frontend/flutter_trainer/lib/features/consultations/data/repositories/consultation_repository.dart
@@ -1,0 +1,203 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare_trainer/core/config/app_config.dart';
+import 'package:oncare_trainer/core/errors/app_error.dart';
+import 'package:oncare_trainer/core/network/dio_client.dart';
+import 'package:oncare_trainer/features/consultations/data/dtos/consultation_dtos.dart';
+import 'package:oncare_trainer/features/consultations/domain/entities/consultation_request.dart';
+import 'package:oncare_trainer/shared/services/client_repository.dart';
+
+/// Reads the trainer's consultation inbox and decides requests.
+///
+/// Two implementations, selected by [consultationRepositoryProvider] via
+/// [AppConfig.useMockApi]:
+///  * [DemoConsultationRepository] — demo / `USE_MOCK_API=true`. The demo
+///    has no member backend to receive requests from, and its roster is
+///    seeded, so the inbox is empty and the sidebar row is hidden. The
+///    demo screens stay exactly as they are.
+///  * [DioConsultationRepository] — the real backend, where accepting is
+///    what creates the trainer↔member link.
+abstract interface class ConsultationRepository {
+  /// Whether this build can actually receive and decide requests.
+  ///
+  /// Drives whether the 상담 요청 destination appears at all — a dead nav
+  /// row that always says "요청이 없어요" is worse than no row.
+  bool get supportsInbox;
+
+  /// Pending requests, newest first. `status` may be `pending` or `all`.
+  Future<List<ConsultationRequest>> fetch({String status = 'pending'});
+
+  /// Number of undecided requests — the sidebar badge.
+  Future<int> pendingCount();
+
+  /// Accepts [id], creating the trainer↔member link server-side.
+  Future<void> accept(String id);
+
+  /// Rejects [id]. [note] is delivered to the member as the reason.
+  Future<void> reject(String id, {String? note});
+}
+
+/// Demo build: no inbox. Reads succeed with nothing so any consumer that
+/// does run (tests, a deep link) renders an empty state instead of an
+/// error, and decisions are refused rather than silently doing nothing.
+class DemoConsultationRepository implements ConsultationRepository {
+  /// Creates the demo source.
+  const DemoConsultationRepository();
+
+  @override
+  bool get supportsInbox => false;
+
+  @override
+  Future<List<ConsultationRequest>> fetch({String status = 'pending'}) async =>
+      const <ConsultationRequest>[];
+
+  @override
+  Future<int> pendingCount() async => 0;
+
+  @override
+  Future<void> accept(String id) async =>
+      throw const ValidationError(message: '데모 모드에서는 상담을 처리할 수 없어요');
+
+  @override
+  Future<void> reject(String id, {String? note}) async =>
+      throw const ValidationError(message: '데모 모드에서는 상담을 처리할 수 없어요');
+}
+
+/// Real backend: `/trainer/consultations`.
+class DioConsultationRepository implements ConsultationRepository {
+  /// Creates the API-backed repository.
+  const DioConsultationRepository(this._dio);
+
+  final Dio _dio;
+
+  @override
+  bool get supportsInbox => true;
+
+  @override
+  Future<List<ConsultationRequest>> fetch({String status = 'pending'}) async {
+    try {
+      final res = await _dio.get<List<dynamic>>(
+        '/trainer/consultations',
+        queryParameters: <String, Object?>{'status': status},
+      );
+      return (res.data ?? const <dynamic>[])
+          .whereType<Map<String, Object?>>()
+          .map(consultationRequestFromJson)
+          .toList();
+    } on DioException catch (e) {
+      throw AppError.fromDio(e);
+    }
+  }
+
+  @override
+  Future<int> pendingCount() async {
+    try {
+      final res = await _dio.get<Map<String, Object?>>(
+        '/trainer/consultations/pending-count',
+      );
+      final count = res.data?['count'];
+      return count is int ? count : 0;
+    } on DioException catch (e) {
+      throw AppError.fromDio(e);
+    }
+  }
+
+  @override
+  Future<void> accept(String id) => _decide(id, 'accept', null);
+
+  @override
+  Future<void> reject(String id, {String? note}) =>
+      _decide(id, 'reject', note);
+
+  /// Both decisions share their failure modes, so they share the mapping.
+  ///
+  /// 409 carries the server's own reason — already decided, or the member
+  /// already has another trainer. That sentence is exactly what the
+  /// trainer needs, so it is surfaced instead of a generic network error.
+  Future<void> _decide(String id, String action, String? note) async {
+    try {
+      await _dio.post<Map<String, Object?>>(
+        '/trainer/consultations/${Uri.encodeComponent(id)}/$action',
+        data: <String, Object?>{'note': note},
+      );
+    } on DioException catch (e) {
+      final status = e.response?.statusCode;
+      if (status == 409 || status == 400 || status == 422) {
+        throw ValidationError(message: _detail(e) ?? '상담을 처리할 수 없어요');
+      }
+      throw AppError.fromDio(e);
+    }
+  }
+
+  String? _detail(DioException e) {
+    final data = e.response?.data;
+    if (data is! Map) return null;
+    final detail = data['detail'];
+    return detail is String ? detail : null;
+  }
+}
+
+/// Provides the inbox source for the current mode.
+final consultationRepositoryProvider = Provider<ConsultationRepository>((ref) {
+  if (ref.watch(appConfigProvider).useMockApi) {
+    return const DemoConsultationRepository();
+  }
+  return DioConsultationRepository(ref.watch(dioProvider));
+}, name: 'consultationRepository');
+
+/// Whether the console shows the 상담 요청 destination at all.
+final consultationInboxEnabledProvider = Provider<bool>(
+  (ref) => ref.watch(consultationRepositoryProvider).supportsInbox,
+  name: 'consultationInboxEnabled',
+);
+
+/// Current inbox filter — `pending` (default) or `all`.
+final consultationFilterProvider = StateProvider<String>(
+  (ref) => 'pending',
+  name: 'consultationFilter',
+);
+
+/// The inbox list for the active filter.
+final consultationsProvider = FutureProvider<List<ConsultationRequest>>((
+  ref,
+) async {
+  final status = ref.watch(consultationFilterProvider);
+  return ref.watch(consultationRepositoryProvider).fetch(status: status);
+}, name: 'consultations');
+
+/// Pending count for the sidebar badge.
+///
+/// Its own request rather than `consultationsProvider.length`: the badge
+/// must stay correct while the trainer is looking at the `all` filter, and
+/// it is read from the sidebar on every page.
+final consultationPendingCountProvider = FutureProvider<int>((ref) async {
+  if (!ref.watch(consultationInboxEnabledProvider)) return 0;
+  return ref.watch(consultationRepositoryProvider).pendingCount();
+}, name: 'consultationPendingCount');
+
+/// Accepts a request and refreshes everything it changed.
+///
+/// The roster is invalidated too — accepting is precisely the moment a new
+/// client appears, and a stale 고객 tab would make the trainer wonder
+/// whether the approval worked.
+Future<void> acceptConsultation(WidgetRef ref, String id) async {
+  await ref.read(consultationRepositoryProvider).accept(id);
+  _refreshAfterDecision(ref);
+  ref.invalidate(clientsProvider);
+}
+
+/// Rejects a request. The roster is untouched, so it is not invalidated.
+Future<void> rejectConsultation(
+  WidgetRef ref,
+  String id, {
+  String? note,
+}) async {
+  await ref.read(consultationRepositoryProvider).reject(id, note: note);
+  _refreshAfterDecision(ref);
+}
+
+void _refreshAfterDecision(WidgetRef ref) {
+  ref.invalidate(consultationsProvider);
+  ref.invalidate(consultationPendingCountProvider);
+}

--- a/frontend/flutter_trainer/lib/features/consultations/domain/entities/consultation_request.dart
+++ b/frontend/flutter_trainer/lib/features/consultations/domain/entities/consultation_request.dart
@@ -1,0 +1,70 @@
+/// One member's consultation request as the trainer sees it.
+///
+/// The member app writes these (`POST /consultations`); until a trainer
+/// accepts one there is no trainer↔member link, so this is the only place
+/// a real roster can start. Accepting is what creates the link — the demo
+/// roster comes from seed data instead.
+class ConsultationRequest {
+  /// Creates a request card.
+  const ConsultationRequest({
+    required this.id,
+    required this.memberId,
+    required this.memberName,
+    required this.goalLabel,
+    required this.purposeLabel,
+    required this.preferredDate,
+    required this.preferredTimeLabel,
+    required this.status,
+    this.message,
+    this.purposeDetail,
+    this.viaGym = false,
+    this.gymName,
+    this.decisionNote,
+  });
+
+  /// Server id — the path segment for accept / reject.
+  final String id;
+
+  /// The requesting member's user id.
+  final String memberId;
+
+  /// Display name. Falls back to a placeholder when the account is gone.
+  final String memberName;
+
+  /// 운동 목표, already localized (체중 감량 …).
+  final String goalLabel;
+
+  /// 건강관리 목적, already localized (만성질환 관리 …).
+  final String purposeLabel;
+
+  /// Free-text detail the member added to 건강관리 목적, if any.
+  final String? purposeDetail;
+
+  /// Requested date (`YYYY-MM-DD` parsed).
+  final DateTime preferredDate;
+
+  /// 희망 시간대, already localized (저녁 …).
+  final String preferredTimeLabel;
+
+  /// The member's own note to the trainer.
+  final String? message;
+
+  /// `pending` | `accepted` | `rejected`.
+  final String status;
+
+  /// Whether this came to the gym rather than to this trainer by name.
+  ///
+  /// A gym enquiry can be picked up by any trainer at that gym, so the
+  /// card says so — otherwise the trainer cannot tell whether the member
+  /// asked for them specifically.
+  final bool viaGym;
+
+  /// Gym name for a gym-routed request.
+  final String? gymName;
+
+  /// Rejection reason, once decided.
+  final String? decisionNote;
+
+  /// Whether this request is still waiting on a decision.
+  bool get isPending => status == 'pending';
+}

--- a/frontend/flutter_trainer/lib/features/consultations/presentation/pages/consultations_page.dart
+++ b/frontend/flutter_trainer/lib/features/consultations/presentation/pages/consultations_page.dart
@@ -108,6 +108,12 @@ class _RequestCardState extends ConsumerState<_RequestCard> {
       await action();
       messenger.showSnackBar(SnackBar(content: Text(success)));
     } on AppError catch (e) {
+      // A failed decision usually means the request moved on without us —
+      // another trainer at the same gym accepted it first. Refresh before
+      // showing the reason, or the card stays actionable and the trainer
+      // can keep pressing 승인 on something already decided (review).
+      ref.invalidate(consultationsProvider);
+      ref.invalidate(consultationPendingCountProvider);
       // 409 carries the server's reason (이미 처리됨 / 다른 트레이너가 담당 중)
       // — that sentence is the whole point, so it is shown verbatim.
       messenger.showSnackBar(

--- a/frontend/flutter_trainer/lib/features/consultations/presentation/pages/consultations_page.dart
+++ b/frontend/flutter_trainer/lib/features/consultations/presentation/pages/consultations_page.dart
@@ -1,0 +1,454 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare_trainer/core/errors/app_error.dart';
+import 'package:oncare_trainer/core/utils/date_format.dart';
+import 'package:oncare_trainer/design_system/tokens/colors.dart';
+import 'package:oncare_trainer/design_system/tokens/radius.dart';
+import 'package:oncare_trainer/design_system/tokens/spacing.dart';
+import 'package:oncare_trainer/features/consultations/data/repositories/consultation_repository.dart';
+import 'package:oncare_trainer/features/consultations/domain/entities/consultation_request.dart';
+import 'package:oncare_trainer/shared/widgets/action_button.dart';
+import 'package:oncare_trainer/shared/widgets/client_avatar.dart';
+import 'package:oncare_trainer/shared/widgets/page_scaffold.dart';
+import 'package:oncare_trainer/shared/widgets/section_card.dart';
+
+/// 상담 요청 — the inbox where a member becomes a client.
+///
+/// Accepting is the only path from "someone asked" to a real trainer↔member
+/// link, so the card carries everything a trainer needs to decide without
+/// opening anything else: who, what they want, and when they can come.
+///
+/// Two request sources land here — a member who picked this trainer by
+/// name, and a member who asked the gym. The second kind is badged, since
+/// any trainer at that gym can pick it up and the first to accept wins.
+///
+/// The demo build never reaches this page: its repository reports no inbox
+/// and the sidebar row is not rendered (see [consultationInboxEnabledProvider]).
+class ConsultationsPage extends ConsumerWidget {
+  /// Creates the inbox page.
+  const ConsultationsPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final filter = ref.watch(consultationFilterProvider);
+    final requests = ref.watch(consultationsProvider);
+    final pending = ref.watch(consultationPendingCountProvider).valueOrNull;
+
+    return PageScaffold(
+      title: '상담 요청',
+      subtitle: pending == null
+          ? null
+          : (pending > 0 ? '대기 중 $pending건' : '대기 중인 요청이 없어요'),
+      actions: <Widget>[
+        ActionButton(
+          label: filter == 'pending' ? '전체 보기' : '대기 중만',
+          icon: Icons.filter_list,
+          onPressed: () => ref
+              .read(consultationFilterProvider.notifier)
+              .state = filter == 'pending' ? 'all' : 'pending',
+        ),
+      ],
+      child: requests.when(
+        loading: () => const Padding(
+          padding: EdgeInsets.only(top: AppSpacing.xxl),
+          child: Center(child: CircularProgressIndicator()),
+        ),
+        error: (error, _) => _InboxMessage(
+          icon: Icons.error_outline,
+          title: '상담 요청을 불러오지 못했어요',
+          detail: (error is AppError ? error.message : null) ?? '잠시 후 다시 시도해 주세요',
+          action: ActionButton(
+            label: '다시 시도',
+            onPressed: () => ref.invalidate(consultationsProvider),
+          ),
+        ),
+        data: (list) => list.isEmpty
+            ? _InboxMessage(
+                icon: Icons.inbox_outlined,
+                title: filter == 'pending'
+                    ? '대기 중인 상담 요청이 없어요'
+                    : '상담 요청 이력이 없어요',
+                detail: '회원이 헬스장이나 나를 지정해 상담을 신청하면 여기에 표시돼요',
+              )
+            : Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  for (final request in list) ...<Widget>[
+                    _RequestCard(request: request),
+                    const SizedBox(height: AppSpacing.md),
+                  ],
+                ],
+              ),
+      ),
+    );
+  }
+}
+
+/// One request. Pending cards carry the 승인 / 거절 actions; decided ones
+/// keep their place under the 전체 filter as a read-only record.
+class _RequestCard extends ConsumerStatefulWidget {
+  const _RequestCard({required this.request});
+
+  final ConsultationRequest request;
+
+  @override
+  ConsumerState<_RequestCard> createState() => _RequestCardState();
+}
+
+class _RequestCardState extends ConsumerState<_RequestCard> {
+  /// Blocks both actions while one is in flight — a double-tapped 승인
+  /// would otherwise race and the second call would 409.
+  bool _busy = false;
+
+  Future<void> _run(Future<void> Function() action, String success) async {
+    setState(() => _busy = true);
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      await action();
+      messenger.showSnackBar(SnackBar(content: Text(success)));
+    } on AppError catch (e) {
+      // 409 carries the server's reason (이미 처리됨 / 다른 트레이너가 담당 중)
+      // — that sentence is the whole point, so it is shown verbatim.
+      messenger.showSnackBar(
+        SnackBar(content: Text(e.message ?? '상담을 처리하지 못했어요')),
+      );
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _accept() => _run(
+    () => acceptConsultation(ref, widget.request.id),
+    '${widget.request.memberName} 회원을 담당 고객으로 등록했어요',
+  );
+
+  Future<void> _reject() async {
+    final note = await showDialog<String?>(
+      context: context,
+      builder: (_) => const _RejectDialog(),
+    );
+    if (note == null) return;
+    await _run(
+      () => rejectConsultation(ref, widget.request.id, note: note),
+      '상담 요청을 반려했어요',
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final request = widget.request;
+    return SectionCard(
+      title: request.memberName,
+      trailing: request.viaGym
+          ? const _Tag(label: '헬스장 문의', tone: AppColors.brandOrange)
+          : const _Tag(label: '트레이너 지정', tone: AppColors.primary),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              ClientAvatar(
+                label: request.memberName.isEmpty
+                    ? '?'
+                    : request.memberName.characters.first,
+              ),
+              const SizedBox(width: AppSpacing.md),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    _Field(label: '운동 목표', value: request.goalLabel),
+                    _Field(
+                      label: '건강관리 목적',
+                      value: request.purposeDetail == null
+                          ? request.purposeLabel
+                          : '${request.purposeLabel} · ${request.purposeDetail}',
+                    ),
+                    _Field(
+                      label: '희망 일시',
+                      value:
+                          '${koreanDateLabel(request.preferredDate)} '
+                          '${request.preferredTimeLabel}',
+                    ),
+                    if (request.gymName != null)
+                      _Field(label: '문의 헬스장', value: request.gymName!),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          if (request.message != null) ...<Widget>[
+            const SizedBox(height: AppSpacing.md),
+            _Quote(text: request.message!),
+          ],
+          if (!request.isPending) ...<Widget>[
+            const SizedBox(height: AppSpacing.md),
+            _DecisionSummary(request: request),
+          ],
+          if (request.isPending) ...<Widget>[
+            const SizedBox(height: AppSpacing.lg),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: <Widget>[
+                ActionButton(
+                  label: '거절',
+                  tone: AppColors.destructive,
+                  onPressed: _busy ? null : _reject,
+                ),
+                const SizedBox(width: AppSpacing.sm),
+                ActionButton(
+                  label: '승인',
+                  primary: true,
+                  onPressed: _busy ? null : _accept,
+                ),
+              ],
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+/// Rejection reason. Optional — a trainer who is simply full should not
+/// have to compose a sentence, but the field is offered because the member
+/// receives whatever is written here as their notification body.
+class _RejectDialog extends StatefulWidget {
+  const _RejectDialog();
+
+  @override
+  State<_RejectDialog> createState() => _RejectDialogState();
+}
+
+class _RejectDialogState extends State<_RejectDialog> {
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      backgroundColor: AppColors.card,
+      title: const Text('상담 요청 반려'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          const Text(
+            '입력한 사유는 회원에게 알림으로 전달돼요.',
+            style: TextStyle(fontSize: 12.5, color: AppColors.mutedForeground),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          TextField(
+            controller: _controller,
+            maxLength: 500,
+            maxLines: 3,
+            decoration: const InputDecoration(
+              hintText: '예) 이번 달은 정원이 찼어요',
+              filled: true,
+              fillColor: AppColors.inputBackground,
+            ),
+          ),
+        ],
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('취소'),
+        ),
+        TextButton(
+          // Returns '' rather than null when left blank: null is the
+          // cancel signal, and an empty note is a valid "no reason given".
+          onPressed: () => Navigator.of(context).pop(_controller.text.trim()),
+          child: const Text('반려하기'),
+        ),
+      ],
+    );
+  }
+}
+
+/// What happened to a request that is no longer pending.
+class _DecisionSummary extends StatelessWidget {
+  const _DecisionSummary({required this.request});
+
+  final ConsultationRequest request;
+
+  @override
+  Widget build(BuildContext context) {
+    final accepted = request.status == 'accepted';
+    return Row(
+      children: <Widget>[
+        Icon(
+          accepted ? Icons.check_circle : Icons.cancel,
+          size: 16,
+          color: accepted ? AppColors.success : AppColors.destructive,
+        ),
+        const SizedBox(width: AppSpacing.xs),
+        Expanded(
+          child: Text(
+            accepted
+                ? '담당 고객으로 등록됨'
+                : '반려됨${request.decisionNote == null ? '' : ' · ${request.decisionNote}'}',
+            style: const TextStyle(
+              fontSize: 12.5,
+              color: AppColors.mutedForeground,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _Field extends StatelessWidget {
+  const _Field({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: AppSpacing.xs),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          SizedBox(
+            width: 84,
+            child: Text(
+              label,
+              style: const TextStyle(
+                fontSize: 12,
+                color: AppColors.subtleForeground,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          Expanded(
+            child: Text(
+              value,
+              style: const TextStyle(
+                fontSize: 13,
+                color: AppColors.foreground,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The member's own note, set apart from the structured fields.
+class _Quote extends StatelessWidget {
+  const _Quote({required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(AppSpacing.md),
+      decoration: const BoxDecoration(
+        color: AppColors.accentSurface,
+        borderRadius: BorderRadius.all(AppRadius.card),
+      ),
+      child: Text(
+        text,
+        style: const TextStyle(
+          fontSize: 13,
+          height: 1.5,
+          color: AppColors.foreground,
+        ),
+      ),
+    );
+  }
+}
+
+class _Tag extends StatelessWidget {
+  const _Tag({required this.label, required this.tone});
+
+  final String label;
+  final Color tone;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.sm,
+        vertical: 3,
+      ),
+      decoration: BoxDecoration(
+        color: tone.withValues(alpha: 0.12),
+        borderRadius: const BorderRadius.all(AppRadius.pill),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w700,
+          color: tone,
+        ),
+      ),
+    );
+  }
+}
+
+/// Shared empty / error presentation so both read as the same surface.
+class _InboxMessage extends StatelessWidget {
+  const _InboxMessage({
+    required this.icon,
+    required this.title,
+    required this.detail,
+    this.action,
+  });
+
+  final IconData icon;
+  final String title;
+  final String detail;
+  final Widget? action;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: AppSpacing.xxl),
+      child: Column(
+        children: <Widget>[
+          Icon(icon, size: 40, color: AppColors.disabledForeground),
+          const SizedBox(height: AppSpacing.md),
+          Text(
+            title,
+            textAlign: TextAlign.center,
+            style: const TextStyle(
+              fontSize: 15,
+              fontWeight: FontWeight.w700,
+              color: AppColors.foreground,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.xs),
+          Text(
+            detail,
+            textAlign: TextAlign.center,
+            style: const TextStyle(
+              fontSize: 12.5,
+              color: AppColors.mutedForeground,
+            ),
+          ),
+          if (action != null) ...<Widget>[
+            const SizedBox(height: AppSpacing.lg),
+            action!,
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/flutter_trainer/test/features/consultations/consultation_dtos_test.dart
+++ b/frontend/flutter_trainer/test/features/consultations/consultation_dtos_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare_trainer/features/consultations/data/dtos/consultation_dtos.dart';
+
+Map<String, Object?> _json({
+  Object? memberName = '김민수',
+  Object? goal = 'weight_loss',
+  Object? purpose = 'chronic',
+  Object? detail,
+  Object? date = '2026-08-12',
+  Object? slot = 'evening',
+  Object? message = '  상담 부탁드립니다.  ',
+  Object? status = 'pending',
+  Object? viaGym = false,
+  Object? gymName,
+  Object? note,
+}) => <String, Object?>{
+  'id': 'consult-1',
+  'member_id': 'user-1',
+  'member_name': memberName,
+  'exercise_goal': goal,
+  'health_purpose_type': purpose,
+  'health_purpose_detail': detail,
+  'preferred_date': date,
+  'preferred_time_slot': slot,
+  'message': message,
+  'status': status,
+  'via_gym': viaGym,
+  'gym_name': gymName,
+  'decision_note': note,
+};
+
+void main() {
+  test('maps the request into display-ready labels', () {
+    final request = consultationRequestFromJson(_json());
+
+    expect(request.id, 'consult-1');
+    expect(request.memberId, 'user-1');
+    expect(request.memberName, '김민수');
+    expect(request.goalLabel, '체중 감량');
+    expect(request.purposeLabel, '만성질환 관리');
+    expect(request.preferredDate, DateTime(2026, 8, 12));
+    expect(request.preferredTimeLabel, '저녁');
+    expect(request.isPending, isTrue);
+  });
+
+  test('trims free text and collapses blanks to null', () {
+    final request = consultationRequestFromJson(
+      _json(message: '   ', detail: '  혈압 관리  '),
+    );
+
+    // A whitespace-only note would otherwise render an empty quote block.
+    expect(request.message, isNull);
+    expect(request.purposeDetail, '혈압 관리');
+  });
+
+  test('an unknown enum code falls back to the raw code, not a blank', () {
+    final request = consultationRequestFromJson(_json(goal: 'sports_rehab'));
+
+    // A backend that adds a goal should still show something actionable.
+    expect(request.goalLabel, 'sports_rehab');
+  });
+
+  test('a missing member name gets a placeholder', () {
+    final request = consultationRequestFromJson(_json(memberName: null));
+
+    expect(request.memberName, '알 수 없는 회원');
+  });
+
+  test('an unparseable date does not throw', () {
+    // One malformed row must not blank the whole inbox.
+    final request = consultationRequestFromJson(_json(date: 'not-a-date'));
+
+    expect(request.preferredDate, DateTime.fromMillisecondsSinceEpoch(0));
+  });
+
+  test('carries the gym routing flag and decision note', () {
+    final request = consultationRequestFromJson(
+      _json(
+        viaGym: true,
+        gymName: '온케어짐 신촌점',
+        status: 'rejected',
+        note: '정원이 찼어요',
+      ),
+    );
+
+    expect(request.viaGym, isTrue);
+    expect(request.gymName, '온케어짐 신촌점');
+    expect(request.isPending, isFalse);
+    expect(request.decisionNote, '정원이 찼어요');
+  });
+}

--- a/frontend/flutter_trainer/test/features/consultations/consultations_page_test.dart
+++ b/frontend/flutter_trainer/test/features/consultations/consultations_page_test.dart
@@ -1,0 +1,193 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare_trainer/app/router/routes.dart';
+import 'package:oncare_trainer/app/shell/nav_destinations.dart';
+import 'package:oncare_trainer/core/errors/app_error.dart';
+import 'package:oncare_trainer/features/consultations/data/repositories/consultation_repository.dart';
+import 'package:oncare_trainer/features/consultations/domain/entities/consultation_request.dart';
+
+import '../../helpers/pump_app.dart';
+
+ConsultationRequest _request({
+  String id = 'consult-1',
+  String name = '김민수',
+  String status = 'pending',
+  bool viaGym = false,
+  String? message = '상담 부탁드립니다.',
+}) => ConsultationRequest(
+  id: id,
+  memberId: 'user-$id',
+  memberName: name,
+  goalLabel: '체중 감량',
+  purposeLabel: '만성질환 관리',
+  preferredDate: DateTime(2026, 8, 12),
+  preferredTimeLabel: '저녁',
+  message: message,
+  status: status,
+  viaGym: viaGym,
+);
+
+/// A stand-in inbox that reports itself enabled (so the nav row renders)
+/// and records the decisions made against it.
+class _FakeConsultationRepository implements ConsultationRepository {
+  _FakeConsultationRepository({
+    List<ConsultationRequest>? requests,
+    this.failure,
+  }) : requests = requests ?? <ConsultationRequest>[];
+
+  List<ConsultationRequest> requests;
+  final AppError? failure;
+
+  final List<String> accepted = <String>[];
+  final List<(String, String?)> rejected = <(String, String?)>[];
+
+  @override
+  bool get supportsInbox => true;
+
+  @override
+  Future<List<ConsultationRequest>> fetch({String status = 'pending'}) async {
+    if (failure != null) throw failure!;
+    return status == 'pending'
+        ? requests.where((r) => r.isPending).toList()
+        : requests;
+  }
+
+  @override
+  Future<int> pendingCount() async => requests.where((r) => r.isPending).length;
+
+  @override
+  Future<void> accept(String id) async {
+    accepted.add(id);
+    requests = requests
+        .map((r) => r.id == id ? _request(id: id, status: 'accepted') : r)
+        .toList();
+  }
+
+  @override
+  Future<void> reject(String id, {String? note}) async {
+    rejected.add((id, note));
+    requests = requests
+        .map((r) => r.id == id ? _request(id: id, status: 'rejected') : r)
+        .toList();
+  }
+}
+
+Future<ProviderContainer> _pumpInbox(
+  WidgetTester tester,
+  _FakeConsultationRepository repo,
+) => pumpTrainerApp(
+  tester,
+  token: 'demo-token',
+  at: AppRoutes.consultations,
+  extraOverrides: <Override>[
+    consultationRepositoryProvider.overrideWithValue(repo),
+  ],
+);
+
+void main() {
+  testWidgets('renders a pending request with its decision actions', (
+    tester,
+  ) async {
+    await _pumpInbox(
+      tester,
+      _FakeConsultationRepository(requests: <ConsultationRequest>[_request()]),
+    );
+
+    expect(find.text('상담 요청'), findsWidgets);
+    expect(find.text('김민수'), findsOneWidget);
+    expect(find.text('체중 감량'), findsOneWidget);
+    expect(find.text('상담 부탁드립니다.'), findsOneWidget);
+    expect(find.text('승인'), findsOneWidget);
+    expect(find.text('거절'), findsOneWidget);
+  });
+
+  testWidgets('badges a gym-routed request so the trainer can tell', (
+    tester,
+  ) async {
+    await _pumpInbox(
+      tester,
+      _FakeConsultationRepository(
+        requests: <ConsultationRequest>[_request(viaGym: true)],
+      ),
+    );
+
+    expect(find.text('헬스장 문의'), findsOneWidget);
+    expect(find.text('트레이너 지정'), findsNothing);
+  });
+
+  testWidgets('accepting sends the decision to the repository', (tester) async {
+    final repo = _FakeConsultationRepository(
+      requests: <ConsultationRequest>[_request()],
+    );
+    await _pumpInbox(tester, repo);
+
+    await tester.tap(find.text('승인'));
+    await settle(tester);
+
+    expect(repo.accepted, <String>['consult-1']);
+  });
+
+  testWidgets('a decided request shows its outcome, not the actions', (
+    tester,
+  ) async {
+    final repo = _FakeConsultationRepository(
+      requests: <ConsultationRequest>[_request(status: 'accepted')],
+    );
+    await _pumpInbox(tester, repo);
+    // 처리된 건은 '전체' 필터에서만 보인다.
+    await tester.tap(find.text('전체 보기'));
+    await settle(tester);
+
+    expect(find.text('담당 고객으로 등록됨'), findsOneWidget);
+    expect(find.text('승인'), findsNothing);
+  });
+
+  testWidgets('an empty inbox explains itself instead of showing nothing', (
+    tester,
+  ) async {
+    await _pumpInbox(tester, _FakeConsultationRepository());
+
+    expect(find.text('대기 중인 상담 요청이 없어요'), findsOneWidget);
+  });
+
+  testWidgets('a failed load offers a retry', (tester) async {
+    await _pumpInbox(
+      tester,
+      _FakeConsultationRepository(
+        failure: const NetworkError(message: '연결이 불안정해요'),
+      ),
+    );
+
+    expect(find.text('상담 요청을 불러오지 못했어요'), findsOneWidget);
+    expect(find.text('다시 시도'), findsOneWidget);
+  });
+
+  testWidgets('the demo console never shows the 상담 요청 row', (tester) async {
+    // 데모는 지금 그대로여야 한다 — 목 모드에서는 인박스 진입점이 아예 없다.
+    await withWideSurface(tester, () async {
+      await pumpTrainerApp(tester, token: 'demo-token');
+
+      expect(find.text(consultationsDestination.label), findsNothing);
+      for (final destination in navDestinations) {
+        expect(find.text(destination.label), findsWidgets);
+      }
+    });
+  });
+
+  testWidgets('the real-API console does show it', (tester) async {
+    await withWideSurface(tester, () async {
+      await pumpTrainerApp(
+        tester,
+        token: 'demo-token',
+        extraOverrides: <Override>[
+          consultationRepositoryProvider.overrideWithValue(
+            _FakeConsultationRepository(),
+          ),
+        ],
+      );
+
+      expect(find.text(consultationsDestination.label), findsOneWidget);
+    });
+  });
+}

--- a/frontend/flutter_trainer/test/features/consultations/dio_consultation_repository_test.dart
+++ b/frontend/flutter_trainer/test/features/consultations/dio_consultation_repository_test.dart
@@ -1,0 +1,299 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:oncare_trainer/core/config/app_config.dart';
+import 'package:oncare_trainer/core/errors/app_error.dart';
+import 'package:oncare_trainer/core/network/dio_client.dart';
+import 'package:oncare_trainer/features/consultations/data/repositories/consultation_repository.dart';
+
+class _MockDio extends Mock implements Dio {}
+
+Response<T> _ok<T>(T body, String path) => Response<T>(
+  requestOptions: RequestOptions(path: path),
+  statusCode: 200,
+  data: body,
+);
+
+DioException _httpError(int status, String path, {Object? body}) =>
+    DioException(
+      requestOptions: RequestOptions(path: path),
+      type: DioExceptionType.badResponse,
+      response: Response<Object?>(
+        requestOptions: RequestOptions(path: path),
+        statusCode: status,
+        data: body,
+      ),
+    );
+
+const AppConfig _demoConfig = AppConfig(
+  environment: Environment.dev,
+  apiBaseUrl: 'http://localhost/v1',
+  useMockApi: true,
+);
+
+const AppConfig _realConfig = AppConfig(
+  environment: Environment.dev,
+  apiBaseUrl: 'http://localhost/v1',
+  useMockApi: false,
+);
+
+void main() {
+  late _MockDio dio;
+  late DioConsultationRepository repo;
+
+  setUp(() {
+    dio = _MockDio();
+    repo = DioConsultationRepository(dio);
+  });
+
+  group('DioConsultationRepository', () {
+    test('fetch defaults to the pending filter', () async {
+      when(
+        () => dio.get<List<dynamic>>(
+          '/trainer/consultations',
+          queryParameters: any(named: 'queryParameters'),
+        ),
+      ).thenAnswer(
+        (_) async => _ok<List<dynamic>>(
+          <dynamic>[
+            <String, Object?>{
+              'id': 'consult-1',
+              'member_id': 'u1',
+              'member_name': '김민수',
+              'exercise_goal': 'strength',
+              'health_purpose_type': 'general',
+              'preferred_date': '2026-08-12',
+              'preferred_time_slot': 'morning',
+              'status': 'pending',
+              'via_gym': true,
+            },
+          ],
+          '/trainer/consultations',
+        ),
+      );
+
+      final list = await repo.fetch();
+
+      expect(list, hasLength(1));
+      expect(list.single.memberName, '김민수');
+      expect(list.single.viaGym, isTrue);
+      final captured = verify(
+        () => dio.get<List<dynamic>>(
+          '/trainer/consultations',
+          queryParameters: captureAny(named: 'queryParameters'),
+        ),
+      ).captured.single as Map<String, Object?>;
+      expect(captured['status'], 'pending');
+    });
+
+    test('fetch skips malformed elements instead of throwing', () async {
+      when(
+        () => dio.get<List<dynamic>>(
+          '/trainer/consultations',
+          queryParameters: any(named: 'queryParameters'),
+        ),
+      ).thenAnswer(
+        (_) async => _ok<List<dynamic>>(<dynamic>[
+          'nonsense',
+          <String, Object?>{
+            'id': 'consult-2',
+            'member_id': 'u2',
+            'member_name': '이지수',
+            'exercise_goal': 'fitness',
+            'health_purpose_type': 'general',
+            'preferred_date': '2026-08-13',
+            'preferred_time_slot': 'evening',
+            'status': 'pending',
+          },
+        ], '/trainer/consultations'),
+      );
+
+      final list = await repo.fetch();
+
+      expect(list.map((r) => r.id), <String>['consult-2']);
+    });
+
+    test('pendingCount reads the count field', () async {
+      when(
+        () => dio.get<Map<String, Object?>>(
+          '/trainer/consultations/pending-count',
+        ),
+      ).thenAnswer(
+        (_) async => _ok<Map<String, Object?>>(
+          <String, Object?>{'count': 3},
+          '/trainer/consultations/pending-count',
+        ),
+      );
+
+      expect(await repo.pendingCount(), 3);
+    });
+
+    test('accept posts to the accept path', () async {
+      when(
+        () => dio.post<Map<String, Object?>>(
+          '/trainer/consultations/consult-1/accept',
+          data: any(named: 'data'),
+        ),
+      ).thenAnswer(
+        (_) async => _ok<Map<String, Object?>>(
+          <String, Object?>{},
+          '/trainer/consultations/consult-1/accept',
+        ),
+      );
+
+      await repo.accept('consult-1');
+
+      verify(
+        () => dio.post<Map<String, Object?>>(
+          '/trainer/consultations/consult-1/accept',
+          data: any(named: 'data'),
+        ),
+      ).called(1);
+    });
+
+    test('reject carries the note the member will receive', () async {
+      when(
+        () => dio.post<Map<String, Object?>>(
+          '/trainer/consultations/consult-1/reject',
+          data: any(named: 'data'),
+        ),
+      ).thenAnswer(
+        (_) async => _ok<Map<String, Object?>>(
+          <String, Object?>{},
+          '/trainer/consultations/consult-1/reject',
+        ),
+      );
+
+      await repo.reject('consult-1', note: '정원이 찼어요');
+
+      final data = verify(
+        () => dio.post<Map<String, Object?>>(
+          '/trainer/consultations/consult-1/reject',
+          data: captureAny(named: 'data'),
+        ),
+      ).captured.single as Map<String, Object?>;
+      expect(data['note'], '정원이 찼어요');
+    });
+
+    test("409's own reason survives as the message shown to the trainer", () async {
+      when(
+        () => dio.post<Map<String, Object?>>(
+          '/trainer/consultations/consult-1/accept',
+          data: any(named: 'data'),
+        ),
+      ).thenThrow(
+        _httpError(
+          409,
+          '/trainer/consultations/consult-1/accept',
+          body: <String, Object?>{'detail': '이미 다른 트레이너가 담당 중인 회원입니다.'},
+        ),
+      );
+
+      // The whole point of the 409 is its sentence — a generic network
+      // error would leave the trainer with no idea why it failed.
+      await expectLater(
+        repo.accept('consult-1'),
+        throwsA(
+          isA<ValidationError>().having(
+            (e) => e.message,
+            'message',
+            '이미 다른 트레이너가 담당 중인 회원입니다.',
+          ),
+        ),
+      );
+    });
+
+    test('a 404 stays a typed transport error', () async {
+      when(
+        () => dio.post<Map<String, Object?>>(
+          '/trainer/consultations/nope/accept',
+          data: any(named: 'data'),
+        ),
+      ).thenThrow(_httpError(404, '/trainer/consultations/nope/accept'));
+
+      await expectLater(
+        repo.accept('nope'),
+        throwsA(isA<NotFoundError>()),
+      );
+    });
+
+    test('ids are percent-encoded into the path', () async {
+      when(
+        () => dio.post<Map<String, Object?>>(
+          '/trainer/consultations/a%2Fb/accept',
+          data: any(named: 'data'),
+        ),
+      ).thenAnswer(
+        (_) async => _ok<Map<String, Object?>>(
+          <String, Object?>{},
+          '/trainer/consultations/a%2Fb/accept',
+        ),
+      );
+
+      await repo.accept('a/b');
+
+      verify(
+        () => dio.post<Map<String, Object?>>(
+          '/trainer/consultations/a%2Fb/accept',
+          data: any(named: 'data'),
+        ),
+      ).called(1);
+    });
+  });
+
+  group('consultationRepositoryProvider', () {
+    test('demo mode resolves the inbox-less source', () {
+      final container = ProviderContainer(
+        overrides: <Override>[
+          appConfigProvider.overrideWithValue(_demoConfig),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(
+        container.read(consultationRepositoryProvider),
+        isA<DemoConsultationRepository>(),
+      );
+      // The demo console must look exactly as it does today — no inbox
+      // row, no badge.
+      expect(container.read(consultationInboxEnabledProvider), isFalse);
+    });
+
+    test('real-API mode resolves the Dio source', () {
+      final container = ProviderContainer(
+        overrides: <Override>[
+          appConfigProvider.overrideWithValue(_realConfig),
+          dioProvider.overrideWithValue(dio),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(
+        container.read(consultationRepositoryProvider),
+        isA<DioConsultationRepository>(),
+      );
+      expect(container.read(consultationInboxEnabledProvider), isTrue);
+    });
+
+    test('the demo badge count is zero without issuing a request', () async {
+      final container = ProviderContainer(
+        overrides: <Override>[
+          appConfigProvider.overrideWithValue(_demoConfig),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(await container.read(consultationPendingCountProvider.future), 0);
+    });
+
+    test('the demo source refuses decisions rather than faking them', () async {
+      const repo = DemoConsultationRepository();
+
+      expect(await repo.fetch(), isEmpty);
+      await expectLater(repo.accept('x'), throwsA(isA<ValidationError>()));
+      await expectLater(repo.reject('x'), throwsA(isA<ValidationError>()));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

* 상담 요청이 `pending` 으로 저장된 뒤 아무도 볼 수 없던 문제를 해소했습니다. 트레이너가 요청을 조회하고 승인·거절할 수 있습니다.
* 승인이 `TrainerClient` 담당 링크를 만듭니다 — 지금까지 이 링크를 만드는 코드는 시드 스크립트뿐이어서, 실서비스에서 신규 회원이 트레이너를 가질 방법이 없었습니다.
* 데모 화면은 지금과 완전히 동일합니다. 트레이너 앱 데모에는 상담 인박스 진입점이 생기지 않습니다.

---

## Changes

### ✨ Features

* `GET /trainer/consultations` — 나를 지정한 요청과 내 소속 헬스장으로 온 요청을 함께 조회합니다(기본 `pending`, `all` 필터 지원).
* `GET /trainer/consultations/pending-count` — 사이드바 배지용 미처리 건수입니다.
* `POST /trainer/consultations/{id}/accept` — 담당 링크 생성, 회원↔헬스장 연결, 회원 알림을 한 트랜잭션으로 처리합니다.
* `POST /trainer/consultations/{id}/reject` — 거절 사유를 기록하고 회원에게 알림을 남깁니다.
* 트레이너 앱에 상담 요청 인박스 화면을 추가했습니다. 회원 이름·운동 목표·건강관리 목적·희망 일시·메시지를 한 카드에 싣고 승인·거절을 그 자리에서 처리합니다.

### 🔧 Improvements

* 승인 성공 시 고객 로스터를 무효화해 새 고객이 즉시 고객 탭에 나타납니다.
* 휴면 상태의 기존 링크가 있으면 새 행을 만들지 않고 되살립니다. 지난 루틴·채팅 이력이 갈라지지 않습니다.
* 헬스장으로 온 문의는 카드에 배지로 구분합니다. 같은 헬스장 트레이너 누구나 받을 수 있어, 트레이너 지정 요청과 섞이면 누구를 향한 요청인지 화면에서 알 수 없습니다.

### 🎨 UI/UX

* 상담 인박스 진입점은 실 API 모드에서만 렌더합니다. 데모에는 요청을 보낼 회원 백엔드가 없어 영구히 빈 목적지가 되기 때문입니다.
* 거절 사유 입력은 선택 사항입니다. 입력한 문장이 회원 알림 본문으로 그대로 전달됩니다.

### 📝 Docs

* 마이그레이션과 서비스 주석에 상태 전이 규칙과 404/409 선택 근거를 남겼습니다.

### 🐛 Fixes

* 회원당 활성 담당 1명 불변식을 `IntegrityError` 로 만나기 전에 확인해 409 와 사유를 돌려줍니다. 이전에는 DB 제약에 걸려 트레이너에게 보여 줄 문구가 없었습니다.

---

## Commits

1. 77c08d4 feat(consultation): 트레이너 상담 인박스와 승인·거절 API
2. c6fff50 feat(consultation): 트레이너 앱 상담 요청 인박스

---

## Notes

**데모 불변 보장 (3중)**

1. `DemoConsultationRepository.supportsInbox = false` 이므로 사이드바 행이 아예 빌드되지 않습니다.
2. 상담 요청 브랜치를 `내 정보`(branch 5) **뒤에** 붙였습니다. `navDestinations` 사이에 끼우면 `AppShell.myBranchIndex`(= `navDestinations.length`)가 밀려 푸터 선택이 조용히 깨집니다. `consultationsDestination` 을 `navDestinations` 에 넣지 않은 것도 같은 이유입니다 — 그 목록의 길이가 빌드 설정에 따라 달라져서는 안 됩니다.
3. 시드(`seed_trainer.py`, `seed_data.dart`)는 수정하지 않았습니다.

**응답 호환성**

마이그레이션 `0023` 은 nullable 컬럼만 추가하고 백필하지 않습니다. 회원용 `ConsultationOut` 응답 형태를 바꾸지 않았으므로 이미 배포된 사용자 앱 화면은 영향받지 않습니다. `alembic heads` 는 1개입니다.

**404 vs 403**

남의 헬스장 요청은 403 이 아니라 404 로 돌립니다. 403 은 그 id 의 요청이 존재한다는 사실을 알려 주어, id 를 훑는 것만으로 다른 헬스장의 상담 건수를 셀 수 있습니다.

**다른 작업과의 충돌**

이 PR 은 `backend/**` 와 `frontend/flutter_trainer/**` 만 수정합니다. 그 사이 병합된 #468(#466 회원앱 여백)과 #469(#426 예약 슬롯)는 모두 `frontend/flutter/**` 만 건드려 파일이 하나도 겹치지 않습니다. 최신 `main`(57f72da) 위로 리베이스한 뒤 전체 테스트를 다시 돌렸습니다.

**범위 밖 (후속)**

회원 측 상담 상태 표시(대기·승인·거절)는 별도 이슈로 분리했습니다. 그 UI 가 들어갈 `gym_tab.dart` 가 #426 의 `_ReservationPanel` 과 같은 파일이라 충돌을 피하기 위해서입니다. 푸시 알림(FCM) 발송도 범위 밖이며, 이번에는 `notifications` 행 생성까지만 합니다.

---

## Screenshots (Optional)

데모(목 모드) 트레이너 콘솔을 직접 띄워 확인했습니다 — 사이드바는 대시보드 / 고객 / 스케줄 / AI 코칭 / 리포트 5행 그대로이고 상담 요청 행은 나타나지 않으며, 대시보드 내용도 동일합니다.

---

## Test Plan

* [x] 백엔드 신규 테스트 14개 통과 (조회 스코프, 승인 시 로스터 편입, 헬스장 연결, 알림 생성, 중복 승인 409, 타 트레이너 담당 회원 409, 남의 요청 404, 휴면 링크 재활성화, 거절 흐름)
* [x] 백엔드 전체 450개 통과
* [x] `alembic upgrade head` 로컬 적용 및 `alembic heads` 단일 확인
* [x] 트레이너 앱 신규 테스트 26개 통과 (DTO 매핑, Dio 계약, provider 분기, 인박스 위젯)
* [x] 트레이너 앱 전체 350개 통과, `flutter analyze` 무경고
* [x] 데모 모드에서 사이드바에 상담 요청 행이 없는지 위젯 테스트와 실제 실행으로 이중 확인

### Manual Test Steps

1. 트레이너 앱을 목 모드로 실행해 사이드바가 기존 5행 그대로인지 확인합니다.
2. 백엔드를 띄우고 회원 앱에서 헬스장 또는 트레이너를 지정해 상담을 신청합니다.
3. 트레이너 앱을 `USE_MOCK_API=false` 로 실행해 상담 요청 탭에서 해당 요청을 확인합니다.
4. 승인하고 고객 탭에 회원이 나타나는지 확인합니다.
5. 같은 요청을 다시 승인해 409 안내가 뜨는지 확인합니다.
6. 회원 앱 알림에서 승인 알림이 도착했는지 확인합니다.

---

## Related Issues

Closes #467

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 트레이너가 상담 요청 인박스를 조회하고 대기 건수를 확인할 수 있습니다.
  * 상담 요청을 승인하거나 거절하고, 선택적으로 처리 메모를 남길 수 있습니다.
  * 상담 요청을 전체·대기·승인·거절 상태로 필터링할 수 있습니다.
  * 처리 결과와 회원 정보, 상담 내용, 경유 헬스장 정보를 확인할 수 있습니다.
  * 새 상담 요청 메뉴와 대기 건수 배지를 제공합니다.

* **개선 사항**
  * 승인·거절 결과가 회원 연결 및 알림에 반영됩니다.
  * 중복 처리나 이미 담당 중인 회원에 대한 충돌 안내를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->