### PR TITLE
test(trainer): 가입한 트레이너가 상담을 받는 이음매 검증

### DIFF
--- a/backend/tests/test_signup_consultation_seam.py
+++ b/backend/tests/test_signup_consultation_seam.py
@@ -1,0 +1,214 @@
+"""가입한 트레이너가 상담을 받는 이음매. (#485)
+
+#467(상담 승인)과 #475(트레이너 가입)는 각각 테스트가 있지만, 두 기능이 만나는
+지점은 어디에서도 확인되지 않았다. 상담 테스트가 쓰는 트레이너는 가입
+엔드포인트를 통과한 계정이 아니라 DB 에 직접 넣은 행이고, 가입 테스트는
+`/trainer/me` 가 200 을 주는 것까지만 본다.
+
+깨질 수 있는 실제 경로가 있다: 인박스 조회는 `TrainerProfile.gym_id` 로 헬스장
+문의를 찾는데, 가입이 그 값을 채우는 방식이 바뀌면 인박스가 조용히 빈다. 양쪽
+테스트는 그대로 통과한다.
+
+**의도적으로 이음매만 본다.** 각 단계는 이미 단위 테스트가 덮고 있어, 전체를 다시
+검증하는 큰 테스트는 중복이 되고 깨졌을 때 원인을 가리키지 못한다.
+
+DB 가 필요하므로 로컬에서는 skip 되고 CI(Postgres) 에서 실행된다.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from uuid import uuid4
+
+import pytest
+
+from app.models.models import (
+    ConsultationRequest,
+    MemberGym,
+    Notification,
+    Place,
+    TrainerClient,
+    TrainerInviteCode,
+    TrainerProfile,
+    User,
+)
+
+EMAIL_PREFIX = "seam-test-"
+PLACE_PREFIX = "seam-place-"
+CODE_PREFIX = "SEAMTEST"
+PASSWORD = "seam-pw-1234"
+
+
+@pytest.fixture(autouse=True)
+def _cleanup(db_session):
+    yield
+    db_session.rollback()
+    user_ids = [
+        row[0]
+        for row in db_session.query(User.id)
+        .filter(User.email.like(f"{EMAIL_PREFIX}%"))
+        .all()
+    ]
+    db_session.query(TrainerInviteCode).filter(
+        TrainerInviteCode.code.like(f"{CODE_PREFIX}%")
+    ).delete(synchronize_session=False)
+    if user_ids:
+        db_session.query(ConsultationRequest).filter(
+            (ConsultationRequest.member_id.in_(user_ids))
+            | (ConsultationRequest.trainer_id.in_(user_ids))
+            | (ConsultationRequest.decided_by.in_(user_ids))
+        ).delete(synchronize_session=False)
+        db_session.query(TrainerClient).filter(
+            (TrainerClient.trainer_id.in_(user_ids))
+            | (TrainerClient.member_id.in_(user_ids))
+        ).delete(synchronize_session=False)
+        db_session.query(Notification).filter(
+            Notification.user_id.in_(user_ids)
+        ).delete(synchronize_session=False)
+        db_session.query(MemberGym).filter(
+            MemberGym.member_id.in_(user_ids)
+        ).delete(synchronize_session=False)
+        db_session.query(TrainerProfile).filter(
+            TrainerProfile.trainer_id.in_(user_ids)
+        ).delete(synchronize_session=False)
+        db_session.query(User).filter(User.id.in_(user_ids)).delete(
+            synchronize_session=False
+        )
+    db_session.query(Place).filter(Place.id.like(f"{PLACE_PREFIX}%")).delete(
+        synchronize_session=False
+    )
+    db_session.commit()
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _login(client, email: str) -> str:
+    response = client.post(
+        "/v1/auth/login", data={"username": email, "password": PASSWORD}
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["access_token"]
+
+
+def _gym(db_session) -> Place:
+    place = Place(
+        id=f"{PLACE_PREFIX}{uuid4().hex[:10]}",
+        name="이음매 테스트 헬스장",
+        category="fitness",
+        address="서울",
+    )
+    db_session.add(place)
+    db_session.commit()
+    return place
+
+
+def _invite_code(db_session, gym: Place) -> str:
+    code = TrainerInviteCode(
+        code=f"{CODE_PREFIX}{uuid4().hex[:8].upper()}", gym_id=gym.id
+    )
+    db_session.add(code)
+    db_session.commit()
+    return code.code
+
+
+def _sign_up_trainer(client, code: str) -> tuple[str, str]:
+    """가입 엔드포인트로 트레이너를 만든다. (id, token)
+
+    DB 직접 삽입이 아니라 이 경로를 쓰는 것이 이 테스트의 핵심이다.
+    """
+    email = f"{EMAIL_PREFIX}trainer-{uuid4().hex[:10]}@oncare.com"
+    response = client.post(
+        "/v1/auth/trainer/register",
+        json={
+            "email": email,
+            "password": PASSWORD,
+            "name": "가입 트레이너",
+            "invite_code": code,
+        },
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["id"], _login(client, email)
+
+
+def _member(client) -> tuple[str, str]:
+    email = f"{EMAIL_PREFIX}member-{uuid4().hex[:10]}@oncare.com"
+    response = client.post(
+        "/v1/auth/register",
+        json={"email": email, "password": PASSWORD, "name": "이음매 회원"},
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["id"], _login(client, email)
+
+
+def _request_consultation(client, token: str, gym_id: str) -> str:
+    response = client.post(
+        "/v1/consultations",
+        headers=_auth(token),
+        json={
+            "target_type": "gym",
+            "gym_id": gym_id,
+            "trainer_id": None,
+            "exercise_goal": "strength",
+            "health_purpose_type": "general",
+            "health_purpose_detail": None,
+            "preferred_date": (date.today() + timedelta(days=1)).isoformat(),
+            "preferred_time_slot": "morning",
+            "message": "상담 부탁드립니다.",
+        },
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["id"]
+
+
+def test_a_signed_up_trainer_can_receive_and_accept_a_consultation(
+    client, db_session
+):
+    """가입 → 헬스장 상담 → 인박스 → 승인 → 로스터.
+
+    여기서 확인하는 것은 각 단계의 동작이 아니라 **초대 코드가 채운 소속이 인박스
+    조회 조건과 실제로 이어지는가**다. 그 연결이 끊기면 새로 가입한 트레이너의
+    인박스가 조용히 비고, 양쪽 단위 테스트는 모두 통과한다.
+    """
+    gym = _gym(db_session)
+    code = _invite_code(db_session, gym)
+
+    trainer_id, trainer_token = _sign_up_trainer(client, code)
+    member_id, member_token = _member(client)
+    consultation_id = _request_consultation(client, member_token, gym.id)
+
+    inbox = client.get("/v1/trainer/consultations", headers=_auth(trainer_token))
+    assert inbox.status_code == 200, inbox.text
+    assert consultation_id in {item["id"] for item in inbox.json()}, (
+        "초대 코드가 채운 소속이 인박스 조회 조건과 이어지지 않았다"
+    )
+
+    accepted = client.post(
+        f"/v1/trainer/consultations/{consultation_id}/accept",
+        headers=_auth(trainer_token),
+        json={},
+    )
+    assert accepted.status_code == 200, accepted.text
+    assert accepted.json()["decided_by"] == trainer_id
+
+    roster = client.get("/v1/trainer/clients", headers=_auth(trainer_token))
+    assert roster.status_code == 200, roster.text
+    assert member_id in {c["id"] for c in roster.json()}
+
+
+def test_a_signed_up_trainer_sees_only_their_own_gym(client, db_session):
+    """가입한 트레이너의 인박스가 자기 헬스장으로 좁혀져 있다.
+
+    위 테스트만 있으면 "인박스가 모든 요청을 준다"는 잘못된 구현도 통과한다.
+    """
+    mine = _gym(db_session)
+    other = _gym(db_session)
+    _, trainer_token = _sign_up_trainer(client, _invite_code(db_session, mine))
+    _, member_token = _member(client)
+
+    foreign_id = _request_consultation(client, member_token, other.id)
+
+    inbox = client.get("/v1/trainer/consultations", headers=_auth(trainer_token))
+
+    assert inbox.status_code == 200, inbox.text
+    assert foreign_id not in {item["id"] for item in inbox.json()}


### PR DESCRIPTION
## Summary

* #467(상담 승인)과 #475(트레이너 가입)가 만나는 이음매를 검증합니다. 지금까지 이 지점은 어디에서도 확인되지 않았습니다.
* 가입 엔드포인트를 통과한 트레이너가 실제로 상담을 받고 승인할 수 있는지 봅니다.
* 테스트만 추가합니다. 제품 코드 변경은 없습니다.

---

## Changes

### ✅ Tests

* 가입 → 헬스장 상담 → 인박스 → 승인 → 로스터를 한 번 이어서 확인합니다.
* 가입한 트레이너의 인박스가 자기 헬스장으로 좁혀져 있는지 함께 확인합니다.

---

## Commits

1. d6fda99 test(trainer): 가입한 트레이너가 상담을 받는 이음매 검증

---

## Notes

**왜 지금까지 비어 있었나**

상담 승인 테스트가 쓰는 트레이너는 가입 엔드포인트를 통과한 계정이 아니라 DB 에 직접 넣은 행입니다.

```python
trainer = User(id=..., role="trainer", ...)   # 직접 삽입
db_session.add(TrainerProfile(trainer_id=trainer.id, gym_id=...))
```

반대로 가입 테스트는 `/trainer/me` 가 200 을 주고 소속이 붙는 것까지만 봅니다. 그래서 "초대 코드로 가입한 트레이너가 실제로 상담을 받을 수 있는가"가 빈 채로 남았습니다.

깨질 수 있는 실제 경로가 있습니다. 인박스 조회는 `TrainerProfile.gym_id` 로 헬스장 문의를 찾는데, 가입이 그 값을 채우는 방식이 바뀌면 인박스가 조용히 빕니다. 양쪽 단위 테스트는 그대로 통과합니다.

**의도적으로 좁게 만들었습니다**

전체 흐름을 재검증하는 큰 E2E 는 만들지 않았습니다. 각 단계(가입·상담 신청·인박스 조회·승인·로스터·채팅)는 이미 단위 테스트가 덮고 있어 중복이 되고, 그런 테스트는 깨졌을 때 체인 끝을 가리켜 원인을 알려주지 못하면서 관련 모듈이 바뀔 때마다 함께 깨집니다. 여기서는 **이음매만** 봅니다.

**두 번째 테스트가 중복이 아닌 이유**

범위 격리(자기 헬스장 요청만 보임)는 `test_inbox_excludes_other_trainers_requests` 와 겹쳐 보입니다. 다만 첫 번째 단언만 두면 "인박스가 모든 요청을 준다"는 잘못된 구현으로도 통과합니다. 긍정 단언을 신뢰할 수 있게 만드는 짝입니다.

**테스트에 실제로 이빨이 있는지 확인했습니다**

통과하는 것만으로는 회귀를 잡는다는 증거가 되지 않아, 이음매를 일부러 끊어(가입이 `gym_id` 를 채우지 않도록 변형) 실행했습니다. 이 테스트가 실패하는 것을 확인한 뒤 원복했습니다.

덧붙이면 그 변형은 `test_invite_code_creates_a_working_trainer` 도 함께 잡습니다. 즉 이 PR 은 지금 뚫려 있는 구멍을 막는다기보다, **두 기능이 앞으로 따로 바뀔 때 조합이 깨지는 것을 막는** 성격입니다.

---

## Test Plan

* [x] 신규 2건 통과
* [x] 이음매를 끊은 변형에서 실패하는지 확인 후 원복
* [x] 백엔드 전체 466건 통과

### Manual Test Steps

1. `pytest tests/test_signup_consultation_seam.py` 를 실행합니다.
2. `trainer_signup_service.register_trainer` 가 `gym_id` 를 채우지 않도록 잠시 바꾸면 첫 번째 테스트가 실패하는지 확인합니다.

---

## Related Issues

Closes #485

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인
