### PR TITLE
feat(schedule): 트레이너가 배정한 PT 일정을 회원 앱에 표시

### DIFF
--- a/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
@@ -16,6 +16,8 @@ import 'package:oncare/features/diet/domain/entities/meal_recommendation.dart';
 import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
 import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
+import 'package:oncare/features/member_coach/domain/entities/member_coach.dart';
+import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
 import 'package:oncare/features/member_coach/presentation/widgets/trainer_chat_header_button.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 import 'package:oncare/shared/widgets/coaching_sheet.dart';
@@ -1795,17 +1797,57 @@ class _RecMealCard extends StatelessWidget {
 
 // ───────────────────────────────────────────────────────── schedule ──
 
-class _ScheduleCard extends StatelessWidget {
+class _ScheduleCard extends ConsumerWidget {
   const _ScheduleCard({required this.items});
 
   final List<ScheduleItem> items;
 
+  /// 트레이너가 잡아 준 오늘의 PT 를 일정 항목으로 바꾼다. (#490)
+  ///
+  /// 별도 카드를 만들지 않고 여기 합치는 이유: 회원 입장에서 '오늘 뭐 하지'는
+  /// 하나의 질문이다. PT 만 따로 떼면 같은 시간대를 두 곳에서 봐야 한다.
+  ///
+  /// 데모는 담당 일정이 없어(`MockMemberCoachRepository.fetchSessions`) 빈
+  /// 목록이 오므로 카드가 지금과 똑같이 그려진다.
+  static List<ScheduleItem> _todaysSessions(List<CoachSession> sessions) {
+    final DateTime now = DateTime.now();
+    final DateTime today = DateTime(now.year, now.month, now.day);
+    return <ScheduleItem>[
+      for (final CoachSession session in sessions)
+        if (session.isUpcoming && session.date != null)
+          if (DateTime(
+                session.date!.year,
+                session.date!.month,
+                session.date!.day,
+              ) ==
+              today)
+            ScheduleItem(
+              time: session.time,
+              title: session.type,
+              emoji: '🏋️',
+            ),
+    ];
+  }
+
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final AppLocalizations l = AppLocalizations.of(context);
     final DateTime now = DateTime.now();
     final String weekday = _weekDayLabels(l)[now.weekday - 1];
     final String todayLabel = l.homeScheduleDate(weekday, now.month, now.day);
+    // 트레이너 일정과 내가 만든 일정을 한 목록으로 보여 준다. 시간순으로 섞어야
+    // '다음에 뭐가 있는지'를 한 번에 읽을 수 있다.
+    final List<ScheduleItem> merged =
+        <ScheduleItem>[
+          ...items,
+          ..._todaysSessions(
+            ref.watch(coachSessionsProvider).valueOrNull ??
+                const <CoachSession>[],
+          ),
+        ]..sort(
+          (ScheduleItem first, ScheduleItem second) =>
+              first.time.compareTo(second.time),
+        );
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
@@ -1850,7 +1892,7 @@ class _ScheduleCard extends StatelessWidget {
           ],
         ),
         const SizedBox(height: 12),
-        if (items.isEmpty)
+        if (merged.isEmpty)
           Container(
             width: double.infinity,
             padding: const EdgeInsets.all(16),
@@ -1867,9 +1909,9 @@ class _ScheduleCard extends StatelessWidget {
             ),
           )
         else
-          for (int index = 0; index < items.length; index++) ...<Widget>[
-            _ScheduleItemCard(item: items[index]),
-            if (index != items.length - 1) const SizedBox(height: 8),
+          for (int index = 0; index < merged.length; index++) ...<Widget>[
+            _ScheduleItemCard(item: merged[index]),
+            if (index != merged.length - 1) const SizedBox(height: 8),
           ],
       ],
     );

--- a/frontend/flutter/lib/features/member_coach/data/dtos/member_coach_dtos.dart
+++ b/frontend/flutter/lib/features/member_coach/data/dtos/member_coach_dtos.dart
@@ -26,6 +26,23 @@ CoachRoutine coachRoutineFromJson(Map<String, Object?> json) {
   );
 }
 
