### PR TITLE
feat(reservation): persist trainer slots and member bookings

### DIFF
--- a/backend/app/api/v1/reservations.py
+++ b/backend/app/api/v1/reservations.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.api.deps import RequireMember, RequireTrainer
+from app.db.session import get_db
+from app.schemas.reservation_api import (
+    ReservationCreate,
+    ReservationOut,
+    TrainerSlotCreate,
+    TrainerSlotOut,
+    TrainerSlotUpdate,
+)
+from app.services import reservation_service
+
+router = APIRouter(tags=["reservations"])
+
+ReservationError = (
+    reservation_service.SlotNotFound,
+    reservation_service.SlotUnavailable,
+    reservation_service.DuplicateReservation,
+    reservation_service.CapacityConflict,
+)
+
+
+def _slot_error(exc: Exception) -> HTTPException:
+    if isinstance(exc, reservation_service.SlotNotFound):
+        return HTTPException(status_code=404, detail=str(exc))
+    if isinstance(
+        exc,
+        (
+            reservation_service.SlotUnavailable,
+            reservation_service.DuplicateReservation,
+            reservation_service.CapacityConflict,
+        ),
+    ):
+        return HTTPException(status_code=409, detail=str(exc))
+    raise exc
+
+
+@router.get("/trainers/{trainer_id}/slots", response_model=list[TrainerSlotOut])
+def member_trainer_slots(
+    trainer_id: str,
+    member: RequireMember,
+    db: Annotated[Session, Depends(get_db)],
+) -> list[TrainerSlotOut]:
+    return reservation_service.list_member_slots(db, trainer_id)
+
+
+@router.post("/reservations", response_model=ReservationOut, status_code=201)
+def create_reservation(
+    payload: ReservationCreate,
+    member: RequireMember,
+    db: Annotated[Session, Depends(get_db)],
+) -> ReservationOut:
+    try:
+        return reservation_service.reserve(db, member, payload.slot_id)
+    except ReservationError as exc:
+        raise _slot_error(exc) from exc
+
+
+@router.get("/trainer/reservation-slots", response_model=list[TrainerSlotOut])
+def trainer_slots(
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+    include_past: bool = Query(False),
+) -> list[TrainerSlotOut]:
+    return reservation_service.list_trainer_slots(
+        db, trainer.id, include_past=include_past
+    )
+
+
+@router.post(
+    "/trainer/reservation-slots", response_model=TrainerSlotOut, status_code=201
+)
+def create_trainer_slot(
+    payload: TrainerSlotCreate,
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> TrainerSlotOut:
+    try:
+        return reservation_service.create_slot(
+            db, trainer.id, payload.starts_at, payload.capacity
+        )
+    except ReservationError as exc:
+        raise _slot_error(exc) from exc
+
+
+@router.put("/trainer/reservation-slots/{slot_id}", response_model=TrainerSlotOut)
+def update_trainer_slot(
+    slot_id: str,
+    payload: TrainerSlotUpdate,
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> TrainerSlotOut:
+    try:
+        return reservation_service.update_slot(
+            db,
+            trainer.id,
+            slot_id,
+            payload.model_dump(exclude_unset=True),
+        )
+    except ReservationError as exc:
+        raise _slot_error(exc) from exc
+
+
+@router.delete("/trainer/reservation-slots/{slot_id}", response_model=TrainerSlotOut)
+def close_trainer_slot(
+    slot_id: str,
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> TrainerSlotOut:
+    try:
+        return reservation_service.close_slot(db, trainer.id, slot_id)
+    except ReservationError as exc:
+        raise _slot_error(exc) from exc

--- a/backend/app/api/v1/trainer.py
+++ b/backend/app/api/v1/trainer.py
@@ -482,7 +482,11 @@ def trainer_delete_session(
     db: Annotated[Session, Depends(get_db)],
 ) -> dict:
     """예약 삭제."""
-    if not trainer_service.delete_session(db, trainer.id, session_id):
+    try:
+        deleted = trainer_service.delete_session(db, trainer.id, session_id)
+    except trainer_service.ScheduleConflict as e:
+        raise HTTPException(status_code=409, detail=str(e)) from e
+    if not deleted:
         raise HTTPException(status_code=404, detail="일정을 찾을 수 없습니다.")
     return {"status": "deleted"}
 

--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -34,7 +34,7 @@ from app.schemas.user import (
     ProfileView, RefreshRequest, RiskInfo, SettingItem, Token, TrainerRegister,
     UserHealth, UserMe, UserRegister,
 )
-from app.services import trainer_signup_service
+from app.services import reservation_service, trainer_signup_service
 from app.services.health_service import DEMO_SETTINGS
 
 router = APIRouter(tags=["users"])
@@ -192,8 +192,11 @@ def delete_me(
     user: RequireMember,
     db: Annotated[Session, Depends(get_db)],
 ) -> dict:
-    """회원 탈퇴. FK(ondelete=CASCADE)로 프로필·식단·운동·일정·알림·
-    소셜계정·개인 코치문서가 함께 삭제된다."""
+    """회원 탈퇴. 예약 좌석을 복구한 뒤 프로필·식단·운동·일정·알림·
+    소셜계정·개인 코치문서를 함께 삭제한다."""
+    reservation_service.cancel_member_reservations_for_account_deletion(
+        db, user.id
+    )
     db.delete(user)
     db.commit()
     return {"status": "deleted"}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ FastAPI 진입점 (STEP 1: 골격 재구성).
 실행: uvicorn app.main:app --reload
 문서: http://localhost:8000/docs
 """
+
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
@@ -13,9 +14,23 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.v1 import (
-    ai_coach, coach_docs, consultations, dashboard, diet, exercise, gyms,
-    member_coach, notifications, places, schedule, social, system, trainer,
-    trainers, users,
+    ai_coach,
+    coach_docs,
+    consultations,
+    dashboard,
+    diet,
+    exercise,
+    gyms,
+    member_coach,
+    notifications,
+    places,
+    reservations,
+    schedule,
+    social,
+    system,
+    trainer,
+    trainers,
+    users,
 )
 from app.core import observability
 from app.core.config import get_settings
@@ -71,6 +86,7 @@ if settings.security_headers:
             )
         return response
 
+
 # 관측성: request-id 미들웨어(가장 바깥 — 컨텍스트를 먼저 세팅) + 액세스 로그 + 전역 500 핸들러.
 # 보안 헤더 미들웨어 뒤에 설치해 request-id 미들웨어가 최외곽에서 감싸게 한다.
 observability.install(app)
@@ -90,6 +106,7 @@ app.include_router(coach_docs.router, prefix=settings.api_v1_prefix)
 app.include_router(trainer.router, prefix=settings.api_v1_prefix)
 app.include_router(member_coach.router, prefix=settings.api_v1_prefix)
 app.include_router(consultations.router, prefix=settings.api_v1_prefix)
+app.include_router(reservations.router, prefix=settings.api_v1_prefix)
 # 회원앱 헬스장·트레이너 디렉터리(#324). trainer(단수, 트레이너 앱 전용)와 별개다.
 app.include_router(gyms.router, prefix=settings.api_v1_prefix)
 app.include_router(trainers.router, prefix=settings.api_v1_prefix)

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -794,13 +794,13 @@ class TrainerReservation(Base):
 
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
     member_id: Mapped[str] = mapped_column(
-        ForeignKey("users.id", ondelete="CASCADE"), index=True
+        ForeignKey("users.id", ondelete="RESTRICT"), index=True
     )
     slot_id: Mapped[str] = mapped_column(
         ForeignKey("trainer_reservation_slots.id", ondelete="RESTRICT"), index=True
     )
     schedule_id: Mapped[str] = mapped_column(
-        ForeignKey("trainer_schedule.id", ondelete="CASCADE"), unique=True
+        ForeignKey("trainer_schedule.id", ondelete="RESTRICT"), unique=True
     )
     status: Mapped[str] = mapped_column(
         String(20), nullable=False, server_default="booked", default="booked"

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -8,14 +8,27 @@ ORM 모델 — 프론트 계약(LocalApiInterceptor + drift 스키마)에 맞춤
 
 이번 STEP 1 에서는 테이블 생성만 검증하고, 살은 이후 STEP 에서 채웁니다.
 """
+
 from __future__ import annotations
 
 from datetime import datetime
 
 from pgvector.sqlalchemy import Vector
 from sqlalchemy import (
-    Boolean, DateTime, Float, ForeignKey, Index, Integer, String, Text, UniqueConstraint,
-    false, func, text, true,
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    false,
+    func,
+    text,
+    true,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -42,7 +55,9 @@ class User(Base):
     role: Mapped[str] = mapped_column(
         String(20), default="member", server_default="member", index=True
     )
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
 
     health_profile: Mapped["HealthProfile | None"] = relationship(
         back_populates="user", uselist=False, cascade="all, delete-orphan"
@@ -51,21 +66,26 @@ class User(Base):
 
 class HealthProfile(Base):
     """건강 위험 정보 — /users/me/health 의 risk + 메타."""
+
     __tablename__ = "health_profiles"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    user_id: Mapped[str] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), unique=True)
+    user_id: Mapped[str] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), unique=True
+    )
 
     risk_title: Mapped[str] = mapped_column(String(200), default="")
     risk_body: Mapped[str] = mapped_column(Text, default="")
-    risk_level: Mapped[str] = mapped_column(String(20), default="low")  # low|medium|high
+    risk_level: Mapped[str] = mapped_column(
+        String(20), default="low"
+    )  # low|medium|high
     conditions: Mapped[str] = mapped_column(Text, default="")  # "고혈압, 당뇨 전단계"
     goals: Mapped[str] = mapped_column(Text, default="")
 
     # 개인정보(내 프로필 모달) + 온보딩 인구통계
     phone: Mapped[str] = mapped_column(String(20), default="")
-    birth_date: Mapped[str] = mapped_column(String(10), default="")   # YYYY-MM-DD
-    gender: Mapped[str] = mapped_column(String(10), default="")       # male|female|other
+    birth_date: Mapped[str] = mapped_column(String(10), default="")  # YYYY-MM-DD
+    gender: Mapped[str] = mapped_column(String(10), default="")  # male|female|other
     height_cm: Mapped[float | None] = mapped_column(Float, nullable=True)
 
     # 일일 영양 목표(식단 관리용)
@@ -78,7 +98,9 @@ class HealthProfile(Base):
 
     # 주간 운동 목표(운동 관리용)
     weekly_workout_goal: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    weekly_exercise_minutes_goal: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    weekly_exercise_minutes_goal: Mapped[int | None] = mapped_column(
+        Integer, nullable=True
+    )
     weekly_burn_goal: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
     # 온보딩 완료 여부(프론트 온보딩 게이팅용)
@@ -95,10 +117,13 @@ class HealthProfile(Base):
 
 class DietEntry(Base):
     """식단 기록 — drift DietEntries 대응. 나트륨·당류 포함."""
+
     __tablename__ = "diet_entries"
 
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
-    user_id: Mapped[str] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), index=True)
+    user_id: Mapped[str] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
     date: Mapped[str] = mapped_column(String(10), index=True)  # YYYY-MM-DD
     meal_type: Mapped[str] = mapped_column(String(20))  # breakfast|lunch|dinner|snack
     time_label: Mapped[str] = mapped_column(String(10), default="")
@@ -111,13 +136,19 @@ class DietEntry(Base):
     # 당류는 소수. 음식 단위(FoodNutrient.sugar_g)가 이미 Float 이라 항목 단위만
     # Integer 로 남아 있으면 6.3+8.5 같은 합이 절삭된다(프론트도 double 로 다룸).
     sugar_g: Mapped[float] = mapped_column(Float, default=0.0)
