### PR TITLE
feat(consultation): 회원 앱 상담 요청 상태 표시

### DIFF
--- a/backend/app/schemas/consultation_api.py
+++ b/backend/app/schemas/consultation_api.py
@@ -97,6 +97,14 @@ class ConsultationOut(BaseModel):
     preferred_time_slot: PreferredTimeSlot
     message: str | None
     status: str
+    #: 거절 사유. 트레이너가 남긴 문장이 그대로 온다. (#473)
+    #:
+    #: 처리자 id(`decided_by`)는 **회원 응답에 싣지 않는다** — 회원에게 필요한 것은
+    #: 결과와 이유이지 누가 눌렀는지가 아니고, 헬스장으로 보낸 문의는 소속 트레이너
+    #: 누구나 처리할 수 있어 id 를 흘리면 지정하지도 않은 트레이너를 알게 된다.
+    decision_note: str | None = None
+    #: 처리 시각. 화면이 "언제 답을 받았는지"를 보여 준다.
+    decided_at: datetime | None = None
     created_at: datetime
     updated_at: datetime
 
@@ -115,6 +123,6 @@ class TrainerConsultationOut(ConsultationOut):
     #: 카드가 "헬스장 문의" 배지를 다는 근거이며, 트레이너 지정 요청과 섞이면
     #: 누구를 향한 요청인지 화면에서 구분할 수 없다.
     via_gym: bool = False
+    #: 처리한 트레이너. 헬스장 문의는 소속 트레이너 누구나 받을 수 있어, 인박스
+    #: 이력에서 "누가 가져갔는지"가 필요하다. 회원 응답에는 없는 필드다.
     decided_by: str | None = None
-    decided_at: datetime | None = None
-    decision_note: str | None = None

--- a/backend/app/services/consultation_service.py
+++ b/backend/app/services/consultation_service.py
@@ -266,13 +266,13 @@ def _to_trainer_out(
     }
     out: list[TrainerConsultationOut] = []
     for row in rows:
+        # `decision_note` / `decided_at` 은 회원용 스키마가 이미 갖고 있어
+        # model_dump() 에 실려 온다(#473). 여기서 다시 넘기면 중복 인자다.
         item = TrainerConsultationOut(
             **base[row.id].model_dump(),
             member_name=member_names.get(row.member_id),
             via_gym=row.target_type == "gym",
             decided_by=row.decided_by,
-            decided_at=row.decided_at,
-            decision_note=row.decision_note,
         )
         out.append(item)
     return out

--- a/backend/tests/test_consultation_decision.py
+++ b/backend/tests/test_consultation_decision.py
@@ -568,6 +568,58 @@ def test_reject_records_the_reason_and_creates_no_link(client, db_session):
     assert rejected and rejected[0]["body"] == "이번 달은 정원이 찼어요"
 
 
+def test_member_sees_the_reason_but_never_the_deciding_trainer(
+    client, db_session
+):
+    """회원 응답에는 사유·처리 시각만 싣고 처리자 id 는 싣지 않는다. (#473)
+
+    헬스장으로 보낸 문의는 소속 트레이너 누구나 처리할 수 있어, `decided_by` 를
+    흘리면 회원이 지정하지도 않은 트레이너를 알게 된다. 회원에게 필요한 것은
+    결과와 이유이지 누가 눌렀는지가 아니다.
+    """
+    gym = _gym(db_session)
+    trainer, trainer_token = _trainer(client, db_session, gym=gym)
+    _, member_token = _member(client)
+    consultation_id = _request_consultation(client, member_token, gym_id=gym.id)
+
+    client.post(
+        f"/v1/trainer/consultations/{consultation_id}/reject",
+        headers=_auth(trainer_token),
+        json={"note": "이번 달은 정원이 찼어요"},
+    )
+
+    mine = client.get("/v1/consultations/me", headers=_auth(member_token))
+
+    assert mine.status_code == 200, mine.text
+    row = next(r for r in mine.json() if r["id"] == consultation_id)
+    assert row["status"] == "rejected"
+    assert row["decision_note"] == "이번 달은 정원이 찼어요"
+    assert row["decided_at"] is not None
+    assert "decided_by" not in row
+    # 트레이너 인박스 쪽에는 그대로 남아 있어야 한다(누가 가져갔는지 이력).
+    inbox = client.get(
+        "/v1/trainer/consultations?status=all", headers=_auth(trainer_token)
+    )
+    taken = next(r for r in inbox.json() if r["id"] == consultation_id)
+    assert taken["decided_by"] == trainer.id
+
+
+def test_pending_consultation_has_no_decision_fields(client, db_session):
+    """대기 중인 요청은 사유·처리 시각이 비어 있다."""
+    trainer, _ = _trainer(client, db_session)
+    _, member_token = _member(client)
+    consultation_id = _request_consultation(
+        client, member_token, trainer_id=trainer.id
+    )
+
+    mine = client.get("/v1/consultations/me", headers=_auth(member_token))
+
+    row = next(r for r in mine.json() if r["id"] == consultation_id)
+    assert row["status"] == "pending"
+    assert row["decision_note"] is None
+    assert row["decided_at"] is None
+
+
 def test_reject_after_accept_conflicts(client, db_session):
     trainer, trainer_token = _trainer(client, db_session)
     _, member_token = _member(client)