+/// `/me/coach/sessions` element (ScheduleSessionOut) → [CoachSession].
+///
+/// 날짜가 깨져도 던지지 않는다 — 한 행 때문에 일정 전체가 사라지면 안 된다.
+/// 화면이 date == null 인 항목을 걸러낸다.
+CoachSession coachSessionFromJson(Map<String, Object?> json) {
+  return CoachSession(
+    id: _str(json['id']),
+    date: DateTime.tryParse(_str(json['date'])),
+    time: _str(json['time']),
+    type: _str(json['type']),
+    durationMinutes: json['duration_minutes'] is num
+        ? (json['duration_minutes']! as num).toInt()
+        : 0,
+    status: _str(json['status']),
+  );
+}
+
 /// `/me/coach/chat` element (ChatMessageOut) → [CoachMessage]. From the
 /// member's viewpoint `sender` is `me` | `trainer`.
 CoachMessage coachMessageFromJson(Map<String, Object?> json) {

--- a/frontend/flutter/lib/features/member_coach/data/repositories/dio_member_coach_repository.dart
+++ b/frontend/flutter/lib/features/member_coach/data/repositories/dio_member_coach_repository.dart
@@ -31,6 +31,10 @@ class DioMemberCoachRepository implements MemberCoachRepository {
       _getList('/me/coach/routines', coachRoutineFromJson);
 
   @override
+  Future<List<CoachSession>> fetchSessions() =>
+      _getList('/me/coach/sessions', coachSessionFromJson);
+
+  @override
   Future<List<CoachMessage>> fetchChat() async {
     final List<CoachMessage> messages = await _getList(
       '/me/coach/chat',

--- a/frontend/flutter/lib/features/member_coach/data/repositories/mock_member_coach_repository.dart
+++ b/frontend/flutter/lib/features/member_coach/data/repositories/mock_member_coach_repository.dart
@@ -63,6 +63,13 @@ class MockMemberCoachRepository implements MemberCoachRepository {
   Future<List<CoachRoutine>> fetchRoutines() async =>
       List<CoachRoutine>.unmodifiable(_routines);
 
+  /// 데모에는 트레이너가 잡은 일정이 없다. (#490)
+  ///
+  /// 시드로 만들어 넣지 않는 이유: 데모 홈에 없던 카드가 생겨 화면이 지금과
+  /// 달라진다. 실모드에서만 나타나는 것이 맞다.
+  @override
+  Future<List<CoachSession>> fetchSessions() async => const <CoachSession>[];
+
   @override
   Future<List<CoachMessage>> fetchChat() async =>
       List<CoachMessage>.unmodifiable(_chat);

--- a/frontend/flutter/lib/features/member_coach/domain/entities/member_coach.dart
+++ b/frontend/flutter/lib/features/member_coach/domain/entities/member_coach.dart
@@ -45,6 +45,45 @@ class CoachRoutine {
   bool get isAiRecommended => source == 'ai';
 }
 
+/// A PT session the coach booked for the member — `/me/coach/sessions`.
+///
+/// The trainer owns the schedule: the member can see it but not change it, so
+/// this carries no edit affordance. (#490)
+class CoachSession {
+  /// Creates a booked session.
+  const CoachSession({
+    required this.id,
+    required this.date,
+    required this.time,
+    required this.type,
+    required this.durationMinutes,
+    required this.status,
+  });
+
+  /// Server id.
+  final String id;
+
+  /// `YYYY-MM-DD` parsed. Unparseable dates keep the session out of the
+  /// screen rather than throwing — one bad row must not blank the list.
+  final DateTime? date;
+
+  /// `HH:MM` as the server sent it.
+  final String time;
+
+  /// 1:1 PT · 그룹 · 상담 …
+  final String type;
+
+  /// Session length.
+  final int durationMinutes;
+
+  /// 예정 | 완료 | 공백.
+  final String status;
+
+  /// Whether this session is still ahead. 완료된 세션은 '오늘의 일정'에
+  /// 남겨 둘 이유가 없다.
+  bool get isUpcoming => status != '완료';
+}
+
 /// Chat message viewpoint for the member: their own message vs the coach's.
 enum CoachSender { me, trainer }
 

--- a/frontend/flutter/lib/features/member_coach/domain/repositories/member_coach_repository.dart
+++ b/frontend/flutter/lib/features/member_coach/domain/repositories/member_coach_repository.dart
@@ -14,6 +14,10 @@ abstract interface class MemberCoachRepository {
   /// Routines the coach has assigned (newest first).
   Future<List<CoachRoutine>> fetchRoutines();
 
+  /// PT sessions the coach booked. The trainer owns the schedule — the
+  /// member reads it only. (#490)
+  Future<List<CoachSession>> fetchSessions();
+
   /// The chat thread (oldest → newest).
   Future<List<CoachMessage>> fetchChat();
 

--- a/frontend/flutter/lib/features/member_coach/presentation/controllers/member_coach_providers.dart
+++ b/frontend/flutter/lib/features/member_coach/presentation/controllers/member_coach_providers.dart
@@ -27,6 +27,12 @@ final coachRoutinesProvider = FutureProvider<List<CoachRoutine>>((ref) {
   return ref.watch(memberCoachRepositoryProvider).fetchRoutines();
 });
 
+/// 트레이너가 잡아 준 PT 일정. 담당이 없거나 잡힌 일정이 없으면 빈 목록이라,
+/// 화면이 늘어나지 않는다. (#490)
+final coachSessionsProvider = FutureProvider<List<CoachSession>>((ref) {
+  return ref.watch(memberCoachRepositoryProvider).fetchSessions();
+}, name: 'coachSessions');
+
 /// The member↔coach chat thread (oldest → newest).
 final coachChatProvider = FutureProvider<List<CoachMessage>>((ref) {
   return ref.watch(memberCoachRepositoryProvider).fetchChat();

--- a/frontend/flutter/test/features/dashboard/home_coach_sessions_test.dart
+++ b/frontend/flutter/test/features/dashboard/home_coach_sessions_test.dart
@@ -1,0 +1,155 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oncare/features/account/domain/entities/user_profile.dart';
+import 'package:oncare/features/account/presentation/controllers/account_controller.dart';
+import 'package:oncare/features/dashboard/domain/entities/dashboard_summary.dart';
+import 'package:oncare/features/dashboard/presentation/controllers/dashboard_controller.dart';
+import 'package:oncare/features/dashboard/presentation/widgets/dashboard_content.dart';
+import 'package:oncare/features/diet/domain/entities/diet_day.dart';
+import 'package:oncare/features/member_coach/data/repositories/mock_member_coach_repository.dart';
+import 'package:oncare/features/member_coach/domain/entities/member_coach.dart';
+import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+/// 홈 요약 — 일정 한 건만 있는 최소 형태.
+const DashboardSummary _summary = DashboardSummary(
+  indicators: <HealthIndicator>[
+    HealthIndicator(label: '칼로리', current: 1860, max: 2000, unit: 'kcal'),
+  ],
+  macros: DietMacros(
+    carbsG: 200,
+    proteinG: 100,
+    fatG: 60,
+    carbsPct: 44,
+    proteinPct: 24,
+    fatPct: 32,
+  ),
+  dietEntries: 1,
+  exerciseMinutes: 30,
+  exerciseCalories: 300,
+  exerciseCount: 1,
+  todaySchedule: <ScheduleItem>[
+    ScheduleItem(time: '18:00', title: '병원 정기검진', emoji: '🏥'),
+  ],
+  weekScore: 80,
+  weekScoreDelta: 5,
+  sodiumWarning: '',
+  exerciseFeedback: '',
+);
+
+CoachSession _session({
+  String time = '10:00',
+  String type = '1:1 PT',
+  String status = '예정',
+  DateTime? date,
+}) => CoachSession(
+  id: 'sched-$time',
+  date: date ?? DateTime.now(),
+  time: time,
+  type: type,
+  durationMinutes: 50,
+  status: status,
+);
+
+Future<void> _pump(
+  WidgetTester tester, {
+  List<CoachSession>? sessions,
+}) async {
+  await tester.binding.setSurfaceSize(const Size(800, 2400));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        profileProvider.overrideWith(
+          (ref) async => const UserProfile(
+            id: 'member',
+            name: '테스트',
+            email: 'member@example.com',
+          ),
+        ),
+        dashboardSummaryProvider.overrideWith((ref) async => _summary),
+        memberCoachRepositoryProvider.overrideWithValue(
+          MockMemberCoachRepository(),
+        ),
+        if (sessions != null)
+          coachSessionsProvider.overrideWith((ref) async => sessions),
+      ],
+      child: const MaterialApp(
+        locale: Locale('ko'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(body: DashboardContent()),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('트레이너가 잡은 오늘 PT 가 홈 일정에 나타난다', (
+    WidgetTester tester,
+  ) async {
+    await _pump(tester, sessions: <CoachSession>[_session()]);
+
+    expect(find.text('1:1 PT'), findsOneWidget);
+    // 내가 만든 일정도 그대로 남는다.
+    expect(find.text('병원 정기검진'), findsOneWidget);
+  });
+
+  testWidgets('시간순으로 섞인다', (WidgetTester tester) async {
+    // '다음에 뭐가 있는지'를 한 번에 읽으려면 두 출처가 시간순이어야 한다.
+    await _pump(tester, sessions: <CoachSession>[_session()]);
+
+    final double ptY = tester.getTopLeft(find.text('1:1 PT')).dy;
+    final double checkupY = tester.getTopLeft(find.text('병원 정기검진')).dy;
+    expect(ptY, lessThan(checkupY));
+  });
+
+  testWidgets('완료된 세션은 오늘의 일정에 남지 않는다', (WidgetTester tester) async {
+    await _pump(
+      tester,
+      sessions: <CoachSession>[_session(status: '완료')],
+    );
+
+    expect(find.text('1:1 PT'), findsNothing);
+  });
+
+  testWidgets('다른 날 세션은 오늘에 끼어들지 않는다', (WidgetTester tester) async {
+    await _pump(
+      tester,
+      sessions: <CoachSession>[
+        _session(date: DateTime.now().add(const Duration(days: 3))),
+      ],
+    );
+
+    expect(find.text('1:1 PT'), findsNothing);
+  });
+
+  testWidgets('날짜가 없는 세션은 걸러진다', (WidgetTester tester) async {
+    // 서버가 깨진 날짜를 줘도 화면이 흔들리지 않아야 한다.
+    await _pump(
+      tester,
+      sessions: <CoachSession>[
+        const CoachSession(
+          id: 'broken',
+          date: null,
+          time: '09:00',
+          type: '1:1 PT',
+          durationMinutes: 50,
+          status: '예정',
+        ),
+      ],
+    );
+
+    expect(find.text('1:1 PT'), findsNothing);
+  });
+
+  testWidgets('데모 홈 일정은 지금과 같다', (WidgetTester tester) async {
+    // override 없이 — 데모는 목 저장소가 빈 목록을 주므로 카드가 그대로다.
+    await _pump(tester);
+
+    expect(find.text('병원 정기검진'), findsOneWidget);
+    expect(find.text('1:1 PT'), findsNothing);
+  });
+}

--- a/frontend/flutter/test/features/member_coach/coach_sessions_test.dart
+++ b/frontend/flutter/test/features/member_coach/coach_sessions_test.dart
@@ -1,0 +1,138 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/core/network/dio_client.dart';
+import 'package:oncare/features/member_coach/data/dtos/member_coach_dtos.dart';
+import 'package:oncare/features/member_coach/data/repositories/dio_member_coach_repository.dart';
+import 'package:oncare/features/member_coach/data/repositories/mock_member_coach_repository.dart';
+import 'package:oncare/features/member_coach/domain/entities/member_coach.dart';
+import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
+
+class _MockDio extends Mock implements Dio {}
+
+Response<T> _ok<T>(T body) => Response<T>(
+  requestOptions: RequestOptions(path: '/me/coach/sessions'),
+  statusCode: 200,
+  data: body,
+);
+
+Map<String, Object?> _row({
+  Object? id = 'sched-1',
+  Object? date = '2026-08-20',
+  Object? time = '10:00',
+  Object? type = '1:1 PT',
+  Object? minutes = 50,
+  Object? status = '예정',
+}) => <String, Object?>{
+  'id': id,
+  'date': date,
+  'time': time,
+  'client_name': '김민수',
+  'type': type,
+  'duration_minutes': minutes,
+  'status': status,
+  'note': '',
+  'program': <Object?>[],
+};
+
+const AppConfig _demo = AppConfig(
+  environment: Environment.dev,
+  apiBaseUrl: 'https://dev.api.test',
+  useMockApi: true,
+);
+
+const AppConfig _real = AppConfig(
+  environment: Environment.dev,
+  apiBaseUrl: 'https://dev.api.test',
+  useMockApi: false,
+);
+
+void main() {
+  group('DTO', () {
+    test('세션 한 건을 읽는다', () {
+      final CoachSession session = coachSessionFromJson(_row());
+
+      expect(session.id, 'sched-1');
+      expect(session.date, DateTime(2026, 8, 20));
+      expect(session.time, '10:00');
+      expect(session.type, '1:1 PT');
+      expect(session.durationMinutes, 50);
+      expect(session.isUpcoming, isTrue);
+    });
+
+    test('완료된 세션은 예정이 아니다', () {
+      expect(coachSessionFromJson(_row(status: '완료')).isUpcoming, isFalse);
+    });
+
+    test('날짜가 깨져도 던지지 않는다', () {
+      // 한 행 때문에 일정 전체가 사라지면 안 된다 — 화면이 null 을 걸러낸다.
+      final CoachSession session = coachSessionFromJson(
+        _row(date: 'not-a-date'),
+      );
+
+      expect(session.date, isNull);
+    });
+
+    test('시간 필드가 없어도 빈 문자열로 둔다', () {
+      expect(coachSessionFromJson(_row(time: null)).time, '');
+    });
+  });
+
+  group('저장소', () {
+    test('실모드는 세션 엔드포인트를 읽는다', () async {
+      final dio = _MockDio();
+      when(
+        () => dio.get<List<dynamic>>('/me/coach/sessions'),
+      ).thenAnswer((_) async => _ok<List<dynamic>>(<dynamic>[_row()]));
+
+      final List<CoachSession> sessions = await DioMemberCoachRepository(
+        dio,
+      ).fetchSessions();
+
+      expect(sessions.single.id, 'sched-1');
+      verify(() => dio.get<List<dynamic>>('/me/coach/sessions')).called(1);
+    });
+
+    test('데모는 담당 일정이 없다 — 홈에 없던 카드가 생기지 않는다', () async {
+      expect(await MockMemberCoachRepository().fetchSessions(), isEmpty);
+    });
+  });
+
+  group('provider 분기', () {
+    test('데모는 목 저장소를 쓰고 네트워크로 나가지 않는다', () async {
+      final dio = _MockDio();
+      final container = ProviderContainer(
+        overrides: <Override>[
+          appConfigProvider.overrideWithValue(_demo),
+          dioProvider.overrideWithValue(dio),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(await container.read(coachSessionsProvider.future), isEmpty);
+      verifyNever(() => dio.get<List<dynamic>>(any()));
+    });
+
+    test('실모드는 백엔드에서 읽는다', () async {
+      final dio = _MockDio();
+      when(
+        () => dio.get<List<dynamic>>('/me/coach/sessions'),
+      ).thenAnswer((_) async => _ok<List<dynamic>>(<dynamic>[_row()]));
+      final container = ProviderContainer(
+        overrides: <Override>[
+          appConfigProvider.overrideWithValue(_real),
+          dioProvider.overrideWithValue(dio),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final List<CoachSession> sessions = await container.read(
+        coachSessionsProvider.future,
+      );
+
+      expect(sessions, hasLength(1));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

* 트레이너가 잡아 준 PT 일정이 회원 앱 홈 '오늘의 일정'에 나타납니다.
* 새 API 도 새 화면도 만들지 않았습니다. **이미 있던 것을 이었습니다.**
* 데모 화면은 지금과 동일합니다.

---

## Changes

### ✨ Features

* `CoachSession` 엔티티와 DTO 를 추가하고, `MemberCoachRepository` 에 `fetchSessions()` 를 더했습니다(Dio·mock 양쪽).
* `coachSessionsProvider` 를 추가했습니다.
* 홈 '오늘의 일정' 카드가 내 일정과 트레이너 PT 를 **시간순으로 섞어** 보여줍니다.

### 🎨 UI/UX

* 완료된 세션은 남기지 않습니다.
* 다른 날 세션은 오늘에 끼어들지 않습니다.
* 담당 트레이너가 없거나 잡힌 일정이 없으면 카드가 늘어나지 않습니다.

---

## Commits

1. 44f0f95 feat(schedule): 트레이너가 배정한 PT 일정을 회원 홈에 표시

---

## Notes

**왜 지금까지 안 보였나**

`GET /me/coach/sessions` 는 백엔드에 구현되어 있었지만 사용자 앱이 한 번도 호출하지 않았습니다.

```
$ grep -rn "me/coach/sessions" frontend/flutter/lib
(결과 없음)
```

같은 `MemberCoachRepository` 의 다른 메서드(`fetchCoach`·`fetchRoutines`·`fetchChat`)는 모두 화면에 연결돼 있어 이 하나만 빠진 상태였습니다. 그래서 회원은 자기 PT 가 언제인지 채팅으로 물어야 했습니다.

**왜 별도 카드가 아닌가**

회원 입장에서 "오늘 뭐 하지"는 하나의 질문입니다. PT 만 따로 떼면 같은 시간대를 두 곳에서 봐야 합니다. 두 출처를 시간순으로 섞어야 "다음에 뭐가 있는지"를 한 번에 읽습니다.

**데모 불변**

`MockMemberCoachRepository.fetchSessions()` 가 빈 목록을 줍니다. 시드로 일정을 만들어 넣지 않은 이유는, 데모 홈에 없던 항목이 생겨 화면이 지금과 달라지기 때문입니다. 실모드에서만 나타나는 것이 맞습니다. 데모에서 네트워크로 나가지 않는 것까지 테스트로 고정했습니다.

**깨진 데이터**

날짜를 파싱하지 못한 행은 DTO 가 `null` 로 두고 화면이 걸러냅니다. 던지면 한 행 때문에 일정 전체가 사라집니다.

**범위 밖**

회원이 일정을 만들거나 고치는 기능은 넣지 않았습니다 — 일정의 주인은 트레이너입니다. 백엔드는 손대지 않았고, 해당 엔드포인트는 `test_member_coach.py::test_my_routines_and_sessions` 가 이미 덮고 있습니다.

---

## Test Plan

* [x] 사용자 앱 신규 14건 — DTO(정상·완료·깨진 날짜·빈 시간), 저장소(실모드 경로·데모 빈 목록), provider 분기(데모에서 네트워크 미사용), 홈 렌더(표시·시간순 정렬·완료 제외·다른 날 제외·날짜 없음 제외·데모 불변)
* [x] 사용자 앱 전체 390건 통과, `flutter analyze` 무경고

### Manual Test Steps

1. 백엔드를 띄우고 트레이너 앱에서 회원의 오늘 일정을 등록합니다.
2. 회원 앱 홈 '오늘의 일정'에 그 PT 가 시간순 위치에 나타나는지 확인합니다.
3. 트레이너 앱에서 세션을 완료 처리하면 홈에서 사라지는지 확인합니다.
4. 데모(둘러보기) 홈 일정이 기존과 같은지 확인합니다.

---

## Related Issues

Closes #490

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인
