### PR TITLE
feat(trainer-my): persist profile and gym affiliation

### DIFF
--- a/frontend/flutter_trainer/lib/features/auth/data/dtos/trainer_me_dto.dart
+++ b/frontend/flutter_trainer/lib/features/auth/data/dtos/trainer_me_dto.dart
@@ -12,6 +12,7 @@ TrainerProfile trainerProfileFromJson(Map<String, Object?> json) {
   final gymJson = json['gym'];
   final gym = gymJson is Map<String, Object?>
       ? TrainerGym(
+          id: gymJson['id'] as String?,
           name: _str(gymJson['name']),
           address: _str(gymJson['address']),
           hours: _str(gymJson['hours']),

--- a/frontend/flutter_trainer/lib/features/auth/data/dtos/trainer_me_dto.dart
+++ b/frontend/flutter_trainer/lib/features/auth/data/dtos/trainer_me_dto.dart
@@ -12,7 +12,7 @@ TrainerProfile trainerProfileFromJson(Map<String, Object?> json) {
   final gymJson = json['gym'];
   final gym = gymJson is Map<String, Object?>
       ? TrainerGym(
-          id: gymJson['id'] as String?,
+          id: _nullableStr(gymJson['id']),
           name: _str(gymJson['name']),
           address: _str(gymJson['address']),
           hours: _str(gymJson['hours']),
@@ -38,3 +38,5 @@ TrainerProfile trainerProfileFromJson(Map<String, Object?> json) {
 }
 
 String _str(Object? v) => v is String ? v : '';
+
+String? _nullableStr(Object? value) => value?.toString();

--- a/frontend/flutter_trainer/lib/features/auth/presentation/controllers/session_controller.dart
+++ b/frontend/flutter_trainer/lib/features/auth/presentation/controllers/session_controller.dart
@@ -222,12 +222,16 @@ class SessionController extends StateNotifier<SessionState> {
     state = const SessionState(status: SessionStatus.demo);
   }
 
-  /// Replaces the authenticated profile after a successful `/trainer/me`
-  /// mutation. Keeping this in the session owner prevents MY, the sidebar,
-  /// and subsequent consumers from showing different snapshots.
+  /// Replaces the authenticated or demo profile after a successful profile
+  /// mutation. Demo keeps its status and only updates the in-memory snapshot.
+  /// Keeping this in the session owner prevents MY, the sidebar, and
+  /// subsequent consumers from showing different snapshots.
   void replaceProfile(TrainerProfile profile) {
-    if (state.status != SessionStatus.authenticated) return;
-    state = SessionState(status: SessionStatus.authenticated, profile: profile);
+    final status = state.status;
+    if (status != SessionStatus.authenticated && status != SessionStatus.demo) {
+      return;
+    }
+    state = SessionState(status: status, profile: profile);
   }
 
   /// Signs out — clears persisted tokens and returns to the login screen.

--- a/frontend/flutter_trainer/lib/features/auth/presentation/controllers/session_controller.dart
+++ b/frontend/flutter_trainer/lib/features/auth/presentation/controllers/session_controller.dart
@@ -9,6 +9,7 @@ import 'package:oncare_trainer/features/auth/data/repositories/dio_trainer_auth_
 import 'package:oncare_trainer/features/auth/domain/entities/auth_tokens.dart';
 import 'package:oncare_trainer/features/auth/domain/entities/session_state.dart';
 import 'package:oncare_trainer/features/auth/domain/repositories/trainer_auth_repository.dart';
+import 'package:oncare_trainer/shared/models/trainer_profile.dart';
 
 /// Owns the trainer session lifecycle: restore-on-launch (with token
 /// refresh), login / register / social login, demo bypass, and sign-out.
@@ -219,6 +220,14 @@ class SessionController extends StateNotifier<SessionState> {
     unawaited(_clearPersistedTokens());
     _setAccessToken(null);
     state = const SessionState(status: SessionStatus.demo);
+  }
+
+  /// Replaces the authenticated profile after a successful `/trainer/me`
+  /// mutation. Keeping this in the session owner prevents MY, the sidebar,
+  /// and subsequent consumers from showing different snapshots.
+  void replaceProfile(TrainerProfile profile) {
+    if (state.status != SessionStatus.authenticated) return;
+    state = SessionState(status: SessionStatus.authenticated, profile: profile);
   }
 
   /// Signs out — clears persisted tokens and returns to the login screen.

--- a/frontend/flutter_trainer/lib/features/my/data/trainer_profile_repository.dart
+++ b/frontend/flutter_trainer/lib/features/my/data/trainer_profile_repository.dart
@@ -7,7 +7,10 @@ import 'package:oncare_trainer/core/network/dio_client.dart';
 import 'package:oncare_trainer/features/auth/data/dtos/trainer_me_dto.dart';
 import 'package:oncare_trainer/shared/models/trainer_profile.dart';
 
-/// Editable fields accepted by `PUT /trainer/me`.
+/// Editable fields accepted by `PUT /v1/trainer/me`.
+///
+/// Dio's base URL already contains `/v1`, so the request path stays
+/// `/trainer/me` rather than duplicating the API prefix.
 class TrainerProfileUpdate {
   const TrainerProfileUpdate({
     required this.phone,
@@ -49,11 +52,15 @@ class TrainerGymChoice {
     required this.id,
     required this.name,
     required this.address,
+    this.hours = '',
+    this.phone = '',
   });
 
   final String id;
   final String name;
   final String address;
+  final String hours;
+  final String phone;
 }
 
 abstract class TrainerProfileRepository {
@@ -88,6 +95,8 @@ class DioTrainerProfileRepository implements TrainerProfileRepository {
               id: row['id']! as String,
               name: row['name'] as String? ?? '',
               address: row['address'] as String? ?? '',
+              hours: row['weekday_hours'] as String? ?? '',
+              phone: row['phone'] as String? ?? '',
             ),
       ];
     } on DioException catch (error) {
@@ -162,8 +171,20 @@ class MockTrainerProfileRepository implements TrainerProfileRepository {
 
   @override
   Future<List<TrainerGymChoice>> listGyms() async => const <TrainerGymChoice>[
-    TrainerGymChoice(id: 'gym-1', name: '온케어짐 신촌점', address: '서울 서대문구'),
-    TrainerGymChoice(id: 'gym-2', name: '온케어짐 강남점', address: '서울 강남구'),
+    TrainerGymChoice(
+      id: 'gym-1',
+      name: '온케어짐 신촌점',
+      address: '서울 서대문구',
+      hours: '06:00 – 23:00',
+      phone: '02-1234-5678',
+    ),
+    TrainerGymChoice(
+      id: 'gym-2',
+      name: '온케어짐 강남점',
+      address: '서울 강남구',
+      hours: '06:00 – 24:00',
+      phone: '02-9876-5432',
+    ),
   ];
 
   @override
@@ -203,8 +224,8 @@ class MockTrainerProfileRepository implements TrainerProfileRepository {
         id: gymId,
         name: choice.name,
         address: choice.address,
-        hours: '',
-        phone: '',
+        hours: choice.hours,
+        phone: choice.phone,
       ),
     );
     return _profile;

--- a/frontend/flutter_trainer/lib/features/my/data/trainer_profile_repository.dart
+++ b/frontend/flutter_trainer/lib/features/my/data/trainer_profile_repository.dart
@@ -1,0 +1,233 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare_trainer/core/config/app_config.dart';
+import 'package:oncare_trainer/core/errors/app_error.dart';
+import 'package:oncare_trainer/core/network/dio_client.dart';
+import 'package:oncare_trainer/features/auth/data/dtos/trainer_me_dto.dart';
+import 'package:oncare_trainer/shared/models/trainer_profile.dart';
+
+/// Editable fields accepted by `PUT /trainer/me`.
+class TrainerProfileUpdate {
+  const TrainerProfileUpdate({
+    required this.phone,
+    required this.specialty,
+    required this.careerYears,
+    required this.intro,
+    required this.certifications,
+    this.gymName,
+    this.gymAddress,
+    this.gymHours,
+    this.gymPhone,
+  });
+
+  final String phone;
+  final String specialty;
+  final int careerYears;
+  final String intro;
+  final List<String> certifications;
+  final String? gymName;
+  final String? gymAddress;
+  final String? gymHours;
+  final String? gymPhone;
+
+  Map<String, Object?> toJson() => <String, Object?>{
+    'phone': phone,
+    'specialty': specialty,
+    'career_years': careerYears,
+    'intro': intro,
+    'certifications': certifications,
+    if (gymName != null) 'gym_name': gymName,
+    if (gymAddress != null) 'gym_address': gymAddress,
+    if (gymHours != null) 'gym_hours': gymHours,
+    if (gymPhone != null) 'gym_phone': gymPhone,
+  };
+}
+
+class TrainerGymChoice {
+  const TrainerGymChoice({
+    required this.id,
+    required this.name,
+    required this.address,
+  });
+
+  final String id;
+  final String name;
+  final String address;
+}
+
+abstract class TrainerProfileRepository {
+  Future<TrainerProfile> fetch();
+
+  Future<List<TrainerGymChoice>> listGyms();
+
+  Future<TrainerProfile> update(TrainerProfileUpdate update);
+
+  Future<TrainerProfile> setGym(String gymId);
+
+  Future<TrainerProfile> clearGym();
+}
+
+class DioTrainerProfileRepository implements TrainerProfileRepository {
+  DioTrainerProfileRepository(this._dio);
+
+  final Dio _dio;
+
+  @override
+  Future<TrainerProfile> fetch() =>
+      _profileCall(() => _dio.get<Map<String, Object?>>('/trainer/me'));
+
+  @override
+  Future<List<TrainerGymChoice>> listGyms() async {
+    try {
+      final response = await _dio.get<List<Object?>>('/gyms');
+      return <TrainerGymChoice>[
+        for (final row in response.data ?? const <Object?>[])
+          if (row is Map<String, Object?> && row['id'] is String)
+            TrainerGymChoice(
+              id: row['id']! as String,
+              name: row['name'] as String? ?? '',
+              address: row['address'] as String? ?? '',
+            ),
+      ];
+    } on DioException catch (error) {
+      throw _mapDio(error);
+    }
+  }
+
+  @override
+  Future<TrainerProfile> update(TrainerProfileUpdate update) => _profileCall(
+    () => _dio.put<Map<String, Object?>>('/trainer/me', data: update.toJson()),
+  );
+
+  @override
+  Future<TrainerProfile> setGym(String gymId) => _profileCall(
+    () => _dio.put<Map<String, Object?>>(
+      '/trainer/me/gym',
+      data: <String, Object?>{'gym_id': gymId},
+    ),
+  );
+
+  @override
+  Future<TrainerProfile> clearGym() =>
+      _profileCall(() => _dio.delete<Map<String, Object?>>('/trainer/me/gym'));
+
+  Future<TrainerProfile> _profileCall(
+    Future<Response<Map<String, Object?>>> Function() call,
+  ) async {
+    try {
+      final response = await call();
+      final data = response.data;
+      if (data == null) {
+        throw const ServerError(message: '프로필 응답이 비어 있습니다.');
+      }
+      return trainerProfileFromJson(data);
+    } on DioException catch (error) {
+      throw _mapDio(error);
+    }
+  }
+
+  AppError _mapDio(DioException error) {
+    final detail = _detail(error.response?.data);
+    final code = error.response?.statusCode;
+    if (code == 400 || code == 422) {
+      return ValidationError(message: detail ?? '입력값을 확인해 주세요.');
+    }
+    if (code == 409) {
+      return ServerError(
+        statusCode: code,
+        message: detail ?? '현재 소속 상태와 충돌합니다.',
+      );
+    }
+    if (code == 404) {
+      return NotFoundError(message: detail ?? '헬스장을 찾을 수 없습니다.');
+    }
+    return AppError.fromDio(error);
+  }
+
+  String? _detail(Object? data) {
+    if (data is! Map) return null;
+    final detail = data['detail'];
+    if (detail is String && detail.trim().isNotEmpty) return detail;
+    return null;
+  }
+}
+
+/// Stateful mock with the same mutation contract as the real repository.
+class MockTrainerProfileRepository implements TrainerProfileRepository {
+  TrainerProfile _profile = seedTrainerProfile;
+
+  @override
+  Future<TrainerProfile> fetch() async => _profile;
+
+  @override
+  Future<List<TrainerGymChoice>> listGyms() async => const <TrainerGymChoice>[
+    TrainerGymChoice(id: 'gym-1', name: '온케어짐 신촌점', address: '서울 서대문구'),
+    TrainerGymChoice(id: 'gym-2', name: '온케어짐 강남점', address: '서울 강남구'),
+  ];
+
+  @override
+  Future<TrainerProfile> update(TrainerProfileUpdate update) async {
+    _profile = _profile.copyWith(
+      phone: update.phone,
+      specialty: update.specialty,
+      career: '${update.careerYears}년',
+      intro: update.intro,
+      certifications: List<String>.unmodifiable(update.certifications),
+      gym: update.gymName == null
+          ? _profile.gym
+          : TrainerGym(
+              name: update.gymName!,
+              address: update.gymAddress ?? '',
+              hours: update.gymHours ?? '',
+              phone: update.gymPhone ?? '',
+            ),
+    );
+    return _profile;
+  }
+
+  @override
+  Future<TrainerProfile> setGym(String gymId) async {
+    TrainerGymChoice? choice;
+    for (final item in await listGyms()) {
+      if (item.id == gymId) {
+        choice = item;
+        break;
+      }
+    }
+    if (choice == null) {
+      throw const NotFoundError(message: '헬스장을 찾을 수 없습니다.');
+    }
+    _profile = _profile.copyWith(
+      gym: TrainerGym(
+        id: gymId,
+        name: choice.name,
+        address: choice.address,
+        hours: '',
+        phone: '',
+      ),
+    );
+    return _profile;
+  }
+
+  @override
+  Future<TrainerProfile> clearGym() async {
+    _profile = _profile.copyWith(
+      gym: const TrainerGym(name: '', address: '', hours: '', phone: ''),
+    );
+    return _profile;
+  }
+}
+
+final trainerProfileRepositoryProvider = Provider<TrainerProfileRepository>((
+  ref,
+) {
+  final config = ref.watch(appConfigProvider);
+  if (config.useMockApi) return MockTrainerProfileRepository();
+  return DioTrainerProfileRepository(ref.watch(dioProvider));
+}, name: 'trainerProfileRepository');
+
+final trainerGymChoicesProvider =
+    FutureProvider.autoDispose<List<TrainerGymChoice>>((ref) {
+      return ref.watch(trainerProfileRepositoryProvider).listGyms();
+    }, name: 'trainerGymChoices');

--- a/frontend/flutter_trainer/lib/features/my/presentation/pages/my_page.dart
+++ b/frontend/flutter_trainer/lib/features/my/presentation/pages/my_page.dart
@@ -71,6 +71,7 @@ class _MyPageState extends ConsumerState<MyPage> {
       <String, TextEditingController>{};
   final TextEditingController _newCert = TextEditingController();
   late List<String> _draftCerts;
+  late String _draftGymId;
 
   @override
   void initState() {
@@ -80,6 +81,7 @@ class _MyPageState extends ConsumerState<MyPage> {
     _gym = _profile.gym;
     _certs = List<String>.of(_profile.certifications);
     _draftCerts = List<String>.of(_certs);
+    _draftGymId = _gym.id ?? '';
   }
 
   @override
@@ -100,6 +102,7 @@ class _MyPageState extends ConsumerState<MyPage> {
     setState(() {
       _editing = true;
       _draftCerts = List<String>.of(_certs);
+      _draftGymId = _gym.id ?? '';
       _field('name', _profile.name).text = _profile.name;
       _field('email', _profile.email).text = _profile.email;
       _field('phone', _profile.phone).text = _profile.phone;
@@ -110,15 +113,15 @@ class _MyPageState extends ConsumerState<MyPage> {
       _field('gymAddress', _gym.address).text = _gym.address;
       _field('gymHours', _gym.hours).text = _gym.hours;
       _field('gymPhone', _gym.phone).text = _gym.phone;
-      _field('gymId', _gym.id ?? '').text = _gym.id ?? '';
     });
   }
 
   Future<void> _save() async {
     if (_saving) return;
-    final careerYears = int.tryParse(
-      RegExp(r'\d+').firstMatch(_fields['career']!.text)?.group(0) ?? '',
-    );
+    final careerMatch = RegExp(
+      r'^\s*(\d+)\s*년?\s*$',
+    ).firstMatch(_fields['career']!.text);
+    final careerYears = int.tryParse(careerMatch?.group(1) ?? '');
     if (careerYears == null || careerYears < 0 || careerYears > 80) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('경력은 0~80 사이의 연수로 입력해 주세요.')),
@@ -128,8 +131,9 @@ class _MyPageState extends ConsumerState<MyPage> {
 
     setState(() => _saving = true);
     final repository = ref.read(trainerProfileRepositoryProvider);
+    var profileSaved = false;
     try {
-      final draftGymId = _fields['gymId']!.text.trim();
+      final draftGymId = _draftGymId.trim();
       final currentGymId = _gym.id ?? '';
       var saved = await repository.update(
         TrainerProfileUpdate(
@@ -154,6 +158,7 @@ class _MyPageState extends ConsumerState<MyPage> {
               : null,
         ),
       );
+      profileSaved = true;
       if (draftGymId != currentGymId) {
         saved = draftGymId.isEmpty
             ? await repository.clearGym()
@@ -171,9 +176,7 @@ class _MyPageState extends ConsumerState<MyPage> {
       if (!mounted) return;
       if (restored != null) _applyRestoredProfile(restored);
       setState(() => _saving = false);
-      final message = error is AppError
-          ? error.message ?? '프로필을 저장하지 못했습니다.'
-          : '프로필을 저장하지 못했습니다.';
+      final message = _saveFailureMessage(error, profileSaved: profileSaved);
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(SnackBar(content: Text(message)));
@@ -186,6 +189,13 @@ class _MyPageState extends ConsumerState<MyPage> {
     });
   }
 
+  String _saveFailureMessage(Object error, {required bool profileSaved}) {
+    final detail = error is AppError ? error.message : null;
+    if (!profileSaved) return detail ?? '프로필을 저장하지 못했습니다.';
+    const partial = '소속 헬스장 변경에 실패했습니다. 나머지 프로필 정보는 저장됐어요.';
+    return detail == null ? partial : '$partial $detail';
+  }
+
   void _applySavedProfile(TrainerProfile saved) {
     ref.read(sessionControllerProvider.notifier).replaceProfile(saved);
     setState(() {
@@ -193,6 +203,7 @@ class _MyPageState extends ConsumerState<MyPage> {
       _gym = saved.gym;
       _certs = List<String>.of(saved.certifications);
       _draftCerts = List<String>.of(_certs);
+      _draftGymId = saved.gym.id ?? '';
       _editing = false;
       _saving = false;
       _saveFlash = true;
@@ -207,6 +218,7 @@ class _MyPageState extends ConsumerState<MyPage> {
       _gym = restored.gym;
       _certs = List<String>.of(restored.certifications);
       _draftCerts = List<String>.of(_certs);
+      _draftGymId = restored.gym.id ?? '';
       _editing = false;
     });
   }
@@ -270,13 +282,14 @@ class _MyPageState extends ConsumerState<MyPage> {
               label: '취소',
               background: AppColors.inputBackground,
               foreground: AppColors.subtleForeground,
-              onTap: () => setState(() {
-                if (_saving) return;
-                _editing = false;
-                // Drop the un-added cert draft too — otherwise it
-                // reappears on the next edit (PR review).
-                _newCert.clear();
-              }),
+              onTap: _saving
+                  ? null
+                  : () => setState(() {
+                      _editing = false;
+                      // Drop the un-added cert draft too — otherwise it
+                      // reappears on the next edit (PR review).
+                      _newCert.clear();
+                    }),
             ),
           ),
           const SizedBox(height: AppSpacing.sm),
@@ -335,6 +348,8 @@ class _MyPageState extends ConsumerState<MyPage> {
           editing: _editing,
           field: _field,
           choices: ref.watch(trainerGymChoicesProvider),
+          selectedGymId: _draftGymId,
+          onGymChanged: (value) => setState(() => _draftGymId = value),
         ),
       ],
     );
@@ -527,7 +542,7 @@ class _ChipButton extends StatelessWidget {
   final String label;
   final Color background;
   final Color foreground;
-  final VoidCallback onTap;
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -660,7 +675,11 @@ class _ProfileCard extends StatelessWidget {
               controller: field('email', profile.email),
               enabled: false,
             ),
-            _EditField(label: '연락처', controller: field('phone', profile.phone)),
+            _EditField(
+              label: '연락처',
+              controller: field('phone', profile.phone),
+              inputKey: const ValueKey<String>('profile-phone'),
+            ),
             _EditField(
               label: '전문 분야',
               controller: field('specialty', profile.specialty),
@@ -668,6 +687,7 @@ class _ProfileCard extends StatelessWidget {
             _EditField(
               label: '경력',
               controller: field('career', profile.career),
+              inputKey: const ValueKey<String>('profile-career'),
             ),
             _EditField(
               label: '소개',
@@ -716,12 +736,14 @@ class _EditField extends StatelessWidget {
     required this.controller,
     this.maxLines = 1,
     this.enabled = true,
+    this.inputKey,
   });
 
   final String label;
   final TextEditingController controller;
   final int maxLines;
   final bool enabled;
+  final Key? inputKey;
 
   @override
   Widget build(BuildContext context) {
@@ -740,6 +762,7 @@ class _EditField extends StatelessWidget {
           ),
           const SizedBox(height: 3),
           TextField(
+            key: inputKey,
             controller: controller,
             enabled: enabled,
             maxLines: maxLines,
@@ -979,12 +1002,16 @@ class _GymCard extends StatelessWidget {
     required this.editing,
     required this.field,
     required this.choices,
+    required this.selectedGymId,
+    required this.onGymChanged,
   });
 
   final TrainerGym gym;
   final bool editing;
   final TextEditingController Function(String, String) field;
   final AsyncValue<List<TrainerGymChoice>> choices;
+  final String selectedGymId;
+  final ValueChanged<String> onGymChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -1006,27 +1033,28 @@ class _GymCard extends StatelessWidget {
                 _GymChoiceField(
                   currentGym: gym,
                   choices: choices,
-                  controller: field('gymId', gym.id ?? ''),
+                  selectedGymId: selectedGymId,
+                  onChanged: onGymChanged,
                 ),
                 _EditField(
                   label: '헬스장 이름',
                   controller: field('gymName', gym.name),
-                  enabled: gym.id == null,
+                  enabled: selectedGymId.isEmpty,
                 ),
                 _EditField(
                   label: '주소',
                   controller: field('gymAddress', gym.address),
-                  enabled: gym.id == null,
+                  enabled: selectedGymId.isEmpty,
                 ),
                 _EditField(
                   label: '운영 시간',
                   controller: field('gymHours', gym.hours),
-                  enabled: gym.id == null,
+                  enabled: selectedGymId.isEmpty,
                 ),
                 _EditField(
                   label: '연락처',
                   controller: field('gymPhone', gym.phone),
-                  enabled: gym.id == null,
+                  enabled: selectedGymId.isEmpty,
                 ),
               ],
             )
@@ -1098,12 +1126,14 @@ class _GymChoiceField extends StatelessWidget {
   const _GymChoiceField({
     required this.currentGym,
     required this.choices,
-    required this.controller,
+    required this.selectedGymId,
+    required this.onChanged,
   });
 
   final TrainerGym currentGym;
   final AsyncValue<List<TrainerGymChoice>> choices;
-  final TextEditingController controller;
+  final String selectedGymId;
+  final ValueChanged<String> onChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -1128,11 +1158,12 @@ class _GymChoiceField extends StatelessWidget {
               style: TextStyle(color: AppColors.destructive, fontSize: 11),
             ),
             data: (items) {
-              final currentId = controller.text;
+              final currentId = selectedGymId;
               final hasCurrent =
                   currentId.isEmpty ||
                   items.any((choice) => choice.id == currentId);
               return DropdownButtonFormField<String>(
+                key: ValueKey<String>(currentId),
                 initialValue: currentId,
                 isExpanded: true,
                 decoration: const InputDecoration(
@@ -1165,7 +1196,7 @@ class _GymChoiceField extends StatelessWidget {
                       ),
                     ),
                 ],
-                onChanged: (value) => controller.text = value ?? '',
+                onChanged: (value) => onChanged(value ?? ''),
               );
             },
           ),

--- a/frontend/flutter_trainer/lib/features/my/presentation/pages/my_page.dart
+++ b/frontend/flutter_trainer/lib/features/my/presentation/pages/my_page.dart
@@ -16,6 +16,7 @@ import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/core/errors/app_error.dart';
 import 'package:oncare_trainer/features/auth/presentation/controllers/session_controller.dart';
 import 'package:oncare_trainer/features/my/data/trainer_account_repository.dart';
+import 'package:oncare_trainer/features/my/data/trainer_profile_repository.dart';
 import 'package:oncare_trainer/features/my/data/trainer_settings.dart';
 import 'package:oncare_trainer/shared/widgets/status_dot_label.dart';
 import 'package:oncare_trainer/shared/models/trainer_profile.dart';
@@ -31,7 +32,8 @@ import 'package:oncare_trainer/shared/widgets/section_card.dart';
 /// five surfaces they use every day. Two sections behind one switch:
 ///
 ///  * **내 정보** — profile, certifications, this month's stats, gym.
-///    Editing is page-local (mock) until `PUT /v1/trainer/me` lands.
+///    Edits persist through `PUT /v1/trainer/me` and the gym affiliation
+///    endpoints; mock mode follows the same repository contract.
 ///  * **설정** — notifications, account, app info, 로그아웃. Most rows
 ///    are placeholders today; they are shown (disabled, with a reason)
 ///    rather than hidden so the shape of the screen doesn't change when
@@ -55,6 +57,7 @@ class _MyPageState extends ConsumerState<MyPage> {
   late int _tab = widget.tab == 'settings' ? 1 : 0;
 
   bool _editing = false;
+  bool _saving = false;
   bool _saveFlash = false;
   Timer? _flashTimer;
 
@@ -107,35 +110,104 @@ class _MyPageState extends ConsumerState<MyPage> {
       _field('gymAddress', _gym.address).text = _gym.address;
       _field('gymHours', _gym.hours).text = _gym.hours;
       _field('gymPhone', _gym.phone).text = _gym.phone;
+      _field('gymId', _gym.id ?? '').text = _gym.id ?? '';
     });
   }
 
-  void _save() {
-    setState(() {
-      _gym = TrainerGym(
-        name: _fields['gymName']!.text,
-        address: _fields['gymAddress']!.text,
-        hours: _fields['gymHours']!.text,
-        phone: _fields['gymPhone']!.text,
+  Future<void> _save() async {
+    if (_saving) return;
+    final careerYears = int.tryParse(
+      RegExp(r'\d+').firstMatch(_fields['career']!.text)?.group(0) ?? '',
+    );
+    if (careerYears == null || careerYears < 0 || careerYears > 80) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('경력은 0~80 사이의 연수로 입력해 주세요.')),
       );
-      _profile = TrainerProfile(
-        name: _fields['name']!.text,
-        email: _fields['email']!.text,
-        phone: _fields['phone']!.text,
-        specialty: _fields['specialty']!.text,
-        career: _fields['career']!.text,
-        intro: _fields['intro']!.text,
-        certifications: List<String>.of(_draftCerts),
-        gym: _gym,
+      return;
+    }
+
+    setState(() => _saving = true);
+    final repository = ref.read(trainerProfileRepositoryProvider);
+    try {
+      final draftGymId = _fields['gymId']!.text.trim();
+      final currentGymId = _gym.id ?? '';
+      var saved = await repository.update(
+        TrainerProfileUpdate(
+          phone: _fields['phone']!.text.trim(),
+          specialty: _fields['specialty']!.text.trim(),
+          careerYears: careerYears,
+          intro: _fields['intro']!.text.trim(),
+          certifications: List<String>.of(_draftCerts),
+          // Affiliated gym text is derived by the server. Legacy profiles
+          // without a place id retain the original editable text contract.
+          gymName: currentGymId.isEmpty && draftGymId.isEmpty
+              ? _fields['gymName']!.text.trim()
+              : null,
+          gymAddress: currentGymId.isEmpty && draftGymId.isEmpty
+              ? _fields['gymAddress']!.text.trim()
+              : null,
+          gymHours: currentGymId.isEmpty && draftGymId.isEmpty
+              ? _fields['gymHours']!.text.trim()
+              : null,
+          gymPhone: currentGymId.isEmpty && draftGymId.isEmpty
+              ? _fields['gymPhone']!.text.trim()
+              : null,
+        ),
       );
-      _certs = List<String>.of(_draftCerts);
-      _editing = false;
-      _saveFlash = true;
-      _newCert.clear(); // same for save — a stale draft shouldn't linger
-    });
+      if (draftGymId != currentGymId) {
+        saved = draftGymId.isEmpty
+            ? await repository.clearGym()
+            : await repository.setGym(draftGymId);
+      }
+      if (!mounted) return;
+      _applySavedProfile(saved);
+    } catch (error) {
+      TrainerProfile? restored;
+      try {
+        restored = await repository.fetch();
+      } catch (_) {
+        restored = ref.read(sessionControllerProvider).profile;
+      }
+      if (!mounted) return;
+      if (restored != null) _applyRestoredProfile(restored);
+      setState(() => _saving = false);
+      final message = error is AppError
+          ? error.message ?? '프로필을 저장하지 못했습니다.'
+          : '프로필을 저장하지 못했습니다.';
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(message)));
+      return;
+    }
+
     _flashTimer?.cancel();
     _flashTimer = Timer(const Duration(seconds: 2), () {
       if (mounted) setState(() => _saveFlash = false);
+    });
+  }
+
+  void _applySavedProfile(TrainerProfile saved) {
+    ref.read(sessionControllerProvider.notifier).replaceProfile(saved);
+    setState(() {
+      _profile = saved;
+      _gym = saved.gym;
+      _certs = List<String>.of(saved.certifications);
+      _draftCerts = List<String>.of(_certs);
+      _editing = false;
+      _saving = false;
+      _saveFlash = true;
+      _newCert.clear();
+    });
+  }
+
+  void _applyRestoredProfile(TrainerProfile restored) {
+    ref.read(sessionControllerProvider.notifier).replaceProfile(restored);
+    setState(() {
+      _profile = restored;
+      _gym = restored.gym;
+      _certs = List<String>.of(restored.certifications);
+      _draftCerts = List<String>.of(_certs);
+      _editing = false;
     });
   }
 
@@ -170,16 +242,16 @@ class _MyPageState extends ConsumerState<MyPage> {
         if (_tab == 0)
           if (_editing)
             ActionButton(
-              label: '저장',
-              icon: Icons.check,
+              label: _saving ? '저장 중' : '저장',
+              icon: _saving ? Icons.hourglass_top : Icons.check,
               primary: true,
-              onPressed: _save,
+              onPressed: _saving ? null : _save,
             )
           else
             ActionButton(
               label: '프로필 수정',
               icon: Icons.edit_outlined,
-              onPressed: _startEdit,
+              onPressed: _saving ? null : _startEdit,
             ),
       ],
       child: _tab == 0 ? _buildProfile() : _buildSettings(),
@@ -199,6 +271,7 @@ class _MyPageState extends ConsumerState<MyPage> {
               background: AppColors.inputBackground,
               foreground: AppColors.subtleForeground,
               onTap: () => setState(() {
+                if (_saving) return;
                 _editing = false;
                 // Drop the un-added cert draft too — otherwise it
                 // reappears on the next edit (PR review).
@@ -257,7 +330,12 @@ class _MyPageState extends ConsumerState<MyPage> {
         const SizedBox(height: AppSpacing.lg),
         _sectionLabel('소속 헬스장'),
         const SizedBox(height: AppSpacing.sm),
-        _GymCard(gym: _gym, editing: _editing, field: _field),
+        _GymCard(
+          gym: _gym,
+          editing: _editing,
+          field: _field,
+          choices: ref.watch(trainerGymChoicesProvider),
+        ),
       ],
     );
   }
@@ -572,8 +650,16 @@ class _ProfileCard extends StatelessWidget {
               padding: EdgeInsets.symmetric(vertical: AppSpacing.md),
               child: Divider(height: 1, color: AppColors.borderStrong),
             ),
-            _EditField(label: '이름', controller: field('name', profile.name)),
-            _EditField(label: '이메일', controller: field('email', profile.email)),
+            _EditField(
+              label: '이름 (계정 정보)',
+              controller: field('name', profile.name),
+              enabled: false,
+            ),
+            _EditField(
+              label: '이메일 (계정 정보)',
+              controller: field('email', profile.email),
+              enabled: false,
+            ),
             _EditField(label: '연락처', controller: field('phone', profile.phone)),
             _EditField(
               label: '전문 분야',
@@ -629,11 +715,13 @@ class _EditField extends StatelessWidget {
     required this.label,
     required this.controller,
     this.maxLines = 1,
+    this.enabled = true,
   });
 
   final String label;
   final TextEditingController controller;
   final int maxLines;
+  final bool enabled;
 
   @override
   Widget build(BuildContext context) {
@@ -653,6 +741,7 @@ class _EditField extends StatelessWidget {
           const SizedBox(height: 3),
           TextField(
             controller: controller,
+            enabled: enabled,
             maxLines: maxLines,
             style: const TextStyle(
               fontSize: 12.5,
@@ -889,11 +978,13 @@ class _GymCard extends StatelessWidget {
     required this.gym,
     required this.editing,
     required this.field,
+    required this.choices,
   });
 
   final TrainerGym gym;
   final bool editing;
   final TextEditingController Function(String, String) field;
+  final AsyncValue<List<TrainerGymChoice>> choices;
 
   @override
   Widget build(BuildContext context) {
@@ -912,21 +1003,30 @@ class _GymCard extends StatelessWidget {
       child: editing
           ? Column(
               children: <Widget>[
+                _GymChoiceField(
+                  currentGym: gym,
+                  choices: choices,
+                  controller: field('gymId', gym.id ?? ''),
+                ),
                 _EditField(
                   label: '헬스장 이름',
                   controller: field('gymName', gym.name),
+                  enabled: gym.id == null,
                 ),
                 _EditField(
                   label: '주소',
                   controller: field('gymAddress', gym.address),
+                  enabled: gym.id == null,
                 ),
                 _EditField(
                   label: '운영 시간',
                   controller: field('gymHours', gym.hours),
+                  enabled: gym.id == null,
                 ),
                 _EditField(
                   label: '연락처',
                   controller: field('gymPhone', gym.phone),
+                  enabled: gym.id == null,
                 ),
               ],
             )
@@ -990,6 +1090,87 @@ class _GymCard extends StatelessWidget {
                 ),
               ],
             ),
+    );
+  }
+}
+
+class _GymChoiceField extends StatelessWidget {
+  const _GymChoiceField({
+    required this.currentGym,
+    required this.choices,
+    required this.controller,
+  });
+
+  final TrainerGym currentGym;
+  final AsyncValue<List<TrainerGymChoice>> choices;
+  final TextEditingController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: AppSpacing.sm),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          const Text(
+            '소속 헬스장',
+            style: TextStyle(
+              fontSize: 9.5,
+              fontWeight: FontWeight.w600,
+              color: AppColors.subtleForeground,
+            ),
+          ),
+          const SizedBox(height: 3),
+          choices.when(
+            loading: () => const LinearProgressIndicator(minHeight: 2),
+            error: (_, _) => const Text(
+              '헬스장 목록을 불러오지 못했습니다.',
+              style: TextStyle(color: AppColors.destructive, fontSize: 11),
+            ),
+            data: (items) {
+              final currentId = controller.text;
+              final hasCurrent =
+                  currentId.isEmpty ||
+                  items.any((choice) => choice.id == currentId);
+              return DropdownButtonFormField<String>(
+                initialValue: currentId,
+                isExpanded: true,
+                decoration: const InputDecoration(
+                  isDense: true,
+                  filled: true,
+                  fillColor: AppColors.background,
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.all(AppRadius.md),
+                    borderSide: BorderSide.none,
+                  ),
+                ),
+                items: <DropdownMenuItem<String>>[
+                  const DropdownMenuItem<String>(
+                    value: '',
+                    child: Text('소속 없음'),
+                  ),
+                  if (!hasCurrent)
+                    DropdownMenuItem<String>(
+                      value: currentId,
+                      child: Text(currentGym.name),
+                    ),
+                  for (final choice in items)
+                    DropdownMenuItem<String>(
+                      value: choice.id,
+                      child: Text(
+                        choice.address.isEmpty
+                            ? choice.name
+                            : '${choice.name} · ${choice.address}',
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                ],
+                onChanged: (value) => controller.text = value ?? '',
+              );
+            },
+          ),
+        ],
+      ),
     );
   }
 }

--- a/frontend/flutter_trainer/lib/shared/models/trainer_profile.dart
+++ b/frontend/flutter_trainer/lib/shared/models/trainer_profile.dart
@@ -2,11 +2,17 @@
 class TrainerGym {
   /// Creates gym details.
   const TrainerGym({
+    this.id,
     required this.name,
     required this.address,
     required this.hours,
     required this.phone,
   });
+
+  /// Backend `places.id` used by `PUT /trainer/me/gym`.
+  ///
+  /// Legacy/demo profiles may not be affiliated with a persisted place.
+  final String? id;
 
   /// Gym name (e.g. "온케어짐 신촌점").
   final String name;

--- a/frontend/flutter_trainer/test/features/auth/session_controller_test.dart
+++ b/frontend/flutter_trainer/test/features/auth/session_controller_test.dart
@@ -338,6 +338,23 @@ void main() {
       );
     });
 
+    test(
+      'replaceProfile updates demo data without changing demo status',
+      () async {
+        final container = _makeContainer();
+        final controller = container.read(sessionControllerProvider.notifier);
+        await _settle();
+        controller.enterDemo();
+        final changed = seedTrainerProfile.copyWith(phone: '010-9999-0000');
+
+        controller.replaceProfile(changed);
+
+        final state = container.read(sessionControllerProvider);
+        expect(state.status, SessionStatus.demo);
+        expect(state.profile?.phone, '010-9999-0000');
+      },
+    );
+
     test('signOut clears tokens and returns to signed out', () async {
       final container = _makeContainer();
       final controller = container.read(sessionControllerProvider.notifier);

--- a/frontend/flutter_trainer/test/features/auth/trainer_me_dto_test.dart
+++ b/frontend/flutter_trainer/test/features/auth/trainer_me_dto_test.dart
@@ -15,6 +15,7 @@ void main() {
         'intro': '안녕하세요',
         'certifications': <Object?>['CPT', '영양사'],
         'gym': <String, Object?>{
+          'id': 'gym-1',
           'name': '온케어짐 신촌점',
           'address': '서울 서대문구 신촌로 120',
           'hours': '06:00 – 23:00',
@@ -26,6 +27,7 @@ void main() {
       expect(profile.career, '7년');
       expect(profile.certifications, <String>['CPT', '영양사']);
       expect(profile.gym.name, '온케어짐 신촌점');
+      expect(profile.gym.id, 'gym-1');
       expect(profile.gym.hours, '06:00 – 23:00');
     });
 

--- a/frontend/flutter_trainer/test/features/auth/trainer_me_dto_test.dart
+++ b/frontend/flutter_trainer/test/features/auth/trainer_me_dto_test.dart
@@ -51,5 +51,13 @@ void main() {
 
       expect(profile.certifications, isEmpty);
     });
+
+    test('safely converts a non-string gym id', () {
+      final profile = trainerProfileFromJson(<String, Object?>{
+        'gym': <String, Object?>{'id': 42, 'name': '온케어짐'},
+      });
+
+      expect(profile.gym.id, '42');
+    });
   });
 }

--- a/frontend/flutter_trainer/test/features/my/my_page_test.dart
+++ b/frontend/flutter_trainer/test/features/my/my_page_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:oncare_trainer/app/router/routes.dart';
+import 'package:oncare_trainer/features/auth/presentation/controllers/session_controller.dart';
 
 import '../../helpers/pump_app.dart';
 
@@ -62,19 +63,28 @@ void main() {
     testWidgets('edit mode saves changes with a confirmation flash', (
       tester,
     ) async {
-      await openTab(tester);
+      final container = await pumpTrainerApp(
+        tester,
+        token: 'demo-trainer-token',
+        at: AppRoutes.my,
+      );
 
       await tester.tap(find.text('프로필 수정'));
       await tester.pump();
       expect(find.text('저장'), findsOneWidget);
 
-      // First edit field is 이름.
-      await tester.enterText(find.byType(TextField).first, '박트레이너');
+      // Name/email belong to the account and are read-only. The first
+      // editable profile field is the phone number.
+      await tester.enterText(find.byType(TextField).at(2), '010-9999-0000');
       await tester.tap(find.text('저장'));
       await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
 
       expect(find.text('변경사항이 저장됐어요'), findsOneWidget);
-      expect(find.text('박트레이너'), findsWidgets);
+      expect(
+        container.read(sessionControllerProvider).profile?.phone,
+        '010-9999-0000',
+      );
 
       // Flash expires (no pending timers at test end).
       await tester.pump(const Duration(seconds: 3));

--- a/frontend/flutter_trainer/test/features/my/my_page_test.dart
+++ b/frontend/flutter_trainer/test/features/my/my_page_test.dart
@@ -1,10 +1,55 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:oncare_trainer/app/router/routes.dart';
+import 'package:oncare_trainer/core/errors/app_error.dart';
 import 'package:oncare_trainer/features/auth/presentation/controllers/session_controller.dart';
+import 'package:oncare_trainer/features/my/data/trainer_profile_repository.dart';
+import 'package:oncare_trainer/shared/models/trainer_profile.dart';
 
 import '../../helpers/pump_app.dart';
+
+class _GymFailureRepository implements TrainerProfileRepository {
+  final MockTrainerProfileRepository _delegate = MockTrainerProfileRepository();
+
+  @override
+  Future<TrainerProfile> fetch() => _delegate.fetch();
+
+  @override
+  Future<List<TrainerGymChoice>> listGyms() => _delegate.listGyms();
+
+  @override
+  Future<TrainerProfile> update(TrainerProfileUpdate update) =>
+      _delegate.update(update);
+
+  @override
+  Future<TrainerProfile> setGym(String gymId) {
+    throw const ServerError(message: '헬스장 연결 요청이 실패했습니다.');
+  }
+
+  @override
+  Future<TrainerProfile> clearGym() => _delegate.clearGym();
+}
+
+class _UpdateFailureRepository implements TrainerProfileRepository {
+  @override
+  Future<TrainerProfile> fetch() async => seedTrainerProfile;
+
+  @override
+  Future<List<TrainerGymChoice>> listGyms() async => const <TrainerGymChoice>[];
+
+  @override
+  Future<TrainerProfile> update(TrainerProfileUpdate update) {
+    throw const ValidationError(message: '프로필 입력값을 확인해 주세요.');
+  }
+
+  @override
+  Future<TrainerProfile> setGym(String gymId) => throw UnimplementedError();
+
+  @override
+  Future<TrainerProfile> clearGym() => throw UnimplementedError();
+}
 
 void main() {
   group('MyPage', () {
@@ -73,9 +118,10 @@ void main() {
       await tester.pump();
       expect(find.text('저장'), findsOneWidget);
 
-      // Name/email belong to the account and are read-only. The first
-      // editable profile field is the phone number.
-      await tester.enterText(find.byType(TextField).at(2), '010-9999-0000');
+      await tester.enterText(
+        find.byKey(const ValueKey<String>('profile-phone')),
+        '010-9999-0000',
+      );
       await tester.tap(find.text('저장'));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 200));
@@ -89,6 +135,122 @@ void main() {
       // Flash expires (no pending timers at test end).
       await tester.pump(const Duration(seconds: 3));
       expect(find.text('변경사항이 저장됐어요'), findsNothing);
+    });
+
+    testWidgets('career validation rejects a signed or embedded number', (
+      tester,
+    ) async {
+      await openTab(tester);
+      await tester.tap(find.text('프로필 수정'));
+      await tester.pump();
+
+      await tester.enterText(
+        find.byKey(const ValueKey<String>('profile-career')),
+        '-1년',
+      );
+      await tester.tap(find.text('저장'));
+      await tester.pump();
+
+      expect(find.text('경력은 0~80 사이의 연수로 입력해 주세요.'), findsOneWidget);
+    });
+
+    testWidgets('gym selection rebuilds the manual gym fields', (tester) async {
+      await openTab(tester);
+      await tester.tap(find.text('프로필 수정'));
+      await tester.pump();
+      await tester.ensureVisible(
+        find.byType(DropdownButtonFormField<String>).last,
+      );
+      await tester.pump();
+
+      Finder gymNameField() => find.byWidgetPredicate(
+        (widget) =>
+            widget is TextField && widget.controller?.text == '온케어짐 신촌점',
+      );
+
+      expect(tester.widget<TextField>(gymNameField()).enabled, isTrue);
+      final dropdown = tester.widget<DropdownButtonFormField<String>>(
+        find.byType(DropdownButtonFormField<String>).last,
+      );
+      dropdown.onChanged!('gym-1');
+      await tester.pump();
+      expect(tester.widget<TextField>(gymNameField()).enabled, isFalse);
+
+      await tester.tap(find.byType(DropdownButtonFormField<String>).last);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('소속 없음').last);
+      await tester.pumpAndSettle();
+      expect(tester.widget<TextField>(gymNameField()).enabled, isTrue);
+    });
+
+    testWidgets('gym-only failure reports that profile fields were saved', (
+      tester,
+    ) async {
+      final repository = _GymFailureRepository();
+      final container = await pumpTrainerApp(
+        tester,
+        token: 'demo-trainer-token',
+        at: AppRoutes.my,
+        extraOverrides: <Override>[
+          trainerProfileRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+
+      await tester.tap(find.text('프로필 수정'));
+      await tester.pump();
+      await tester.enterText(
+        find.byKey(const ValueKey<String>('profile-phone')),
+        '010-9999-0000',
+      );
+      await tester.ensureVisible(
+        find.byType(DropdownButtonFormField<String>).last,
+      );
+      await tester.pump();
+      final dropdown = tester.widget<DropdownButtonFormField<String>>(
+        find.byType(DropdownButtonFormField<String>).last,
+      );
+      dropdown.onChanged!('gym-1');
+      await tester.pump();
+
+      await tester.tap(find.text('저장'));
+      await settle(tester);
+
+      expect(find.textContaining('소속 헬스장 변경에 실패했습니다'), findsOneWidget);
+      expect(
+        container.read(sessionControllerProvider).profile?.phone,
+        '010-9999-0000',
+      );
+    });
+
+    testWidgets('profile update failure restores the server snapshot', (
+      tester,
+    ) async {
+      final container = await pumpTrainerApp(
+        tester,
+        token: 'demo-trainer-token',
+        at: AppRoutes.my,
+        extraOverrides: <Override>[
+          trainerProfileRepositoryProvider.overrideWithValue(
+            _UpdateFailureRepository(),
+          ),
+        ],
+      );
+
+      await tester.tap(find.text('프로필 수정'));
+      await tester.pump();
+      await tester.enterText(
+        find.byKey(const ValueKey<String>('profile-phone')),
+        '010-0000-0000',
+      );
+      await tester.tap(find.text('저장'));
+      await settle(tester);
+
+      expect(find.text('프로필 입력값을 확인해 주세요.'), findsOneWidget);
+      expect(
+        container.read(sessionControllerProvider).profile?.phone,
+        seedTrainerProfile.phone,
+      );
+      expect(find.text('프로필 수정'), findsOneWidget);
     });
   });
 }

--- a/frontend/flutter_trainer/test/features/my/trainer_profile_repository_test.dart
+++ b/frontend/flutter_trainer/test/features/my/trainer_profile_repository_test.dart
@@ -106,7 +106,13 @@ void main() {
           requestOptions: RequestOptions(path: '/gyms'),
           statusCode: 200,
           data: <Object?>[
-            <String, Object?>{'id': 'gym-1', 'name': '온케어짐', 'address': '서울'},
+            <String, Object?>{
+              'id': 'gym-1',
+              'name': '온케어짐',
+              'address': '서울',
+              'weekday_hours': '06:00 – 23:00',
+              'phone': '02-1234-5678',
+            },
           ],
         ),
       );
@@ -115,6 +121,8 @@ void main() {
 
       expect(gyms.single.id, 'gym-1');
       expect(gyms.single.name, '온케어짐');
+      expect(gyms.single.hours, '06:00 – 23:00');
+      expect(gyms.single.phone, '02-1234-5678');
     });
 
     test('clearGym calls DELETE and returns the server view', () async {
@@ -166,6 +174,47 @@ void main() {
         ),
       );
     });
+
+    for (final scenario in <({int status, Type type, String detail})>[
+      (status: 422, type: ValidationError, detail: '경력 값을 확인해 주세요.'),
+      (status: 404, type: NotFoundError, detail: '선택한 헬스장이 없습니다.'),
+    ]) {
+      test('${scenario.status} preserves detail as ${scenario.type}', () async {
+        when(
+          () => dio.put<Map<String, Object?>>(
+            '/trainer/me',
+            data: any(named: 'data'),
+          ),
+        ).thenThrow(
+          DioException(
+            requestOptions: RequestOptions(path: '/trainer/me'),
+            type: DioExceptionType.badResponse,
+            response: Response<Object?>(
+              requestOptions: RequestOptions(path: '/trainer/me'),
+              statusCode: scenario.status,
+              data: <String, Object?>{'detail': scenario.detail},
+            ),
+          ),
+        );
+
+        await expectLater(
+          repository.update(
+            const TrainerProfileUpdate(
+              phone: '',
+              specialty: '',
+              careerYears: 0,
+              intro: '',
+              certifications: <String>[],
+            ),
+          ),
+          throwsA(
+            isA<AppError>()
+                .having((error) => error.runtimeType, 'type', scenario.type)
+                .having((error) => error.message, 'message', scenario.detail),
+          ),
+        );
+      });
+    }
   });
 
   test('mock repository persists profile and affiliation mutations', () async {
@@ -186,5 +235,9 @@ void main() {
     expect(restored.phone, '010-7777-8888');
     expect(restored.career, '9년');
     expect(restored.gym.id, 'gym-2');
+    expect(restored.gym.hours, '06:00 – 24:00');
+
+    await repository.clearGym();
+    expect((await repository.fetch()).gym.id, isNull);
   });
 }

--- a/frontend/flutter_trainer/test/features/my/trainer_profile_repository_test.dart
+++ b/frontend/flutter_trainer/test/features/my/trainer_profile_repository_test.dart
@@ -1,0 +1,190 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:oncare_trainer/core/errors/app_error.dart';
+import 'package:oncare_trainer/features/my/data/trainer_profile_repository.dart';
+
+class _MockDio extends Mock implements Dio {}
+
+Response<Map<String, Object?>> _profileResponse({
+  String gymId = 'gym-1',
+  String phone = '010-1111-2222',
+}) => Response<Map<String, Object?>>(
+  requestOptions: RequestOptions(path: '/trainer/me'),
+  statusCode: 200,
+  data: <String, Object?>{
+    'name': '김트레이너',
+    'email': 'trainer@oncare.com',
+    'phone': phone,
+    'specialty': '재활',
+    'career': '7년',
+    'intro': '소개',
+    'certifications': <String>['CPT'],
+    'gym': <String, Object?>{
+      'id': gymId,
+      'name': '온케어짐',
+      'address': '서울',
+      'hours': '06:00 - 23:00',
+      'phone': '02-0000-0000',
+    },
+  },
+);
+
+void main() {
+  setUpAll(() => registerFallbackValue(<String, Object?>{}));
+
+  group('DioTrainerProfileRepository', () {
+    late _MockDio dio;
+    late DioTrainerProfileRepository repository;
+
+    setUp(() {
+      dio = _MockDio();
+      repository = DioTrainerProfileRepository(dio);
+    });
+
+    test(
+      'update sends backend fields and returns the server profile',
+      () async {
+        when(
+          () => dio.put<Map<String, Object?>>(
+            '/trainer/me',
+            data: any(named: 'data'),
+          ),
+        ).thenAnswer((_) async => _profileResponse(phone: '010-9999-0000'));
+
+        final result = await repository.update(
+          const TrainerProfileUpdate(
+            phone: '010-9999-0000',
+            specialty: '재활',
+            careerYears: 8,
+            intro: '새 소개',
+            certifications: <String>['CPT'],
+          ),
+        );
+
+        expect(result.phone, '010-9999-0000');
+        final body =
+            verify(
+                  () => dio.put<Map<String, Object?>>(
+                    '/trainer/me',
+                    data: captureAny(named: 'data'),
+                  ),
+                ).captured.single
+                as Map<String, Object?>;
+        expect(body['career_years'], 8);
+        expect(body, isNot(contains('name')));
+        expect(body, isNot(contains('email')));
+      },
+    );
+
+    test(
+      'setGym uses the affiliation endpoint and maps its response',
+      () async {
+        when(
+          () => dio.put<Map<String, Object?>>(
+            '/trainer/me/gym',
+            data: any(named: 'data'),
+          ),
+        ).thenAnswer((_) async => _profileResponse(gymId: 'gym-2'));
+
+        final result = await repository.setGym('gym-2');
+
+        expect(result.gym.id, 'gym-2');
+        verify(
+          () => dio.put<Map<String, Object?>>(
+            '/trainer/me/gym',
+            data: <String, Object?>{'gym_id': 'gym-2'},
+          ),
+        ).called(1);
+      },
+    );
+
+    test('listGyms maps selectable affiliation options', () async {
+      when(() => dio.get<List<Object?>>('/gyms')).thenAnswer(
+        (_) async => Response<List<Object?>>(
+          requestOptions: RequestOptions(path: '/gyms'),
+          statusCode: 200,
+          data: <Object?>[
+            <String, Object?>{'id': 'gym-1', 'name': '온케어짐', 'address': '서울'},
+          ],
+        ),
+      );
+
+      final gyms = await repository.listGyms();
+
+      expect(gyms.single.id, 'gym-1');
+      expect(gyms.single.name, '온케어짐');
+    });
+
+    test('clearGym calls DELETE and returns the server view', () async {
+      when(
+        () => dio.delete<Map<String, Object?>>('/trainer/me/gym'),
+      ).thenAnswer((_) async => _profileResponse(gymId: ''));
+
+      await repository.clearGym();
+
+      verify(
+        () => dio.delete<Map<String, Object?>>('/trainer/me/gym'),
+      ).called(1);
+    });
+
+    test('409 preserves the backend conflict detail', () async {
+      when(
+        () => dio.put<Map<String, Object?>>(
+          '/trainer/me',
+          data: any(named: 'data'),
+        ),
+      ).thenThrow(
+        DioException(
+          requestOptions: RequestOptions(path: '/trainer/me'),
+          type: DioExceptionType.badResponse,
+          response: Response<Object?>(
+            requestOptions: RequestOptions(path: '/trainer/me'),
+            statusCode: 409,
+            data: <String, Object?>{'detail': '소속 헬스장 정보와 충돌합니다.'},
+          ),
+        ),
+      );
+
+      await expectLater(
+        repository.update(
+          const TrainerProfileUpdate(
+            phone: '',
+            specialty: '',
+            careerYears: 0,
+            intro: '',
+            certifications: <String>[],
+          ),
+        ),
+        throwsA(
+          isA<ServerError>().having(
+            (error) => error.message,
+            'message',
+            contains('충돌'),
+          ),
+        ),
+      );
+    });
+  });
+
+  test('mock repository persists profile and affiliation mutations', () async {
+    final repository = MockTrainerProfileRepository();
+
+    await repository.update(
+      const TrainerProfileUpdate(
+        phone: '010-7777-8888',
+        specialty: '체형 교정',
+        careerYears: 9,
+        intro: '새 소개',
+        certifications: <String>['CPT'],
+      ),
+    );
+    await repository.setGym('gym-2');
+
+    final restored = await repository.fetch();
+    expect(restored.phone, '010-7777-8888');
+    expect(restored.career, '9년');
+    expect(restored.gym.id, 'gym-2');
+  });
+}


### PR DESCRIPTION
## Summary

* 트레이너 MY 프로필 변경사항을 실제 백엔드에 저장하도록 연동했습니다.
* 전문 분야, 경력, 소개, 자격증을 저장하고 재접속 시 다시 조회할 수 있습니다.
* 헬스장 목록 조회와 소속 헬스장 설정·해제를 실제 API로 연결했습니다.
* 저장 실패 시 서버 데이터를 다시 불러오고 사용자에게 오류를 안내합니다.

---

## Changes

### ✨ Features

* 트레이너 프로필 조회 및 수정 repository 추가
* 전문 분야, 경력, 소개, 자격증 저장 기능 추가
* 소속 헬스장 목록 조회 및 설정·해제 기능 추가
* mock API와 real API 환경 지원

### 🔧 Improvements

* 프로필 저장 완료 후 세션 상태 즉시 갱신
* 저장 실패 시 기존 서버 데이터로 복구
* 필수 입력값과 경력 입력 범위 검증
* 이름과 이메일을 읽기 전용 계정 정보로 분리

### 🎨 UI/UX

* MY 수정 화면에 저장 진행 상태 표시
* 소속 헬스장을 직접 입력하는 대신 목록에서 선택하도록 변경
* 저장 성공 및 실패 피드백 추가

### 📝 Docs

* 해당 없음

### 🐛 Fixes

* 화면에서 수정한 프로필이 실제로 저장되지 않던 문제 해결
* 재접속 시 프로필과 헬스장 변경사항이 사라지던 문제 해결

---

## Commits

1. `50c70314` feat(trainer-my): persist profile and gym affiliation

---

## Notes

* 이름과 이메일은 프로필 수정 API 범위에서 제외하고 읽기 전용으로 유지했습니다.
* `USE_MOCK_API=true`에서는 mock repository, `false`에서는 실제 API를 사용합니다.
* 최신 `main` 기준으로 rebase했으며 #478 브랜치와 변경 파일이 겹치지 않습니다.

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [ ] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 트레이너 앱에서 MY 탭으로 이동한 후 `프로필 수정`을 선택합니다.
2. 전문 분야, 경력, 소개, 자격증 또는 소속 헬스장을 변경하고 저장합니다.
3. MY 화면에 변경사항이 반영되는지 확인합니다.
4. 앱을 다시 실행하거나 프로필을 다시 조회한 후 변경사항이 유지되는지 확인합니다.
5. 저장 요청을 실패시켜 오류 안내와 기존 데이터 복구 여부를 확인합니다.

---

## Related Issues

Closes #477

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [ ] 데모 시나리오 영향 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 트레이너 프로필을 서버에 저장하고, 저장 성공 시 로그인 세션에도 즉시 반영합니다.
  * 헬스장 목록에서 소속을 선택하거나 해제할 수 있습니다.
  * 이름과 이메일은 계정 정보로 표시되며 수정할 수 없습니다.
* **개선**
  * 경력 입력값을 0~80년으로 검증합니다.
  * 저장 중 중복 요청을 방지하고, 처리 상태와 결과를 안내합니다.
  * 저장 실패 시 기존 프로필을 복원하고 오류 메시지를 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->