### PR TITLE
feat(notification): 알림 생성 지점 신설과 회원 알림 설정 서버 저장

### DIFF
--- a/backend/app/api/v1/notifications.py
+++ b/backend/app/api/v1/notifications.py
@@ -3,6 +3,9 @@
 
   GET  /notifications              -> 최신순 배열 (time_ago 포함)
   POST /notifications/{id}/read    -> 읽음 처리
+
+회원 알림 수신 설정(GET/PUT /users/me/notification-settings)도 여기 둔다 — 알림을
+만드는 일과 끄는 일은 같은 도메인이다. (#489)
 """
 from __future__ import annotations
 
@@ -13,10 +16,15 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import func, select, update
 from sqlalchemy.orm import Session
 
-from app.api.deps import CurrentUser
+from app.api.deps import CurrentUser, RequireMember
 from app.db.session import get_db
 from app.models.models import Notification
 from app.schemas.misc_api import NotificationAction, NotificationOut
+from app.schemas.user import (
+    MemberNotificationSettings,
+    MemberNotificationSettingsUpdate,
+)
+from app.services import notification_service
 
 router = APIRouter(tags=["notifications"])
 
@@ -64,6 +72,47 @@ def list_notifications(
         )
         for r in rows
     ]
+
+
+@router.get(
+    "/users/me/notification-settings",
+    response_model=MemberNotificationSettings,
+)
+def get_notification_settings(
+    user: CurrentUser,
+    db: Annotated[Session, Depends(get_db)],
+) -> MemberNotificationSettings:
+    """회원 알림 수신 설정. 저장한 적이 없으면 기본값을 준다. (#489)
+
+    전에는 앱이 SharedPreferences 에만 저장해 기기를 바꾸면 초기화됐고, 서버가
+    설정을 몰라 알림을 만들 때 끌 수도 없었다.
+    """
+    return MemberNotificationSettings(
+        **_settings_payload(notification_service.get_settings(db, user.id))
+    )
+
+
+@router.put(
+    "/users/me/notification-settings",
+    response_model=MemberNotificationSettings,
+)
+def update_notification_settings(
+    payload: MemberNotificationSettingsUpdate,
+    user: RequireMember,
+    db: Annotated[Session, Depends(get_db)],
+) -> MemberNotificationSettings:
+    """보낸 항목만 반영한다."""
+    fields = {
+        f"notif_{name}": value
+        for name, value in payload.model_dump(exclude_none=True).items()
+    }
+    updated = notification_service.update_settings(db, user.id, fields)
+    return MemberNotificationSettings(**_settings_payload(updated))
+
+
+def _settings_payload(settings: dict[str, bool]) -> dict[str, bool]:
+    """서비스의 `notif_*` 키를 응답 필드 이름으로 옮긴다."""
+    return {key.removeprefix("notif_"): value for key, value in settings.items()}
 
 
 @router.get("/notifications/unread-count", response_model=dict)

--- a/backend/app/api/v1/trainer.py
+++ b/backend/app/api/v1/trainer.py
@@ -39,6 +39,7 @@ from app.schemas.trainer_api import (
 )
 from app.services import (
     consultation_service,
+    notification_service,
     trainer_routine_options_service,
     trainer_service,
 )
@@ -302,7 +303,10 @@ def trainer_send_chat(
     text = payload.text.strip()
     if not text:
         raise HTTPException(status_code=400, detail="빈 메시지는 보낼 수 없습니다.")
-    return trainer_service.send_message(db, trainer.id, member_id, "trainer", text)
+    return trainer_service.send_message(
+        db, trainer.id, member_id, "trainer", text,
+        notify=notification_service.TRAINER_MESSAGE,
+    )
 
 
 @router.post("/trainer/clients/{member_id}/chat/read")
@@ -574,7 +578,10 @@ def trainer_send_report(
             db, trainer.id, member_id, _date.fromisoformat(day)
         )
         text = report.message
-    return trainer_service.send_message(db, trainer.id, member_id, "trainer", text)
+    return trainer_service.send_message(
+        db, trainer.id, member_id, "trainer", text,
+        notify=notification_service.WEEKLY_REPORT,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -187,6 +187,46 @@ class Notification(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
 
+class MemberNotificationSetting(Base):
+    """회원 알림 수신 설정 — 기기가 아니라 계정 단위. (#489)
+
+    전에는 사용자 앱이 SharedPreferences 에만 저장해 기기를 바꾸면 초기화됐고,
+    무엇보다 **서버가 몰라서 알림을 만들 때 끌 수가 없었다.**
+
+    컬럼 이름은 앱이 쓰던 키(`notif_*`)에서 접두사만 뗀 것이다. 새 이름을 만들면
+    앱 화면과 대응이 흐려진다. 트레이너 쪽(`TrainerProfile.notify_*`)과 대칭이지만
+    항목이 달라 테이블을 나눈다.
+
+    행이 없으면 기본값(`notification_service.DEFAULTS`)이다 — 가입할 때마다 행을
+    만들지 않아도 되고, 기본값을 바꾸면 한 번도 설정을 건드리지 않은 회원에게
+    바로 적용된다.
+    """
+    __tablename__ = "member_notification_settings"
+
+    member_id: Mapped[str] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+    )
+    diet_log: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=true(), default=True
+    )
+    exercise_reminder: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=true(), default=True
+    )
+    trainer_message: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=true(), default=True
+    )
+    ai_coaching: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=true(), default=True
+    )
+    #: 주간 리포트만 기본 꺼짐 — 앱의 현재 기본값과 같다.
+    weekly_report: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=false(), default=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+
 class CoachDocument(Base):
     """RAG 코치용 문서 + 임베딩 (STEP 7).
 

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from typing import Any, Optional
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 # ---- GET /users/me ----
@@ -57,6 +57,25 @@ class MemberNotificationSettingsUpdate(BaseModel):
     trainer_message: bool | None = None
     ai_coaching: bool | None = None
     weekly_report: bool | None = None
+
+    @model_validator(mode="after")
+    def _reject_null_for_non_nullable_fields(
+        self,
+    ) -> MemberNotificationSettingsUpdate:
+        """명시적 null 은 422. 누락은 '변경 없음'이다.
+
+        `None` 은 두 가지를 뜻할 수 있다 — 항목을 아예 안 보냈거나, `null` 을
+        보냈거나. 여기 다섯 항목은 모두 DB NOT NULL 이라 null 로 바꿀 수 있는
+        값이 아니다. 구분하지 않으면 `{"weekly_report": null}` 이 조용히 성공하고
+        아무것도 바뀌지 않는다.
+
+        `ScheduleUpdateRequest._reject_null_for_non_nullable_fields` 와 같은
+        규약이다(#377).
+        """
+        for field in self.model_fields_set:
+            if getattr(self, field) is None:
+                raise ValueError(f"{field}에는 null을 사용할 수 없습니다.")
+        return self
 
 
 class UserHealth(BaseModel):

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -34,6 +34,31 @@ class SettingItem(BaseModel):
     kind: str
 
 
+class MemberNotificationSettings(BaseModel):
+    """회원 알림 수신 설정. (#489)
+
+    필드 이름은 사용자 앱이 로컬에 쓰던 키(`notif_*`)에서 접두사만 뗀 것이다 —
+    앱이 저장 위치만 서버로 옮기는 것이므로 새 이름을 만들면 화면과 대응이
+    흐려진다.
+    """
+
+    diet_log: bool
+    exercise_reminder: bool
+    trainer_message: bool
+    ai_coaching: bool
+    weekly_report: bool
+
+
+class MemberNotificationSettingsUpdate(BaseModel):
+    """부분 수정 — 보낸 항목만 반영한다."""
+
+    diet_log: bool | None = None
+    exercise_reminder: bool | None = None
+    trainer_message: bool | None = None
+    ai_coaching: bool | None = None
+    weekly_report: bool | None = None
+
+
 class UserHealth(BaseModel):
     profile: HealthProfileBrief
     risk: RiskInfo

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -64,6 +64,11 @@ def update_settings(
     db: Session, member_id: str, fields: dict[str, bool]
 ) -> dict[str, bool]:
     """보낸 항목만 반영한다. 없던 행은 기본값에서 시작해 만든다."""
+    # 바꿀 게 없으면 행을 만들지 않는다. 행 없음 == 기본값이므로 빈 요청에
+    # 기본값 행을 새로 남기는 것은 의미 없는 쓰기다(리뷰).
+    if not fields:
+        return get_settings(db, member_id)
+
     row = db.get(MemberNotificationSetting, member_id)
     if row is None:
         row = MemberNotificationSetting(
@@ -97,10 +102,16 @@ def wants(db: Session, member_id: str, kind: str) -> bool:
 
     설정을 읽지 못하면 **받는 쪽으로** 둔다 — 알림이 하나 더 오는 것보다 놓치는
     쪽이 나쁘다.
+
+    조회를 **savepoint 안에서** 한다. 예외를 잡는 것만으로는 부족하다 — DB 오류가
+    나면 세션이 실패 상태로 남아, 이어지는 `db.commit()`(메시지·루틴·일정을
+    저장하는 그 커밋)까지 함께 죽는다. 설정을 못 읽었다는 이유로 메시지가 사라지면
+    안 된다(리뷰). savepoint 를 되돌리면 바깥 트랜잭션은 멀쩡하다.
     """
     try:
-        return get_settings(db, member_id).get(kind, True)
-    except Exception:  # noqa: BLE001 — 설정 조회 실패가 알림을 막지 않는다
+        with db.begin_nested():
+            return get_settings(db, member_id).get(kind, True)
+    except Exception:  # noqa: BLE001 — 설정 조회 실패가 알림도 원래 요청도 막지 않는다
         return True
 
 

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -1,0 +1,147 @@
+"""회원 알림 생성과 수신 설정. (#489)
+
+알림함이 사실상 비어 있었다. `Notification` 행을 만드는 코드가 데모 시드와 상담
+승인·거절(#467) 두 곳뿐이어서, 트레이너가 메시지를 보내도 루틴을 배정해도 일정을
+잡아도 회원은 해당 화면에 직접 들어가야 알 수 있었다.
+
+**설정과 함께 다루는 이유**: 회원 알림 설정이 기기 로컬(SharedPreferences)에만
+있어 서버가 몰랐다. 서버가 모르면 알림을 만들 때 끌 수가 없다. 알림을 만드는 일과
+끄는 일은 같은 문제의 양면이다.
+"""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.models import MemberNotificationSetting, Notification
+
+#: 알림 종류 → 회원 설정 키. 키는 사용자 앱이 이미 쓰던 것 그대로다
+#: (`my_flows.dart` 의 `_notifItems`) — 앱이 로컬에 저장하던 값을 서버로 옮기는
+#: 것이므로 새 이름을 만들면 기존 화면과 어긋난다.
+TRAINER_MESSAGE = "notif_trainer_message"
+EXERCISE = "notif_exercise_reminder"
+WEEKLY_REPORT = "notif_weekly_report"
+DIET_LOG = "notif_diet_log"
+AI_COACHING = "notif_ai_coaching"
+
+#: 설정 키 → 기본값. 사용자 앱의 현재 기본값과 같다(주간 리포트만 꺼짐).
+DEFAULTS: dict[str, bool] = {
+    DIET_LOG: True,
+    EXERCISE: True,
+    TRAINER_MESSAGE: True,
+    AI_COACHING: True,
+    WEEKLY_REPORT: False,
+}
+
+#: 알림 종류 → 목록에 실릴 category. 앱은 이 값으로 이동 경로를 고른다
+#: (`notifications._ACTION_BY_CATEGORY`).
+_CATEGORY: dict[str, str] = {
+    TRAINER_MESSAGE: "system",
+    EXERCISE: "reminder",
+    WEEKLY_REPORT: "achievement",
+    DIET_LOG: "reminder",
+    AI_COACHING: "system",
+}
+
+
+def get_settings(db: Session, member_id: str) -> dict[str, bool]:
+    """회원의 알림 수신 설정. 저장된 적이 없으면 기본값."""
+    row = db.get(MemberNotificationSetting, member_id)
+    if row is None:
+        return dict(DEFAULTS)
+    return {
+        DIET_LOG: row.diet_log,
+        EXERCISE: row.exercise_reminder,
+        TRAINER_MESSAGE: row.trainer_message,
+        AI_COACHING: row.ai_coaching,
+        WEEKLY_REPORT: row.weekly_report,
+    }
+
+
+def update_settings(
+    db: Session, member_id: str, fields: dict[str, bool]
+) -> dict[str, bool]:
+    """보낸 항목만 반영한다. 없던 행은 기본값에서 시작해 만든다."""
+    row = db.get(MemberNotificationSetting, member_id)
+    if row is None:
+        row = MemberNotificationSetting(
+            member_id=member_id,
+            diet_log=DEFAULTS[DIET_LOG],
+            exercise_reminder=DEFAULTS[EXERCISE],
+            trainer_message=DEFAULTS[TRAINER_MESSAGE],
+            ai_coaching=DEFAULTS[AI_COACHING],
+            weekly_report=DEFAULTS[WEEKLY_REPORT],
+        )
+        db.add(row)
+
+    column_by_key = {
+        DIET_LOG: "diet_log",
+        EXERCISE: "exercise_reminder",
+        TRAINER_MESSAGE: "trainer_message",
+        AI_COACHING: "ai_coaching",
+        WEEKLY_REPORT: "weekly_report",
+    }
+    for key, column in column_by_key.items():
+        if key in fields:
+            setattr(row, column, bool(fields[key]))
+
+    db.commit()
+    db.refresh(row)
+    return get_settings(db, member_id)
+
+
+def wants(db: Session, member_id: str, kind: str) -> bool:
+    """이 회원이 [kind] 알림을 받기로 했는가.
+
+    설정을 읽지 못하면 **받는 쪽으로** 둔다 — 알림이 하나 더 오는 것보다 놓치는
+    쪽이 나쁘다.
+    """
+    try:
+        return get_settings(db, member_id).get(kind, True)
+    except Exception:  # noqa: BLE001 — 설정 조회 실패가 알림을 막지 않는다
+        return True
+
+
+def queue(
+    db: Session,
+    *,
+    member_id: str,
+    kind: str,
+    title: str,
+    body: str = "",
+) -> Notification | None:
+    """알림을 세션에 **추가만** 한다(커밋하지 않는다). 꺼져 있으면 None.
+
+    커밋하지 않는 이유: 호출하는 쪽이 이미 자기 변경을 커밋하는 트랜잭션을 갖고
+    있다. 여기서 따로 커밋하면 메시지는 저장됐는데 알림만 없는(또는 그 반대인)
+    반쪽 상태가 생긴다. 같은 트랜잭션에 얹어 함께 성사시킨다.
+
+    별도 실패 모드를 만들지 않는다는 뜻이기도 하다 — 여기서 하는 일은 `db.add`
+    뿐이라 원래 요청을 새로 실패시킬 여지가 없다. 외부 발송(푸시)은 이 함수
+    바깥의 일이다(#474).
+    """
+    if not wants(db, member_id, kind):
+        return None
+    notification = Notification(
+        id=f"noti-{uuid.uuid4().hex[:12]}",
+        user_id=member_id,
+        title=title,
+        body=body,
+        category=_CATEGORY.get(kind, "system"),
+        read=False,
+    )
+    db.add(notification)
+    return notification
+
+
+def unread_count(db: Session, member_id: str) -> int:
+    """읽지 않은 알림 수. 테스트와 배지가 같은 계산을 쓰게 한다."""
+    rows = db.scalars(
+        select(Notification.id).where(
+            Notification.user_id == member_id,
+            Notification.read.is_(False),
+        )
+    ).all()
+    return len(rows)

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -24,6 +24,7 @@ from app.schemas.trainer_api import (
     RoutineOut, ScheduleSessionOut, TrainerClientOut, TrainerGymOut, TrainerMe,
     TrainerNotificationSettings, WeeklyReportOut,
 )
+from app.services import notification_service
 
 # 일일 나트륨 목표(mg). 프론트 `sodiumTargetMg` 와 같은 값 — 리포트의
 # '초과 N일'이 앱 화면의 경고와 어긋나면 안 된다.
@@ -351,10 +352,18 @@ def build_chat_thread(
 
 def send_message(
     db: Session, trainer_id: str, member_id: str, sender: str, text: str,
-    viewer: str = "trainer",
+    viewer: str = "trainer", notify: str | None = None,
 ) -> ChatMessageOut:
     """스레드에 메시지 추가(sender: 'trainer'|'member'). 로스터 last_message 는
-    build_roster 가 최신 메시지를 읽어 자동 반영하므로 별도 비정규화가 없다."""
+    build_roster 가 최신 메시지를 읽어 자동 반영하므로 별도 비정규화가 없다.
+
+    [notify] 가 주어지면 그 종류로 회원 알림을 **같은 트랜잭션에** 얹는다(#489).
+    종류를 호출자가 정하는 이유: 주간 리포트도 이 함수로 나가므로, 여기서 판단하면
+    일반 메시지와 구분할 수 없다.
+
+    회원이 보낸 메시지에는 알림을 만들지 않는다 — 트레이너 앱은 unread 배지를 따로
+    쓰고, 알림함은 회원 것이다.
+    """
     msg = ChatMessage(
         id=f"chat-{uuid.uuid4().hex[:12]}",
         trainer_id=trainer_id,
@@ -364,6 +373,19 @@ def send_message(
         created_at=datetime.now(timezone.utc),
     )
     db.add(msg)
+    if notify is not None and sender == "trainer":
+        trainer_name = db.scalar(select(User.name).where(User.id == trainer_id))
+        notification_service.queue(
+            db,
+            member_id=member_id,
+            kind=notify,
+            title=(
+                "주간 리포트가 도착했어요"
+                if notify == notification_service.WEEKLY_REPORT
+                else f"{trainer_name or '트레이너'} 트레이너의 메시지"
+            ),
+            body=text,
+        )
     db.commit()
     db.refresh(msg)
     return ChatMessageOut(
@@ -449,6 +471,14 @@ def assign_routine(
         created_at=datetime.now(timezone.utc),
     )
     db.add(rt)
+    # 배정은 회원이 앱을 열기 전에는 알 수 없는 변화다(#489).
+    notification_service.queue(
+        db,
+        member_id=member_id,
+        kind=notification_service.EXERCISE,
+        title="새 운동 루틴이 배정되었어요",
+        body=f"{name} · {minutes}분",
+    )
     db.commit()
     db.refresh(rt)
     return RoutineOut(
@@ -600,6 +630,16 @@ def create_session(
         sort_order=0,
     )
     db.add(s)
+    # 회원 몫의 일정이 잡혔을 때만 알린다 — 가망 고객('신규 고객 · 상담')처럼
+    # member_id 가 없는 슬롯은 알릴 대상 자체가 없다(#489).
+    if member_id is not None:
+        notification_service.queue(
+            db,
+            member_id=member_id,
+            kind=notification_service.EXERCISE,
+            title="새 일정이 등록되었어요",
+            body=f"{date} {time} · {type_}",
+        )
     db.commit()
     db.refresh(s)
     return _schedule_out(s)

--- a/backend/migrations/versions/0025_member_notification_settings.py
+++ b/backend/migrations/versions/0025_member_notification_settings.py
@@ -1,0 +1,74 @@
+"""회원 알림 수신 설정
+
+회원 알림 설정이 기기 로컬(SharedPreferences)에만 있어 기기를 바꾸면 초기화됐고,
+무엇보다 서버가 몰라서 알림을 만들 때 끌 수가 없었다. 트레이너는
+`trainer_profiles.notify_*` 로 계정 단위 저장이 이미 되어 있어 두 앱이
+비대칭이었다. (#489)
+
+행이 없으면 기본값으로 본다 — 가입할 때마다 행을 만들지 않아도 되고, 기본값을
+바꾸면 한 번도 설정을 건드리지 않은 회원에게 바로 적용된다. 그래서 기존 회원을
+백필하지 않는다.
+
+컬럼 기본값은 사용자 앱의 현재 기본값과 같다(주간 리포트만 꺼짐).
+
+Revision ID: 0025_member_noti_settings
+Revises: 0024_trainer_invite_codes
+Create Date: 2026-08-08
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0025_member_noti_settings"
+down_revision: str | Sequence[str] | None = "0024_trainer_invite_codes"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "member_notification_settings",
+        sa.Column("member_id", sa.String(length=64), nullable=False),
+        sa.Column(
+            "diet_log", sa.Boolean(), server_default=sa.true(), nullable=False
+        ),
+        sa.Column(
+            "exercise_reminder",
+            sa.Boolean(),
+            server_default=sa.true(),
+            nullable=False,
+        ),
+        sa.Column(
+            "trainer_message",
+            sa.Boolean(),
+            server_default=sa.true(),
+            nullable=False,
+        ),
+        sa.Column(
+            "ai_coaching",
+            sa.Boolean(),
+            server_default=sa.true(),
+            nullable=False,
+        ),
+        sa.Column(
+            "weekly_report",
+            sa.Boolean(),
+            server_default=sa.false(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["member_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("member_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("member_notification_settings")

--- a/backend/tests/test_notification_hooks.py
+++ b/backend/tests/test_notification_hooks.py
@@ -1,0 +1,382 @@
+"""알림 생성 지점과 회원 알림 설정. (#489)
+
+알림함이 사실상 비어 있었다 — `Notification` 행을 만드는 코드가 데모 시드와 상담
+승인·거절(#467) 두 곳뿐이어서, 트레이너가 메시지를 보내도 루틴을 배정해도 일정을
+잡아도 회원은 해당 화면에 직접 들어가야 알 수 있었다.
+
+설정과 함께 검증하는 이유: 서버가 설정을 모르면 알림을 만들 때 끌 수가 없다.
+"둘 다 되는가"가 아니라 "끈 항목이 실제로 안 만들어지는가"가 핵심이다.
+
+DB 가 필요하므로 로컬에서는 skip 되고 CI(Postgres) 에서 실행된다.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from uuid import uuid4
+
+import pytest
+
+from app.core.security import hash_password
+from app.models.models import (
+    ChatMessage,
+    MemberNotificationSetting,
+    Notification,
+    Place,
+    TrainerClient,
+    TrainerProfile,
+    TrainerRoutine,
+    TrainerSchedule,
+    User,
+)
+
+EMAIL_PREFIX = "noti-test-"
+PLACE_PREFIX = "noti-place-"
+PASSWORD = "noti-pw-1234"
+
+
+@pytest.fixture(autouse=True)
+def _cleanup(db_session):
+    yield
+    db_session.rollback()
+    user_ids = [
+        row[0]
+        for row in db_session.query(User.id)
+        .filter(User.email.like(f"{EMAIL_PREFIX}%"))
+        .all()
+    ]
+    if user_ids:
+        for model, column in (
+            (Notification, Notification.user_id),
+            (MemberNotificationSetting, MemberNotificationSetting.member_id),
+            (ChatMessage, ChatMessage.member_id),
+            (TrainerRoutine, TrainerRoutine.member_id),
+            (TrainerSchedule, TrainerSchedule.member_id),
+            (TrainerClient, TrainerClient.member_id),
+        ):
+            db_session.query(model).filter(column.in_(user_ids)).delete(
+                synchronize_session=False
+            )
+        for model, column in (
+            (ChatMessage, ChatMessage.trainer_id),
+            (TrainerRoutine, TrainerRoutine.trainer_id),
+            (TrainerSchedule, TrainerSchedule.trainer_id),
+            (TrainerClient, TrainerClient.trainer_id),
+            (TrainerProfile, TrainerProfile.trainer_id),
+        ):
+            db_session.query(model).filter(column.in_(user_ids)).delete(
+                synchronize_session=False
+            )
+        db_session.query(User).filter(User.id.in_(user_ids)).delete(
+            synchronize_session=False
+        )
+    db_session.query(Place).filter(Place.id.like(f"{PLACE_PREFIX}%")).delete(
+        synchronize_session=False
+    )
+    db_session.commit()
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _login(client, email: str) -> str:
+    response = client.post(
+        "/v1/auth/login", data={"username": email, "password": PASSWORD}
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["access_token"]
+
+
+def _pair(client, db_session) -> tuple[str, str, str, str]:
+    """담당 관계가 맺어진 (트레이너 토큰, 회원 id, 회원 토큰, 헬스장 id)."""
+    suffix = uuid4().hex[:10]
+    place = Place(
+        id=f"{PLACE_PREFIX}{suffix}",
+        name="알림 테스트 헬스장",
+        category="fitness",
+        address="서울",
+    )
+    db_session.add(place)
+
+    trainer_email = f"{EMAIL_PREFIX}trainer-{suffix}@oncare.com"
+    trainer = User(
+        id=f"noti-trainer-{suffix}",
+        email=trainer_email,
+        name="알림 트레이너",
+        hashed_password=hash_password(PASSWORD),
+        role="trainer",
+        is_active=True,
+    )
+    db_session.add(trainer)
+    db_session.flush()
+    db_session.add(TrainerProfile(trainer_id=trainer.id, gym_id=place.id))
+    db_session.commit()
+
+    member_email = f"{EMAIL_PREFIX}member-{suffix}@oncare.com"
+    created = client.post(
+        "/v1/auth/register",
+        json={"email": member_email, "password": PASSWORD, "name": "알림 회원"},
+    )
+    assert created.status_code == 201, created.text
+    member_id = created.json()["id"]
+
+    db_session.add(
+        TrainerClient(
+            id=f"tc-noti-{suffix}",
+            trainer_id=trainer.id,
+            member_id=member_id,
+            goal="알림 테스트",
+            active=True,
+            sort_order=1,
+        )
+    )
+    db_session.commit()
+
+    return (
+        _login(client, trainer_email),
+        member_id,
+        _login(client, member_email),
+        place.id,
+    )
+
+
+def _titles(client, member_token: str) -> list[str]:
+    response = client.get("/v1/notifications", headers=_auth(member_token))
+    assert response.status_code == 200, response.text
+    return [item["title"] for item in response.json()]
+
+
+# --- 생성 지점 --------------------------------------------------------------
+
+
+def test_trainer_message_creates_a_notification(client, db_session):
+    trainer_token, member_id, member_token, _ = _pair(client, db_session)
+
+    sent = client.post(
+        f"/v1/trainer/clients/{member_id}/chat",
+        headers=_auth(trainer_token),
+        json={"text": "오늘 운동 어떠셨어요?"},
+    )
+
+    assert sent.status_code == 201, sent.text
+    assert any("메시지" in title for title in _titles(client, member_token))
+
+
+def test_routine_assignment_creates_a_notification(client, db_session):
+    trainer_token, member_id, member_token, _ = _pair(client, db_session)
+
+    assigned = client.post(
+        f"/v1/trainer/clients/{member_id}/routines",
+        headers=_auth(trainer_token),
+        json={
+            "name": "인터벌 러닝",
+            "minutes": 30,
+            "type": "유산소",
+            "reason": "체력 향상",
+            "source": "trainer",
+        },
+    )
+
+    assert assigned.status_code == 201, assigned.text
+    assert "새 운동 루틴이 배정되었어요" in _titles(client, member_token)
+
+
+def test_schedule_creates_a_notification(client, db_session):
+    trainer_token, member_id, member_token, _ = _pair(client, db_session)
+
+    created = client.post(
+        "/v1/trainer/schedule",
+        headers=_auth(trainer_token),
+        json={
+            "date": (date.today() + timedelta(days=1)).isoformat(),
+            "time": "10:00",
+            "client_name": "알림 회원",
+            "member_id": member_id,
+            "type": "1:1 PT",
+            "duration_minutes": 50,
+            "note": "",
+            "program": [],
+        },
+    )
+
+    assert created.status_code == 201, created.text
+    assert "새 일정이 등록되었어요" in _titles(client, member_token)
+
+
+def test_report_creates_its_own_notification_kind(client, db_session):
+    """리포트는 주간 리포트 종류로 남는다 — 일반 메시지와 구분된다.
+
+    리포트도 채팅으로 전달되므로, 종류를 서비스가 판단하면 둘을 구분할 수 없다.
+    """
+    trainer_token, member_id, member_token, _ = _pair(client, db_session)
+    # 기본값은 주간 리포트 꺼짐이므로, 받도록 켜고 확인한다.
+    client.put(
+        "/v1/users/me/notification-settings",
+        headers=_auth(member_token),
+        json={"weekly_report": True},
+    )
+
+    sent = client.post(
+        f"/v1/trainer/clients/{member_id}/report/send",
+        headers=_auth(trainer_token),
+        json={"message": "이번 주 잘하셨어요"},
+    )
+
+    assert sent.status_code == 201, sent.text
+    assert "주간 리포트가 도착했어요" in _titles(client, member_token)
+
+
+def test_member_message_creates_no_notification(client, db_session):
+    """회원이 보낸 메시지는 자기 알림함에 남지 않는다."""
+    _, _, member_token, _ = _pair(client, db_session)
+
+    sent = client.post(
+        "/v1/me/coach/chat",
+        headers=_auth(member_token),
+        json={"text": "질문 있어요"},
+    )
+
+    assert sent.status_code == 201, sent.text
+    assert _titles(client, member_token) == []
+
+
+def test_a_schedule_without_a_member_notifies_nobody(client, db_session):
+    """가망 고객 슬롯('신규 고객 · 상담')은 알릴 대상이 없다."""
+    trainer_token, _, member_token, _ = _pair(client, db_session)
+
+    created = client.post(
+        "/v1/trainer/schedule",
+        headers=_auth(trainer_token),
+        json={
+            "date": (date.today() + timedelta(days=1)).isoformat(),
+            "time": "14:00",
+            "client_name": "신규 고객",
+            "member_id": None,
+            "type": "상담",
+            "duration_minutes": 30,
+            "note": "",
+            "program": [],
+        },
+    )
+
+    assert created.status_code == 201, created.text
+    assert _titles(client, member_token) == []
+
+
+# --- 수신 설정 --------------------------------------------------------------
+
+
+def test_settings_default_matches_the_app(client, db_session):
+    """저장한 적이 없으면 앱의 현재 기본값과 같다(주간 리포트만 꺼짐)."""
+    _, _, member_token, _ = _pair(client, db_session)
+
+    settings = client.get(
+        "/v1/users/me/notification-settings", headers=_auth(member_token)
+    )
+
+    assert settings.status_code == 200, settings.text
+    body = settings.json()
+    assert body["trainer_message"] is True
+    assert body["exercise_reminder"] is True
+    assert body["diet_log"] is True
+    assert body["ai_coaching"] is True
+    assert body["weekly_report"] is False
+
+
+def test_settings_survive_a_new_session(client, db_session):
+    """계정 단위 저장 — 기기를 바꿔도 유지된다."""
+    _, _, member_token, _ = _pair(client, db_session)
+    client.put(
+        "/v1/users/me/notification-settings",
+        headers=_auth(member_token),
+        json={"trainer_message": False},
+    )
+
+    # 같은 계정으로 다시 로그인해도(= 다른 기기) 값이 남아 있어야 한다.
+    email = (
+        client.get("/v1/users/me", headers=_auth(member_token)).json()["email"]
+    )
+    fresh = client.get(
+        "/v1/users/me/notification-settings", headers=_auth(_login(client, email))
+    )
+
+    assert fresh.json()["trainer_message"] is False
+
+
+def test_partial_update_leaves_other_items_alone(client, db_session):
+    _, _, member_token, _ = _pair(client, db_session)
+
+    updated = client.put(
+        "/v1/users/me/notification-settings",
+        headers=_auth(member_token),
+        json={"weekly_report": True},
+    )
+
+    assert updated.status_code == 200, updated.text
+    body = updated.json()
+    assert body["weekly_report"] is True
+    assert body["trainer_message"] is True
+
+
+def test_a_disabled_kind_creates_no_notification(client, db_session):
+    """끈 항목은 알림이 만들어지지 않는다 — 설정을 서버가 갖는 이유."""
+    trainer_token, member_id, member_token, _ = _pair(client, db_session)
+    client.put(
+        "/v1/users/me/notification-settings",
+        headers=_auth(member_token),
+        json={"trainer_message": False},
+    )
+
+    sent = client.post(
+        f"/v1/trainer/clients/{member_id}/chat",
+        headers=_auth(trainer_token),
+        json={"text": "알림은 꺼져 있어야 합니다"},
+    )
+
+    assert sent.status_code == 201, sent.text
+    assert _titles(client, member_token) == []
+
+
+def test_a_disabled_kind_still_delivers_the_message(client, db_session):
+    """알림만 끄는 것이지 메시지가 사라지는 게 아니다."""
+    trainer_token, member_id, member_token, _ = _pair(client, db_session)
+    client.put(
+        "/v1/users/me/notification-settings",
+        headers=_auth(member_token),
+        json={"trainer_message": False},
+    )
+
+    client.post(
+        f"/v1/trainer/clients/{member_id}/chat",
+        headers=_auth(trainer_token),
+        json={"text": "메시지는 도착해야 합니다"},
+    )
+
+    thread = client.get("/v1/me/coach/chat", headers=_auth(member_token))
+    assert thread.status_code == 200, thread.text
+    assert any(m["body"] == "메시지는 도착해야 합니다" for m in thread.json())
+
+
+def test_report_is_off_by_default(client, db_session):
+    """주간 리포트는 기본 꺼짐이라 켜기 전에는 알림이 없다."""
+    trainer_token, member_id, member_token, _ = _pair(client, db_session)
+
+    client.post(
+        f"/v1/trainer/clients/{member_id}/report/send",
+        headers=_auth(trainer_token),
+        json={"message": "이번 주 리포트"},
+    )
+
+    assert "주간 리포트가 도착했어요" not in _titles(client, member_token)
+
+
+def test_trainer_cannot_use_the_member_settings_endpoint(client, db_session):
+    trainer_token, _, _, _ = _pair(client, db_session)
+
+    response = client.put(
+        "/v1/users/me/notification-settings",
+        headers=_auth(trainer_token),
+        json={"trainer_message": False},
+    )
+
+    assert response.status_code == 403, response.text

--- a/backend/tests/test_notification_hooks.py
+++ b/backend/tests/test_notification_hooks.py
@@ -295,6 +295,39 @@ def test_a_settings_read_failure_still_delivers_the_message(
     )
 
 
+def test_explicit_null_is_rejected(client, db_session):
+    """명시적 null 은 422 — 누락('변경 없음')과 구분한다. (CodeRabbit 리뷰)
+
+    다섯 항목 모두 DB NOT NULL 이라 null 로 바꿀 수 있는 값이 아니다. 구분하지
+    않으면 `{"weekly_report": null}` 이 조용히 성공하고 아무것도 바뀌지 않는다.
+    `ScheduleUpdateRequest` 와 같은 규약이다(#377).
+    """
+    _, _, member_token, _ = _pair(client, db_session)
+
+    response = client.put(
+        "/v1/users/me/notification-settings",
+        headers=_auth(member_token),
+        json={"weekly_report": None},
+    )
+
+    assert response.status_code == 422, response.text
+
+
+def test_omitted_fields_still_mean_no_change(client, db_session):
+    """누락은 여전히 '변경 없음'이다 — null 거절이 부분 수정을 막지 않는다."""
+    _, _, member_token, _ = _pair(client, db_session)
+
+    updated = client.put(
+        "/v1/users/me/notification-settings",
+        headers=_auth(member_token),
+        json={"weekly_report": True},
+    )
+
+    assert updated.status_code == 200, updated.text
+    assert updated.json()["weekly_report"] is True
+    assert updated.json()["trainer_message"] is True
+
+
 def test_an_empty_settings_update_creates_no_row(client, db_session):
     """바꿀 게 없으면 기본값 행을 새로 남기지 않는다. (CodeRabbit 리뷰)"""
     _, member_id, member_token, _ = _pair(client, db_session)

--- a/backend/tests/test_notification_hooks.py
+++ b/backend/tests/test_notification_hooks.py
@@ -16,6 +16,8 @@ from uuid import uuid4
 
 import pytest
 
+from sqlalchemy import text
+
 from app.core.security import hash_password
 from app.models.models import (
     ChatMessage,
@@ -28,6 +30,7 @@ from app.models.models import (
     TrainerSchedule,
     User,
 )
+from app.services import notification_service
 
 EMAIL_PREFIX = "noti-test-"
 PLACE_PREFIX = "noti-place-"
@@ -261,6 +264,50 @@ def test_a_schedule_without_a_member_notifies_nobody(client, db_session):
 
     assert created.status_code == 201, created.text
     assert _titles(client, member_token) == []
+
+
+def test_a_settings_read_failure_still_delivers_the_message(
+    client, db_session, monkeypatch
+):
+    """설정 조회가 터져도 메시지는 저장된다. (CodeRabbit 리뷰)
+
+    예외를 잡는 것만으로는 부족하다 — DB 오류가 나면 세션이 실패 상태로 남아
+    이어지는 커밋까지 함께 죽는다. savepoint 로 격리해야 원래 요청이 산다.
+    """
+    trainer_token, member_id, member_token, _ = _pair(client, db_session)
+
+    def _boom(db, member_id):  # noqa: ANN001
+        db.execute(text("SELECT 1 FROM does_not_exist"))
+        raise AssertionError("unreachable")
+
+    monkeypatch.setattr(notification_service, "get_settings", _boom)
+
+    sent = client.post(
+        f"/v1/trainer/clients/{member_id}/chat",
+        headers=_auth(trainer_token),
+        json={"text": "설정이 깨져도 도착해야 합니다"},
+    )
+
+    assert sent.status_code == 201, sent.text
+    thread = client.get("/v1/me/coach/chat", headers=_auth(member_token))
+    assert any(
+        m["body"] == "설정이 깨져도 도착해야 합니다" for m in thread.json()
+    )
+
+
+def test_an_empty_settings_update_creates_no_row(client, db_session):
+    """바꿀 게 없으면 기본값 행을 새로 남기지 않는다. (CodeRabbit 리뷰)"""
+    _, member_id, member_token, _ = _pair(client, db_session)
+
+    response = client.put(
+        "/v1/users/me/notification-settings",
+        headers=_auth(member_token),
+        json={},
+    )
+
+    assert response.status_code == 200, response.text
+    db_session.expire_all()
+    assert db_session.get(MemberNotificationSetting, member_id) is None
 
 
 # --- 수신 설정 --------------------------------------------------------------

--- a/frontend/flutter/lib/features/my_health/presentation/widgets/my_flows.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/widgets/my_flows.dart
@@ -627,22 +627,37 @@ class NotificationSettingsPage extends ConsumerStatefulWidget {
 
 class _NotificationSettingsPageState
     extends ConsumerState<NotificationSettingsPage> {
-  /// 저장 중인 값을 덮어쓰는 화면 상태. 서버 응답을 기다리는 동안에도 스위치가
-  /// 즉시 움직여야 한다 — 왕복을 기다리면 눌리지 않는 것처럼 보인다.
-  final Map<String, bool> _pending = <String, bool>{};
+  /// 이 화면에서 바꾼 값. 서버 응답을 기다리는 동안에도 스위치가 즉시 움직여야
+  /// 한다 — 왕복을 기다리면 눌리지 않는 것처럼 보인다.
+  ///
+  /// 저장에 **성공한 값도 여기 남는다.** 지우면 최초 조회값으로 돌아가는데,
+  /// 서버에는 저장된 값이 남아 있어 화면과 어긋난다.
+  final Map<String, bool> _local = <String, bool>{};
 
-  Future<void> _persist(String key, bool value) async {
-    setState(() => _pending[key] = value);
+  /// 키별 최신 요청 번호. 늦게 도착한 옛 응답이 최신 상태를 덮어쓰는 것을 막는다.
+  final Map<String, int> _requestSeq = <String, int>{};
+
+  /// 화면에 그릴 값 — 내가 바꾼 값이 우선, 없으면 서버 값.
+  bool _valueOf(String key, Map<String, bool> saved, bool fallback) =>
+      _local[key] ?? saved[key] ?? fallback;
+
+  Future<void> _persist(String key, bool value, bool previous) async {
+    final int seq = (_requestSeq[key] ?? 0) + 1;
+    _requestSeq[key] = seq;
+    setState(() => _local[key] = value);
     final messenger = ScaffoldMessenger.of(context);
     try {
       await ref
           .read(notificationSettingsRepositoryProvider)
           .setValue(key, value);
     } on Object {
-      // 저장에 실패하면 화면을 서버 값으로 되돌린다. 켜진 줄 알았는데 안 오는
-      // 상태가 가장 나쁘다.
       if (!mounted) return;
-      setState(() => _pending.remove(key));
+      // 이 요청을 기다리는 사이 더 눌렀다면, 옛 실패로 최신 상태를 되돌리지
+      // 않는다(리뷰).
+      if (_requestSeq[key] != seq) return;
+      // 되돌릴 곳은 **직전 값**이지 최초 조회값이 아니다. 한 번 저장에 성공한 뒤
+      // 다음 저장이 실패하면 최초값으로 돌아가 서버와 어긋난다(리뷰).
+      setState(() => _local[key] = previous);
       messenger.showSnackBar(
         const SnackBar(content: Text('알림 설정을 저장하지 못했어요')),
       );
@@ -674,13 +689,22 @@ class _NotificationSettingsPageState
                 ),
               ),
               Switch.adaptive(
-                value:
-                    _pending[kNotificationSettingItems[i].key] ??
-                    saved[kNotificationSettingItems[i].key] ??
-                    kNotificationSettingItems[i].fallback,
+                value: _valueOf(
+                  kNotificationSettingItems[i].key,
+                  saved,
+                  kNotificationSettingItems[i].fallback,
+                ),
                 activeThumbColor: FigmaColors.primary,
-                onChanged: (bool v) =>
-                    _persist(kNotificationSettingItems[i].key, v),
+                onChanged: (bool v) => _persist(
+                  kNotificationSettingItems[i].key,
+                  v,
+                  // 실패했을 때 돌아갈 곳 — 지금 화면에 보이는 값.
+                  _valueOf(
+                    kNotificationSettingItems[i].key,
+                    saved,
+                    kNotificationSettingItems[i].fallback,
+                  ),
+                ),
               ),
             ],
           ),

--- a/frontend/flutter/lib/features/my_health/presentation/widgets/my_flows.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/widgets/my_flows.dart
@@ -3,14 +3,13 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:oncare/app/router/routes.dart';
-import 'package:oncare/core/storage/prefs_store.dart';
 import 'package:oncare/design_system/figma/figma_kit.dart';
 import 'package:oncare/design_system/tokens/breakpoints.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
 import 'package:oncare/features/account/domain/entities/user_profile.dart';
 import 'package:oncare/features/account/presentation/controllers/account_controller.dart';
+import 'package:oncare/features/notification/data/repositories/notification_settings_repository.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 /// 숫자 전용 입력 필터 — 붙여넣기/외부 키보드로 문자가 들어와 저장 시 int
 /// 파싱이 null 로 날아가는 것을 막는다.
@@ -587,22 +586,9 @@ class _GoalsSectionLabel extends StatelessWidget {
 
 // ───────────────────────────────────────────────────────── 알림 설정 ──
 
-/// One notification toggle: SharedPreferences key and the default used before
-/// the user has ever changed it. The display label is resolved from
-/// [_notifLabel] so it is never carried as a hardcoded string.
-class _NotifItem {
-  const _NotifItem(this.prefKey, this.fallback);
-  final String prefKey;
-  final bool fallback;
-}
-
-const List<_NotifItem> _notifItems = <_NotifItem>[
-  _NotifItem('notif_diet_log', true),
-  _NotifItem('notif_exercise_reminder', true),
-  _NotifItem('notif_trainer_message', true),
-  _NotifItem('notif_ai_coaching', true),
-  _NotifItem('notif_weekly_report', false),
-];
+/// 토글 목록은 저장소 계약(`kNotificationSettingItems`)이 갖는다 — 키를 서버와
+/// 공유하므로 화면이 따로 들고 있으면 어긋난다(#489). 표시 라벨은 [_notifLabel]
+/// 이 ARB 에서 찾는다.
 
 /// Localized label for a notification toggle, keyed off its stable prefKey.
 String _notifLabel(AppLocalizations l, String prefKey) {
@@ -622,8 +608,11 @@ String _notifLabel(AppLocalizations l, String prefKey) {
   }
 }
 
-/// Notification preferences — toggles load from and persist to
-/// SharedPreferences so they survive a reload.
+/// 알림 수신 설정.
+///
+/// 실모드는 계정 단위로 서버에 저장한다 — 기기를 바꿔도 유지되고, 무엇보다
+/// 서버가 설정을 알아야 알림을 만들 때 끌 수 있다(#489). 데모/목은 기존대로
+/// SharedPreferences 라 화면과 동작이 지금과 같다.
 Future<void> openNotificationSettingsPage(BuildContext context) {
   return context.push<void>(AppRoutes.mySettingsPath('notifications'));
 }
@@ -638,34 +627,45 @@ class NotificationSettingsPage extends ConsumerStatefulWidget {
 
 class _NotificationSettingsPageState
     extends ConsumerState<NotificationSettingsPage> {
-  late final SharedPreferences _prefs;
-  final Map<String, bool> _on = <String, bool>{};
+  /// 저장 중인 값을 덮어쓰는 화면 상태. 서버 응답을 기다리는 동안에도 스위치가
+  /// 즉시 움직여야 한다 — 왕복을 기다리면 눌리지 않는 것처럼 보인다.
+  final Map<String, bool> _pending = <String, bool>{};
 
-  @override
-  void initState() {
-    super.initState();
-    _prefs = ref.read(sharedPreferencesProvider);
-    for (final _NotifItem item in _notifItems) {
-      _on[item.prefKey] = _prefs.getBool(item.prefKey) ?? item.fallback;
+  Future<void> _persist(String key, bool value) async {
+    setState(() => _pending[key] = value);
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      await ref
+          .read(notificationSettingsRepositoryProvider)
+          .setValue(key, value);
+    } on Object {
+      // 저장에 실패하면 화면을 서버 값으로 되돌린다. 켜진 줄 알았는데 안 오는
+      // 상태가 가장 나쁘다.
+      if (!mounted) return;
+      setState(() => _pending.remove(key));
+      messenger.showSnackBar(
+        const SnackBar(content: Text('알림 설정을 저장하지 못했어요')),
+      );
     }
-  }
-
-  void _persist(String key, bool value) {
-    setState(() => _on[key] = value);
-    _prefs.setBool(key, value);
   }
 
   @override
   Widget build(BuildContext context) {
     final AppLocalizations l = AppLocalizations.of(context);
+    final Map<String, bool> saved =
+        ref.watch(notificationSettingsProvider).valueOrNull ??
+        <String, bool>{
+          for (final NotificationSettingItem item in kNotificationSettingItems)
+            item.key: item.fallback,
+        };
     return _shell(context, l.myNotifTitle, <Widget>[
       _card(<Widget>[
-        for (int i = 0; i < _notifItems.length; i++) ...<Widget>[
+        for (int i = 0; i < kNotificationSettingItems.length; i++) ...<Widget>[
           Row(
             children: <Widget>[
               Expanded(
                 child: Text(
-                  _notifLabel(l, _notifItems[i].prefKey),
+                  _notifLabel(l, kNotificationSettingItems[i].key),
                   style: const TextStyle(
                     fontSize: 15,
                     fontWeight: FontWeight.w600,
@@ -674,13 +674,17 @@ class _NotificationSettingsPageState
                 ),
               ),
               Switch.adaptive(
-                value: _on[_notifItems[i].prefKey] ?? _notifItems[i].fallback,
+                value:
+                    _pending[kNotificationSettingItems[i].key] ??
+                    saved[kNotificationSettingItems[i].key] ??
+                    kNotificationSettingItems[i].fallback,
                 activeThumbColor: FigmaColors.primary,
-                onChanged: (bool v) => _persist(_notifItems[i].prefKey, v),
+                onChanged: (bool v) =>
+                    _persist(kNotificationSettingItems[i].key, v),
               ),
             ],
           ),
-          if (i < _notifItems.length - 1)
+          if (i < kNotificationSettingItems.length - 1)
             const Divider(height: 1, color: FigmaColors.hairline),
         ],
       ]),

--- a/frontend/flutter/lib/features/notification/data/repositories/notification_settings_repository.dart
+++ b/frontend/flutter/lib/features/notification/data/repositories/notification_settings_repository.dart
@@ -1,0 +1,134 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/core/network/dio_client.dart';
+import 'package:oncare/core/storage/prefs_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// 알림 수신 설정 항목. 키는 서버와 공유하는 계약이다. (#489)
+///
+/// 화면 라벨은 ARB 에서 키로 찾으므로 여기에 두지 않는다.
+class NotificationSettingItem {
+  /// Creates a toggle definition.
+  const NotificationSettingItem(this.key, this.fallback);
+
+  /// 저장 키. 로컬(SharedPreferences)과 서버 응답 필드가 이 값을 공유한다 —
+  /// 서버는 `notif_` 접두사를 뗀 이름을 쓰므로 매핑은 repository 가 한다.
+  final String key;
+
+  /// 한 번도 바꾼 적 없을 때의 값.
+  final bool fallback;
+}
+
+/// 화면에 보이는 순서 그대로. 주간 리포트만 기본 꺼짐이다.
+const List<NotificationSettingItem> kNotificationSettingItems =
+    <NotificationSettingItem>[
+      NotificationSettingItem('notif_diet_log', true),
+      NotificationSettingItem('notif_exercise_reminder', true),
+      NotificationSettingItem('notif_trainer_message', true),
+      NotificationSettingItem('notif_ai_coaching', true),
+      NotificationSettingItem('notif_weekly_report', false),
+    ];
+
+/// 알림 수신 설정을 읽고 쓴다.
+///
+/// 두 구현이 [notificationSettingsRepositoryProvider] 뒤에 있고 `useMockApi` 로
+/// 갈린다.
+///
+///  * [LocalNotificationSettingsRepository] — 데모/목. 기기에만 남는다.
+///  * [DioNotificationSettingsRepository] — 실 백엔드. **계정 단위**라 기기를
+///    바꿔도 유지되고, 무엇보다 서버가 설정을 알아야 알림을 만들 때 끌 수 있다.
+///
+/// 데모를 로컬로 남겨 두는 이유: 데모에는 설정을 저장할 백엔드가 없다. 서버로
+/// 보내면 설정 화면이 로딩 실패로 뜨고, 지금 화면과 달라진다.
+abstract class NotificationSettingsRepository {
+  /// 전체 설정. 저장한 적 없는 항목은 기본값으로 채워 온다.
+  Future<Map<String, bool>> fetch();
+
+  /// 한 항목을 바꾼다.
+  Future<void> setValue(String key, bool value);
+}
+
+/// 데모/목 — 기존 동작 그대로 SharedPreferences 에 남긴다.
+class LocalNotificationSettingsRepository
+    implements NotificationSettingsRepository {
+  /// Creates the local source over [_prefs].
+  const LocalNotificationSettingsRepository(this._prefs);
+
+  final SharedPreferences _prefs;
+
+  @override
+  Future<Map<String, bool>> fetch() async => <String, bool>{
+    for (final NotificationSettingItem item in kNotificationSettingItems)
+      item.key: _prefs.getBool(item.key) ?? item.fallback,
+  };
+
+  @override
+  Future<void> setValue(String key, bool value) async {
+    await _prefs.setBool(key, value);
+  }
+}
+
+/// 실 백엔드 — `GET`/`PUT /users/me/notification-settings`.
+class DioNotificationSettingsRepository
+    implements NotificationSettingsRepository {
+  /// Creates the API-backed source.
+  const DioNotificationSettingsRepository(this._dio);
+
+  final Dio _dio;
+
+  static const String _path = '/users/me/notification-settings';
+
+  @override
+  Future<Map<String, bool>> fetch() async {
+    final Response<Map<String, Object?>> res = await _dio
+        .get<Map<String, Object?>>(_path);
+    final Map<String, Object?> body = res.data ?? const <String, Object?>{};
+    return <String, bool>{
+      for (final NotificationSettingItem item in kNotificationSettingItems)
+        item.key: switch (body[_wireName(item.key)]) {
+          final bool value => value,
+          // 서버가 모르는 항목은 기본값으로 둔다 — 배포 시점이 어긋나
+          // 필드가 빠져 와도 토글이 사라지지 않는다.
+          _ => item.fallback,
+        },
+    };
+  }
+
+  @override
+  Future<void> setValue(String key, bool value) async {
+    await _dio.put<Map<String, Object?>>(
+      _path,
+      data: <String, Object?>{_wireName(key): value},
+    );
+  }
+
+  /// `notif_trainer_message` → `trainer_message`. 서버 필드는 접두사가 없다.
+  static String _wireName(String key) => key.replaceFirst('notif_', '');
+}
+
+/// 데모/목은 로컬, 실모드는 백엔드.
+final notificationSettingsRepositoryProvider =
+    Provider<NotificationSettingsRepository>((ref) {
+      if (ref.watch(appConfigProvider).useMockApi) {
+        return LocalNotificationSettingsRepository(
+          ref.watch(sharedPreferencesProvider),
+        );
+      }
+      return DioNotificationSettingsRepository(ref.watch(dioProvider));
+    }, name: 'notificationSettingsRepository');
+
+/// 현재 설정. 실패하면 기본값으로 화면을 그린다 — 설정을 못 읽었다고 토글을
+/// 감추면 사용자가 끌 방법이 사라진다.
+final notificationSettingsProvider = FutureProvider<Map<String, bool>>((
+  ref,
+) async {
+  try {
+    return await ref.watch(notificationSettingsRepositoryProvider).fetch();
+  } on Object {
+    return <String, bool>{
+      for (final NotificationSettingItem item in kNotificationSettingItems)
+        item.key: item.fallback,
+    };
+  }
+}, name: 'notificationSettings');

--- a/frontend/flutter/test/features/notification/notification_settings_page_test.dart
+++ b/frontend/flutter/test/features/notification/notification_settings_page_test.dart
@@ -17,7 +17,11 @@ const AppConfig _demo = AppConfig(
 
 /// 저장 요청을 기록하고, 실패시킬 수도 있는 페이크.
 class _FakeRepository implements NotificationSettingsRepository {
-  _FakeRepository({Map<String, bool>? initial, this.failOnWrite = false})
+  _FakeRepository({
+    Map<String, bool>? initial,
+    this.failOnWrite = false,
+    this.failFrom,
+  })
     : _values =
           initial ??
           <String, bool>{
@@ -28,6 +32,9 @@ class _FakeRepository implements NotificationSettingsRepository {
 
   final Map<String, bool> _values;
   final bool failOnWrite;
+
+  /// N번째 쓰기부터 실패시킨다(1부터). 성공 뒤 실패를 재현할 때 쓴다.
+  final int? failFrom;
   final List<(String, bool)> writes = <(String, bool)>[];
 
   @override
@@ -35,7 +42,10 @@ class _FakeRepository implements NotificationSettingsRepository {
 
   @override
   Future<void> setValue(String key, bool value) async {
-    if (failOnWrite) throw StateError('write failed');
+    final int attempt = writes.length + 1;
+    if (failOnWrite || (failFrom != null && attempt >= failFrom!)) {
+      throw StateError('write failed');
+    }
     writes.add((key, value));
     _values[key] = value;
   }
@@ -125,6 +135,29 @@ void main() {
     final switches = tester.widgetList<Switch>(find.byType(Switch)).toList();
     expect(switches[index].value, isFalse);
     expect(find.text('알림 설정을 저장하지 못했어요'), findsOneWidget);
+  });
+
+  testWidgets('성공한 뒤 실패하면 최초값이 아니라 직전 값으로 돌아간다', (
+    WidgetTester tester,
+  ) async {
+    // 첫 저장이 성공하면 서버에는 그 값이 남는다. 다음 저장이 실패했다고 최초
+    // 조회값으로 되돌리면 화면과 서버가 어긋난다(CodeRabbit 리뷰).
+    final repo = _FakeRepository(failFrom: 2);
+    await _pump(tester, repository: repo);
+    final index = kNotificationSettingItems.indexWhere(
+      (NotificationSettingItem item) => item.key == 'notif_weekly_report',
+    );
+
+    // 1) 끔 → 켬 (성공). 서버 값은 이제 true.
+    await tester.tap(find.byType(Switch).at(index));
+    await tester.pumpAndSettle();
+    // 2) 켬 → 끔 (실패). 되돌아갈 곳은 true 다.
+    await tester.tap(find.byType(Switch).at(index));
+    await tester.pumpAndSettle();
+
+    expect(repo.writes, <(String, bool)>[('notif_weekly_report', true)]);
+    final switches = tester.widgetList<Switch>(find.byType(Switch)).toList();
+    expect(switches[index].value, isTrue);
   });
 
   testWidgets('데모는 기기 저장을 그대로 쓴다', (WidgetTester tester) async {

--- a/frontend/flutter/test/features/notification/notification_settings_page_test.dart
+++ b/frontend/flutter/test/features/notification/notification_settings_page_test.dart
@@ -1,0 +1,160 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/core/storage/prefs_store.dart';
+import 'package:oncare/features/my_health/presentation/widgets/my_flows.dart';
+import 'package:oncare/features/notification/data/repositories/notification_settings_repository.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// 데모/목 설정 — 화면이 기기 저장을 쓰는 쪽.
+const AppConfig _demo = AppConfig(
+  environment: Environment.dev,
+  apiBaseUrl: 'https://dev.api.test',
+  useMockApi: true,
+);
+
+/// 저장 요청을 기록하고, 실패시킬 수도 있는 페이크.
+class _FakeRepository implements NotificationSettingsRepository {
+  _FakeRepository({Map<String, bool>? initial, this.failOnWrite = false})
+    : _values =
+          initial ??
+          <String, bool>{
+            for (final NotificationSettingItem item
+                in kNotificationSettingItems)
+              item.key: item.fallback,
+          };
+
+  final Map<String, bool> _values;
+  final bool failOnWrite;
+  final List<(String, bool)> writes = <(String, bool)>[];
+
+  @override
+  Future<Map<String, bool>> fetch() async => Map<String, bool>.from(_values);
+
+  @override
+  Future<void> setValue(String key, bool value) async {
+    if (failOnWrite) throw StateError('write failed');
+    writes.add((key, value));
+    _values[key] = value;
+  }
+}
+
+Future<void> _pump(
+  WidgetTester tester, {
+  NotificationSettingsRepository? repository,
+}) async {
+  SharedPreferences.setMockInitialValues(<String, Object>{});
+  final prefs = await SharedPreferences.getInstance();
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        appConfigProvider.overrideWithValue(_demo),
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        if (repository != null)
+          notificationSettingsRepositoryProvider.overrideWithValue(repository),
+      ],
+      child: const MaterialApp(
+        locale: Locale('ko'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: NotificationSettingsPage(),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('토글 5개가 그대로 그려진다', (WidgetTester tester) async {
+    // 데모 화면은 지금과 같아야 한다 — 항목 수와 기본 상태가 바뀌면 안 된다.
+    await _pump(tester);
+
+    expect(find.byType(Switch), findsNWidgets(kNotificationSettingItems.length));
+  });
+
+  testWidgets('저장된 값이 화면에 반영된다', (WidgetTester tester) async {
+    final repo = _FakeRepository(
+      initial: <String, bool>{
+        for (final NotificationSettingItem item in kNotificationSettingItems)
+          item.key: item.key == 'notif_trainer_message'
+              ? false
+              : item.fallback,
+      },
+    );
+
+    await _pump(tester, repository: repo);
+
+    final switches = tester.widgetList<Switch>(find.byType(Switch)).toList();
+    final index = kNotificationSettingItems.indexWhere(
+      (NotificationSettingItem item) => item.key == 'notif_trainer_message',
+    );
+    expect(switches[index].value, isFalse);
+  });
+
+  testWidgets('토글하면 저장소에 값을 넘긴다', (WidgetTester tester) async {
+    final repo = _FakeRepository();
+    await _pump(tester, repository: repo);
+
+    // 주간 리포트는 기본 꺼짐이라 켜는 방향으로 눌린다.
+    final index = kNotificationSettingItems.indexWhere(
+      (NotificationSettingItem item) => item.key == 'notif_weekly_report',
+    );
+    await tester.tap(find.byType(Switch).at(index));
+    await tester.pumpAndSettle();
+
+    expect(repo.writes, <(String, bool)>[('notif_weekly_report', true)]);
+  });
+
+  testWidgets('저장에 실패하면 원래 값으로 되돌리고 알린다', (
+    WidgetTester tester,
+  ) async {
+    // 켜진 줄 알았는데 알림이 안 오는 상태가 가장 나쁘다.
+    final repo = _FakeRepository(failOnWrite: true);
+    await _pump(tester, repository: repo);
+    final index = kNotificationSettingItems.indexWhere(
+      (NotificationSettingItem item) => item.key == 'notif_weekly_report',
+    );
+
+    await tester.tap(find.byType(Switch).at(index));
+    await tester.pumpAndSettle();
+
+    final switches = tester.widgetList<Switch>(find.byType(Switch)).toList();
+    expect(switches[index].value, isFalse);
+    expect(find.text('알림 설정을 저장하지 못했어요'), findsOneWidget);
+  });
+
+  testWidgets('데모는 기기 저장을 그대로 쓴다', (WidgetTester tester) async {
+    // repository override 없이 — 데모 설정이 로컬 저장소를 고르는지 확인한다.
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      'notif_diet_log': false,
+    });
+    final prefs = await SharedPreferences.getInstance();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          appConfigProvider.overrideWithValue(_demo),
+          sharedPreferencesProvider.overrideWithValue(prefs),
+        ],
+        child: const MaterialApp(
+          locale: Locale('ko'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: NotificationSettingsPage(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final index = kNotificationSettingItems.indexWhere(
+      (NotificationSettingItem item) => item.key == 'notif_diet_log',
+    );
+    expect(
+      tester.widgetList<Switch>(find.byType(Switch)).toList()[index].value,
+      isFalse,
+    );
+  });
+}

--- a/frontend/flutter/test/features/notification/notification_settings_repository_test.dart
+++ b/frontend/flutter/test/features/notification/notification_settings_repository_test.dart
@@ -1,0 +1,186 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/core/network/dio_client.dart';
+import 'package:oncare/core/storage/prefs_store.dart';
+import 'package:oncare/features/notification/data/repositories/notification_settings_repository.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockDio extends Mock implements Dio {}
+
+Response<T> _ok<T>(T body) => Response<T>(
+  requestOptions: RequestOptions(path: '/users/me/notification-settings'),
+  statusCode: 200,
+  data: body,
+);
+
+const AppConfig _demo = AppConfig(
+  environment: Environment.dev,
+  apiBaseUrl: 'https://dev.api.test',
+  useMockApi: true,
+);
+
+const AppConfig _real = AppConfig(
+  environment: Environment.dev,
+  apiBaseUrl: 'https://dev.api.test',
+  useMockApi: false,
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _MockDio dio;
+
+  setUp(() {
+    dio = _MockDio();
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  Future<ProviderContainer> container({required AppConfig config}) async {
+    final prefs = await SharedPreferences.getInstance();
+    final c = ProviderContainer(
+      overrides: <Override>[
+        appConfigProvider.overrideWithValue(config),
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        dioProvider.overrideWithValue(dio),
+      ],
+    );
+    addTearDown(c.dispose);
+    return c;
+  }
+
+  group('로컬(데모) 저장소', () {
+    test('저장한 적 없으면 기본값 — 주간 리포트만 꺼짐', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final repo = LocalNotificationSettingsRepository(prefs);
+
+      final settings = await repo.fetch();
+
+      expect(settings['notif_trainer_message'], isTrue);
+      expect(settings['notif_weekly_report'], isFalse);
+    });
+
+    test('바꾼 값이 기기에 남는다', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final repo = LocalNotificationSettingsRepository(prefs);
+
+      await repo.setValue('notif_trainer_message', false);
+
+      expect((await repo.fetch())['notif_trainer_message'], isFalse);
+      expect(prefs.getBool('notif_trainer_message'), isFalse);
+    });
+  });
+
+  group('Dio(실모드) 저장소', () {
+    test('접두사를 뗀 서버 필드를 읽는다', () async {
+      when(
+        () => dio.get<Map<String, Object?>>(
+          '/users/me/notification-settings',
+        ),
+      ).thenAnswer(
+        (_) async => _ok<Map<String, Object?>>(<String, Object?>{
+          'diet_log': false,
+          'exercise_reminder': true,
+          'trainer_message': false,
+          'ai_coaching': true,
+          'weekly_report': true,
+        }),
+      );
+
+      final settings = await DioNotificationSettingsRepository(dio).fetch();
+
+      expect(settings['notif_diet_log'], isFalse);
+      expect(settings['notif_trainer_message'], isFalse);
+      expect(settings['notif_weekly_report'], isTrue);
+    });
+
+    test('서버가 모르는 항목은 기본값으로 둔다', () async {
+      // 배포 시점이 어긋나 필드가 빠져 와도 토글이 사라지면 안 된다.
+      when(
+        () => dio.get<Map<String, Object?>>(
+          '/users/me/notification-settings',
+        ),
+      ).thenAnswer(
+        (_) async => _ok<Map<String, Object?>>(<String, Object?>{
+          'trainer_message': false,
+        }),
+      );
+
+      final settings = await DioNotificationSettingsRepository(dio).fetch();
+
+      expect(settings['notif_trainer_message'], isFalse);
+      expect(settings['notif_diet_log'], isTrue);
+      expect(settings['notif_weekly_report'], isFalse);
+      expect(settings.length, kNotificationSettingItems.length);
+    });
+
+    test('바꾼 항목만 접두사 없이 보낸다', () async {
+      when(
+        () => dio.put<Map<String, Object?>>(
+          '/users/me/notification-settings',
+          data: any(named: 'data'),
+        ),
+      ).thenAnswer((_) async => _ok<Map<String, Object?>>(<String, Object?>{}));
+
+      await DioNotificationSettingsRepository(
+        dio,
+      ).setValue('notif_weekly_report', true);
+
+      final data =
+          verify(
+                () => dio.put<Map<String, Object?>>(
+                  '/users/me/notification-settings',
+                  data: captureAny(named: 'data'),
+                ),
+              ).captured.single
+              as Map<String, Object?>;
+      expect(data, <String, Object?>{'weekly_report': true});
+    });
+  });
+
+  group('provider 분기', () {
+    test('데모는 기기 저장을 쓴다 — 화면이 지금과 같아야 한다', () async {
+      final c = await container(config: _demo);
+
+      expect(
+        c.read(notificationSettingsRepositoryProvider),
+        isA<LocalNotificationSettingsRepository>(),
+      );
+      // 데모에서 네트워크로 나가지 않는다.
+      verifyNever(() => dio.get<Map<String, Object?>>(any()));
+    });
+
+    test('실모드는 백엔드를 쓴다', () async {
+      final c = await container(config: _real);
+
+      expect(
+        c.read(notificationSettingsRepositoryProvider),
+        isA<DioNotificationSettingsRepository>(),
+      );
+    });
+
+    test('조회 실패해도 기본값으로 화면을 그린다', () async {
+      // 설정을 못 읽었다고 토글을 감추면 사용자가 끌 방법이 사라진다.
+      when(
+        () => dio.get<Map<String, Object?>>(
+          '/users/me/notification-settings',
+        ),
+      ).thenThrow(
+        DioException(
+          requestOptions: RequestOptions(
+            path: '/users/me/notification-settings',
+          ),
+          type: DioExceptionType.connectionError,
+        ),
+      );
+      final c = await container(config: _real);
+
+      final settings = await c.read(notificationSettingsProvider.future);
+
+      expect(settings['notif_trainer_message'], isTrue);
+      expect(settings['notif_weekly_report'], isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

* 회원이 앱 밖에서 겪는 변화(트레이너 메시지·루틴 배정·일정 등록·주간 리포트)가 알림으로 남습니다.
* 회원 알림 설정을 계정 단위로 서버에 저장하고, **꺼진 항목은 알림을 만들지 않습니다.**
* 데모 화면은 지금과 동일합니다.

---

## Changes

### ✨ Features

* 알림 생성 지점 4곳을 추가했습니다.

| 지점 | 알림 종류 |
| --- | --- |
| 트레이너 메시지 | `notif_trainer_message` |
| 루틴 배정 | `notif_exercise_reminder` |
| 일정 등록 | `notif_exercise_reminder` |
| 주간 리포트 | `notif_weekly_report` |

* `member_notification_settings` 테이블과 `GET`·`PUT /users/me/notification-settings` 를 추가했습니다.
* 사용자 앱 알림 설정이 실모드에서 서버를 읽고 씁니다.

### 🔧 Improvements

* 알림 종류를 호출자가 정합니다. 리포트도 채팅으로 나가므로 서비스가 판단하면 일반 메시지와 구분할 수 없습니다.
* 저장 실패 시 화면 값을 서버 값으로 되돌리고 안내합니다.

### 🎨 UI/UX

* 스위치는 서버 왕복을 기다리지 않고 즉시 움직입니다. 왕복을 기다리면 눌리지 않는 것처럼 보입니다.

### 📝 Docs

* 알림을 같은 트랜잭션에 얹는 이유와 설정 폴백 방향을 서비스 주석에 남겼습니다.

---

## Commits

1. d9232d6 feat(notification): 알림 생성 지점 신설과 회원 알림 설정 서버 저장

---

## Notes

**데모 불변**

데모에는 설정을 저장할 백엔드가 없습니다. 서버로 보내면 설정 화면이 로딩 실패로 뜨고 지금 화면과 달라지므로, 데모/목은 기존대로 `SharedPreferences` 를 씁니다. 데모에서 **네트워크로 나가지 않는 것**까지 테스트로 고정했습니다. 알림 목록도 데모는 기존 하드코딩 `demoAlerts` 그대로입니다.

⚠️ 한 가지 정직하게 남깁니다. 설정 화면이 동기 `initState` 대신 provider 를 읽도록 바뀌어, **값을 바꾼 적이 있으면 첫 프레임에 기본값이 잠깐 보일 수 있습니다.** 로컬 조회는 즉시 끝나 실제로 눈에 띌 가능성은 낮지만, 구조상 가능해 적어 둡니다. 항목 수·라벨·기본 상태는 그대로입니다.

**왜 같은 트랜잭션인가**

`queue()` 는 `db.add` 만 하고 커밋하지 않습니다. 따로 커밋하면 메시지는 저장됐는데 알림만 없는(또는 그 반대인) 반쪽 상태가 생깁니다. 하는 일이 `db.add` 뿐이라 원래 요청에 새로운 실패 모드를 더하지도 않습니다 — 외부 발송(푸시)은 이 함수 바깥의 일입니다(#474).

**설정 폴백 방향**

설정을 읽지 못하면 **보내는 쪽**으로 둡니다. 알림이 하나 더 오는 것보다 놓치는 쪽이 나쁩니다. 앱도 같은 규칙이라, 조회에 실패해도 토글을 감추지 않고 기본값으로 그립니다.

**만들지 않는 경우**

* 회원이 보낸 메시지 — 알림함은 회원 것이고, 트레이너 앱은 unread 배지를 따로 씁니다.
* `member_id` 없는 상담 슬롯('신규 고객 · 상담') — 알릴 대상 자체가 없습니다.

**설정 키**

앱이 쓰던 `notif_*` 를 그대로 씁니다(서버 필드는 접두사 없는 이름, 매핑은 repository 담당). 저장 위치만 옮기는 것이라 새 이름을 만들면 화면과 대응이 흐려집니다. 서버가 모르는 항목이 와도 토글이 사라지지 않도록 기본값으로 채웁니다.

**범위 밖**

푸시 발송(#474)은 자격증명이 선행 조건이라 별건입니다. 이 PR 이 그 선행 작업입니다 — 보낼 알림이 있어야 푸시가 의미를 갖습니다. `notif_diet_log`·`notif_ai_coaching` 은 아직 생성 지점이 없습니다(리마인더 성격이라 스케줄링이 필요합니다). 설정은 미리 갖춰 둡니다.

---

## Test Plan

* [x] 백엔드 신규 13건 — 생성 지점 4곳, 회원 메시지·대상 없는 슬롯은 만들지 않음, 기본값, 계정 단위 유지, 부분 수정, 끈 항목 미생성, 꺼도 메시지는 도착, 리포트 기본 꺼짐, 트레이너 계정 403
* [x] 백엔드 전체 479건 통과, `alembic upgrade head` 적용, `alembic heads` 단일
* [x] 사용자 앱 신규 13건 — 로컬·Dio 저장소, provider 분기(데모에서 네트워크 미사용 포함), 조회 실패 폴백, 토글 렌더·저장·실패 복구
* [x] 사용자 앱 전체 389건 통과, `flutter analyze` 무경고

### Manual Test Steps

1. 백엔드를 띄우고 트레이너 앱에서 회원에게 메시지를 보냅니다.
2. 회원 앱 알림함에 메시지 알림이 있는지 확인합니다.
3. 회원 앱 MY → 알림 설정에서 트레이너 메시지를 끕니다.
4. 다시 메시지를 보내고 알림이 생기지 않는지, 그래도 채팅에는 도착하는지 확인합니다.
5. 로그아웃 후 다시 로그인해 설정이 유지되는지 확인합니다.
6. 데모(둘러보기)에서 알림 설정 화면이 기존과 같은지 확인합니다.

---

## Related Issues

Closes #489

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 알림 설정 화면에서 식단, 운동, 트레이너 메시지, AI 코칭, 주간 리포트 수신 여부를 계정별로 관리할 수 있습니다.
  * 알림 설정은 서버에 저장되며, 항목별로 개별 변경할 수 있습니다.
  * 트레이너 메시지, 루틴 배정, 일정 등록 및 주간 리포트 알림이 설정에 따라 생성됩니다.
  * 읽지 않은 알림 수를 확인할 수 있습니다.

* **개선**
  * 설정을 불러오지 못한 경우에도 기본 알림 설정이 제공됩니다.
  * 저장 실패 시 변경 전 상태로 복원되고 오류 안내가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->