--- a/frontend/flutter/lib/features/exercise/domain/entities/consultation_request.dart
+++ b/frontend/flutter/lib/features/exercise/domain/entities/consultation_request.dart
@@ -21,6 +21,8 @@ class ConsultationRequest {
     required this.message,
     required this.status,
     required this.createdAt,
+    this.decisionNote,
+    this.decidedAt,
   });
 
   /// 서버가 접수하며 준 id 로 갈아끼울 때 쓴다 — 화면이 만든 임시 id 는 트레이너
@@ -41,6 +43,8 @@ class ConsultationRequest {
     message: message,
     status: status,
     createdAt: createdAt,
+    decisionNote: decisionNote,
+    decidedAt: decidedAt,
   );
 
   final String id;
@@ -66,6 +70,18 @@ class ConsultationRequest {
   final String? message;
   final ConsultationStatus status;
   final DateTime createdAt;
+
+  /// 트레이너가 거절하며 남긴 사유. 승인이거나 사유를 적지 않았으면 null. (#473)
+  ///
+  /// "거절됨"만 보여 주면 사용자는 다시 신청해도 되는지, 다른 트레이너를 찾아야
+  /// 하는지 판단할 근거가 없다. 서버가 알림 본문으로도 같은 문장을 보낸다.
+  final String? decisionNote;
+
+  /// 승인·거절된 시각. 대기 중이면 null.
+  final DateTime? decidedAt;
+
+  /// 아직 답을 기다리는 중인가.
+  bool get isPending => status == ConsultationStatus.pending;
 }
 
 /// `GET /consultations/me` 응답 → 엔티티. (#327)
@@ -100,5 +116,11 @@ ConsultationRequest consultationFromJson(Map<String, Object?> j) {
     },
     createdAt:
         DateTime.tryParse((j['created_at'] as String?) ?? '') ?? DateTime.now(),
+    // 공백만 남은 사유는 null 로 접는다 — 빈 안내 줄이 그려지지 않도록.
+    decisionNote: switch (j['decision_note']) {
+      final String note when note.trim().isNotEmpty => note.trim(),
+      _ => null,
+    },
+    decidedAt: DateTime.tryParse((j['decided_at'] as String?) ?? ''),
   );
 }

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/gym_tab.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/gym_tab.dart
@@ -151,6 +151,7 @@ class _RecentConsultationSection extends StatelessWidget {
     final String date = MaterialLocalizations.of(
       context,
     ).formatMediumDate(request.preferredDate);
+    final Widget? outcome = _outcomeNote(context, l);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -241,6 +242,10 @@ class _RecentConsultationSection extends StatelessWidget {
                         color: FigmaColors.textBody,
                       ),
                     ),
+                    if (outcome != null) ...<Widget>[
+                      const SizedBox(height: 10),
+                      outcome,
+                    ],
                   ],
                 ),
               ),
@@ -248,6 +253,75 @@ class _RecentConsultationSection extends StatelessWidget {
           ),
         ),
       ],