-    engine: Mapped[str] = mapped_column(String(20), default="")  # 인식 엔진(gemini|yolo)
+    engine: Mapped[str] = mapped_column(
+        String(20), default=""
+    )  # 인식 엔진(gemini|yolo)
     # 재시도 중복 저장 방지용 멱등키(클라 요청당 1회 생성). NULL 허용 → 기존/무키 요청은 제약 밖.
     idempotency_key: Mapped[str | None] = mapped_column(String(64), nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
 
     __table_args__ = (
-        UniqueConstraint("user_id", "idempotency_key", name="uq_diet_entries_user_idem"),
+        UniqueConstraint(
+            "user_id", "idempotency_key", name="uq_diet_entries_user_idem"
+        ),
     )
 
 
@@ -128,63 +159,87 @@ class FoodNutrient(Base):
     (LLM 은 '무엇인지' 식별에 강하고, 정확한 영양 수치는 이 공공 DB 가 제공.)
     수치는 1회 제공량(serving_size_g) 기준. name_norm 은 매칭용 정규화 이름.
     """
+
     __tablename__ = "food_nutrients"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     name: Mapped[str] = mapped_column(String(100), index=True)
     name_norm: Mapped[str] = mapped_column(String(100), default="", index=True)
-    category: Mapped[str] = mapped_column(String(30), default="")  # 밥류|국·찌개류|구이류...
+    category: Mapped[str] = mapped_column(
+        String(30), default=""
+    )  # 밥류|국·찌개류|구이류...
     serving_size_g: Mapped[float | None] = mapped_column(Float, nullable=True)
-    calories: Mapped[float] = mapped_column(Float, default=0)      # kcal / 1인분
-    sodium_mg: Mapped[float] = mapped_column(Float, default=0)     # mg  / 1인분
-    sugar_g: Mapped[float] = mapped_column(Float, default=0)       # g   / 1인분
+    calories: Mapped[float] = mapped_column(Float, default=0)  # kcal / 1인분
+    sodium_mg: Mapped[float] = mapped_column(Float, default=0)  # mg  / 1인분
+    sugar_g: Mapped[float] = mapped_column(Float, default=0)  # g   / 1인분
     carbs_g: Mapped[float | None] = mapped_column(Float, nullable=True)
     protein_g: Mapped[float | None] = mapped_column(Float, nullable=True)
     fat_g: Mapped[float | None] = mapped_column(Float, nullable=True)
-    source: Mapped[str] = mapped_column(String(20), default="mfds")  # 데이터 출처(식약처=mfds)
+    source: Mapped[str] = mapped_column(
+        String(20), default="mfds"
+    )  # 데이터 출처(식약처=mfds)
 
 
 class ExerciseSession(Base):
     """운동 기록 — drift ExerciseSessions 대응."""
+
     __tablename__ = "exercise_sessions"
 
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
-    user_id: Mapped[str] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), index=True)
+    user_id: Mapped[str] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
     week_start: Mapped[str] = mapped_column(String(10), index=True)  # 월요일 YYYY-MM-DD
     day_label: Mapped[str] = mapped_column(String(4))  # 월/화/...
     type: Mapped[str] = mapped_column(String(20))  # cardio|strength|yoga|walking
     minutes: Mapped[int] = mapped_column(Integer, default=0)
     calories: Mapped[int] = mapped_column(Integer, default=0)
     # 운동 강도 — 칼로리 추정 배수의 근거이자 수정 시트 복원 값. light|moderate|high
-    intensity: Mapped[str] = mapped_column(String(20), default="moderate", server_default="moderate")
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    intensity: Mapped[str] = mapped_column(
+        String(20), default="moderate", server_default="moderate"
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
 
 
 class ScheduleEvent(Base):
     """일정 — drift ScheduleEvents 대응."""
+
     __tablename__ = "schedule_events"
 
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
-    user_id: Mapped[str] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), index=True)
+    user_id: Mapped[str] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
     date: Mapped[str] = mapped_column(String(10), index=True)
     time: Mapped[str] = mapped_column(String(10), default="")
     title: Mapped[str] = mapped_column(String(200))
-    category: Mapped[str] = mapped_column(String(20))  # hospital|exercise|meal|medication|other
+    category: Mapped[str] = mapped_column(
+        String(20)
+    )  # hospital|exercise|meal|medication|other
     emoji: Mapped[str] = mapped_column(String(10), default="")
     color_hex: Mapped[str] = mapped_column(String(10), default="#E0F2F7")
 
 
 class Notification(Base):
     """알림 — drift NotificationItems 대응."""
+
     __tablename__ = "notifications"
 
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
-    user_id: Mapped[str] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), index=True)
+    user_id: Mapped[str] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
     title: Mapped[str] = mapped_column(String(200))
     body: Mapped[str] = mapped_column(Text, default="")
-    category: Mapped[str] = mapped_column(String(20))  # reminder|health_check|achievement|system
+    category: Mapped[str] = mapped_column(
+        String(20)
+    )  # reminder|health_check|achievement|system
     read: Mapped[bool] = mapped_column(Boolean, default=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
 
 
 class CoachDocument(Base):
@@ -197,6 +252,7 @@ class CoachDocument(Base):
     검색 시 (user_id == 현재사용자 OR user_id IS NULL) 로 가져오면
     내 개인기록 + 공용 가이드라인만 나오고 남의 개인기록은 절대 안 섞인다.
     """
+
     __tablename__ = "coach_documents"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
@@ -210,8 +266,12 @@ class CoachDocument(Base):
     domain: Mapped[str] = mapped_column(String(20), default="general", index=True)
     title: Mapped[str] = mapped_column(String(300), default="")
     content: Mapped[str] = mapped_column(Text)
-    embedding: Mapped[list[float] | None] = mapped_column(Vector(EMBED_DIM), nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    embedding: Mapped[list[float] | None] = mapped_column(
+        Vector(EMBED_DIM), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
 
 
 class SocialAccount(Base):
@@ -220,13 +280,20 @@ class SocialAccount(Base):
     (provider, provider_user_id) 는 유일. 소셜 로그인 시 이 조합으로 사용자를 찾고,
     없으면 (이메일이 같은 기존 사용자에 연결하거나) 새 사용자를 만든다.
     """
+
     __tablename__ = "social_accounts"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    user_id: Mapped[str] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), index=True)
-    provider: Mapped[str] = mapped_column(String(20), index=True)  # kakao|google|naver|apple
+    user_id: Mapped[str] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
+    provider: Mapped[str] = mapped_column(
+        String(20), index=True
+    )  # kakao|google|naver|apple
     provider_user_id: Mapped[str] = mapped_column(String(128))
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
 
     __table_args__ = (
         UniqueConstraint("provider", "provider_user_id", name="uq_social_provider_uid"),
@@ -235,11 +302,14 @@ class SocialAccount(Base):
 
 class Place(Base):
     """온오프라인 연결: 장소 — /places/nearby. 카카오맵 연동 자리."""
+
     __tablename__ = "places"
 
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
     name: Mapped[str] = mapped_column(String(200))
-    category: Mapped[str] = mapped_column(String(30))  # medical|fitness|healthy_food|pharmacy
+    category: Mapped[str] = mapped_column(
+        String(30)
+    )  # medical|fitness|healthy_food|pharmacy
     address: Mapped[str] = mapped_column(String(300), default="")
     lat: Mapped[float | None] = mapped_column(Float, nullable=True)
     lng: Mapped[float | None] = mapped_column(Float, nullable=True)
@@ -254,6 +324,7 @@ class GymProfile(Base):
     같은 헬스장 전용 값을 `places` 에 넣으면 병원·약국·건강식이 공유하는 테이블이
     오염되므로 여기로 분리한다(`TrainerProfile` 이 `User` 를 확장하는 것과 같은 꼴).
     """
+
     __tablename__ = "gym_profiles"
 
     place_id: Mapped[str] = mapped_column(
@@ -264,7 +335,9 @@ class GymProfile(Base):
     weekday_hours: Mapped[str] = mapped_column(String(50), default="")
     weekend_hours: Mapped[str] = mapped_column(String(50), default="")
     phone: Mapped[str] = mapped_column(String(20), default="")
-    tags_json: Mapped[str] = mapped_column(Text, default="[]")  # ["다이어트", "재활운동"]
+    tags_json: Mapped[str] = mapped_column(
+        Text, default="[]"
+    )  # ["다이어트", "재활운동"]
     #: 제휴 헬스장만 트레이너 연결·상담이 가능하다.
     is_partner: Mapped[bool] = mapped_column(
         Boolean, nullable=False, server_default=false(), default=False, index=True
@@ -289,6 +362,7 @@ class MemberGym(Base):
     지우면 된다. 회원당 1곳이라는 불변식은 `member_id` 를 PK 로 두어 구조로 강제한다
     (partial unique index 가 필요 없다).
     """
+
     __tablename__ = "member_gyms"
 
     member_id: Mapped[str] = mapped_column(
@@ -307,6 +381,7 @@ class MemberGym(Base):
 
 class ConsultationRequest(Base):
     """회원의 헬스장·트레이너 상담 요청."""
+
     __tablename__ = "consultation_requests"
 
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
@@ -368,9 +443,7 @@ class ConsultationRequest(Base):
             "created_at",
         ),
         # 트레이너 인박스의 두 경로 — 내 앞으로 온 것 / 내 헬스장으로 온 것. (#467)
-        Index(
-            "ix_consultation_requests_trainer_status", "trainer_id", "status"
-        ),
+        Index("ix_consultation_requests_trainer_status", "trainer_id", "status"),
         Index("ix_consultation_requests_gym_status", "gym_id", "status"),
     )
 
@@ -394,18 +467,22 @@ class TrainerProfile(Base):
     회원의 HealthProfile 과 별개(역할이 다른 계정). 이름/이메일은 User 에 있고,
     여기엔 전문분야·경력·자격증·소속 헬스장 정보만 둔다.
     """
+
     __tablename__ = "trainer_profiles"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     trainer_id: Mapped[str] = mapped_column(
         # unique=True 가 이미 유니크 인덱스를 만들므로 index=True 는 잉여(중복 인덱스). 제거.
-        ForeignKey("users.id", ondelete="CASCADE"), unique=True
+        ForeignKey("users.id", ondelete="CASCADE"),
+        unique=True,
     )
     phone: Mapped[str] = mapped_column(String(20), default="")
-    specialty: Mapped[str] = mapped_column(String(50), default="")     # 퍼스널 트레이너
-    career_years: Mapped[int] = mapped_column(Integer, default=0)       # 7 → "7년"
+    specialty: Mapped[str] = mapped_column(String(50), default="")  # 퍼스널 트레이너
+    career_years: Mapped[int] = mapped_column(Integer, default=0)  # 7 → "7년"
     intro: Mapped[str] = mapped_column(Text, default="")
-    certifications_json: Mapped[str] = mapped_column(Text, default="[]")  # ["생활스포츠지도사 2급", ...]
+    certifications_json: Mapped[str] = mapped_column(
+        Text, default="[]"
+    )  # ["생활스포츠지도사 2급", ...]
     #: 소속 헬스장(`places.id`). 아래 gym_* 문자열 컬럼을 대신한다 — 문자열만으로는
     #: 한 헬스장에 여러 트레이너를 묶을 수 없었다(#324, #301). 트레이너 앱이 아직
     #: gym_* 를 읽으므로 두 표현이 당분간 공존하고, 값이 있으면 gym_id 가 우선이다.
@@ -455,6 +532,7 @@ class TrainerInviteCode(Base):
     발급한다 — 사용 횟수를 세는 것보다 "누가 이 코드를 썼는지"가 남는 편이
     나중에 추적할 수 있다.
     """
+
     __tablename__ = "trainer_invite_codes"
 
     #: 사람이 옮겨 적는 값이라 코드 자체가 PK 다. 대문자·숫자만 쓰고 대소문자
@@ -487,6 +565,7 @@ class TrainerClient(Base):
     또한 회원측 API 는 '현재 담당 코치 1명'을 전제하므로, 회원당 active 링크는 최대
     1개로 partial unique index 로 강제한다(복수 트레이너 동시 배정 방지).
     """
+
     __tablename__ = "trainer_clients"
 
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
@@ -499,14 +578,18 @@ class TrainerClient(Base):
     goal: Mapped[str] = mapped_column(String(200), default="")
     active: Mapped[bool] = mapped_column(Boolean, default=True)
     sort_order: Mapped[int] = mapped_column(Integer, default=0)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
 
     __table_args__ = (
         UniqueConstraint("trainer_id", "member_id", name="uq_trainer_client"),
         # 회원당 active 담당은 최대 1명(휴면 링크는 과거 이력으로 여러 개 허용).
         Index(
-            "uq_trainer_client_active_member", "member_id",
-            unique=True, postgresql_where=text("active"),
+            "uq_trainer_client_active_member",
+            "member_id",
+            unique=True,
+            postgresql_where=text("active"),
         ),
     )
 
@@ -517,6 +600,7 @@ class TrainerRoutine(Base):
     source: 'ai'(AI 추천) | 'trainer'(트레이너 직접 배정). 회원 앱에서 '받은 루틴'
     으로도 읽힌다(양쪽에서 보이는 공유 데이터).
     """
+
     __tablename__ = "trainer_routines"
 
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
@@ -528,11 +612,13 @@ class TrainerRoutine(Base):
     )
     name: Mapped[str] = mapped_column(String(100))
     minutes: Mapped[int] = mapped_column(Integer, default=0)
-    type: Mapped[str] = mapped_column(String(20))       # 유산소|근력|스트레칭
+    type: Mapped[str] = mapped_column(String(20))  # 유산소|근력|스트레칭
     reason: Mapped[str] = mapped_column(String(200), default="")
     source: Mapped[str] = mapped_column(String(20), default="ai")  # ai|trainer
     sort_order: Mapped[int] = mapped_column(Integer, default=0)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
 
 
 class RoutineHistory(Base):
@@ -541,6 +627,7 @@ class RoutineHistory(Base):
     회원이 자율 운동을 완료하거나(회원 앱), 트레이너가 PT 세션을 완료 처리하면
     (스케줄 완료 루프) 생성된다. date_label 은 저장하지 않고 date 로부터 파생한다.
     """
+
     __tablename__ = "routine_history"
 
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
@@ -552,12 +639,18 @@ class RoutineHistory(Base):
         ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True
     )
     date: Mapped[str] = mapped_column(String(10), index=True)  # YYYY-MM-DD
-    kind_label: Mapped[str] = mapped_column(String(50), default="")  # 'PT 세션 · 트레이너 지도'
+    kind_label: Mapped[str] = mapped_column(
+        String(50), default=""
+    )  # 'PT 세션 · 트레이너 지도'
     completion_rate: Mapped[int] = mapped_column(Integer, default=0)  # 0..100
-    exercises_json: Mapped[str] = mapped_column(Text, default="[]")   # ["레그프레스 3세트", ...]
+    exercises_json: Mapped[str] = mapped_column(
+        Text, default="[]"
+    )  # ["레그프레스 3세트", ...]
     client_feedback: Mapped[str] = mapped_column(Text, default="")
     trainer_note: Mapped[str] = mapped_column(Text, default="")
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
 
 
 class ChatMessage(Base):
@@ -567,6 +660,7 @@ class ChatMessage(Base):
     로 저장하고, 트레이너 API 응답에선 프론트 계약에 맞춰 'client' 로 노출한다.
     read_at 으로 양쪽 미확인 수를 계산.
     """
+
     __tablename__ = "chat_messages"
 
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
@@ -578,7 +672,9 @@ class ChatMessage(Base):
     )
     sender: Mapped[str] = mapped_column(String(20))  # trainer|member
     body: Mapped[str] = mapped_column(Text)
-    read_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    read_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), index=True
     )
@@ -590,6 +686,7 @@ class TrainerSchedule(Base):
     회원과 매칭된 슬롯은 member_id 를 갖고, 상담/신규/공백은 client_name(표시용)만
     갖는다. status: 예정|완료|공백. program_json: [{name,sets,reps,weight}].
     """
+
     __tablename__ = "trainer_schedule"
 
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
@@ -601,14 +698,79 @@ class TrainerSchedule(Base):
     )
     date: Mapped[str] = mapped_column(String(10), index=True)  # YYYY-MM-DD
     time: Mapped[str] = mapped_column(String(10), default="")  # "10:00"
-    client_name: Mapped[str] = mapped_column(String(100), default="")  # 표시용(상담/신규 포함)
+    client_name: Mapped[str] = mapped_column(
+        String(100), default=""
+    )  # 표시용(상담/신규 포함)
     type: Mapped[str] = mapped_column(String(30), default="")  # 1:1 PT|상담|...
     duration_minutes: Mapped[int] = mapped_column(Integer, default=0)
     status: Mapped[str] = mapped_column(String(10), default="예정")  # 예정|완료|공백
     note: Mapped[str] = mapped_column(Text, default="")
     program_json: Mapped[str] = mapped_column(Text, default="[]")
     sort_order: Mapped[int] = mapped_column(Integer, default=0)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+
+class TrainerReservationSlot(Base):
+    """A trainer-owned, member-bookable calendar slot."""
+
+    __tablename__ = "trainer_reservation_slots"
+    __table_args__ = (
+        CheckConstraint("capacity > 0", name="ck_reservation_slot_capacity_positive"),
+        CheckConstraint(
+            "remaining >= 0 AND remaining <= capacity",
+            name="ck_reservation_slot_remaining_range",
+        ),
+        Index("ix_reservation_slots_trainer_starts", "trainer_id", "starts_at"),
+    )
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    trainer_id: Mapped[str] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
+    starts_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), index=True)
+    capacity: Mapped[int] = mapped_column(Integer)
+    remaining: Mapped[int] = mapped_column(Integer)
+    is_closed: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=false(), default=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+
+class TrainerReservation(Base):
+    """A member's persisted booking for one trainer slot."""
+
+    __tablename__ = "trainer_reservations"
+    __table_args__ = (
+        UniqueConstraint("member_id", "slot_id", name="uq_reservation_member_slot"),
+        Index("ix_reservations_slot_status", "slot_id", "status"),
+    )
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    member_id: Mapped[str] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
+    slot_id: Mapped[str] = mapped_column(
+        ForeignKey("trainer_reservation_slots.id", ondelete="RESTRICT"), index=True
+    )
+    schedule_id: Mapped[str] = mapped_column(
+        ForeignKey("trainer_schedule.id", ondelete="CASCADE"), unique=True
+    )
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default="booked", default="booked"
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    cancelled_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
 
 class AuditLog(Base):
@@ -617,6 +779,7 @@ class AuditLog(Base):
     user_id 는 FK 를 두지 않는다(사용자가 삭제돼도 감사 기록은 남아야 하므로).
     event 예: auth.login, auth.register, auth.social, admin.public_doc_upload.
     """
+
     __tablename__ = "audit_logs"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
@@ -625,7 +788,9 @@ class AuditLog(Base):
     ip: Mapped[str] = mapped_column(String(64), default="")
     success: Mapped[bool] = mapped_column(Boolean, default=True)
     detail: Mapped[str] = mapped_column(Text, default="")
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
 
 
 class AiConversation(Base):
@@ -638,6 +803,7 @@ class AiConversation(Base):
     트레이너↔회원 채팅(chat_messages)과는 다른 도메인이다. 이쪽은 사람 간 대화가
     아니라 LLM 대화라 sender 대신 role(user|coach)을 쓰고 근거 문서를 함께 남긴다.
     """
+
     __tablename__ = "ai_conversations"
 
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
@@ -663,6 +829,7 @@ class AiMessage(Base):
     저장해야 대화를 복원했을 때도 근거 표시가 남는다(재접속 시 근거가 사라지면
     "왜 이렇게 답했는지"를 되짚을 수 없다).
     """
+
     __tablename__ = "ai_messages"
 
     id: Mapped[str] = mapped_column(String(64), primary_key=True)

--- a/backend/app/schemas/reservation_api.py
+++ b/backend/app/schemas/reservation_api.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class TrainerSlotOut(BaseModel):
+    id: str
+    trainer_id: str
+    starts_at: datetime
+    capacity: int
+    remaining: int
+    is_closed: bool = False
+
+
+class TrainerSlotCreate(BaseModel):
+    starts_at: datetime
+    capacity: int = Field(ge=1, le=100)
+
+    @model_validator(mode="after")
+    def require_timezone(self) -> TrainerSlotCreate:
+        if self.starts_at.tzinfo is None or self.starts_at.utcoffset() is None:
+            raise ValueError("starts_at에는 시간대가 포함되어야 합니다.")
+        return self
+
+
+class TrainerSlotUpdate(BaseModel):
+    starts_at: datetime | None = None
+    capacity: int | None = Field(default=None, ge=1, le=100)
+    is_closed: bool | None = None
+
+    @model_validator(mode="after")
+    def validate_update(self) -> TrainerSlotUpdate:
+        if not self.model_fields_set:
+            raise ValueError("수정할 항목이 없습니다.")
+        if "starts_at" in self.model_fields_set:
+            if self.starts_at is None:
+                raise ValueError("starts_at은 null일 수 없습니다.")
+            if self.starts_at.tzinfo is None or self.starts_at.utcoffset() is None:
+                raise ValueError("starts_at에는 시간대가 포함되어야 합니다.")
+        for field in self.model_fields_set:
+            if getattr(self, field) is None:
+                raise ValueError(f"{field}은 null일 수 없습니다.")
+        return self
+
+
+class ReservationCreate(BaseModel):
+    slot_id: str = Field(min_length=1, max_length=64)
+
+
+class ReservationOut(BaseModel):
+    id: str
+    slot_id: str
+    schedule_id: str
+    status: str
+    created_at: datetime

--- a/backend/app/services/reservation_service.py
+++ b/backend/app/services/reservation_service.py
@@ -219,12 +219,23 @@ def reserve(
         status="booked",
     )
     slot.remaining -= 1
-    db.add_all([schedule, reservation])
+    # There is intentionally no ORM relationship between these persistence
+    # models. Without an explicit flush SQLAlchemy is free to INSERT the
+    # reservation before the schedule, which violates the schedule_id FK on
+    # PostgreSQL even though both objects were added before commit (#492).
+    db.add(schedule)
     try:
+        db.flush()
+        db.add(reservation)
         db.commit()
     except IntegrityError as exc:
         db.rollback()
-        raise DuplicateReservation("이미 예약했거나 마감된 슬롯입니다.") from exc
+        constraint = getattr(getattr(exc.orig, "diag", None), "constraint_name", None)
+        if constraint == "uq_reservation_member_slot":
+            raise DuplicateReservation("이미 예약한 슬롯입니다.") from exc
+        # Do not turn an unexpected schema/programming error into a misleading
+        # 409. Let the global error handler report it as a server failure.
+        raise
     db.refresh(reservation)
     return ReservationOut(
         id=reservation.id,

--- a/backend/app/services/reservation_service.py
+++ b/backend/app/services/reservation_service.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.models.models import (
+    TrainerClient,
+    TrainerReservation,
+    TrainerReservationSlot,
+    TrainerSchedule,
+    User,
+)
+from app.schemas.reservation_api import ReservationOut, TrainerSlotOut
+
+SEOUL = ZoneInfo("Asia/Seoul")
+
+
+class SlotNotFound(Exception):
+    pass
+
+
+class SlotUnavailable(Exception):
+    pass
+
+
+class DuplicateReservation(Exception):
+    pass
+
+
+class CapacityConflict(Exception):
+    pass
+
+
+def _aware(value: datetime) -> datetime:
+    return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+
+
+def _slot_out(slot: TrainerReservationSlot) -> TrainerSlotOut:
+    return TrainerSlotOut(
+        id=slot.id,
+        trainer_id=slot.trainer_id,
+        starts_at=_aware(slot.starts_at),
+        capacity=slot.capacity,
+        remaining=0 if slot.is_closed else slot.remaining,
+        is_closed=slot.is_closed,
+    )
+
+
+def list_member_slots(
+    db: Session, trainer_id: str, *, now: datetime | None = None
+) -> list[TrainerSlotOut]:
+    current = now or datetime.now(timezone.utc)
+    rows = db.scalars(
+        select(TrainerReservationSlot)
+        .where(
+            TrainerReservationSlot.trainer_id == trainer_id,
+            TrainerReservationSlot.starts_at > current,
+        )
+        .order_by(TrainerReservationSlot.starts_at)
+    ).all()
+    return [_slot_out(row) for row in rows]
+
+
+def list_trainer_slots(
+    db: Session, trainer_id: str, *, include_past: bool = False
+) -> list[TrainerSlotOut]:
+    query = select(TrainerReservationSlot).where(
+        TrainerReservationSlot.trainer_id == trainer_id
+    )
+    if not include_past:
+        query = query.where(
+            TrainerReservationSlot.starts_at > datetime.now(timezone.utc)
+        )
+    rows = db.scalars(query.order_by(TrainerReservationSlot.starts_at)).all()
+    return [_slot_out(row) for row in rows]
+
+
+def create_slot(
+    db: Session, trainer_id: str, starts_at: datetime, capacity: int
+) -> TrainerSlotOut:
+    if _aware(starts_at) <= datetime.now(timezone.utc):
+        raise SlotUnavailable("지난 시간에는 예약 슬롯을 만들 수 없습니다.")
+    slot = TrainerReservationSlot(
+        id=f"slot-{uuid.uuid4().hex[:12]}",
+        trainer_id=trainer_id,
+        starts_at=starts_at,
+        capacity=capacity,
+        remaining=capacity,
+    )
+    db.add(slot)
+    db.commit()
+    db.refresh(slot)
+    return _slot_out(slot)
+
+
+def update_slot(
+    db: Session,
+    trainer_id: str,
+    slot_id: str,
+    fields: dict,
+) -> TrainerSlotOut:
+    slot = db.scalar(
+        select(TrainerReservationSlot)
+        .where(
+            TrainerReservationSlot.id == slot_id,
+            TrainerReservationSlot.trainer_id == trainer_id,
+        )
+        .with_for_update()
+    )
+    if slot is None:
+        raise SlotNotFound("예약 슬롯을 찾을 수 없습니다.")
+
+    booked = (
+        db.scalar(
+            select(func.count())
+            .select_from(TrainerReservation)
+            .where(
+                TrainerReservation.slot_id == slot.id,
+                TrainerReservation.status == "booked",
+            )
+        )
+        or 0
+    )
+    if "capacity" in fields:
+        capacity = fields["capacity"]
+        if capacity < booked:
+            raise CapacityConflict("이미 예약된 인원보다 정원을 줄일 수 없습니다.")
+        slot.capacity = capacity
+        slot.remaining = capacity - booked
+    if "starts_at" in fields:
+        starts_at = fields["starts_at"]
+        if _aware(starts_at) <= datetime.now(timezone.utc):
+            raise SlotUnavailable("지난 시간으로 슬롯을 변경할 수 없습니다.")
+        slot.starts_at = starts_at
+        local = _aware(starts_at).astimezone(SEOUL)
+        schedules = db.scalars(
+            select(TrainerSchedule)
+            .join(
+                TrainerReservation, TrainerReservation.schedule_id == TrainerSchedule.id
+            )
+            .where(
+                TrainerReservation.slot_id == slot.id,
+                TrainerReservation.status == "booked",
+            )
+        ).all()
+        for schedule in schedules:
+            schedule.date = local.date().isoformat()
+            schedule.time = local.strftime("%H:%M")
+    if "is_closed" in fields:
+        slot.is_closed = fields["is_closed"]
+    db.commit()
+    db.refresh(slot)
+    return _slot_out(slot)
+
+
+def close_slot(db: Session, trainer_id: str, slot_id: str) -> TrainerSlotOut:
+    return update_slot(db, trainer_id, slot_id, {"is_closed": True})
+
+
+def reserve(
+    db: Session, member: User, slot_id: str, *, now: datetime | None = None
+) -> ReservationOut:
+    current = now or datetime.now(timezone.utc)
+    slot = db.scalar(
+        select(TrainerReservationSlot)
+        .where(TrainerReservationSlot.id == slot_id)
+        .with_for_update()
+    )
+    if slot is None:
+        raise SlotNotFound("예약 슬롯을 찾을 수 없습니다.")
+    if slot.is_closed or slot.remaining <= 0 or _aware(slot.starts_at) <= current:
+        raise SlotUnavailable("예약할 수 없는 슬롯입니다.")
+
+    assigned = db.scalar(
+        select(TrainerClient.id).where(
+            TrainerClient.trainer_id == slot.trainer_id,
+            TrainerClient.member_id == member.id,
+            TrainerClient.active.is_(True),
+        )
+    )
+    if assigned is None:
+        raise SlotUnavailable("담당 트레이너의 슬롯만 예약할 수 있습니다.")
+    duplicate = db.scalar(
+        select(TrainerReservation.id).where(
+            TrainerReservation.member_id == member.id,
+            TrainerReservation.slot_id == slot.id,
+        )
+    )
+    if duplicate is not None:
+        raise DuplicateReservation("이미 예약한 슬롯입니다.")
+
+    reservation_id = f"res-{uuid.uuid4().hex[:12]}"
+    schedule_id = f"sched-{uuid.uuid4().hex[:12]}"
+    local = _aware(slot.starts_at).astimezone(SEOUL)
+    schedule = TrainerSchedule(
+        id=schedule_id,
+        trainer_id=slot.trainer_id,
+        member_id=member.id,
+        date=local.date().isoformat(),
+        time=local.strftime("%H:%M"),
+        client_name=member.name,
+        type="1:1 PT",
+        duration_minutes=60,
+        status="예정",
+        note="회원 앱 예약",
+        program_json="[]",
+        sort_order=0,
+    )
+    reservation = TrainerReservation(
+        id=reservation_id,
+        member_id=member.id,
+        slot_id=slot.id,
+        schedule_id=schedule_id,
+        status="booked",
+    )
+    slot.remaining -= 1
+    db.add_all([schedule, reservation])
+    try:
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        raise DuplicateReservation("이미 예약했거나 마감된 슬롯입니다.") from exc
+    db.refresh(reservation)
+    return ReservationOut(
+        id=reservation.id,
+        slot_id=reservation.slot_id,
+        schedule_id=reservation.schedule_id,
+        status=reservation.status,
+        created_at=_aware(reservation.created_at),
+    )

--- a/backend/app/services/reservation_service.py
+++ b/backend/app/services/reservation_service.py
@@ -162,6 +162,57 @@ def close_slot(db: Session, trainer_id: str, slot_id: str) -> TrainerSlotOut:
     return update_slot(db, trainer_id, slot_id, {"is_closed": True})
 
 
+def cancel_member_reservations_for_account_deletion(
+    db: Session, member_id: str
+) -> None:
+    """Cancel a member's bookings before deleting their account.
+
+    The caller owns the transaction. Reservations and their slots are locked,
+    seats are restored, reservation rows are flushed first to satisfy the
+    restrictive schedule/member FKs, and generated schedules are then removed.
+    """
+    reservations = db.scalars(
+        select(TrainerReservation)
+        .where(TrainerReservation.member_id == member_id)
+        .order_by(TrainerReservation.id)
+        .with_for_update()
+    ).all()
+    if not reservations:
+        return
+
+    booked_slot_ids = sorted(
+        {row.slot_id for row in reservations if row.status == "booked"}
+    )
+    slots = (
+        db.scalars(
+            select(TrainerReservationSlot)
+            .where(TrainerReservationSlot.id.in_(booked_slot_ids))
+            .order_by(TrainerReservationSlot.id)
+            .with_for_update()
+        ).all()
+        if booked_slot_ids
+        else []
+    )
+    slots_by_id = {slot.id: slot for slot in slots}
+    schedule_ids = [row.schedule_id for row in reservations]
+
+    for reservation in reservations:
+        if reservation.status == "booked":
+            slot = slots_by_id.get(reservation.slot_id)
+            if slot is not None:
+                slot.remaining = min(slot.capacity, slot.remaining + 1)
+        db.delete(reservation)
+
+    # No ORM relationships describe this ordering; flush the restrictive FK
+    # children before deleting their generated schedules or the member.
+    db.flush()
+    for schedule_id in schedule_ids:
+        schedule = db.get(TrainerSchedule, schedule_id)
+        if schedule is not None:
+            db.delete(schedule)
+    db.flush()
+
+
 def reserve(
     db: Session, member: User, slot_id: str, *, now: datetime | None = None
 ) -> ReservationOut:

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import Session
 
 from app.models.models import (
     ChatMessage, DietEntry, GymProfile, Place, RoutineHistory, TrainerClient,
-    TrainerProfile, TrainerRoutine, TrainerSchedule, User,
+    TrainerProfile, TrainerReservation, TrainerRoutine, TrainerSchedule, User,
 )
 from app.schemas.trainer_api import (
     ChatMessageOut, ClientDietEntryOut, MemberCoachOut, ProgramItem, RoutineHistoryOut,
@@ -580,6 +580,15 @@ def _get_owned_session(db: Session, trainer_id: str, session_id: str) -> Trainer
     return s
 
 
+def _is_reservation_schedule(db: Session, session_id: str) -> bool:
+    """Return whether a member reservation owns this schedule row."""
+    return db.scalar(
+        select(TrainerReservation.id)
+        .where(TrainerReservation.schedule_id == session_id)
+        .limit(1)
+    ) is not None
+
+
 def create_session(
     db: Session, trainer_id: str, *, date: str, time: str, client_name: str,
     member_id: str | None, type_: str, duration_minutes: int, note: str,
@@ -616,6 +625,10 @@ def update_session(
     s = _get_owned_session(db, trainer_id, session_id)
     if s is None:
         return None
+    if _is_reservation_schedule(db, session_id):
+        raise ScheduleConflict(
+            "예약으로 생성된 일정은 일반 일정 화면에서 수정할 수 없습니다."
+        )
     if s.status == "완료":
         raise ScheduleConflict("완료된 세션은 수정할 수 없습니다.")
     if "time" in fields:
@@ -644,6 +657,10 @@ def delete_session(db: Session, trainer_id: str, session_id: str) -> bool:
     s = _get_owned_session(db, trainer_id, session_id)
     if s is None:
         return False
+    if _is_reservation_schedule(db, session_id):
+        raise ScheduleConflict(
+            "예약으로 생성된 일정은 일반 일정 화면에서 삭제할 수 없습니다."
+        )
     # 완료 세션은 완료 시 파생된 운동기록(sched-hist-{id})을 갖는다. 세션을 지우면 그
     # 파생 기록도 함께 지워 고아 레코드가 회원 이력에 남지 않게 한다(완료 시 적재의 역연산).
     if s.status == "완료":

--- a/backend/migrations/versions/0025_trainer_reservations.py
+++ b/backend/migrations/versions/0025_trainer_reservations.py
@@ -1,0 +1,127 @@
+"""Persist trainer availability slots and member reservations.
+
+Revision ID: 0025_trainer_reservations
+Revises: 0024_trainer_invite_codes
+Create Date: 2026-08-08
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0025_trainer_reservations"
+down_revision: str | Sequence[str] | None = "0024_trainer_invite_codes"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "trainer_reservation_slots",
+        sa.Column("id", sa.String(length=64), nullable=False),
+        sa.Column("trainer_id", sa.String(length=64), nullable=False),
+        sa.Column("starts_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("capacity", sa.Integer(), nullable=False),
+        sa.Column("remaining", sa.Integer(), nullable=False),
+        sa.Column("is_closed", sa.Boolean(), server_default=sa.false(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "capacity > 0", name="ck_reservation_slot_capacity_positive"
+        ),
+        sa.CheckConstraint(
+            "remaining >= 0 AND remaining <= capacity",
+            name="ck_reservation_slot_remaining_range",
+        ),
+        sa.ForeignKeyConstraint(["trainer_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_trainer_reservation_slots_trainer_id",
+        "trainer_reservation_slots",
+        ["trainer_id"],
+    )
+    op.create_index(
+        "ix_trainer_reservation_slots_starts_at",
+        "trainer_reservation_slots",
+        ["starts_at"],
+    )
+    op.create_index(
+        "ix_reservation_slots_trainer_starts",
+        "trainer_reservation_slots",
+        ["trainer_id", "starts_at"],
+    )
+
+    op.create_table(
+        "trainer_reservations",
+        sa.Column("id", sa.String(length=64), nullable=False),
+        sa.Column("member_id", sa.String(length=64), nullable=False),
+        sa.Column("slot_id", sa.String(length=64), nullable=False),
+        sa.Column("schedule_id", sa.String(length=64), nullable=False),
+        sa.Column(
+            "status", sa.String(length=20), server_default="booked", nullable=False
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("cancelled_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["member_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["slot_id"], ["trainer_reservation_slots.id"], ondelete="RESTRICT"
+        ),
+        sa.ForeignKeyConstraint(
+            ["schedule_id"], ["trainer_schedule.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("member_id", "slot_id", name="uq_reservation_member_slot"),
+        sa.UniqueConstraint("schedule_id"),
+    )
+    op.create_index(
+        "ix_trainer_reservations_member_id", "trainer_reservations", ["member_id"]
+    )
+    op.create_index(
+        "ix_trainer_reservations_slot_id", "trainer_reservations", ["slot_id"]
+    )
+    op.create_index(
+        "ix_reservations_slot_status",
+        "trainer_reservations",
+        ["slot_id", "status"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_reservations_slot_status", table_name="trainer_reservations")
+    op.drop_index("ix_trainer_reservations_slot_id", table_name="trainer_reservations")
+    op.drop_index(
+        "ix_trainer_reservations_member_id", table_name="trainer_reservations"
+    )
+    op.drop_table("trainer_reservations")
+    op.drop_index(
+        "ix_reservation_slots_trainer_starts",
+        table_name="trainer_reservation_slots",
+    )
+    op.drop_index(
+        "ix_trainer_reservation_slots_starts_at",
+        table_name="trainer_reservation_slots",
+    )
+    op.drop_index(
+        "ix_trainer_reservation_slots_trainer_id",
+        table_name="trainer_reservation_slots",
+    )
+    op.drop_table("trainer_reservation_slots")

--- a/backend/migrations/versions/0026_trainer_reservations.py
+++ b/backend/migrations/versions/0026_trainer_reservations.py
@@ -1,7 +1,7 @@
 """Persist trainer availability slots and member reservations.
 
-Revision ID: 0025_trainer_reservations
-Revises: 0024_trainer_invite_codes
+Revision ID: 0026_trainer_reservations
+Revises: 0025_member_noti_settings
 Create Date: 2026-08-08
 """
 
@@ -12,8 +12,8 @@ from collections.abc import Sequence
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "0025_trainer_reservations"
-down_revision: str | Sequence[str] | None = "0024_trainer_invite_codes"
+revision: str = "0026_trainer_reservations"
+down_revision: str | Sequence[str] | None = "0025_member_noti_settings"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
@@ -81,12 +81,12 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.Column("cancelled_at", sa.DateTime(timezone=True), nullable=True),
-        sa.ForeignKeyConstraint(["member_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["member_id"], ["users.id"], ondelete="RESTRICT"),
         sa.ForeignKeyConstraint(
             ["slot_id"], ["trainer_reservation_slots.id"], ondelete="RESTRICT"
         ),
         sa.ForeignKeyConstraint(
-            ["schedule_id"], ["trainer_schedule.id"], ondelete="CASCADE"
+            ["schedule_id"], ["trainer_schedule.id"], ondelete="RESTRICT"
         ),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("member_id", "slot_id", name="uq_reservation_member_slot"),

--- a/backend/tests/test_reservations.py
+++ b/backend/tests/test_reservations.py
@@ -12,7 +12,7 @@ from app.models.models import (
     TrainerSchedule,
     User,
 )
-from app.services import reservation_service
+from app.services import reservation_service, trainer_service
 
 
 def test_reserve_flushes_schedule_before_reservation() -> None:
@@ -50,6 +50,29 @@ def test_reserve_flushes_schedule_before_reservation() -> None:
     assert first_add < flush < second_add < commit
     assert result.schedule_id.startswith("sched-")
     assert slot.remaining == 0
+
+
+def test_reserved_schedule_is_blocked_from_regular_update_and_delete() -> None:
+    schedule = TrainerSchedule(
+        id="reserved-schedule-test",
+        trainer_id="trainer-demo",
+    )
+    db = Mock(spec=Session)
+    db.get.return_value = schedule
+    db.scalar.return_value = "reservation-test"
+
+    with pytest.raises(trainer_service.ScheduleConflict):
+        trainer_service.update_session(
+            db,
+            "trainer-demo",
+            schedule.id,
+            {"time": "09:00"},
+        )
+    with pytest.raises(trainer_service.ScheduleConflict):
+        trainer_service.delete_session(db, "trainer-demo", schedule.id)
+
+    db.commit.assert_not_called()
+    db.delete.assert_not_called()
 
 
 def _login(client, email: str) -> str:
@@ -151,6 +174,41 @@ def test_reservation_persists_and_appears_in_trainer_schedule(
     )
     assert timeline.status_code == 200
     assert any(row["id"] == schedule.id for row in timeline.json())
+
+
+def test_reserved_schedule_cannot_be_updated_or_deleted_as_regular_schedule(
+    client, db_session, created_slots
+):
+    trainer_token = _login(client, "trainer@oncare.com")
+    member_token = _login(client, "jisu@oncare.com")
+    slot = _create_slot(client, trainer_token, created_slots, capacity=1)
+    booked = client.post(
+        "/v1/reservations",
+        headers=_headers(member_token),
+        json={"slot_id": slot["id"]},
+    )
+    assert booked.status_code == 201, booked.text
+
+    reservation_id = booked.json()["id"]
+    schedule_id = booked.json()["schedule_id"]
+    updated = client.put(
+        f"/v1/trainer/schedule/{schedule_id}",
+        headers=_headers(trainer_token),
+        json={"time": "09:00"},
+    )
+    deleted = client.delete(
+        f"/v1/trainer/schedule/{schedule_id}",
+        headers=_headers(trainer_token),
+    )
+
+    assert updated.status_code == 409, updated.text
+    assert deleted.status_code == 409, deleted.text
+    db_session.expire_all()
+    assert db_session.get(TrainerReservation, reservation_id) is not None
+    assert db_session.get(TrainerSchedule, schedule_id) is not None
+    persisted_slot = db_session.get(TrainerReservationSlot, slot["id"])
+    assert persisted_slot is not None
+    assert persisted_slot.remaining == 0
 
 
 def test_duplicate_and_full_slot_return_409(client, created_slots):

--- a/backend/tests/test_reservations.py
+++ b/backend/tests/test_reservations.py
@@ -1,14 +1,55 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock
 
 import pytest
+from sqlalchemy.orm import Session
 
 from app.models.models import (
     TrainerReservation,
     TrainerReservationSlot,
     TrainerSchedule,
+    User,
 )
+from app.services import reservation_service
+
+
+def test_reserve_flushes_schedule_before_reservation() -> None:
+    """The schedule FK target must exist before PostgreSQL inserts a booking."""
+    now = datetime.now(timezone.utc)
+    slot = TrainerReservationSlot(
+        id="slot-order-test",
+        trainer_id="trainer-demo",
+        starts_at=now + timedelta(days=1),
+        capacity=1,
+        remaining=1,
+    )
+    member = User(
+        id="member-order-test",
+        email="member-order-test@oncare.com",
+        name="예약 순서 회원",
+        role="member",
+    )
+    db = Mock(spec=Session)
+    db.scalar.side_effect = [slot, "trainer-client-id", None]
+
+    def set_database_defaults(instance) -> None:
+        if isinstance(instance, TrainerReservation):
+            instance.created_at = now
+
+    db.refresh.side_effect = set_database_defaults
+
+    result = reservation_service.reserve(db, member, slot.id, now=now)
+
+    call_names = [entry[0] for entry in db.mock_calls]
+    first_add = call_names.index("add")
+    flush = call_names.index("flush")
+    second_add = call_names.index("add", first_add + 1)
+    commit = call_names.index("commit")
+    assert first_add < flush < second_add < commit
+    assert result.schedule_id.startswith("sched-")
+    assert slot.remaining == 0
 
 
 def _login(client, email: str) -> str:

--- a/backend/tests/test_reservations.py
+++ b/backend/tests/test_reservations.py
@@ -298,14 +298,17 @@ def test_member_account_deletion_restores_slot_and_removes_schedule(
     db_session.flush()
     db_session.add(reservation)
     db_session.commit()
+    reservation_id = reservation.id
+    schedule_id = schedule.id
+    slot_id = slot.id
 
     deleted = client.delete("/v1/users/me", headers=_headers(member_token))
 
     assert deleted.status_code == 200, deleted.text
     db_session.expire_all()
-    assert db_session.get(TrainerReservation, reservation.id) is None
-    assert db_session.get(TrainerSchedule, schedule.id) is None
-    persisted_slot = db_session.get(TrainerReservationSlot, slot.id)
+    assert db_session.get(TrainerReservation, reservation_id) is None
+    assert db_session.get(TrainerSchedule, schedule_id) is None
+    persisted_slot = db_session.get(TrainerReservationSlot, slot_id)
     assert persisted_slot is not None
     assert persisted_slot.remaining == 1
     db_session.delete(persisted_slot)

--- a/backend/tests/test_reservations.py
+++ b/backend/tests/test_reservations.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from unittest.mock import Mock
+from unittest.mock import Mock, call
+from uuid import uuid4
 
 import pytest
 from sqlalchemy.orm import Session
@@ -73,6 +74,46 @@ def test_reserved_schedule_is_blocked_from_regular_update_and_delete() -> None:
 
     db.commit.assert_not_called()
     db.delete.assert_not_called()
+
+
+def test_account_deletion_restores_seat_before_removing_booking() -> None:
+    slot = TrainerReservationSlot(
+        id="account-delete-slot",
+        trainer_id="trainer-demo",
+        capacity=2,
+        remaining=1,
+        starts_at=datetime.now(timezone.utc) + timedelta(days=1),
+    )
+    reservation = TrainerReservation(
+        id="account-delete-reservation",
+        member_id="account-delete-member",
+        slot_id=slot.id,
+        schedule_id="account-delete-schedule",
+        status="booked",
+    )
+    schedule = TrainerSchedule(
+        id=reservation.schedule_id,
+        trainer_id="trainer-demo",
+    )
+    reservation_rows = Mock()
+    reservation_rows.all.return_value = [reservation]
+    slot_rows = Mock()
+    slot_rows.all.return_value = [slot]
+    db = Mock(spec=Session)
+    db.scalars.side_effect = [reservation_rows, slot_rows]
+    db.get.return_value = schedule
+
+    reservation_service.cancel_member_reservations_for_account_deletion(
+        db, reservation.member_id
+    )
+
+    assert slot.remaining == 2
+    assert db.mock_calls.index(call.delete(reservation)) < db.mock_calls.index(
+        call.flush()
+    )
+    assert db.mock_calls.index(call.flush()) < db.mock_calls.index(
+        call.delete(schedule)
+    )
 
 
 def _login(client, email: str) -> str:
@@ -209,6 +250,66 @@ def test_reserved_schedule_cannot_be_updated_or_deleted_as_regular_schedule(
     persisted_slot = db_session.get(TrainerReservationSlot, slot["id"])
     assert persisted_slot is not None
     assert persisted_slot.remaining == 0
+
+
+def test_member_account_deletion_restores_slot_and_removes_schedule(
+    client, db_session
+):
+    suffix = uuid4().hex[:10]
+    email = f"reservation-delete-{suffix}@oncare.com"
+    password = "oncare123"
+    registered = client.post(
+        "/v1/auth/register",
+        json={"email": email, "password": password, "name": "탈퇴 예약 회원"},
+    )
+    assert registered.status_code == 201, registered.text
+    member_id = registered.json()["id"]
+    member_token = _login(client, email)
+
+    slot = TrainerReservationSlot(
+        id=f"slot-delete-{suffix}",
+        trainer_id="trainer-demo",
+        starts_at=datetime.now(timezone.utc) + timedelta(days=2),
+        capacity=1,
+        remaining=0,
+    )
+    schedule = TrainerSchedule(
+        id=f"sched-delete-{suffix}",
+        trainer_id="trainer-demo",
+        member_id=member_id,
+        date=(datetime.now(timezone.utc) + timedelta(days=2)).date().isoformat(),
+        time="10:00",
+        client_name="탈퇴 예약 회원",
+        type="1:1 PT",
+        duration_minutes=60,
+        status="예정",
+        note="회원 직접 예약",
+        program_json="[]",
+        sort_order=0,
+    )
+    reservation = TrainerReservation(
+        id=f"res-delete-{suffix}",
+        member_id=member_id,
+        slot_id=slot.id,
+        schedule_id=schedule.id,
+        status="booked",
+    )
+    db_session.add_all([slot, schedule])
+    db_session.flush()
+    db_session.add(reservation)
+    db_session.commit()
+
+    deleted = client.delete("/v1/users/me", headers=_headers(member_token))
+
+    assert deleted.status_code == 200, deleted.text
+    db_session.expire_all()
+    assert db_session.get(TrainerReservation, reservation.id) is None
+    assert db_session.get(TrainerSchedule, schedule.id) is None
+    persisted_slot = db_session.get(TrainerReservationSlot, slot.id)
+    assert persisted_slot is not None
+    assert persisted_slot.remaining == 1
+    db_session.delete(persisted_slot)
+    db_session.commit()
 
 
 def test_duplicate_and_full_slot_return_409(client, created_slots):

--- a/backend/tests/test_reservations.py
+++ b/backend/tests/test_reservations.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.models.models import (
+    TrainerReservation,
+    TrainerReservationSlot,
+    TrainerSchedule,
+)
+
+
+def _login(client, email: str) -> str:
+    response = client.post(
+        "/v1/auth/login",
+        data={"username": email, "password": "oncare123"},
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["access_token"]
+
+
+def _headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def created_slots(db_session):
+    ids: list[str] = []
+    yield ids
+    db_session.rollback()
+    if not ids:
+        return
+    reservations = (
+        db_session.query(TrainerReservation)
+        .filter(TrainerReservation.slot_id.in_(ids))
+        .all()
+    )
+    schedule_ids = [row.schedule_id for row in reservations]
+    db_session.query(TrainerReservation).filter(
+        TrainerReservation.slot_id.in_(ids)
+    ).delete(synchronize_session=False)
+    if schedule_ids:
+        db_session.query(TrainerSchedule).filter(
+            TrainerSchedule.id.in_(schedule_ids)
+        ).delete(synchronize_session=False)
+    db_session.query(TrainerReservationSlot).filter(
+        TrainerReservationSlot.id.in_(ids)
+    ).delete(synchronize_session=False)
+    db_session.commit()
+
+
+def _create_slot(client, trainer_token: str, created_slots, *, capacity: int = 2):
+    starts_at = datetime.now(timezone.utc) + timedelta(days=2)
+    response = client.post(
+        "/v1/trainer/reservation-slots",
+        headers=_headers(trainer_token),
+        json={"starts_at": starts_at.isoformat(), "capacity": capacity},
+    )
+    assert response.status_code == 201, response.text
+    created_slots.append(response.json()["id"])
+    return response.json()
+
+
+def test_trainer_creates_and_member_lists_slots(client, created_slots):
+    trainer_token = _login(client, "trainer@oncare.com")
+    member_token = _login(client, "jisu@oncare.com")
+    slot = _create_slot(client, trainer_token, created_slots)
+
+    response = client.get(
+        "/v1/trainers/trainer-demo/slots", headers=_headers(member_token)
+    )
+
+    assert response.status_code == 200, response.text
+    selected = next(row for row in response.json() if row["id"] == slot["id"])
+    assert selected["capacity"] == 2
+    assert selected["remaining"] == 2
+
+
+def test_reservation_persists_and_appears_in_trainer_schedule(
+    client, db_session, created_slots
+):
+    trainer_token = _login(client, "trainer@oncare.com")
+    member_token = _login(client, "jisu@oncare.com")
+    slot = _create_slot(client, trainer_token, created_slots)
+
+    booked = client.post(
+        "/v1/reservations",
+        headers=_headers(member_token),
+        json={"slot_id": slot["id"]},
+    )
+
+    assert booked.status_code == 201, booked.text
+    db_session.expire_all()
+    reservation = db_session.get(TrainerReservation, booked.json()["id"])
+    assert reservation is not None
+    assert reservation.member_id == "user-jisu"
+    persisted_slot = db_session.get(TrainerReservationSlot, slot["id"])
+    assert persisted_slot.remaining == 1
+    schedule = db_session.get(TrainerSchedule, booked.json()["schedule_id"])
+    assert schedule is not None
+    assert schedule.trainer_id == "trainer-demo"
+    assert schedule.member_id == "user-jisu"
+    assert schedule.client_name == "이지수"
+
+    timeline = client.get(
+        "/v1/trainer/schedule",
+        headers=_headers(trainer_token),
+        params={"date": schedule.date},
+    )
+    assert timeline.status_code == 200
+    assert any(row["id"] == schedule.id for row in timeline.json())
+
+
+def test_duplicate_and_full_slot_return_409(client, created_slots):
+    trainer_token = _login(client, "trainer@oncare.com")
+    member_token = _login(client, "jisu@oncare.com")
+    slot = _create_slot(client, trainer_token, created_slots, capacity=1)
+
+    first = client.post(
+        "/v1/reservations",
+        headers=_headers(member_token),
+        json={"slot_id": slot["id"]},
+    )
+    second = client.post(
+        "/v1/reservations",
+        headers=_headers(member_token),
+        json={"slot_id": slot["id"]},
+    )
+
+    assert first.status_code == 201
+    assert second.status_code == 409
+
+
+def test_trainer_can_change_capacity_and_close_slot(client, created_slots):
+    trainer_token = _login(client, "trainer@oncare.com")
+    member_token = _login(client, "jisu@oncare.com")
+    slot = _create_slot(client, trainer_token, created_slots, capacity=3)
+
+    updated = client.put(
+        f"/v1/trainer/reservation-slots/{slot['id']}",
+        headers=_headers(trainer_token),
+        json={"capacity": 4},
+    )
+    assert updated.status_code == 200
+    assert updated.json()["remaining"] == 4
+
+    closed = client.delete(
+        f"/v1/trainer/reservation-slots/{slot['id']}",
+        headers=_headers(trainer_token),
+    )
+    assert closed.status_code == 200
+    assert closed.json()["is_closed"] is True
+    assert closed.json()["remaining"] == 0
+
+    refused = client.post(
+        "/v1/reservations",
+        headers=_headers(member_token),
+        json={"slot_id": slot["id"]},
+    )
+    assert refused.status_code == 409
+
+
+def test_past_slots_are_not_returned(client, db_session, created_slots):
+    slot = TrainerReservationSlot(
+        id="slot-past-test",
+        trainer_id="trainer-demo",
+        starts_at=datetime.now(timezone.utc) - timedelta(hours=1),
+        capacity=1,
+        remaining=1,
+    )
+    db_session.add(slot)
+    db_session.commit()
+    created_slots.append(slot.id)
+    member_token = _login(client, "jisu@oncare.com")
+
+    response = client.get(
+        "/v1/trainers/trainer-demo/slots", headers=_headers(member_token)
+    )
+
+    assert response.status_code == 200
+    assert slot.id not in {row["id"] for row in response.json()}
+
+
+def test_member_cannot_book_an_unassigned_trainer_slot(
+    client, db_session, created_slots
+):
+    from app.core.security import hash_password
+    from app.models.models import TrainerProfile, User
+
+    trainer = User(
+        id="reservation-other-trainer",
+        email="reservation-other@oncare.com",
+        name="다른 트레이너",
+        hashed_password=hash_password("oncare123"),
+        role="trainer",
+        is_active=True,
+    )
+    db_session.add(trainer)
+    db_session.flush()
+    db_session.add(TrainerProfile(trainer_id=trainer.id))
+    db_session.commit()
+    try:
+        token = _login(client, trainer.email)
+        member_token = _login(client, "jisu@oncare.com")
+        slot = _create_slot(client, token, created_slots)
+
+        response = client.post(
+            "/v1/reservations",
+            headers=_headers(member_token),
+            json={"slot_id": slot["id"]},
+        )
+
+        assert response.status_code == 409
+    finally:
+        db_session.rollback()
+        db_session.query(TrainerProfile).filter(
+            TrainerProfile.trainer_id == trainer.id
+        ).delete(synchronize_session=False)
+        db_session.query(User).filter(User.id == trainer.id).delete(
+            synchronize_session=False
+        )
+        db_session.commit()

--- a/frontend/flutter_trainer/lib/features/schedule/data/repositories/reservation_slot_repository.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/data/repositories/reservation_slot_repository.dart
@@ -1,0 +1,158 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare_trainer/core/config/app_config.dart';
+import 'package:oncare_trainer/core/network/dio_client.dart';
+import 'package:oncare_trainer/features/schedule/domain/entities/reservation_slot.dart';
+
+abstract interface class ReservationSlotRepository {
+  Future<List<ReservationSlot>> list();
+
+  Future<ReservationSlot> create({
+    required DateTime startsAt,
+    required int capacity,
+  });
+
+  Future<ReservationSlot> update(
+    String id, {
+    DateTime? startsAt,
+    int? capacity,
+  });
+
+  Future<ReservationSlot> close(String id);
+}
+
+class DioReservationSlotRepository implements ReservationSlotRepository {
+  const DioReservationSlotRepository(this._dio);
+
+  final Dio _dio;
+
+  @override
+  Future<List<ReservationSlot>> list() async {
+    final response = await _dio.get<List<dynamic>>(
+      '/trainer/reservation-slots',
+    );
+    return (response.data ?? const <dynamic>[])
+        .map((item) => ReservationSlot.fromJson(item as Map<String, dynamic>))
+        .toList();
+  }
+
+  @override
+  Future<ReservationSlot> create({
+    required DateTime startsAt,
+    required int capacity,
+  }) async {
+    final response = await _dio.post<Map<String, dynamic>>(
+      '/trainer/reservation-slots',
+      data: <String, dynamic>{
+        'starts_at': startsAt.toUtc().toIso8601String(),
+        'capacity': capacity,
+      },
+    );
+    return ReservationSlot.fromJson(response.data!);
+  }
+
+  @override
+  Future<ReservationSlot> update(
+    String id, {
+    DateTime? startsAt,
+    int? capacity,
+  }) async {
+    final response = await _dio.put<Map<String, dynamic>>(
+      '/trainer/reservation-slots/$id',
+      data: <String, dynamic>{
+        'starts_at': ?startsAt?.toUtc().toIso8601String(),
+        'capacity': ?capacity,
+      },
+    );
+    return ReservationSlot.fromJson(response.data!);
+  }
+
+  @override
+  Future<ReservationSlot> close(String id) async {
+    final response = await _dio.delete<Map<String, dynamic>>(
+      '/trainer/reservation-slots/$id',
+    );
+    return ReservationSlot.fromJson(response.data!);
+  }
+}
+
+class MockReservationSlotRepository implements ReservationSlotRepository {
+  final List<ReservationSlot> _slots = <ReservationSlot>[];
+
+  @override
+  Future<List<ReservationSlot>> list() async {
+    final now = DateTime.now();
+    return _slots.where((slot) => slot.startsAt.isAfter(now)).toList()
+      ..sort((a, b) => a.startsAt.compareTo(b.startsAt));
+  }
+
+  @override
+  Future<ReservationSlot> create({
+    required DateTime startsAt,
+    required int capacity,
+  }) async {
+    final slot = ReservationSlot(
+      id: 'slot-${DateTime.now().microsecondsSinceEpoch}',
+      startsAt: startsAt,
+      capacity: capacity,
+      remaining: capacity,
+      isClosed: false,
+    );
+    _slots.add(slot);
+    return slot;
+  }
+
+  @override
+  Future<ReservationSlot> update(
+    String id, {
+    DateTime? startsAt,
+    int? capacity,
+  }) async {
+    final index = _slots.indexWhere((slot) => slot.id == id);
+    if (index < 0) throw StateError('예약 슬롯을 찾을 수 없습니다.');
+    final old = _slots[index];
+    final nextCapacity = capacity ?? old.capacity;
+    if (nextCapacity < old.booked) {
+      throw StateError('이미 예약된 인원보다 정원을 줄일 수 없습니다.');
+    }
+    final updated = ReservationSlot(
+      id: old.id,
+      startsAt: startsAt ?? old.startsAt,
+      capacity: nextCapacity,
+      remaining: nextCapacity - old.booked,
+      isClosed: old.isClosed,
+    );
+    _slots[index] = updated;
+    return updated;
+  }
+
+  @override
+  Future<ReservationSlot> close(String id) async {
+    final index = _slots.indexWhere((slot) => slot.id == id);
+    if (index < 0) throw StateError('예약 슬롯을 찾을 수 없습니다.');
+    final old = _slots[index];
+    final closed = ReservationSlot(
+      id: old.id,
+      startsAt: old.startsAt,
+      capacity: old.capacity,
+      remaining: old.remaining,
+      isClosed: true,
+    );
+    _slots[index] = closed;
+    return closed;
+  }
+}
+
+final reservationSlotRepositoryProvider = Provider<ReservationSlotRepository>((
+  ref,
+) {
+  if (ref.watch(appConfigProvider).useMockApi) {
+    return MockReservationSlotRepository();
+  }
+  return DioReservationSlotRepository(ref.watch(dioProvider));
+}, name: 'reservationSlotRepository');
+
+final reservationSlotsProvider = FutureProvider<List<ReservationSlot>>((ref) {
+  return ref.watch(reservationSlotRepositoryProvider).list();
+}, name: 'reservationSlots');

--- a/frontend/flutter_trainer/lib/features/schedule/data/repositories/reservation_slot_repository.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/data/repositories/reservation_slot_repository.dart
@@ -80,6 +80,18 @@ class DioReservationSlotRepository implements ReservationSlotRepository {
 class MockReservationSlotRepository implements ReservationSlotRepository {
   final List<ReservationSlot> _slots = <ReservationSlot>[];
 
+  void _validateCapacity(int capacity) {
+    if (capacity < 1 || capacity > 100) {
+      throw StateError('정원은 1명 이상 100명 이하이어야 합니다.');
+    }
+  }
+
+  void _validateFuture(DateTime startsAt) {
+    if (!startsAt.isAfter(DateTime.now())) {
+      throw StateError('현재보다 이후 시간만 예약 슬롯으로 설정할 수 있습니다.');
+    }
+  }
+
   @override
   Future<List<ReservationSlot>> list() async {
     final now = DateTime.now();
@@ -92,6 +104,8 @@ class MockReservationSlotRepository implements ReservationSlotRepository {
     required DateTime startsAt,
     required int capacity,
   }) async {
+    _validateFuture(startsAt);
+    _validateCapacity(capacity);
     final slot = ReservationSlot(
       id: 'slot-${DateTime.now().microsecondsSinceEpoch}',
       startsAt: startsAt,
@@ -113,6 +127,8 @@ class MockReservationSlotRepository implements ReservationSlotRepository {
     if (index < 0) throw StateError('예약 슬롯을 찾을 수 없습니다.');
     final old = _slots[index];
     final nextCapacity = capacity ?? old.capacity;
+    _validateCapacity(nextCapacity);
+    if (startsAt != null) _validateFuture(startsAt);
     if (nextCapacity < old.booked) {
       throw StateError('이미 예약된 인원보다 정원을 줄일 수 없습니다.');
     }

--- a/frontend/flutter_trainer/lib/features/schedule/domain/entities/reservation_slot.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/domain/entities/reservation_slot.dart
@@ -1,0 +1,28 @@
+/// A reservable PT time exposed by a trainer.
+class ReservationSlot {
+  const ReservationSlot({
+    required this.id,
+    required this.startsAt,
+    required this.capacity,
+    required this.remaining,
+    required this.isClosed,
+  });
+
+  final String id;
+  final DateTime startsAt;
+  final int capacity;
+  final int remaining;
+  final bool isClosed;
+
+  int get booked => capacity - remaining;
+
+  factory ReservationSlot.fromJson(Map<String, dynamic> json) {
+    return ReservationSlot(
+      id: json['id'] as String,
+      startsAt: DateTime.parse(json['starts_at'] as String).toLocal(),
+      capacity: json['capacity'] as int,
+      remaining: json['remaining'] as int,
+      isClosed: json['is_closed'] as bool? ?? false,
+    );
+  }
+}

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
@@ -13,6 +13,7 @@ import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/features/schedule/data/repositories/schedule_repository.dart';
 import 'package:oncare_trainer/features/schedule/domain/entities/schedule_session.dart';
+import 'package:oncare_trainer/features/schedule/presentation/widgets/reservation_slots_sheet.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
 import 'package:oncare_trainer/shared/widgets/action_button.dart';
 import 'package:oncare_trainer/shared/widgets/client_avatar.dart';
@@ -150,6 +151,18 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
     );
   }
 
+  Future<void> _openReservationSlotsSheet() async {
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: AppColors.card,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: AppRadius.card),
+      ),
+      builder: (context) => ReservationSlotsSheet(selectedDay: _selectedDay),
+    );
+  }
+
   Future<void> _confirmDelete(ScheduleSession s) async {
     final ok = await showDialog<bool>(
       context: context,
@@ -262,6 +275,11 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
               ),
             );
           },
+        ),
+        ActionButton(
+          label: '예약 슬롯',
+          icon: Icons.event_available_outlined,
+          onPressed: () => _openReservationSlotsSheet(),
         ),
         ActionButton(
           label: '새 일정',

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/reservation_slots_sheet.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/reservation_slots_sheet.dart
@@ -109,6 +109,7 @@ class _ReservationSlotsSheetState extends ConsumerState<ReservationSlotsSheet> {
               onPressed: () {
                 final capacity = int.tryParse(controller.text);
                 if (capacity == null ||
+                    capacity < 1 ||
                     capacity < slot.booked ||
                     capacity > 100) {
                   return;

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/reservation_slots_sheet.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/reservation_slots_sheet.dart
@@ -1,0 +1,378 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare_trainer/design_system/tokens/colors.dart';
+import 'package:oncare_trainer/design_system/tokens/radius.dart';
+import 'package:oncare_trainer/design_system/tokens/spacing.dart';
+import 'package:oncare_trainer/features/schedule/data/repositories/reservation_slot_repository.dart';
+import 'package:oncare_trainer/features/schedule/domain/entities/reservation_slot.dart';
+
+class ReservationSlotsSheet extends ConsumerStatefulWidget {
+  const ReservationSlotsSheet({super.key, required this.selectedDay});
+
+  final DateTime selectedDay;
+
+  @override
+  ConsumerState<ReservationSlotsSheet> createState() =>
+      _ReservationSlotsSheetState();
+}
+
+class _ReservationSlotsSheetState extends ConsumerState<ReservationSlotsSheet> {
+  TimeOfDay _time = const TimeOfDay(hour: 10, minute: 0);
+  final TextEditingController _capacity = TextEditingController(text: '1');
+  bool _saving = false;
+
+  @override
+  void dispose() {
+    _capacity.dispose();
+    super.dispose();
+  }
+
+  bool _sameDay(DateTime left, DateTime right) =>
+      left.year == right.year &&
+      left.month == right.month &&
+      left.day == right.day;
+
+  DateTime _startsAt(TimeOfDay time) => DateTime(
+    widget.selectedDay.year,
+    widget.selectedDay.month,
+    widget.selectedDay.day,
+    time.hour,
+    time.minute,
+  );
+
+  Future<void> _create() async {
+    final capacity = int.tryParse(_capacity.text);
+    if (capacity == null || capacity < 1 || capacity > 100) {
+      _showMessage('정원은 1명 이상 100명 이하로 입력해 주세요.');
+      return;
+    }
+    final startsAt = _startsAt(_time);
+    if (!startsAt.isAfter(DateTime.now())) {
+      _showMessage('현재보다 이후 시간만 예약 슬롯으로 만들 수 있어요.');
+      return;
+    }
+    setState(() => _saving = true);
+    try {
+      await ref
+          .read(reservationSlotRepositoryProvider)
+          .create(startsAt: startsAt, capacity: capacity);
+      ref.invalidate(reservationSlotsProvider);
+      _showMessage('예약 슬롯을 열었습니다.');
+    } catch (error) {
+      _showMessage(_errorMessage(error));
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  Future<void> _edit(ReservationSlot slot) async {
+    var time = TimeOfDay.fromDateTime(slot.startsAt);
+    final controller = TextEditingController(text: '${slot.capacity}');
+    final changed = await showDialog<(TimeOfDay, int)?>(
+      context: context,
+      builder: (dialogContext) => StatefulBuilder(
+        builder: (context, setDialogState) => AlertDialog(
+          title: const Text('예약 슬롯 수정'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              ListTile(
+                contentPadding: EdgeInsets.zero,
+                title: const Text('시작 시간'),
+                trailing: Text(time.format(context)),
+                onTap: () async {
+                  final picked = await showTimePicker(
+                    context: context,
+                    initialTime: time,
+                  );
+                  if (picked != null) setDialogState(() => time = picked);
+                },
+              ),
+              TextField(
+                controller: controller,
+                keyboardType: TextInputType.number,
+                decoration: InputDecoration(
+                  labelText: '정원',
+                  helperText: '현재 예약 ${slot.booked}명',
+                ),
+              ),
+            ],
+          ),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () => Navigator.pop(dialogContext),
+              child: const Text('취소'),
+            ),
+            FilledButton(
+              onPressed: () {
+                final capacity = int.tryParse(controller.text);
+                if (capacity == null ||
+                    capacity < slot.booked ||
+                    capacity > 100) {
+                  return;
+                }
+                Navigator.pop(dialogContext, (time, capacity));
+              },
+              child: const Text('저장'),
+            ),
+          ],
+        ),
+      ),
+    );
+    controller.dispose();
+    if (changed == null || !mounted) return;
+    setState(() => _saving = true);
+    try {
+      await ref
+          .read(reservationSlotRepositoryProvider)
+          .update(
+            slot.id,
+            startsAt: _startsAt(changed.$1),
+            capacity: changed.$2,
+          );
+      ref.invalidate(reservationSlotsProvider);
+      _showMessage('예약 슬롯을 수정했습니다.');
+    } catch (error) {
+      _showMessage(_errorMessage(error));
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  Future<void> _close(ReservationSlot slot) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('예약 슬롯 닫기'),
+        content: Text('이미 예약된 ${slot.booked}건의 일정은 유지되고, 신규 예약만 중단됩니다.'),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('취소'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text(
+              '닫기',
+              style: TextStyle(color: AppColors.destructive),
+            ),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+    setState(() => _saving = true);
+    try {
+      await ref.read(reservationSlotRepositoryProvider).close(slot.id);
+      ref.invalidate(reservationSlotsProvider);
+      _showMessage('신규 예약을 닫았습니다.');
+    } catch (error) {
+      _showMessage(_errorMessage(error));
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  String _errorMessage(Object error) {
+    if (error is DioException) {
+      final data = error.response?.data;
+      if (data is Map<String, dynamic> && data['detail'] is String) {
+        return data['detail'] as String;
+      }
+    }
+    if (error is StateError) return error.message.toString();
+    return '요청을 처리하지 못했습니다. 잠시 후 다시 시도해 주세요.';
+  }
+
+  void _showMessage(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final slots = ref.watch(reservationSlotsProvider);
+    final bottom = MediaQuery.viewInsetsOf(context).bottom;
+    return SafeArea(
+      child: Padding(
+        padding: EdgeInsets.fromLTRB(
+          AppSpacing.xl,
+          AppSpacing.xl,
+          AppSpacing.xl,
+          AppSpacing.xl + bottom,
+        ),
+        child: SizedBox(
+          height: MediaQuery.sizeOf(context).height * 0.7,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              Row(
+                children: <Widget>[
+                  const Expanded(
+                    child: Text(
+                      '예약 슬롯 관리',
+                      style: TextStyle(
+                        fontSize: 20,
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                  ),
+                  IconButton(
+                    tooltip: '닫기',
+                    onPressed: () => Navigator.pop(context),
+                    icon: const Icon(Icons.close),
+                  ),
+                ],
+              ),
+              const SizedBox(height: AppSpacing.sm),
+              Text(
+                '${widget.selectedDay.month}월 ${widget.selectedDay.day}일에 회원이 예약할 시간을 엽니다.',
+                style: const TextStyle(color: AppColors.mutedForeground),
+              ),
+              const SizedBox(height: AppSpacing.lg),
+              Row(
+                children: <Widget>[
+                  Expanded(
+                    child: OutlinedButton.icon(
+                      onPressed: _saving
+                          ? null
+                          : () async {
+                              final picked = await showTimePicker(
+                                context: context,
+                                initialTime: _time,
+                              );
+                              if (picked != null) {
+                                setState(() => _time = picked);
+                              }
+                            },
+                      icon: const Icon(Icons.schedule),
+                      label: Text(_time.format(context)),
+                    ),
+                  ),
+                  const SizedBox(width: AppSpacing.sm),
+                  SizedBox(
+                    width: 100,
+                    child: TextField(
+                      controller: _capacity,
+                      enabled: !_saving,
+                      keyboardType: TextInputType.number,
+                      decoration: const InputDecoration(
+                        labelText: '정원',
+                        suffixText: '명',
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: AppSpacing.sm),
+                  FilledButton.icon(
+                    onPressed: _saving ? null : _create,
+                    icon: const Icon(Icons.add),
+                    label: const Text('열기'),
+                  ),
+                ],
+              ),
+              const SizedBox(height: AppSpacing.xl),
+              const Divider(height: 1),
+              const SizedBox(height: AppSpacing.md),
+              Expanded(
+                child: slots.when(
+                  loading: () =>
+                      const Center(child: CircularProgressIndicator()),
+                  error: (_, _) => Center(
+                    child: FilledButton.tonalIcon(
+                      onPressed: () => ref.invalidate(reservationSlotsProvider),
+                      icon: const Icon(Icons.refresh),
+                      label: const Text('다시 불러오기'),
+                    ),
+                  ),
+                  data: (allSlots) {
+                    final daySlots = allSlots
+                        .where(
+                          (slot) => _sameDay(slot.startsAt, widget.selectedDay),
+                        )
+                        .toList();
+                    if (daySlots.isEmpty) {
+                      return const Center(
+                        child: Text(
+                          '이 날짜에 열린 예약 슬롯이 없습니다.',
+                          style: TextStyle(color: AppColors.mutedForeground),
+                        ),
+                      );
+                    }
+                    return ListView.separated(
+                      itemCount: daySlots.length,
+                      separatorBuilder: (_, _) =>
+                          const SizedBox(height: AppSpacing.sm),
+                      itemBuilder: (context, index) {
+                        final slot = daySlots[index];
+                        return Container(
+                          padding: const EdgeInsets.all(AppSpacing.md),
+                          decoration: BoxDecoration(
+                            color: slot.isClosed
+                                ? AppColors.inputBackground
+                                : AppColors.card,
+                            border: Border.all(color: AppColors.borderStrong),
+                            borderRadius: const BorderRadius.all(AppRadius.md),
+                          ),
+                          child: Row(
+                            children: <Widget>[
+                              Container(
+                                width: 64,
+                                alignment: Alignment.center,
+                                child: Text(
+                                  TimeOfDay.fromDateTime(
+                                    slot.startsAt,
+                                  ).format(context),
+                                  style: const TextStyle(
+                                    fontWeight: FontWeight.w800,
+                                  ),
+                                ),
+                              ),
+                              const SizedBox(width: AppSpacing.md),
+                              Expanded(
+                                child: Text(
+                                  slot.isClosed
+                                      ? '예약 닫힘 · 예약 ${slot.booked}명'
+                                      : '예약 ${slot.booked}명 · 잔여 ${slot.remaining}명',
+                                  style: TextStyle(
+                                    color: slot.isClosed
+                                        ? AppColors.subtleForeground
+                                        : AppColors.foreground,
+                                  ),
+                                ),
+                              ),
+                              if (!slot.isClosed) ...<Widget>[
+                                IconButton(
+                                  tooltip: '수정',
+                                  onPressed: _saving ? null : () => _edit(slot),
+                                  icon: const Icon(Icons.edit_outlined),
+                                ),
+                                IconButton(
+                                  tooltip: '예약 닫기',
+                                  onPressed: _saving
+                                      ? null
+                                      : () => _close(slot),
+                                  icon: const Icon(
+                                    Icons.lock_outline,
+                                    color: AppColors.destructive,
+                                  ),
+                                ),
+                              ],
+                            ],
+                          ),
+                        );
+                      },
+                    );
+                  },
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/flutter_trainer/test/features/schedule/reservation_slot_repository_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/reservation_slot_repository_test.dart
@@ -1,0 +1,118 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:oncare_trainer/features/schedule/data/repositories/reservation_slot_repository.dart';
+
+class _MockDio extends Mock implements Dio {}
+
+void main() {
+  late _MockDio dio;
+  late DioReservationSlotRepository repository;
+
+  setUpAll(() => registerFallbackValue(<String, dynamic>{}));
+
+  setUp(() {
+    dio = _MockDio();
+    repository = DioReservationSlotRepository(dio);
+  });
+
+  Map<String, dynamic> slotJson({int remaining = 2}) => <String, dynamic>{
+    'id': 'slot-1',
+    'trainer_id': 'trainer-1',
+    'starts_at': '2026-08-10T01:00:00Z',
+    'capacity': 3,
+    'remaining': remaining,
+    'is_closed': false,
+  };
+
+  test('list maps the trainer slot API response', () async {
+    when(() => dio.get<List<dynamic>>('/trainer/reservation-slots')).thenAnswer(
+      (_) async => Response<List<dynamic>>(
+        requestOptions: RequestOptions(path: '/trainer/reservation-slots'),
+        statusCode: 200,
+        data: <dynamic>[slotJson()],
+      ),
+    );
+
+    final result = await repository.list();
+
+    expect(result.single.id, 'slot-1');
+    expect(result.single.capacity, 3);
+    expect(result.single.remaining, 2);
+    expect(result.single.booked, 1);
+  });
+
+  test('create sends UTC time and capacity', () async {
+    when(
+      () => dio.post<Map<String, dynamic>>(
+        '/trainer/reservation-slots',
+        data: any(named: 'data'),
+      ),
+    ).thenAnswer(
+      (_) async => Response<Map<String, dynamic>>(
+        requestOptions: RequestOptions(path: '/trainer/reservation-slots'),
+        statusCode: 201,
+        data: slotJson(remaining: 3),
+      ),
+    );
+
+    await repository.create(
+      startsAt: DateTime.parse('2026-08-10T10:00:00+09:00'),
+      capacity: 3,
+    );
+
+    final data =
+        verify(
+              () => dio.post<Map<String, dynamic>>(
+                '/trainer/reservation-slots',
+                data: captureAny(named: 'data'),
+              ),
+            ).captured.single
+            as Map<String, dynamic>;
+    expect(data, <String, dynamic>{
+      'starts_at': '2026-08-10T01:00:00.000Z',
+      'capacity': 3,
+    });
+  });
+
+  test('update and close use the slot-scoped endpoints', () async {
+    when(
+      () => dio.put<Map<String, dynamic>>(
+        '/trainer/reservation-slots/slot-1',
+        data: any(named: 'data'),
+      ),
+    ).thenAnswer(
+      (_) async => Response<Map<String, dynamic>>(
+        requestOptions: RequestOptions(
+          path: '/trainer/reservation-slots/slot-1',
+        ),
+        statusCode: 200,
+        data: slotJson(),
+      ),
+    );
+    when(
+      () =>
+          dio.delete<Map<String, dynamic>>('/trainer/reservation-slots/slot-1'),
+    ).thenAnswer(
+      (_) async => Response<Map<String, dynamic>>(
+        requestOptions: RequestOptions(
+          path: '/trainer/reservation-slots/slot-1',
+        ),
+        statusCode: 200,
+        data: <String, dynamic>{...slotJson(), 'is_closed': true},
+      ),
+    );
+
+    await repository.update('slot-1', capacity: 4);
+    final closed = await repository.close('slot-1');
+
+    verify(
+      () => dio.put<Map<String, dynamic>>(
+        '/trainer/reservation-slots/slot-1',
+        data: <String, dynamic>{'capacity': 4},
+      ),
+    ).called(1);
+    expect(closed.isClosed, isTrue);
+  });
+}

--- a/frontend/flutter_trainer/test/features/schedule/reservation_slot_repository_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/reservation_slot_repository_test.dart
@@ -115,4 +115,56 @@ void main() {
     ).called(1);
     expect(closed.isClosed, isTrue);
   });
+
+  group('MockReservationSlotRepository validation', () {
+    test('create rejects past times and capacities outside 1 to 100', () async {
+      final mockRepository = MockReservationSlotRepository();
+      final future = DateTime.now().add(const Duration(days: 1));
+
+      await expectLater(
+        mockRepository.create(
+          startsAt: DateTime.now().subtract(const Duration(minutes: 1)),
+          capacity: 1,
+        ),
+        throwsStateError,
+      );
+      await expectLater(
+        mockRepository.create(startsAt: future, capacity: 0),
+        throwsStateError,
+      );
+      await expectLater(
+        mockRepository.create(startsAt: future, capacity: 101),
+        throwsStateError,
+      );
+      expect(await mockRepository.list(), isEmpty);
+    });
+
+    test('update rejects past times and capacities outside 1 to 100', () async {
+      final mockRepository = MockReservationSlotRepository();
+      final slot = await mockRepository.create(
+        startsAt: DateTime.now().add(const Duration(days: 1)),
+        capacity: 2,
+      );
+
+      await expectLater(
+        mockRepository.update(slot.id, capacity: 0),
+        throwsStateError,
+      );
+      await expectLater(
+        mockRepository.update(slot.id, capacity: 101),
+        throwsStateError,
+      );
+      await expectLater(
+        mockRepository.update(
+          slot.id,
+          startsAt: DateTime.now().subtract(const Duration(minutes: 1)),
+        ),
+        throwsStateError,
+      );
+
+      final unchanged = (await mockRepository.list()).single;
+      expect(unchanged.capacity, 2);
+      expect(unchanged.startsAt, slot.startsAt);
+    });
+  });
 }

--- a/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
@@ -87,18 +87,20 @@ void main() {
             ..where((t) => t.id.equals('seed-client-1')))
           .write(const TrainerClientsCompanion(name: Value('김민수2')));
 
-      final after = await repo
-          .watchClientSessions((id: 'seed-client-1', name: '김민수2'))
-          .first;
+      final after = await repo.watchClientSessions((
+        id: 'seed-client-1',
+        name: '김민수2',
+      )).first;
       expect(after.length, before.length);
     });
 
     test('이름이 같아도 다른 고객의 세션은 섞이지 않는다', () async {
       final repo = DriftScheduleRepository(db);
       // 이름만 같고 id 가 다른 고객은 남의 세션을 가져오면 안 된다.
-      final sessions = await repo
-          .watchClientSessions((id: 'other-client', name: '김민수'))
-          .first;
+      final sessions = await repo.watchClientSessions((
+        id: 'other-client',
+        name: '김민수',
+      )).first;
       expect(sessions, isEmpty);
     });
 
@@ -421,6 +423,19 @@ void main() {
       // rather than an exact count.
       expect(find.text('빈 시간'), findsWidgets);
       expect(find.text('예정'), findsWidgets);
+    });
+
+    testWidgets('예약 슬롯 action opens the selected-day management sheet', (
+      tester,
+    ) async {
+      await openSchedule(tester);
+
+      await tester.tap(find.text('예약 슬롯'));
+      await settle(tester);
+
+      expect(find.text('예약 슬롯 관리'), findsOneWidget);
+      expect(find.textContaining('회원이 예약할 시간을 엽니다'), findsOneWidget);
+      expect(find.text('열기'), findsOneWidget);
     });
 
     testWidgets('completed session expands to program, note, and send flow', (


### PR DESCRIPTION
## Summary

* 트레이너 예약 슬롯과 회원 예약을 백엔드에 영속화했습니다.
* 회원의 예약 확정 시 잔여 정원을 원자적으로 차감하고 트레이너 일정을 생성합니다.
* 트레이너 앱에서 예약 슬롯을 생성·수정·마감할 수 있도록 구현했습니다.
* 기존 #469 회원 앱 예약 UI가 사용하는 API 계약을 실제 백엔드와 연결했습니다.

---

## Changes

### ✨ Features

* 트레이너 예약 슬롯 및 회원 예약 모델 추가
* `0025_trainer_reservations` Alembic migration 추가
* 회원용 예약 슬롯 조회 API 구현
* 회원용 예약 확정 API 구현
* 트레이너용 슬롯 조회·생성·수정·마감 API 구현
* 예약 확정 시 트레이너 PT 일정 자동 생성
* 트레이너 일정 화면에 예약 슬롯 관리 기능 추가
* mock API와 real API repository 지원

### 🔧 Improvements

* row lock을 사용한 원자적 잔여 정원 차감
* 지난 슬롯, 마감 슬롯 및 정원 초과 예약 차단
* 동일 회원의 중복 예약 차단
* 현재 담당 트레이너가 아닌 슬롯 예약 차단
* 슬롯 시간 변경 시 연결된 트레이너 일정도 함께 갱신
* 슬롯 마감 시 기존 예약 일정은 유지하고 신규 예약만 차단

### 🎨 UI/UX

* 일정 화면에 `예약 슬롯` 관리 진입 버튼 추가
* 선택한 날짜 기준으로 슬롯 생성 및 목록 조회
* 슬롯 시작 시간과 정원 수정 기능 추가
* 예약 인원과 잔여 인원 표시
* 슬롯 마감 전 기존 예약 유지 여부 안내

### 📝 Docs

* 해당 없음

### 🐛 Fixes

* #469 예약 UI가 실제 백엔드에 저장되지 않던 문제 해결
* 예약 후 다시 조회하면 잔여 인원이 복구되던 문제 해결
* 회원 예약이 트레이너 일정에 표시되지 않던 문제 해결

---

## Commits

1. `ee1a9afb` feat(reservations): persist trainer slots and bookings

---

## Notes

* 다음 회원 앱 API 계약을 구현했습니다.
  * `GET /trainers/{trainer_id}/slots`
  * `POST /reservations`
* 실제 PostgreSQL이 필요한 통합 테스트 6개는 로컬 DB 미실행으로 정상 수집 후 skip되었습니다.
* CI의 PostgreSQL 환경에서 migration 및 통합 테스트 최종 확인이 필요합니다.
* 최신 `main` 기준으로 rebase했으며 #477 브랜치와 상호 병합 충돌이 없습니다.

---

## Test Plan

* [ ] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [ ] 빌드 성공
* [ ] 관련 테스트 통과

### Manual Test Steps

1. 트레이너 앱 일정 화면에서 미래 날짜를 선택하고 `예약 슬롯`을 누릅니다.
2. 시작 시간과 정원을 입력하여 슬롯을 생성합니다.
3. 담당 회원 계정으로 해당 트레이너의 슬롯을 조회하고 예약합니다.
4. 예약 후 잔여 인원이 감소하는지 확인합니다.
5. 트레이너 일정 화면에 회원의 PT 일정이 생성됐는지 확인합니다.
6. 동일 슬롯 중복 예약과 마감 슬롯 예약이 거부되는지 확인합니다.
7. 트레이너 앱에서 슬롯 시간·정원을 수정하고 신규 예약을 마감합니다.
8. Alembic migration과 백엔드 통합 테스트를 PostgreSQL 환경에서 실행합니다.

---

## Related Issues

Closes #478

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [ ] 데모 시나리오 영향 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 트레이너가 예약 슬롯을 생성·조회·수정·종료할 수 있습니다.
  * 회원이 트레이너의 예약 가능 슬롯을 확인하고 예약할 수 있습니다.
  * 일정 화면에 예약 슬롯 관리 버튼과 관리 시트를 추가했습니다.
  * 예약 인원, 잔여 정원, 예약 상태를 확인할 수 있습니다.

* **버그 수정**
  * 중복 예약, 정원 초과, 과거 슬롯 예약을 방지합니다.
  * 예약된 일정의 임의 수정 및 삭제를 차단합니다.
  * 슬롯 관련 오류를 적절한 안내 오류로 처리합니다.

* **테스트**
  * 예약 및 슬롯 관리 기능에 대한 백엔드·앱 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->