### PR TITLE
fix(test): 트레이너 채팅 테스트 간헐 실패 수정

### DIFF
--- a/backend/tests/test_trainer_chat.py
+++ b/backend/tests/test_trainer_chat.py
@@ -30,16 +30,27 @@ def _reset_seeded_threads(db_session):
 
 
 def _purge(db_session) -> None:
-    from app.db.seed_trainer import TRAINER_ID
+    """시드 회원의 비시드 채팅·루틴을 지운다.
+
+    범위를 **시드 회원(`_MEMBERS`)으로 한정**한다. `trainer_id` 만 걸면 페이지네이션
+    테스트가 즉석에서 만드는 회원(`pgmember-…`)처럼 다른 테스트가 자기 책임으로
+    만들고 지우는 데이터까지 함께 지운다 — 그건 이 픽스처가 관여할 범위가 아니다
+    (리뷰).
+    """
+    from app.db.seed_trainer import _MEMBERS, TRAINER_ID
     from app.models.models import ChatMessage, TrainerRoutine
+
+    seeded_members = [member_id for member_id, *_ in _MEMBERS]
 
     db_session.rollback()
     db_session.query(ChatMessage).filter(
         ChatMessage.trainer_id == TRAINER_ID,
+        ChatMessage.member_id.in_(seeded_members),
         ~ChatMessage.id.like("seed-chat-%"),
     ).delete(synchronize_session=False)
     db_session.query(TrainerRoutine).filter(
         TrainerRoutine.trainer_id == TRAINER_ID,
+        TrainerRoutine.member_id.in_(seeded_members),
         ~TrainerRoutine.id.like("seed-routine-%"),
     ).delete(synchronize_session=False)
     db_session.commit()