+    );
+  }
+
+  /// 처리된 요청에 붙는 결과 안내. 대기 중이면 null. (#473)
+  ///
+  /// 거절은 사유가 본체다 — "거절됨" 배지만 보면 다시 신청해도 되는지, 다른
+  /// 트레이너를 찾아야 하는지 판단할 근거가 없다. 트레이너가 사유를 적지 않았을
+  /// 수도 있으므로 그때는 다음 행동을 안내한다.
+  Widget? _outcomeNote(BuildContext context, AppLocalizations l) {
+    switch (request.status) {
+      case ConsultationStatus.pending:
+        return null;
+      case ConsultationStatus.accepted:
+        return _OutcomeNote(
+          tone: FigmaColors.primary,
+          text: l.exConsultAcceptedGuide,
+        );
+      case ConsultationStatus.rejected:
+        final String? note = request.decisionNote;
+        return _OutcomeNote(
+          tone: FigmaColors.textMuted,
+          label: note == null ? null : l.exConsultRejectedReasonLabel,
+          text: note ?? l.exConsultRejectedNoReason,
+        );
+    }
+  }
+}
+
+/// 상태 카드 하단의 결과 안내 한 덩어리 — 승인 안내 또는 거절 사유.
+class _OutcomeNote extends StatelessWidget {
+  const _OutcomeNote({required this.tone, required this.text, this.label});
+
+  final Color tone;
+  final String? label;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(11),
+      decoration: BoxDecoration(
+        color: tone.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          if (label != null) ...<Widget>[
+            Text(
+              label!,
+              style: TextStyle(
+                fontSize: 10.5,
+                fontWeight: FontWeight.w700,
+                color: tone,
+              ),
+            ),
+            const SizedBox(height: 3),
+          ],
+          Text(
+            text,
+            style: const TextStyle(
+              fontSize: 12,
+              height: 1.45,
+              color: FigmaColors.textBody,
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/frontend/flutter/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations.dart
@@ -2833,6 +2833,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Consultation Request Status'**
   String get exConsultStatusSection;
+
+  /// No description provided for @exConsultRejectedReasonLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Reason for decline'**
+  String get exConsultRejectedReasonLabel;
+
+  /// No description provided for @exConsultRejectedNoReason.
+  ///
+  /// In en, this message translates to:
+  /// **'No reason was given. Try requesting a consultation with another trainer.'**
+  String get exConsultRejectedNoReason;
+
+  /// No description provided for @exConsultAcceptedGuide.
+  ///
+  /// In en, this message translates to:
+  /// **'You\'re connected with your trainer. You can start chatting now.'**
+  String get exConsultAcceptedGuide;
 }
 
 class _AppLocalizationsDelegate

--- a/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
@@ -1503,4 +1503,15 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get exConsultStatusSection => 'Consultation Request Status';
+
+  @override
+  String get exConsultRejectedReasonLabel => 'Reason for decline';
+
+  @override
+  String get exConsultRejectedNoReason =>
+      'No reason was given. Try requesting a consultation with another trainer.';
+
+  @override
+  String get exConsultAcceptedGuide =>
+      'You\'re connected with your trainer. You can start chatting now.';
 }

--- a/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
@@ -1477,4 +1477,14 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get exConsultStatusSection => '상담 요청 현황';
+
+  @override
+  String get exConsultRejectedReasonLabel => '거절 사유';
+
+  @override
+  String get exConsultRejectedNoReason =>
+      '사유를 남기지 않았어요. 다른 트레이너에게 상담을 요청해 보세요.';
+
+  @override
+  String get exConsultAcceptedGuide => '담당 트레이너와 연결되었어요. 이제 채팅으로 상담할 수 있어요.';
 }

--- a/frontend/flutter/lib/l10n/app_en.arb
+++ b/frontend/flutter/lib/l10n/app_en.arb
@@ -771,5 +771,8 @@
   "exConsultAcceptedStatus": "Accepted",
   "exConsultRejectedStatus": "Rejected",
   "exReturnExercise": "Return to Exercise",
-  "exConsultStatusSection": "Consultation Request Status"
+  "exConsultStatusSection": "Consultation Request Status",
+  "exConsultRejectedReasonLabel": "Reason for decline",
+  "exConsultRejectedNoReason": "No reason was given. Try requesting a consultation with another trainer.",
+  "exConsultAcceptedGuide": "You're connected with your trainer. You can start chatting now."
 }

--- a/frontend/flutter/lib/l10n/app_ko.arb
+++ b/frontend/flutter/lib/l10n/app_ko.arb
@@ -516,5 +516,8 @@
   "exConsultAcceptedStatus": "요청 수락",
   "exConsultRejectedStatus": "요청 거절",
   "exReturnExercise": "운동 탭으로 돌아가기",
