### PR TITLE
feat(auth): 트레이너 계정 생성 경로 신설

### DIFF
--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -31,9 +31,10 @@ from app.db.session import get_db
 from app.models.models import HealthProfile, User
 from app.schemas.user import (
     HealthGoalsUpdate, HealthProfileBrief, OnboardingRequest, ProfileUpdate,
-    ProfileView, RefreshRequest, RiskInfo, SettingItem, Token, UserHealth,
-    UserMe, UserRegister,
+    ProfileView, RefreshRequest, RiskInfo, SettingItem, Token, TrainerRegister,
+    UserHealth, UserMe, UserRegister,
 )
+from app.services import trainer_signup_service
 from app.services.health_service import DEMO_SETTINGS
 
 router = APIRouter(tags=["users"])
@@ -230,6 +231,59 @@ def register(
     db.refresh(user)
     audit(db, event="auth.register", user_id=user.id, ip=client_ip(request), success=True)
     return UserMe(id=user.id, name=user.name, email=user.email)
+
+
+@router.post(
+    "/auth/trainer/register",
+    response_model=UserMe,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(rate_limit("auth-register"))],
+)
+def register_trainer(
+    request: Request,
+    payload: TrainerRegister,
+    db: Annotated[Session, Depends(get_db)],
+) -> UserMe:
+    """헬스장 초대 코드로 트레이너 계정을 만든다. (#475)
+
+    `/auth/register` 와 나누는 이유: 그쪽은 `role='member'` 를 만든다. 한 엔드포인트에
+    역할 분기를 넣으면 코드 없이 트레이너를 만들 수 있는 경로가 생기기 쉽다.
+
+    코드가 소속 헬스장을 결정한다 — 소속 없는 트레이너는 상담 대상이 될 수 없어
+    (#443·#451) 가입 직후 아무것도 못 하는 상태가 된다.
+
+    회원 가입과 같은 rate limit 버킷을 쓴다. 코드를 무작위로 넣어 보는 시도도
+    가입 시도이므로 같은 한도가 맞다.
+    """
+    try:
+        trainer = trainer_signup_service.register_trainer(db, payload)
+    except trainer_signup_service.InviteCodeInvalid as exc:
+        audit(
+            db,
+            event="auth.trainer_register",
+            ip=client_ip(request),
+            success=False,
+            detail=payload.email,
+        )
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except trainer_signup_service.TrainerEmailTaken as exc:
+        audit(
+            db,
+            event="auth.trainer_register",
+            ip=client_ip(request),
+            success=False,
+            detail=payload.email,
+        )
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    audit(
+        db,
+        event="auth.trainer_register",
+        user_id=trainer.id,
+        ip=client_ip(request),
+        success=True,
+    )
+    return UserMe(id=trainer.id, name=trainer.name, email=trainer.email)
 
 
 @router.post(

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -439,6 +439,46 @@ class TrainerProfile(Base):
     )
 
 