--- a/backend/tests/test_trainer_chat.py
+++ b/backend/tests/test_trainer_chat.py
@@ -1,6 +1,49 @@
 """트레이너 채팅 + 루틴 배정(#251). DB 필요(로컬 skip, CI 실행)."""
 from __future__ import annotations
 
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_seeded_threads(db_session):
+    """시드 회원의 스레드를 매 테스트마다 시드 상태로 되돌린다. (#484)
+
+    `build_chat_thread` 는 최신 `limit`(기본 50)건만 준다. 그런데 메시지를 보내는
+    테스트가 시드 회원 스레드에 남긴 메시지를 지우지 않아, 실행을 거듭할수록 창이
+    테스트 잔여물로 채워졌다. 결국 시드 첫 메시지가 창 밖으로 밀려나
+    `test_chat_thread_seeded_and_sender_mapped` 가 간헐적으로 깨졌다 — 한 로컬
+    DB 에서는 `user-jisu` 스레드가 89건(시드 3건, 잔여물 86건)까지 불어 있었다.
+
+    CI 는 매 실행마다 DB 가 새것이라 초록불이었고, 그래서 로컬에서 반복 실행하는
+    사람에게만 걸렸다.
+
+    시드 행은 결정론적 id(`seed-chat-…` / `seed-routine-…`)를 갖는다. 그 밖의 것만
+    지우므로 시드는 그대로 남는다. **테스트 전에도** 지우는 이유: 이미 잔여물이
+    쌓인 DB 에서도 첫 실행부터 통과해야 한다.
+
+    루틴도 같은 방식으로 누적된다(한 로컬 DB 에서 `user-jisu` 55건). 지금은 단언이
+    최신 항목만 보지만, 목록에 limit 이 생기면 같은 방식으로 깨진다.
+    """
+    _purge(db_session)
+    yield
+    _purge(db_session)
+
+
+def _purge(db_session) -> None:
+    from app.db.seed_trainer import TRAINER_ID
+    from app.models.models import ChatMessage, TrainerRoutine
+
+    db_session.rollback()
+    db_session.query(ChatMessage).filter(
+        ChatMessage.trainer_id == TRAINER_ID,
+        ~ChatMessage.id.like("seed-chat-%"),
+    ).delete(synchronize_session=False)
+    db_session.query(TrainerRoutine).filter(
+        TrainerRoutine.trainer_id == TRAINER_ID,
+        ~TrainerRoutine.id.like("seed-routine-%"),
+    ).delete(synchronize_session=False)
+    db_session.commit()
+
 
 def _tok(client) -> str:
     return client.post(


### PR DESCRIPTION
## Summary

* 로컬에서 세 번에 한 번꼴로 깨지던 `test_chat_thread_seeded_and_sender_mapped` 를 안정화했습니다.
* 원인은 테스트가 시드 회원 스레드에 남긴 메시지가 실행할 때마다 영구히 쌓인 것이었습니다.
* `main` 동작에는 영향이 없습니다. 테스트 하네스만 고칩니다.

---

## Changes

### 🐛 Fixes

* `tests/test_trainer_chat.py` 에 정리 픽스처를 추가했습니다. 시드 회원 스레드를 매 테스트마다 시드 상태로 되돌립니다.
* 같은 방식으로 누적되던 배정 루틴도 함께 정리합니다.

### 🔧 Improvements

* 정리를 테스트 **전에도** 수행합니다. 이미 잔여물이 쌓인 DB 에서도 첫 실행부터 통과합니다.

---

## Commits

1. 948b28c fix(test): 트레이너 채팅 테스트가 누적 데이터로 간헐 실패하던 문제

---

## Notes

**왜 CI 는 초록불이었나**

CI 는 매 실행마다 Postgres 컨테이너를 새로 띄워 DB 가 비어 있습니다. 잔여물이 쌓일 새가 없어 이 문제가 드러나지 않았고, 그래서 로컬에서 반복 실행하는 사람에게만 걸렸습니다.

**원인**

세 가지가 겹칩니다.

1. `build_chat_thread` 는 무제한 로드를 막으려고 최신 `limit`(기본 50)건만 가져옵니다.
2. `test_chat_thread_seeded_and_sender_mapped` 는 스레드 **첫 메시지가 트레이너 것**임을 확인합니다. 오래된→최신 정렬과 sender 매핑을 함께 보는 단언입니다.
3. `test_send_message_reflects_in_thread_and_roster` 가 `user-jisu` 스레드에 메시지를 보내고 지우지 않습니다.

실행할 때마다 한 건씩 쌓여 50건 창이 잔여물로 채워지면 시드 첫 메시지가 창 밖으로 밀려납니다. 한 로컬 DB 에서 `user-jisu` 스레드가 89건(시드 3건, 잔여물 86건)까지 불어 있었습니다.

**고르지 않은 선택지**

`build_chat_thread` 의 `limit` 은 건드리지 않았습니다. 무제한 로드를 막는 의도된 설계입니다(리뷰 PR 251-#3). 단언을 느슨하게 푸는 방법도 있었지만, 그러면 "오래된→최신 정렬"이라는 이 테스트의 본래 목적이 사라집니다. 데이터를 남기지 않는 쪽이 맞습니다.

**함께 정리한 것**

루틴도 같은 방식으로 누적되고 있었습니다(같은 DB 에서 `user-jisu` 55건). 지금은 단언이 최신 항목만 보지만 목록에 limit 이 생기면 같은 방식으로 깨지므로 함께 정리했습니다.

시드 행은 결정론적 id(`seed-chat-…` / `seed-routine-…`)를 가지므로 그 밖의 것만 지웁니다.

---

## Test Plan

* [x] 문제 조합(`test_consultation_decision` + `test_trainer_signup` + `test_trainer_chat`) 5회 반복 통과 — 수정 전에는 3회 중 1회 실패
* [x] 잔여물이 실제로 제거되는지 확인: `user-jisu` 채팅 89건 → 3건, 루틴 55건 → 3건
* [x] 백엔드 전체 464건 통과

### Manual Test Steps

1. `pytest tests/test_trainer_chat.py` 를 여러 번 반복 실행합니다.
2. 시드 회원의 채팅·루틴 건수가 늘어나지 않는지 확인합니다.

---

## Related Issues

Closes #484

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트**
  - 테스트 실행 전후에 테스트 데이터를 자동으로 정리하도록 개선했습니다.
  - 테스트 간 데이터가 서로 영향을 주지 않아 결과의 일관성과 재현성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->