-  "exConsultStatusSection": "상담 요청 현황"
+  "exConsultStatusSection": "상담 요청 현황",
+  "exConsultRejectedReasonLabel": "거절 사유",
+  "exConsultRejectedNoReason": "사유를 남기지 않았어요. 다른 트레이너에게 상담을 요청해 보세요.",
+  "exConsultAcceptedGuide": "담당 트레이너와 연결되었어요. 이제 채팅으로 상담할 수 있어요."
 }

--- a/frontend/flutter/test/features/exercise/consultation_decision_test.dart
+++ b/frontend/flutter/test/features/exercise/consultation_decision_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/exercise/domain/entities/consultation_request.dart';
+
+/// `GET /consultations/me` 한 건. 처리 결과 필드는 케이스별로 덮어쓴다.
+Map<String, Object?> _row({
+  Object? status = 'pending',
+  Object? note,
+  Object? decidedAt,
+}) => <String, Object?>{
+  'id': 'consult-abc123',
+  'member_id': 'user-demo',
+  'target_type': 'gym',
+  'gym_id': 'gym-oncare-sinchon',
+  'trainer_id': null,
+  'gym_name': '온케어짐 신촌점',
+  'trainer_name': null,
+  'exercise_goal': 'weight_loss',
+  'health_purpose_type': 'chronic',
+  'health_purpose_detail': null,
+  'preferred_date': '2026-08-20',
+  'preferred_time_slot': 'afternoon',
+  'message': '문의합니다',
+  'status': status,
+  'decision_note': note,
+  'decided_at': decidedAt,
+  'created_at': '2026-08-07T10:00:00Z',
+  'updated_at': '2026-08-07T10:00:00Z',
+};
+
+void main() {
+  test('대기 중인 요청은 처리 정보가 비어 있다', () {
+    final ConsultationRequest request = consultationFromJson(_row());
+
+    expect(request.status, ConsultationStatus.pending);
+    expect(request.isPending, isTrue);
+    expect(request.decisionNote, isNull);
+    expect(request.decidedAt, isNull);
+  });
+
+  test('거절 사유와 처리 시각을 읽는다', () {
+    final ConsultationRequest request = consultationFromJson(
+      _row(
+        status: 'rejected',
+        note: '이번 달은 정원이 찼어요',
+        decidedAt: '2026-08-08T04:30:00Z',
+      ),
+    );
+
+    expect(request.status, ConsultationStatus.rejected);
+    expect(request.isPending, isFalse);
+    expect(request.decisionNote, '이번 달은 정원이 찼어요');
+    expect(request.decidedAt, DateTime.parse('2026-08-08T04:30:00Z'));
+  });
+
+  test('공백뿐인 사유는 null 로 접는다', () {
+    // 그대로 두면 화면에 빈 안내 줄이 그려진다.
+    final ConsultationRequest request = consultationFromJson(
+      _row(status: 'rejected', note: '   '),
+    );
+
+    expect(request.decisionNote, isNull);
+  });
+
+  test('사유 앞뒤 공백을 정리한다', () {
+    final ConsultationRequest request = consultationFromJson(
+      _row(status: 'rejected', note: '  일정이 어려워요  '),
+    );
+
+    expect(request.decisionNote, '일정이 어려워요');
+  });
+
+  test('승인은 사유 없이도 정상이다', () {
+    final ConsultationRequest request = consultationFromJson(
+      _row(status: 'accepted', decidedAt: '2026-08-08T04:30:00Z'),
+    );
+
+    expect(request.status, ConsultationStatus.accepted);
+    expect(request.decisionNote, isNull);
+    expect(request.decidedAt, isNotNull);
+  });
+
+  test('처리 정보가 없는 예전 응답도 그대로 읽힌다', () {
+    // 배포된 서버가 아직 필드를 주지 않아도 화면이 깨지면 안 된다.
+    final Map<String, Object?> legacy = _row()
+      ..remove('decision_note')
+      ..remove('decided_at');
+
+    final ConsultationRequest request = consultationFromJson(legacy);
+
+    expect(request.status, ConsultationStatus.pending);
+    expect(request.decisionNote, isNull);
+    expect(request.decidedAt, isNull);
+  });
+
+  test('copyWith 가 처리 정보를 잃지 않는다', () {
+    // 접수 직후 서버 id 로 갈아끼울 때 쓰는 경로다.
+    final ConsultationRequest request = consultationFromJson(
+      _row(status: 'rejected', note: '정원이 찼어요'),
+    ).copyWith(id: 'server-id');
+
+    expect(request.id, 'server-id');
+    expect(request.decisionNote, '정원이 찼어요');
+  });
+}