+class TrainerInviteCode(Base):
+    """헬스장이 발급하는 트레이너 가입 초대 코드. (#475)
+
+    트레이너 계정은 시드 스크립트로만 만들 수 있었다 — `/auth/register` 는 회원
+    전용이라 트레이너 앱에서 가입해도 member 계정이 생겨 `/trainer/me` 가 403 을
+    돌려줬다. 그래서 트레이너 앱의 가입 진입점이 데모에서만 열려 있었다.
+
+    코드가 **소속을 결정한다**는 점이 핵심이다. 상담 대상 트레이너에게는 소속
+    헬스장이 요구되므로(#443·#451), 소속을 가입 시점에 확정하면 "가입은 됐는데
+    아무것도 못 하는" 상태가 생기지 않는다. 아무나 트레이너로 가입해 회원 상담을
+    받는 것도 구조로 막힌다.
+
+    한 번 쓰면 끝이다(`used_by`). 여러 명을 받으려면 헬스장이 코드를 여러 개
+    발급한다 — 사용 횟수를 세는 것보다 "누가 이 코드를 썼는지"가 남는 편이
+    나중에 추적할 수 있다.
+    """
+    __tablename__ = "trainer_invite_codes"
+
+    #: 사람이 옮겨 적는 값이라 코드 자체가 PK 다. 대문자·숫자만 쓰고 대소문자
+    #: 구분 없이 조회한다(입력 실수를 코드 오류로 만들지 않는다).
+    code: Mapped[str] = mapped_column(String(32), primary_key=True)
+    gym_id: Mapped[str] = mapped_column(
+        ForeignKey("places.id", ondelete="CASCADE"), index=True
+    )
+    #: 만료 시각. NULL 이면 만료 없음.
+    expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    #: 이 코드로 가입한 트레이너. NULL 이면 아직 쓰이지 않았다.
+    used_by: Mapped[str | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    used_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+
 class TrainerClient(Base):
     """트레이너↔회원 담당 링크. 트레이너의 '고객 목록'은 이 링크로 정의된다.
 

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -5,8 +5,8 @@
 """
 from __future__ import annotations
 
-from typing import Optional
-from pydantic import BaseModel
+from typing import Any, Optional
+from pydantic import BaseModel, Field, field_validator
 
 
 # ---- GET /users/me ----
@@ -62,6 +62,25 @@ class UserRegister(BaseModel):
     email: str
     password: str
     name: str = ""
+
+
+class TrainerRegister(UserRegister):
+    """트레이너 가입 — 회원 가입에 헬스장 초대 코드를 더한다. (#475)
+
+    코드가 소속 헬스장을 결정한다. 소속 없는 트레이너는 상담 대상이 될 수 없어
+    (#443·#451) 가입 직후 아무것도 못 하는 상태가 되므로, 소속을 가입 시점에
+    확정한다.
+    """
+
+    invite_code: str = Field(min_length=1, max_length=32)
+
+    @field_validator("invite_code", mode="before")
+    @classmethod
+    def _normalize_code(cls, value: Any) -> Any:
+        # 사람이 옮겨 적는 값이다. 공백과 대소문자 차이를 코드 오류로 만들지 않는다.
+        if isinstance(value, str):
+            return value.strip().upper()
+        return value
 
 
 # ---- 프로필 / 온보딩 / 건강 목표 ----

--- a/backend/app/services/trainer_signup_service.py
+++ b/backend/app/services/trainer_signup_service.py
@@ -1,0 +1,101 @@
+"""트레이너 가입 — 헬스장 초대 코드로만. (#475)
+
+트레이너 계정을 만들 방법이 시드 스크립트뿐이었다. `/auth/register` 는 회원
+전용이라 트레이너 앱에서 가입해도 `role='member'` 계정이 생기고 `/trainer/me` 가
+403 을 돌려줬다 — 그래서 가입 진입점이 데모에서만 열려 있었다.
+
+**왜 초대 코드인가.** 상담 대상 트레이너에게는 소속 헬스장이 요구된다(#443·#451).
+소속을 가입 시점에 확정하지 않으면 가입 직후 상담을 받을 수 없는 상태가 되고,
+공개 가입은 아무나 트레이너로 등록해 회원 상담을 받는 길을 열어 준다. 코드가
+소속을 결정하면 두 문제가 함께 사라진다.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.core.security import hash_password
+from app.models.models import Place, TrainerInviteCode, TrainerProfile, User
+from app.schemas.user import TrainerRegister
+
+
+class InviteCodeInvalid(Exception):
+    """없는 코드, 이미 쓰인 코드, 만료된 코드 — 모두 422.
+
+    셋을 나누지 않는 이유: 코드를 훑는 쪽에 "이 코드는 존재하지만 이미 쓰였다"를
+    알려 주면 유효한 코드 공간을 좁혀 준다. 사용자에게는 어느 경우든 다시 받아야
+    한다는 결론이 같다.
+    """
+
+
+class TrainerEmailTaken(Exception):
+    """이미 가입된 이메일 — 409."""
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _claim_code(db: Session, code: str) -> TrainerInviteCode:
+    """쓸 수 있는 코드를 잠근 채로 가져온다.
+
+    `with_for_update()` 로 잠그는 이유: 같은 코드를 두 사람이 동시에 넣으면 둘 다
+    '미사용' 검사를 통과해 트레이너가 두 명 생긴다. 코드는 1회용이라는 규칙이
+    조용히 깨진다.
+    """
+    row = db.scalar(
+        select(TrainerInviteCode)
+        .where(TrainerInviteCode.code == code)
+        .with_for_update()
+    )
+    if row is None or row.used_by is not None:
+        raise InviteCodeInvalid("사용할 수 없는 초대 코드입니다.")
+    if row.expires_at is not None and row.expires_at <= _now():
+        raise InviteCodeInvalid("사용할 수 없는 초대 코드입니다.")
+    # 코드가 가리키는 헬스장이 사라졌다면 소속을 만들 수 없다. FK 가 CASCADE 라
+    # 정상 경로에서는 코드도 함께 지워지지만, 방어적으로 확인한다.
+    if db.scalar(select(Place.id).where(Place.id == row.gym_id)) is None:
+        raise InviteCodeInvalid("사용할 수 없는 초대 코드입니다.")
+    return row
+
+
+def register_trainer(db: Session, payload: TrainerRegister) -> User:
+    """초대 코드를 확인하고 트레이너 계정과 프로필을 만든다.
+
+    계정 생성·프로필 생성·코드 소진을 **한 트랜잭션**으로 커밋한다. 나눠 커밋하면
+    계정만 만들어지고 소속이 없는 트레이너가 남거나, 코드만 소진되고 계정은 없는
+    상태가 생긴다.
+    """
+    code = _claim_code(db, payload.invite_code)
+
+    if db.scalar(select(User.id).where(User.email == payload.email)) is not None:
+        raise TrainerEmailTaken("이미 가입된 이메일입니다.")
+
+    trainer = User(
+        id=f"trainer-{uuid.uuid4().hex[:12]}",
+        email=payload.email,
+        name=payload.name or payload.email.split("@")[0],
+        hashed_password=hash_password(payload.password),
+        role="trainer",
+    )
+    db.add(trainer)
+    db.flush()
+
+    db.add(TrainerProfile(trainer_id=trainer.id, gym_id=code.gym_id))
+    code.used_by = trainer.id
+    code.used_at = _now()
+
+    try:
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        # 이메일 유니크 제약만이 여기서 경합으로 터질 수 있다 — 코드는 위에서
+        # 잠갔고 트레이너 id 는 새로 만든 UUID 다.
+        raise TrainerEmailTaken("이미 가입된 이메일입니다.") from exc
+
+    db.refresh(trainer)
+    return trainer

--- a/backend/migrations/versions/0024_trainer_invite_codes.py
+++ b/backend/migrations/versions/0024_trainer_invite_codes.py
@@ -1,0 +1,60 @@
+"""트레이너 가입 초대 코드
+
+트레이너 계정을 만들 방법이 시드 스크립트뿐이었다. `/auth/register` 는 회원 전용
+이라 트레이너 앱에서 가입해도 member 계정이 생기고 `/trainer/me` 가 403 을
+돌려줬다. 그래서 가입 진입점이 데모에서만 열려 있었다. (#475)
+
+헬스장이 발급한 코드로만 트레이너가 가입하게 한다. 코드가 소속(`gym_id`)을
+결정하므로, 상담 대상 트레이너에게 소속을 요구하는 기존 조건(#443·#451)을 가입
+시점에 자연히 만족시킨다.
+
+코드 자체가 PK 다 — 사람이 옮겨 적는 값이고, 별도 대리키를 두면 조회 때마다
+유니크 인덱스를 한 번 더 타야 한다.
+
+Revision ID: 0024_trainer_invite_codes
+Revises: 0023_consultation_decision
+Create Date: 2026-08-08
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0024_trainer_invite_codes"
+down_revision: str | Sequence[str] | None = "0023_consultation_decision"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "trainer_invite_codes",
+        sa.Column("code", sa.String(length=32), nullable=False),
+        sa.Column("gym_id", sa.String(length=64), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("used_by", sa.String(length=64), nullable=True),
+        sa.Column("used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        # 헬스장이 사라지면 그 코드로 가입시킬 소속도 없다 — 함께 지운다.
+        sa.ForeignKeyConstraint(["gym_id"], ["places.id"], ondelete="CASCADE"),
+        # 가입한 트레이너가 탈퇴해도 코드 사용 이력은 남긴다.
+        sa.ForeignKeyConstraint(["used_by"], ["users.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("code"),
+    )
+    op.create_index(
+        "ix_trainer_invite_codes_gym_id", "trainer_invite_codes", ["gym_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_trainer_invite_codes_gym_id", table_name="trainer_invite_codes"
+    )
+    op.drop_table("trainer_invite_codes")

--- a/backend/tests/test_trainer_signup.py
+++ b/backend/tests/test_trainer_signup.py
@@ -1,0 +1,228 @@
+"""트레이너 가입 — 헬스장 초대 코드. (#475)
+
+트레이너 계정을 만들 방법이 시드 스크립트뿐이었다. 가입한 계정이 실제로
+트레이너로 동작하는지(= `/trainer/me` 가 200 을 주고 소속이 붙는지)를 확인한다 —
+`users.role` 만 보면 "가입은 됐는데 아무것도 못 하는" 상태를 놓친다.
+
+DB 가 필요하므로 로컬에서는 skip 되고 CI(Postgres) 에서 실행된다.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+
+from app.models.models import (
+    Place,
+    TrainerInviteCode,
+    TrainerProfile,
+    User,
+)
+
+EMAIL_PREFIX = "signup-test-"
+PLACE_PREFIX = "signup-place-"
+CODE_PREFIX = "SIGNUPTEST"
+PASSWORD = "signup-pw-1234"
+
+
+@pytest.fixture(autouse=True)
+def _cleanup(db_session):
+    yield
+    db_session.rollback()
+    user_ids = [
+        row[0]
+        for row in db_session.query(User.id)
+        .filter(User.email.like(f"{EMAIL_PREFIX}%"))
+        .all()
+    ]
+    db_session.query(TrainerInviteCode).filter(
+        TrainerInviteCode.code.like(f"{CODE_PREFIX}%")
+    ).delete(synchronize_session=False)
+    if user_ids:
+        db_session.query(TrainerProfile).filter(
+            TrainerProfile.trainer_id.in_(user_ids)
+        ).delete(synchronize_session=False)
+        db_session.query(User).filter(User.id.in_(user_ids)).delete(
+            synchronize_session=False
+        )
+    db_session.query(Place).filter(Place.id.like(f"{PLACE_PREFIX}%")).delete(
+        synchronize_session=False
+    )
+    db_session.commit()
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _gym(db_session) -> Place:
+    place = Place(
+        id=f"{PLACE_PREFIX}{uuid4().hex[:10]}",
+        name="가입 테스트 헬스장",
+        category="fitness",
+        address="서울",
+    )
+    db_session.add(place)
+    db_session.commit()
+    return place
+
+
+def _code(
+    db_session,
+    *,
+    gym: Place | None = None,
+    used_by: str | None = None,
+    expires_at: datetime | None = None,
+) -> TrainerInviteCode:
+    code = TrainerInviteCode(
+        code=f"{CODE_PREFIX}{uuid4().hex[:8].upper()}",
+        gym_id=(gym or _gym(db_session)).id,
+        used_by=used_by,
+        expires_at=expires_at,
+    )
+    db_session.add(code)
+    db_session.commit()
+    return code
+
+
+def _payload(code: str, *, email: str | None = None) -> dict:
+    return {
+        "email": email or f"{EMAIL_PREFIX}{uuid4().hex[:10]}@oncare.com",
+        "password": PASSWORD,
+        "name": "신규 트레이너",
+        "invite_code": code,
+    }
+
+
+def _login(client, email: str) -> str:
+    response = client.post(
+        "/v1/auth/login", data={"username": email, "password": PASSWORD}
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["access_token"]
+
+
+def test_invite_code_creates_a_working_trainer(client, db_session):
+    """가입한 계정이 실제로 트레이너로 동작하고 소속이 붙는다."""
+    gym = _gym(db_session)
+    code = _code(db_session, gym=gym)
+    payload = _payload(code.code)
+
+    response = client.post("/v1/auth/trainer/register", json=payload)
+
+    assert response.status_code == 201, response.text
+    assert response.json()["email"] == payload["email"]
+
+    # role 만 보지 않는다 — 트레이너 앱이 처음 부르는 엔드포인트로 확인한다.
+    me = client.get("/v1/trainer/me", headers=_auth(_login(client, payload["email"])))
+    assert me.status_code == 200, me.text
+    assert me.json()["gym"]["id"] == gym.id
+
+
+def test_the_code_is_spent_after_use(client, db_session):
+    """코드는 1회용이다 — 두 번째 가입은 거절된다."""
+    code = _code(db_session)
+
+    first = client.post("/v1/auth/trainer/register", json=_payload(code.code))
+    second = client.post("/v1/auth/trainer/register", json=_payload(code.code))
+
+    assert first.status_code == 201, first.text
+    assert second.status_code == 422, second.text
+
+    db_session.expire_all()
+    spent = db_session.get(TrainerInviteCode, code.code)
+    assert spent.used_by == first.json()["id"]
+    assert spent.used_at is not None
+
+
+def test_unknown_code_is_rejected(client):
+    response = client.post(
+        "/v1/auth/trainer/register", json=_payload(f"{CODE_PREFIX}NOPE")
+    )
+    assert response.status_code == 422, response.text
+
+
+def test_expired_code_is_rejected(client, db_session):
+    code = _code(
+        db_session,
+        expires_at=datetime.now(timezone.utc) - timedelta(days=1),
+    )
+
+    response = client.post("/v1/auth/trainer/register", json=_payload(code.code))
+
+    assert response.status_code == 422, response.text
+
+
+def test_code_is_matched_case_insensitively(client, db_session):
+    """사람이 옮겨 적는 값이다 — 소문자·공백을 코드 오류로 만들지 않는다."""
+    code = _code(db_session)
+    payload = _payload(f"  {code.code.lower()}  ")
+
+    response = client.post("/v1/auth/trainer/register", json=payload)
+
+    assert response.status_code == 201, response.text
+
+
+def test_duplicate_email_conflicts_and_keeps_the_code_usable(
+    client, db_session
+):
+    """이메일이 겹쳐 실패하면 코드는 소진되지 않아야 한다.
+
+    코드만 날아가면 트레이너는 오타 한 번에 헬스장에 코드를 다시 요청해야 한다.
+    """
+    code = _code(db_session)
+    taken = f"{EMAIL_PREFIX}{uuid4().hex[:10]}@oncare.com"
+    client.post("/v1/auth/register", json={
+        "email": taken, "password": PASSWORD, "name": "회원",
+    })
+
+    response = client.post(
+        "/v1/auth/trainer/register", json=_payload(code.code, email=taken)
+    )
+
+    assert response.status_code == 409, response.text
+    db_session.expire_all()
+    assert db_session.get(TrainerInviteCode, code.code).used_by is None
+
+
+def test_failed_signup_leaves_no_half_built_account(client, db_session):
+    """실패한 가입은 계정도 프로필도 남기지 않는다."""
+    email = f"{EMAIL_PREFIX}{uuid4().hex[:10]}@oncare.com"
+
+    response = client.post(
+        "/v1/auth/trainer/register",
+        json=_payload(f"{CODE_PREFIX}MISSING", email=email),
+    )
+
+    assert response.status_code == 422, response.text
+    assert db_session.query(User).filter(User.email == email).count() == 0
+
+
+def test_member_register_still_creates_a_member(client):
+    """회원 가입 경로는 그대로다 — 트레이너가 되지 않는다."""
+    email = f"{EMAIL_PREFIX}{uuid4().hex[:10]}@oncare.com"
+    created = client.post(
+        "/v1/auth/register",
+        json={"email": email, "password": PASSWORD, "name": "회원"},
+    )
+    assert created.status_code == 201, created.text
+
+    me = client.get("/v1/trainer/me", headers=_auth(_login(client, email)))
+
+    # 회원 계정은 트레이너 엔드포인트에서 403 이어야 한다.
+    assert me.status_code == 403, me.text
+
+
+def test_signup_requires_an_invite_code(client):
+    """코드 없이 트레이너로 가입할 수 있는 경로가 없어야 한다."""
+    response = client.post(
+        "/v1/auth/trainer/register",
+        json={
+            "email": f"{EMAIL_PREFIX}{uuid4().hex[:10]}@oncare.com",
+            "password": PASSWORD,
+            "name": "코드 없음",
+        },
+    )
+
+    assert response.status_code == 422, response.text

--- a/frontend/flutter_trainer/lib/features/auth/data/repositories/dio_trainer_auth_repository.dart
+++ b/frontend/flutter_trainer/lib/features/auth/data/repositories/dio_trainer_auth_repository.dart
@@ -37,19 +37,28 @@ class DioTrainerAuthRepository implements TrainerAuthRepository {
     required String email,
     required String password,
     required String name,
+    required String inviteCode,
   }) async {
     try {
+      // 회원용 `/auth/register` 가 아니다 — 그쪽은 role='member' 를 만들어,
+      // 가입은 되는데 `/trainer/me` 가 403 을 주는 계정이 생겼다. (#475)
       await _dio.post<Map<String, Object?>>(
-        '/auth/register',
+        '/auth/trainer/register',
         data: <String, Object?>{
           'email': email,
           'password': password,
           'name': name,
+          'invite_code': inviteCode,
         },
       );
     } on DioException catch (e) {
       if (e.response?.statusCode == 409) {
         throw const AuthException('이미 가입된 이메일입니다.');
+      }
+      if (e.response?.statusCode == 422) {
+        // 서버는 없는·만료된·이미 쓰인 코드를 구분하지 않는다. 어느 경우든
+        // 트레이너가 할 일은 헬스장에 코드를 다시 받는 것이라 결론이 같다.
+        throw const AuthException('사용할 수 없는 초대 코드예요. 헬스장에 확인해 주세요.');
       }
       throw _asAuth(e);
     }

--- a/frontend/flutter_trainer/lib/features/auth/data/repositories/mock_trainer_auth_repository.dart
+++ b/frontend/flutter_trainer/lib/features/auth/data/repositories/mock_trainer_auth_repository.dart
@@ -37,11 +37,14 @@ class MockTrainerAuthRepository implements TrainerAuthRepository {
     required String email,
     required String password,
     required String name,
+    required String inviteCode,
   }) async {
     await Future<void>.delayed(_loginDelay);
     if (email.trim().isEmpty || password.isEmpty) {
       throw const AuthException('이메일과 비밀번호를 입력해 주세요');
     }
+    // 데모에는 코드를 검증할 백엔드가 없다. 화면이 기존과 똑같이 동작하도록
+    // 코드는 보지 않고 통과시킨다.
     return _demoTokens('signup');
   }
 

--- a/frontend/flutter_trainer/lib/features/auth/domain/repositories/trainer_auth_repository.dart
+++ b/frontend/flutter_trainer/lib/features/auth/domain/repositories/trainer_auth_repository.dart
@@ -35,12 +35,19 @@ abstract class TrainerAuthRepository {
     required String password,
   });
 
-  /// Creates a new trainer account (POST /v1/auth/register) and returns
-  /// tokens. Throws [AuthException] (e.g. 409 duplicate email).
+  /// Creates a new trainer account (POST /v1/auth/trainer/register) and
+  /// returns tokens. Throws [AuthException] (409 duplicate email, 422
+  /// unusable invite code).
+  ///
+  /// [inviteCode] is the gym's invite code and is **required**: it decides
+  /// which gym the new trainer belongs to. A trainer with no gym cannot be
+  /// a consultation target, so signing up without one would land the
+  /// account in a state where nothing works. (#475)
   Future<TrainerAuthTokens> register({
     required String email,
     required String password,
     required String name,
+    required String inviteCode,
   });
 
   /// Exchanges a provider (kakao/google) [token] for tokens

--- a/frontend/flutter_trainer/lib/features/auth/presentation/controllers/session_controller.dart
+++ b/frontend/flutter_trainer/lib/features/auth/presentation/controllers/session_controller.dart
@@ -166,12 +166,14 @@ class SessionController extends StateNotifier<SessionState> {
     required String email,
     required String password,
     required String name,
+    required String inviteCode,
   }) async {
     _userActionStarted = true;
     final tokens = await _repo.register(
       email: email,
       password: password,
       name: name,
+      inviteCode: inviteCode,
     );
     await _establish(tokens);
   }

--- a/frontend/flutter_trainer/lib/features/auth/presentation/pages/trainer_sign_in_page.dart
+++ b/frontend/flutter_trainer/lib/features/auth/presentation/pages/trainer_sign_in_page.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:oncare_trainer/app/router/routes.dart';
-import 'package:oncare_trainer/core/config/app_config.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/features/auth/domain/repositories/trainer_auth_repository.dart';
@@ -92,8 +91,11 @@ class _TrainerSignInPageState extends ConsumerState<TrainerSignInPage> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    // Self sign-up only makes sense in demo/mock mode (see below).
-    final signUpEnabled = ref.watch(appConfigProvider).useMockApi;
+    // 가입 경로는 이제 실 API 모드에서도 열린다 — `/auth/trainer/register` 가
+    // 헬스장 초대 코드로 트레이너 계정을 만든다(#475). 전에는 회원용
+    // `/auth/register` 로 나가 role='member' 계정이 생겼고, 그 계정은
+    // `/trainer/me` 에서 403 이라 가입해도 아무것도 할 수 없었다.
+    const signUpEnabled = true;
     return Scaffold(
       // 사용자 앱 로그인 화면과 동일한 흰색 배경.
       backgroundColor: Colors.white,

--- a/frontend/flutter_trainer/lib/features/auth/presentation/pages/trainer_sign_up_page.dart
+++ b/frontend/flutter_trainer/lib/features/auth/presentation/pages/trainer_sign_up_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:oncare_trainer/app/router/routes.dart';
+import 'package:oncare_trainer/core/config/app_config.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/features/auth/domain/repositories/trainer_auth_repository.dart';
@@ -10,8 +11,14 @@ import 'package:oncare_trainer/features/auth/presentation/controllers/session_co
 import 'package:oncare_trainer/features/auth/presentation/widgets/auth_fields.dart';
 
 /// 트레이너 회원가입 화면 — 사용자 앱 회원가입과 동일한 디자인. 이름/이메일/
-/// 비밀번호로 계정을 만들고, 성공 시 자동 로그인해 고객 탭으로 진입한다
-/// (라우터 가드가 인증 상태를 감지).
+/// 비밀번호와 **헬스장 초대 코드**로 계정을 만들고, 성공 시 자동 로그인해 고객
+/// 탭으로 진입한다 (라우터 가드가 인증 상태를 감지).
+///
+/// 초대 코드가 소속 헬스장을 결정한다(#475). 소속 없는 트레이너는 상담 대상이
+/// 될 수 없어(#443·#451) 가입 직후 아무것도 못 하는 계정이 된다.
+///
+/// **데모에서는 코드 입력을 아예 그리지 않는다.** 검증할 백엔드가 없어 무엇을
+/// 넣든 통과하는 죽은 입력이 되고, 무엇보다 데모 화면이 지금과 달라진다.
 class TrainerSignUpPage extends ConsumerStatefulWidget {
   /// Creates the trainer sign-up screen.
   const TrainerSignUpPage({super.key});
@@ -25,6 +32,7 @@ class _TrainerSignUpPageState extends ConsumerState<TrainerSignUpPage> {
   final TextEditingController _email = TextEditingController();
   final TextEditingController _password = TextEditingController();
   final TextEditingController _passwordConfirm = TextEditingController();
+  final TextEditingController _inviteCode = TextEditingController();
   bool _obscure = true;
   bool _loading = false;
 
@@ -34,6 +42,7 @@ class _TrainerSignUpPageState extends ConsumerState<TrainerSignUpPage> {
     _email.dispose();
     _password.dispose();
     _passwordConfirm.dispose();
+    _inviteCode.dispose();
     super.dispose();
   }
 
@@ -52,6 +61,9 @@ class _TrainerSignUpPageState extends ConsumerState<TrainerSignUpPage> {
     final email = _email.text.trim();
     final password = _password.text;
     final confirm = _passwordConfirm.text;
+    // 데모에는 코드를 검증할 백엔드가 없어 입력 자체를 그리지 않는다.
+    final requiresInviteCode = !ref.read(appConfigProvider).useMockApi;
+    final inviteCode = _inviteCode.text.trim();
     if (email.isEmpty || password.isEmpty) {
       messenger.showSnackBar(
         const SnackBar(content: Text('이메일과 비밀번호를 입력해 주세요')),
@@ -68,11 +80,22 @@ class _TrainerSignUpPageState extends ConsumerState<TrainerSignUpPage> {
       messenger.showSnackBar(const SnackBar(content: Text('비밀번호가 일치하지 않아요')));
       return;
     }
+    if (requiresInviteCode && inviteCode.isEmpty) {
+      messenger.showSnackBar(
+        const SnackBar(content: Text('헬스장에서 받은 초대 코드를 입력해 주세요')),
+      );
+      return;
+    }
     setState(() => _loading = true);
     try {
       await ref
           .read(sessionControllerProvider.notifier)
-          .register(email: email, password: password, name: name);
+          .register(
+            email: email,
+            password: password,
+            name: name,
+            inviteCode: inviteCode,
+          );
       if (!mounted) return;
       context.go(AppRoutes.dashboard);
     } on AuthException catch (e) {
@@ -89,6 +112,8 @@ class _TrainerSignUpPageState extends ConsumerState<TrainerSignUpPage> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    // 데모 가입 화면은 지금과 동일해야 한다 — 코드 입력을 그리지 않는다.
+    final showInviteCode = !ref.watch(appConfigProvider).useMockApi;
     return Scaffold(
       backgroundColor: Colors.white,
       body: SafeArea(
@@ -165,8 +190,27 @@ class _TrainerSignUpPageState extends ConsumerState<TrainerSignUpPage> {
                         hint: '비밀번호 확인',
                         icon: Icons.lock_outline,
                         obscure: _obscure,
-                        onSubmitted: (_) => _register(),
+                        // 데모에서는 이 필드가 마지막이라 제출 액션이 여기 붙는다.
+                        onSubmitted: showInviteCode ? null : (_) => _register(),
                       ),
+                      if (showInviteCode) ...<Widget>[
+                        const SizedBox(height: AppSpacing.md),
+                        AuthField(
+                          controller: _inviteCode,
+                          hint: '헬스장 초대 코드',
+                          icon: Icons.confirmation_number_outlined,
+                          textCapitalization: TextCapitalization.characters,
+                          onSubmitted: (_) => _register(),
+                        ),
+                        const SizedBox(height: AppSpacing.xs),
+                        const Text(
+                          '소속 헬스장에서 발급받은 코드를 입력해 주세요.',
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: Color(0xFF64748B),
+                          ),
+                        ),
+                      ],
                       const SizedBox(height: AppSpacing.xl),
 
                       AuthGradientButton(

--- a/frontend/flutter_trainer/lib/features/auth/presentation/widgets/auth_fields.dart
+++ b/frontend/flutter_trainer/lib/features/auth/presentation/widgets/auth_fields.dart
@@ -34,6 +34,7 @@ class AuthField extends StatelessWidget {
     this.trailing,
     this.onSubmitted,
     this.textInputAction,
+    this.textCapitalization = TextCapitalization.none,
   });
 
   /// Field controller.
@@ -60,12 +61,18 @@ class AuthField extends StatelessWidget {
   /// Overrides the keyboard action button.
   final TextInputAction? textInputAction;
 
+  /// Auto-capitalisation. 초대 코드처럼 대문자로 적는 값에 쓴다 — 서버가
+  /// 대소문자를 구분하지 않지만, 화면이 코드 모양대로 보이는 편이 옮겨 적기
+  /// 쉽다. (#475)
+  final TextCapitalization textCapitalization;
+
   @override
   Widget build(BuildContext context) {
     return TextField(
       controller: controller,
       obscureText: obscure,
       keyboardType: keyboardType,
+      textCapitalization: textCapitalization,
       style: const TextStyle(color: _authText),
       textInputAction:
           textInputAction ??

--- a/frontend/flutter_trainer/test/features/auth/dio_trainer_auth_repository_test.dart
+++ b/frontend/flutter_trainer/test/features/auth/dio_trainer_auth_repository_test.dart
@@ -104,17 +104,26 @@ void main() {
   });
 
   group('register', () {
+    // 회원용 `/auth/register` 가 아니라 트레이너 전용 경로다 — 그쪽은
+    // role='member' 를 만들어 `/trainer/me` 가 403 인 계정이 생겼다. (#475)
+    const String path = '/auth/trainer/register';
+
     test('maps 409 to a duplicate-email AuthException', () async {
       when(
         () => dio.post<Map<String, Object?>>(
-          '/auth/register',
+          path,
           data: any(named: 'data'),
           options: any(named: 'options'),
         ),
-      ).thenThrow(_httpError(409, '/auth/register'));
+      ).thenThrow(_httpError(409, path));
 
       await expectLater(
-        repo.register(email: 'e@x.com', password: 'pw', name: '김'),
+        repo.register(
+          email: 'e@x.com',
+          password: 'pw',
+          name: '김',
+          inviteCode: 'ONCARE1',
+        ),
         throwsA(
           isA<AuthException>().having(
             (e) => e.message,
@@ -123,6 +132,66 @@ void main() {
           ),
         ),
       );
+    });
+
+    test('maps 422 to an invite-code message', () async {
+      // 없는·만료된·이미 쓰인 코드를 서버가 구분하지 않는다. 트레이너가 할 일은
+      // 어느 경우든 헬스장에 코드를 다시 받는 것이라 결론이 같다.
+      when(
+        () => dio.post<Map<String, Object?>>(
+          path,
+          data: any(named: 'data'),
+          options: any(named: 'options'),
+        ),
+      ).thenThrow(_httpError(422, path));
+
+      await expectLater(
+        repo.register(
+          email: 'e@x.com',
+          password: 'pw',
+          name: '김',
+          inviteCode: 'NOPE',
+        ),
+        throwsA(
+          isA<AuthException>().having(
+            (e) => e.message,
+            'message',
+            contains('초대 코드'),
+          ),
+        ),
+      );
+    });
+
+    test('sends the invite code to the trainer signup path', () async {
+      when(
+        () => dio.post<Map<String, Object?>>(
+          path,
+          data: any(named: 'data'),
+          options: any(named: 'options'),
+        ),
+      ).thenThrow(_httpError(409, path));
+
+      // 409 로 끝나지만, 여기서 확인하려는 것은 나간 payload 다.
+      await expectLater(
+        repo.register(
+          email: 'e@x.com',
+          password: 'pw',
+          name: '김',
+          inviteCode: 'ONCARE1',
+        ),
+        throwsA(isA<AuthException>()),
+      );
+
+      final data =
+          verify(
+                () => dio.post<Map<String, Object?>>(
+                  path,
+                  data: captureAny(named: 'data'),
+                  options: any(named: 'options'),
+                ),
+              ).captured.first
+              as Map<String, Object?>;
+      expect(data['invite_code'], 'ONCARE1');
     });
   });
 

--- a/frontend/flutter_trainer/test/features/auth/session_controller_test.dart
+++ b/frontend/flutter_trainer/test/features/auth/session_controller_test.dart
@@ -392,6 +392,7 @@ class _FakeAuthRepository implements TrainerAuthRepository {
     required String email,
     required String password,
     required String name,
+    required String inviteCode,
   }) async => _tokens('register');
 
   @override

--- a/frontend/flutter_trainer/test/features/auth/trainer_sign_up_page_test.dart
+++ b/frontend/flutter_trainer/test/features/auth/trainer_sign_up_page_test.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare_trainer/app/router/routes.dart';
+import 'package:oncare_trainer/core/config/app_config.dart';
+import 'package:oncare_trainer/features/auth/data/repositories/dio_trainer_auth_repository.dart';
+import 'package:oncare_trainer/features/auth/domain/entities/auth_tokens.dart';
+import 'package:oncare_trainer/features/auth/domain/repositories/trainer_auth_repository.dart';
+import 'package:oncare_trainer/shared/models/trainer_profile.dart';
+
+import '../../helpers/pump_app.dart';
+
+/// 가입 호출의 인자를 기록하는 페이크. 로그인까지는 성공시킨다.
+class _RecordingAuthRepository implements TrainerAuthRepository {
+  String? email;
+  String? name;
+  String? inviteCode;
+  int registerCalls = 0;
+
+  static const TrainerAuthTokens _tokens = TrainerAuthTokens(
+    access: 'a',
+    refresh: 'r',
+  );
+
+  @override
+  Future<TrainerAuthTokens> login({
+    required String email,
+    required String password,
+  }) async => _tokens;
+
+  @override
+  Future<TrainerAuthTokens> register({
+    required String email,
+    required String password,
+    required String name,
+    required String inviteCode,
+  }) async {
+    registerCalls++;
+    this.email = email;
+    this.name = name;
+    this.inviteCode = inviteCode;
+    return _tokens;
+  }
+
+  @override
+  Future<TrainerAuthTokens> socialLogin({
+    required String provider,
+    required String token,
+  }) async => _tokens;
+
+  @override
+  Future<TrainerAuthTokens> refresh(String refreshToken) async => _tokens;
+
+  @override
+  Future<TrainerProfile> fetchProfile(String accessToken) async =>
+      const TrainerProfile(
+        name: '신규 트레이너',
+        email: 'new@oncare.com',
+        phone: '',
+        specialty: '',
+        career: '',
+        intro: '',
+        certifications: <String>[],
+        gym: TrainerGym(name: '', address: '', hours: '', phone: ''),
+      );
+}
+
+/// 실 API 모드 설정 — 초대 코드 입력이 그려지는 쪽.
+const AppConfig _realConfig = AppConfig(
+  environment: Environment.dev,
+  apiBaseUrl: 'http://localhost/v1',
+  useMockApi: false,
+);
+
+Future<_RecordingAuthRepository> _pumpSignUp(
+  WidgetTester tester, {
+  bool demo = false,
+}) async {
+  final repo = _RecordingAuthRepository();
+  await pumpTrainerApp(
+    tester,
+    at: AppRoutes.signUp,
+    extraOverrides: <Override>[
+      if (!demo) appConfigProvider.overrideWithValue(_realConfig),
+      trainerAuthRepositoryProvider.overrideWithValue(repo),
+    ],
+  );
+  return repo;
+}
+
+Future<void> _fill(
+  WidgetTester tester, {
+  String name = '김신규',
+  String email = 'new@oncare.com',
+  String password = 'signup-pw-1234',
+  String confirm = 'signup-pw-1234',
+  String? code,
+}) async {
+  await tester.enterText(find.widgetWithText(TextField, '이름'), name);
+  await tester.enterText(find.widgetWithText(TextField, '이메일'), email);
+  await tester.enterText(
+    find.widgetWithText(TextField, '비밀번호 (8자 이상)'),
+    password,
+  );
+  await tester.enterText(find.widgetWithText(TextField, '비밀번호 확인'), confirm);
+  if (code != null) {
+    await tester.enterText(find.widgetWithText(TextField, '헬스장 초대 코드'), code);
+  }
+  await tester.pump();
+}
+
+void main() {
+  testWidgets('가입 화면에 초대 코드 입력이 있다', (WidgetTester tester) async {
+    await _pumpSignUp(tester);
+
+    expect(find.widgetWithText(TextField, '헬스장 초대 코드'), findsOneWidget);
+    expect(find.text('소속 헬스장에서 발급받은 코드를 입력해 주세요.'), findsOneWidget);
+  });
+
+  testWidgets('초대 코드를 그대로 실어 보낸다', (WidgetTester tester) async {
+    final repo = await _pumpSignUp(tester);
+    await _fill(tester, code: 'ONCARE1');
+
+    await tester.tap(find.text('가입하고 시작하기'));
+    await settle(tester);
+
+    expect(repo.registerCalls, 1);
+    expect(repo.inviteCode, 'ONCARE1');
+    expect(repo.email, 'new@oncare.com');
+  });
+
+  testWidgets('코드 앞뒤 공백은 정리해서 보낸다', (WidgetTester tester) async {
+    final repo = await _pumpSignUp(tester);
+    await _fill(tester, code: '  ONCARE1  ');
+
+    await tester.tap(find.text('가입하고 시작하기'));
+    await settle(tester);
+
+    expect(repo.inviteCode, 'ONCARE1');
+  });
+
+  testWidgets('코드 없이는 가입 요청을 보내지 않는다', (WidgetTester tester) async {
+    // 코드가 소속을 결정하므로, 없으면 서버에 물어볼 것도 없다.
+    final repo = await _pumpSignUp(tester);
+    await _fill(tester);
+
+    await tester.tap(find.text('가입하고 시작하기'));
+    await settle(tester);
+
+    expect(repo.registerCalls, 0);
+    expect(find.text('헬스장에서 받은 초대 코드를 입력해 주세요'), findsOneWidget);
+  });
+
+  testWidgets('비밀번호가 다르면 코드가 있어도 보내지 않는다', (
+    WidgetTester tester,
+  ) async {
+    final repo = await _pumpSignUp(tester);
+    await _fill(tester, confirm: 'different-pw', code: 'ONCARE1');
+
+    await tester.tap(find.text('가입하고 시작하기'));
+    await settle(tester);
+
+    expect(repo.registerCalls, 0);
+  });
+
+  // --- 데모 불변 -----------------------------------------------------------
+
+  testWidgets('데모 가입 화면에는 코드 입력이 없다', (WidgetTester tester) async {
+    // 데모에는 코드를 검증할 백엔드가 없다. 무엇을 넣어도 통과하는 죽은 입력을
+    // 두느니 그리지 않는다 — 데모 화면이 지금 그대로여야 한다.
+    await _pumpSignUp(tester, demo: true);
+
+    expect(find.widgetWithText(TextField, '헬스장 초대 코드'), findsNothing);
+    expect(find.text('소속 헬스장에서 발급받은 코드를 입력해 주세요.'), findsNothing);
+  });
+
+  testWidgets('데모에서는 코드 없이도 가입이 진행된다', (WidgetTester tester) async {
+    final repo = await _pumpSignUp(tester, demo: true);
+    await _fill(tester);
+
+    await tester.tap(find.text('가입하고 시작하기'));
+    await settle(tester);
+
+    expect(repo.registerCalls, 1);
+    expect(repo.inviteCode, '');
+  });
+}

--- a/frontend/flutter_trainer/test/features/coaching/coaching_page_test.dart
+++ b/frontend/flutter_trainer/test/features/coaching/coaching_page_test.dart
@@ -184,6 +184,7 @@ class _FakeTrainerAuthRepository implements TrainerAuthRepository {
     required String email,
     required String password,
     required String name,
+    required String inviteCode,
   }) async => _tokens;
 
   @override


### PR DESCRIPTION
## Summary

* 헬스장이 발급한 초대 코드로 트레이너가 직접 가입할 수 있습니다. 지금까지 트레이너 계정은 시드 스크립트로만 만들 수 있었습니다.
* 코드가 소속 헬스장을 결정합니다 — 소속 없는 트레이너는 상담 대상이 될 수 없어(#443·#451) 가입 직후 아무것도 못 하는 계정이 됩니다.
* 데모 화면은 지금과 동일합니다. 데모 가입 화면에는 코드 입력이 그려지지 않습니다.

---

## Changes

### ✨ Features

* `trainer_invite_codes` 테이블을 추가했습니다. 코드가 PK 이고, `gym_id` 가 소속을 결정하며, `used_by` 로 1회용입니다.
* `POST /auth/trainer/register` — 초대 코드를 확인하고 트레이너 계정과 프로필을 만듭니다.
* 트레이너 앱 회원가입 화면에 초대 코드 입력을 추가했습니다.
* 실 API 모드에서 회원가입 진입점을 엽니다.

### 🔧 Improvements

* `AuthField` 에 `textCapitalization` 을 더했습니다. 코드는 대문자로 적는 값이라 화면이 코드 모양대로 보이는 편이 옮겨 적기 쉽습니다.

### 🎨 UI/UX

* 데모에서는 코드 입력을 그리지 않고, 마지막 필드가 비밀번호 확인이 되므로 제출 액션을 그쪽으로 옮겼습니다.
* 서버가 구분하지 않는 코드 실패는 "헬스장에 확인해 주세요" 한 문장으로 안내합니다.

### 📝 Docs

* 초대 코드를 고른 이유와 다른 후보(관리자 승인·공개 가입)를 이슈 #475 본문에 남겼습니다.

### 🐛 Fixes

* 트레이너 앱의 `register` 가 회원용 `/auth/register` 로 나가던 문제를 고쳤습니다. 가입하면 `role='member'` 계정이 생겨 `/trainer/me` 가 403 이었고, 그래서 진입점이 데모에서만 열려 있었습니다.

---

## Commits

1. c05c806 feat(auth): 헬스장 초대 코드로 트레이너 계정 생성

---

## Notes

**가정 — 가입 정책은 A안(초대 코드)입니다**

이슈 #475 에 세 후보(초대 코드 / 관리자 승인 / 공개 가입)를 적고 A 를 권장안으로 제시했으며, 이 PR 은 그 가정 위에 구현했습니다. 다른 정책을 원하시면 이슈에 코멘트를 남겨 주세요 — 관리자 승인(B)으로 바꾸면 대기 상태 UX 와 관리자 화면이 추가로 필요합니다.

**스택 PR — #470 다음에 병합해 주세요**

이 PR 은 #470 (이슈 #467) 브랜치 위에 쌓여 있습니다. 마이그레이션 `0024` 의 `down_revision` 이 그 PR 의 `0023` 입니다. **#470 을 먼저 병합한 뒤 이 PR 의 base 를 `main` 으로 바꿔 병합**해 주세요. 하나로 합쳐 병합하면 #470 이 "Closed" 로 남고 이슈 연결이 어긋납니다.

같은 이유로 #476(이슈 #473)과도 형제 관계입니다. #476 에는 마이그레이션이 없어 순서를 타지 않습니다.

**설계 판단**

* 회원 경로(`/auth/register`)와 엔드포인트를 나눴습니다. 한 엔드포인트에 역할 분기를 넣으면 코드 없이 트레이너를 만들 수 있는 경로가 생기기 쉽습니다.
* 코드 조회를 `with_for_update()` 로 잠급니다. 같은 코드를 두 사람이 동시에 넣으면 둘 다 '미사용' 검사를 통과해 1회용 규칙이 조용히 깨집니다.
* 계정·프로필·코드 소진을 한 트랜잭션으로 커밋합니다. 이메일 중복으로 실패하면 코드는 소진되지 않습니다 — 오타 한 번에 헬스장에 코드를 다시 요청하게 둘 수 없습니다.
* 없는·만료된·이미 쓰인 코드를 구분하지 않고 422 로 모읍니다. 구분해 주면 코드를 훑는 쪽에 유효한 코드 공간을 좁혀 주고, 사용자에게는 어느 경우든 결론이 같습니다.

**범위 밖**

코드 발급 화면은 만들지 않았습니다. 현재는 운영자가 DB 에 직접 넣는 것을 전제로 합니다. 헬스장 사업자 검증과 자격증 진위 확인, 관리자 웹 화면도 범위 밖입니다.

---

## Screenshots (Optional)

실 API 모드 가입 화면에 초대 코드 입력과 안내 문구가 한 줄 추가됩니다. 데모 가입 화면은 변화가 없습니다.

---

## Test Plan

* [x] 백엔드 신규 9건 — 가입한 계정이 `/trainer/me` 200 과 소속을 갖는지, 코드 1회용, 없는·만료 코드 거절, 대소문자·공백 허용, 이메일 중복 시 코드 미소진, 실패 시 계정 미생성, 회원 가입 경로 불변, 코드 없이 가입 불가
* [x] 백엔드 전체 462건 통과, `alembic upgrade head` 로컬 적용, `alembic heads` 단일
* [x] 트레이너 앱 신규 9건 — 코드 전달·공백 정리·코드 없음 차단·비밀번호 불일치 차단, Dio 422/409 매핑과 요청 경로, 데모에서 코드 입력 미표시·코드 없이 가입 진행
* [x] 트레이너 앱 전체 359건 통과, `flutter analyze` 무경고

### Manual Test Steps

1. DB 에 `trainer_invite_codes` 행을 하나 넣습니다(코드, 소속 헬스장 `gym_id`).
2. 트레이너 앱을 `USE_MOCK_API=false` 로 실행하고 로그인 화면에서 회원가입으로 들어갑니다.
3. 그 코드로 가입하면 대시보드로 진입하고, MY 탭에 소속 헬스장이 보이는지 확인합니다.
4. 회원 앱에서 그 헬스장으로 상담을 신청하면 새 트레이너의 상담 인박스(#467)에 나타나는지 확인합니다.
5. 같은 코드로 다시 가입을 시도해 거절되는지 확인합니다.
6. 데모(둘러보기)로 들어가 가입 화면에 코드 입력이 없는지 확인합니다.

---

## Related Issues

Closes #475

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인