--- a/frontend/flutter/test/features/exercise/gym_tab_action_test.dart
+++ b/frontend/flutter/test/features/exercise/gym_tab_action_test.dart
@@ -52,7 +52,10 @@ const AppConfig _config = AppConfig(
   useMockApi: true,
 );
 
-ConsultationRequest _consultation(ConsultationStatus status) {
+ConsultationRequest _consultation(
+  ConsultationStatus status, {
+  String? decisionNote,
+}) {
   return ConsultationRequest(
     id: 'consultation-${status.name}',
     targetType: ConsultationTargetType.trainer,
@@ -69,6 +72,10 @@ ConsultationRequest _consultation(ConsultationStatus status) {
     message: null,
     status: status,
     createdAt: DateTime(2026, 7, 31),
+    decisionNote: decisionNote,
+    decidedAt: status == ConsultationStatus.pending
+        ? null
+        : DateTime(2026, 8, 2),
   );
 }
 
@@ -363,6 +370,75 @@ void main() {
       expect(find.text(l.exViewConsultationRequest), findsNothing);
     });
   }
+
+  // --- 처리 결과 안내 (#473) --------------------------------------------
+  //
+  // "거절됨" 배지만으로는 다시 신청해도 되는지, 다른 트레이너를 찾아야 하는지
+  // 알 수 없다. 사유가 결과 전달의 본체다.
+
+  testWidgets('거절된 요청은 트레이너가 남긴 사유를 보여준다', (
+    WidgetTester tester,
+  ) async {
+    await pumpGymTab(
+      tester,
+      consultation: _consultation(
+        ConsultationStatus.rejected,
+        decisionNote: '이번 달은 정원이 찼어요',
+      ),
+    );
+    await scrollToCard(tester);
+
+    final AppLocalizations l = AppLocalizations.of(
+      tester.element(find.byType(Scaffold).first),
+    );
+    expect(find.text('이번 달은 정원이 찼어요'), findsOneWidget);
+    expect(find.text(l.exConsultRejectedReasonLabel), findsOneWidget);
+  });
+
+  testWidgets('사유 없이 거절되면 다음 행동을 안내한다', (WidgetTester tester) async {
+    await pumpGymTab(
+      tester,
+      consultation: _consultation(ConsultationStatus.rejected),
+    );
+    await scrollToCard(tester);
+
+    final AppLocalizations l = AppLocalizations.of(
+      tester.element(find.byType(Scaffold).first),
+    );
+    // 빈 사유 칸을 그리는 대신, 다른 트레이너를 찾도록 안내한다.
+    expect(find.text(l.exConsultRejectedNoReason), findsOneWidget);
+    expect(find.text(l.exConsultRejectedReasonLabel), findsNothing);
+  });
+
+  testWidgets('승인된 요청은 채팅으로 이어지는 안내를 보여준다', (
+    WidgetTester tester,
+  ) async {
+    await pumpGymTab(
+      tester,
+      consultation: _consultation(ConsultationStatus.accepted),
+      coach: _coach,
+    );
+    await scrollToCard(tester);
+
+    final AppLocalizations l = AppLocalizations.of(
+      tester.element(find.byType(Scaffold).first),
+    );
+    expect(find.text(l.exConsultAcceptedGuide), findsOneWidget);
+  });
+
+  testWidgets('대기 중인 요청에는 결과 안내가 붙지 않는다', (WidgetTester tester) async {
+    await pumpGymTab(
+      tester,
+      consultation: _consultation(ConsultationStatus.pending),
+    );
+    await scrollToCard(tester);
+
+    final AppLocalizations l = AppLocalizations.of(
+      tester.element(find.byType(Scaffold).first),
+    );
+    expect(find.text(l.exConsultAcceptedGuide), findsNothing);
+    expect(find.text(l.exConsultRejectedNoReason), findsNothing);
+  });
 
   testWidgets('my gym information keeps its detail route', (
     WidgetTester tester,


### PR DESCRIPTION
## Summary

* 회원이 자기 상담 요청의 처리 결과와 **거절 사유**를 앱에서 확인할 수 있습니다.
* 처리한 트레이너 id 는 회원 응답에 싣지 않습니다 — 헬스장으로 보낸 문의는 소속 트레이너 누구나 처리할 수 있어, 회원이 지정하지도 않은 트레이너를 알게 되기 때문입니다.
* 데모 화면은 지금과 동일합니다.

---

## Changes

### ✨ Features

* 회원용 `ConsultationOut` 에 `decision_note` 와 `decided_at` 을 노출합니다.
* 운동 탭의 상담 요청 현황 카드에 처리 결과 안내를 붙였습니다.
  * 거절: 트레이너가 남긴 사유를 그대로 보여줍니다.
  * 사유 없이 거절: 다른 트레이너를 찾도록 안내합니다.
  * 승인: 채팅으로 이어지는 안내를 보여줍니다.

### 🔧 Improvements

* `TrainerConsultationOut` 에서 중복 선언을 걷어냈습니다. 두 필드는 이제 회원용 스키마가 갖고 있어 상속으로 내려옵니다.
* 공백뿐인 사유는 `null` 로 접습니다. 그대로 두면 빈 안내 줄이 그려집니다.

### 🎨 UI/UX

* 결과 안내는 대기 중인 요청에는 붙지 않습니다. 상태 배지만 있던 기존 카드 모양이 대기 상태에서 그대로 유지됩니다.

### 📝 Docs

* 처리자 id 를 회원에게 노출하지 않는 이유를 스키마 주석에 남겼습니다.

---

## Commits

1. b049bc5 feat(consultation): 회원 앱에 상담 처리 결과와 거절 사유 표시

---

## Notes

**스택 PR — #470 다음에 병합해 주세요**

이 PR 은 #470 (이슈 #467) 브랜치 위에 쌓여 있습니다. 처리 결과 컬럼을 만드는 마이그레이션 `0023` 이 그 PR 에 있습니다. **#470 을 먼저 병합한 뒤 이 PR 의 base 를 `main` 으로 바꿔 병합**해 주세요. 하나로 합쳐 병합하면 #470 이 "Closed" 로 남고 이슈 연결이 어긋납니다.

**처리자 id 를 감추는 이유**

`decided_by` 는 트레이너 인박스 응답(`TrainerConsultationOut`)에는 그대로 있습니다 — 헬스장 문의를 누가 가져갔는지는 트레이너 쪽에 필요한 이력입니다. 회원에게 필요한 것은 결과와 이유뿐이고, 담당 트레이너가 누구인지는 `GET /me/coach` 가 이미 알려줍니다.

**응답 호환성**

두 필드 모두 선택값입니다. 필드를 주지 않는 서버와 이미 배포된 앱 조합에서도 화면이 깨지지 않으며, 그 경우를 테스트로 고정했습니다.

**범위**

승인 시 운동 탭이 트레이너 연결 상태로 바뀌는 동작은 이미 `GET /me/coach` 기준으로 동작하고 있어 이번에 손대지 않았습니다. 거절 후 재신청도 대기 상태만 막는 기존 `hasPending` 규칙 그대로 가능합니다. 두 동작 모두 기존 테스트가 덮고 있습니다.

---

## Screenshots (Optional)

UI 추가는 상담 현황 카드 하단의 안내 한 덩어리입니다. 대기 상태에서는 렌더되지 않아 데모 화면에 변화가 없습니다.

---

## Test Plan

* [x] 사용자 앱 DTO 테스트 신규 7건 (사유 파싱·공백 정리·처리 시각·필드 없는 예전 응답·copyWith 보존)
* [x] 사용자 앱 위젯 테스트 신규 4건 (사유 표시·사유 없음 안내·승인 안내·대기 중 미표시)
* [x] 사용자 앱 전체 375건 통과, `flutter analyze` 무경고
* [x] 백엔드 테스트 신규 2건 (회원 응답에 사유는 있고 처리자 id 는 없음, 대기 중 요청은 두 필드 모두 비어 있음)
* [x] 백엔드 전체 455건 통과

### Manual Test Steps

1. 백엔드를 띄우고 회원 앱에서 헬스장에 상담을 신청합니다.
2. 트레이너 앱에서 사유를 적어 거절합니다.
3. 회원 앱 운동 탭의 상담 요청 현황 카드에 그 사유가 표시되는지 확인합니다.
4. 사유 없이 거절하면 다른 트레이너를 찾으라는 안내가 대신 나오는지 확인합니다.
5. 승인하면 채팅으로 이어지는 안내가 나오는지 확인합니다.
6. 데모(둘러보기)에서 상담을 신청하고 카드가 기존과 동일한지 확인합니다.

---

## Related Issues

Closes #473

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인
