### PR TITLE
feat(trainer): 담당 회원 기반 AI 코칭 상담을 트레이너 앱에 연결

### DIFF
--- a/frontend/flutter_trainer/lib/features/clients/data/repositories/client_coach_repository.dart
+++ b/frontend/flutter_trainer/lib/features/clients/data/repositories/client_coach_repository.dart
@@ -1,0 +1,127 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare_trainer/core/config/app_config.dart';
+import 'package:oncare_trainer/core/errors/app_error.dart';
+import 'package:oncare_trainer/core/network/dio_client.dart';
+
+/// AI 코칭 상담의 답변 한 건. (#497)
+class ClientCoachAnswer {
+  /// Creates an answer.
+  const ClientCoachAnswer({required this.reply, this.sources = const <String>[]});
+
+  /// AI 가 만든 답변.
+  final String reply;
+
+  /// 답의 근거로 쓰인 문서 제목.
+  ///
+  /// 근거 없이 답만 보여 주면 트레이너가 그 말을 믿어도 되는지 판단할 수 없다.
+  /// 이 목록이 비어 있을 수도 있다 — 회원 기록만으로 답한 경우다.
+  final List<String> sources;
+}
+
+/// 담당 회원에 대해 AI 에게 묻는다 — `POST /trainer/clients/{id}/ai-coach`.
+///
+/// 회원 앱의 `/ai-coach/chat` 과 같은 RAG 파이프라인이지만 **검색 스코프가
+/// 담당 회원**이다. 트레이너가 자기 자신의(비어 있는) 기록으로 코칭받는 일이
+/// 없도록 서버가 그렇게 짜여 있다.
+///
+/// 두 구현이 [clientCoachRepositoryProvider] 뒤에 있고 `useMockApi` 로 갈린다.
+///
+///  * [DemoClientCoachRepository] — 데모. 근거로 삼을 회원 데이터가 없다.
+///  * [DioClientCoachRepository] — 실 백엔드.
+abstract interface class ClientCoachRepository {
+  /// 이 빌드가 실제로 물어볼 수 있는가.
+  ///
+  /// 데모에는 근거가 될 회원 기록이 없어, 무엇을 물어도 의미 있는 답이 나오지
+  /// 않는다. 진입점 노출 여부를 이 값으로 정한다 — 눌러도 소용없는 버튼을
+  /// 두느니 보이지 않는 편이 낫고, 데모 화면도 지금 그대로 남는다.
+  bool get supportsAsk;
+
+  /// [memberId] 회원에 대해 [message] 를 묻고 답을 받는다.
+  Future<ClientCoachAnswer> ask({
+    required String memberId,
+    required String message,
+  });
+}
+
+/// 데모 빌드: 물어볼 근거가 없다.
+class DemoClientCoachRepository implements ClientCoachRepository {
+  /// Creates the demo source.
+  const DemoClientCoachRepository();
+
+  @override
+  bool get supportsAsk => false;
+
+  @override
+  Future<ClientCoachAnswer> ask({
+    required String memberId,
+    required String message,
+  }) async =>
+      throw const ValidationError(message: '데모 모드에서는 AI 코칭을 사용할 수 없어요');
+}
+
+/// 실 백엔드 구현.
+class DioClientCoachRepository implements ClientCoachRepository {
+  /// Creates the API-backed repository.
+  const DioClientCoachRepository(this._dio);
+
+  final Dio _dio;
+
+  @override
+  bool get supportsAsk => true;
+
+  @override
+  Future<ClientCoachAnswer> ask({
+    required String memberId,
+    required String message,
+  }) async {
+    try {
+      final res = await _dio.post<Map<String, Object?>>(
+        '/trainer/clients/${Uri.encodeComponent(memberId)}/ai-coach',
+        data: <String, Object?>{'message': message},
+      );
+      final body = res.data ?? const <String, Object?>{};
+      return ClientCoachAnswer(
+        reply: body['reply'] is String ? body['reply']! as String : '',
+        sources: <String>[
+          for (final Object? item in body['sources'] as List<Object?>? ??
+              const <Object?>[])
+            if (item is String && item.trim().isNotEmpty) item.trim(),
+        ],
+      );
+    } on DioException catch (e) {
+      final status = e.response?.statusCode;
+      // 404 는 '남의 고객'이다 — 서버가 존재조차 드러내지 않는다. 트레이너에게는
+      // 담당이 아니라는 사실이 필요한 정보다.
+      if (status == 404) {
+        throw const NotFoundError(message: '담당 고객이 아니에요');
+      }
+      if (status == 400 || status == 422) {
+        throw ValidationError(message: _detail(e) ?? '질문을 보낼 수 없어요');
+      }
+      throw AppError.fromDio(e);
+    }
+  }
+
+  String? _detail(DioException e) {
+    final data = e.response?.data;
+    if (data is! Map) return null;
+    final detail = data['detail'];
+    return detail is String ? detail : null;
+  }
+}
+
+/// 현재 모드에 맞는 저장소.
+final clientCoachRepositoryProvider = Provider<ClientCoachRepository>((ref) {
+  if (ref.watch(appConfigProvider).useMockApi) {
+    return const DemoClientCoachRepository();
+  }
+  return DioClientCoachRepository(ref.watch(dioProvider));
+}, name: 'clientCoachRepository');
+
+/// 고객 상세에 'AI 에게 묻기' 를 노출할지.
+final clientCoachEnabledProvider = Provider<bool>(
+  (ref) => ref.watch(clientCoachRepositoryProvider).supportsAsk,
+  name: 'clientCoachEnabled',
+);

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_coach_sheet.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_coach_sheet.dart
@@ -1,0 +1,187 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:oncare_trainer/core/errors/app_error.dart';
+import 'package:oncare_trainer/design_system/tokens/colors.dart';
+import 'package:oncare_trainer/design_system/tokens/radius.dart';
+import 'package:oncare_trainer/design_system/tokens/spacing.dart';
+import 'package:oncare_trainer/features/clients/data/repositories/client_coach_repository.dart';
+import 'package:oncare_trainer/shared/widgets/action_button.dart';
+
+/// 담당 회원에 대해 AI 에게 묻는 시트를 연다. (#497)
+Future<void> showClientCoachSheet(
+  BuildContext context, {
+  required String memberId,
+  required String clientName,
+}) {
+  return showDialog<void>(
+    context: context,
+    builder: (_) => _ClientCoachSheet(memberId: memberId, clientName: clientName),
+  );
+}
+
+/// AI 코칭 상담 — 이 회원에 대해 묻고, 근거와 함께 답을 받는다.
+///
+/// 탭이 아니라 시트인 이유: 트레이너가 상시로 보는 화면이 아니라 판단이 필요할
+/// 때 한 번 여는 도구다. 대상이 '이 회원'이라 고객 상세에서 연다.
+///
+/// 대화를 이어 가지 않는다 — 서버 엔드포인트가 무상태이고, 회원 앱의 대화
+/// 저장(#274)과는 별개 도메인이다. 한 번에 한 질문으로 충분하다.
+class _ClientCoachSheet extends ConsumerStatefulWidget {
+  const _ClientCoachSheet({required this.memberId, required this.clientName});
+
+  final String memberId;
+  final String clientName;
+
+  @override
+  ConsumerState<_ClientCoachSheet> createState() => _ClientCoachSheetState();
+}
+
+class _ClientCoachSheetState extends ConsumerState<_ClientCoachSheet> {
+  final TextEditingController _question = TextEditingController();
+  bool _asking = false;
+  ClientCoachAnswer? _answer;
+  String? _error;
+
+  @override
+  void dispose() {
+    _question.dispose();
+    super.dispose();
+  }
+
+  Future<void> _ask() async {
+    final String message = _question.text.trim();
+    // 빈 질문은 서버도 400 이다. 왕복할 이유가 없다.
+    if (message.isEmpty || _asking) return;
+
+    setState(() {
+      _asking = true;
+      _error = null;
+    });
+    try {
+      final ClientCoachAnswer answer = await ref
+          .read(clientCoachRepositoryProvider)
+          .ask(memberId: widget.memberId, message: message);
+      if (!mounted) return;
+      setState(() {
+        _answer = answer;
+        _asking = false;
+      });
+    } on AppError catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = e.message ?? 'AI 코칭을 불러오지 못했어요';
+        _asking = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      backgroundColor: AppColors.card,
+      title: Text('${widget.clientName} 코칭 상담'),
+      content: SizedBox(
+        width: 460,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              const Text(
+                '이 회원의 식단·운동 기록을 근거로 답해요.',
+                style: TextStyle(
+                  fontSize: 12.5,
+                  color: AppColors.mutedForeground,
+                ),
+              ),
+              const SizedBox(height: AppSpacing.md),
+              TextField(
+                controller: _question,
+                maxLines: 3,
+                maxLength: 1000,
+                enabled: !_asking,
+                onSubmitted: (_) => _ask(),
+                decoration: const InputDecoration(
+                  hintText: '예) 나트륨이 계속 높은데 어떤 식단을 권할까요?',
+                  filled: true,
+                  fillColor: AppColors.inputBackground,
+                ),
+              ),
+              if (_asking) ...<Widget>[
+                const SizedBox(height: AppSpacing.md),
+                const Center(child: CircularProgressIndicator()),
+              ],
+              if (_error != null) ...<Widget>[
+                const SizedBox(height: AppSpacing.md),
+                _Note(tone: AppColors.destructive, text: _error!),
+              ],
+              if (_answer != null && !_asking) ...<Widget>[
+                const SizedBox(height: AppSpacing.md),
+                _Note(tone: AppColors.primary, text: _answer!.reply),
+                if (_answer!.sources.isNotEmpty) ...<Widget>[
+                  const SizedBox(height: AppSpacing.sm),
+                  const Text(
+                    '근거',
+                    style: TextStyle(
+                      fontSize: 11,
+                      fontWeight: FontWeight.w700,
+                      color: AppColors.subtleForeground,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  for (final String source in _answer!.sources)
+                    Text(
+                      '· $source',
+                      style: const TextStyle(
+                        fontSize: 12,
+                        color: AppColors.mutedForeground,
+                      ),
+                    ),
+                ],
+              ],
+            ],
+          ),
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: _asking ? null : () => Navigator.of(context).pop(),
+          child: const Text('닫기'),
+        ),
+        ActionButton(
+          label: _answer == null ? '물어보기' : '다시 묻기',
+          primary: true,
+          onPressed: _asking ? null : _ask,
+        ),
+      ],
+    );
+  }
+}
+
+/// 답변·오류를 담는 색 있는 블록.
+class _Note extends StatelessWidget {
+  const _Note({required this.tone, required this.text});
+
+  final Color tone;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(AppSpacing.md),
+      decoration: BoxDecoration(
+        color: tone.withValues(alpha: 0.08),
+        borderRadius: const BorderRadius.all(AppRadius.card),
+      ),
+      child: Text(
+        text,
+        style: const TextStyle(
+          fontSize: 13,
+          height: 1.5,
+          color: AppColors.foreground,
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_detail_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_detail_view.dart
@@ -3,6 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:oncare_trainer/app/router/routes.dart';
+import 'package:oncare_trainer/features/clients/presentation/widgets/client_coach_sheet.dart';
+import 'package:oncare_trainer/features/clients/data/repositories/client_coach_repository.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
@@ -215,7 +217,7 @@ class _StatusView extends StatelessWidget {
 /// Identity, why this client is flagged, today's numbers, and the two
 /// things the trainer most often does next — above the tabs, so all of it
 /// stays on screen no matter which tab is open.
-class _Header extends StatelessWidget {
+class _Header extends ConsumerWidget {
   const _Header({
     required this.client,
     required this.alerts,
@@ -236,7 +238,7 @@ class _Header extends StatelessWidget {
   final VoidCallback? onToggleActive;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Container(
       padding: const EdgeInsets.symmetric(
         horizontal: AppSpacing.lg,
@@ -308,6 +310,21 @@ class _Header extends StatelessWidget {
               ),
             ],
           ),
+          // AI 코칭 상담(#497)은 실 API 모드에서만 — 데모에는 근거로 삼을 회원
+          // 기록이 없어 무엇을 물어도 의미 있는 답이 나오지 않는다. 기존 두
+          // 버튼 행은 그대로 두고 아래에 붙여, 데모 헤더가 지금과 같게 남는다.
+          if (ref.watch(clientCoachEnabledProvider)) ...<Widget>[
+            const SizedBox(height: AppSpacing.sm),
+            ActionButton(
+              label: 'AI에게 묻기',
+              icon: Icons.psychology_outlined,
+              onPressed: () => showClientCoachSheet(
+                context,
+                memberId: client.id,
+                clientName: client.name,
+              ),
+            ),
+          ],
         ],
       ),
     );

--- a/frontend/flutter_trainer/test/features/clients/client_coach_entry_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_coach_entry_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oncare_trainer/app/router/routes.dart';
+import 'package:oncare_trainer/core/errors/app_error.dart';
+import 'package:oncare_trainer/features/clients/data/repositories/client_coach_repository.dart';
+
+import '../../helpers/pump_app.dart';
+
+/// 시드된 고객 id — 상세는 id 로 주소를 갖는다.
+const String _minsuId = 'seed-client-1';
+
+/// 질문을 기록하고 정해진 답을 주는 페이크.
+class _FakeCoachRepository implements ClientCoachRepository {
+  _FakeCoachRepository({this.answer, this.failure});
+
+  final ClientCoachAnswer? answer;
+  final AppError? failure;
+  final List<(String, String)> asked = <(String, String)>[];
+
+  @override
+  bool get supportsAsk => true;
+
+  @override
+  Future<ClientCoachAnswer> ask({
+    required String memberId,
+    required String message,
+  }) async {
+    asked.add((memberId, message));
+    if (failure != null) throw failure!;
+    return answer ?? const ClientCoachAnswer(reply: 'ok');
+  }
+}
+
+Future<void> _openClient(
+  WidgetTester tester, {
+  ClientCoachRepository? coach,
+}) async {
+  await pumpTrainerApp(
+    tester,
+    token: 'demo-trainer-token',
+    at: AppRoutes.clientDetail(_minsuId, section: 'diet'),
+    extraOverrides: <Override>[
+      if (coach != null)
+        clientCoachRepositoryProvider.overrideWithValue(coach),
+    ],
+  );
+}
+
+void main() {
+  testWidgets('데모 고객 상세에는 AI 상담 버튼이 없다', (WidgetTester tester) async {
+    // 데모에는 근거로 삼을 회원 기록이 없다. 화면이 지금과 같아야 한다.
+    await _openClient(tester);
+
+    expect(find.text('AI에게 묻기'), findsNothing);
+    // 기존 두 액션은 그대로다.
+    expect(find.text('AI 루틴 만들기'), findsWidgets);
+    expect(find.text('주간 리포트'), findsWidgets);
+  });
+
+  testWidgets('실 API 모드에서는 버튼이 보인다', (WidgetTester tester) async {
+    await _openClient(tester, coach: _FakeCoachRepository());
+
+    expect(find.text('AI에게 묻기'), findsOneWidget);
+  });
+
+  testWidgets('질문을 보내고 답변과 근거를 보여준다', (WidgetTester tester) async {
+    final repo = _FakeCoachRepository(
+      answer: const ClientCoachAnswer(
+        reply: '국물을 남기도록 안내해 보세요.',
+        sources: <String>['고혈압 식이 가이드'],
+      ),
+    );
+    await _openClient(tester, coach: repo);
+
+    await tester.tap(find.text('AI에게 묻기'));
+    await settle(tester);
+    await tester.enterText(find.byType(TextField).last, '나트륨이 높아요');
+    await tester.tap(find.text('물어보기'));
+    await settle(tester);
+
+    expect(repo.asked.single.$2, '나트륨이 높아요');
+    expect(find.text('국물을 남기도록 안내해 보세요.'), findsOneWidget);
+    // 근거 없이 답만 보여 주면 트레이너가 믿어도 되는지 판단할 수 없다.
+    expect(find.text('· 고혈압 식이 가이드'), findsOneWidget);
+  });
+
+  testWidgets('빈 질문은 서버로 보내지 않는다', (WidgetTester tester) async {
+    final repo = _FakeCoachRepository();
+    await _openClient(tester, coach: repo);
+
+    await tester.tap(find.text('AI에게 묻기'));
+    await settle(tester);
+    await tester.tap(find.text('물어보기'));
+    await settle(tester);
+
+    expect(repo.asked, isEmpty);
+  });
+
+  testWidgets('실패하면 사유를 보여준다', (WidgetTester tester) async {
+    final repo = _FakeCoachRepository(
+      failure: const NotFoundError(message: '담당 고객이 아니에요'),
+    );
+    await _openClient(tester, coach: repo);
+
+    await tester.tap(find.text('AI에게 묻기'));
+    await settle(tester);
+    await tester.enterText(find.byType(TextField).last, '질문');
+    await tester.tap(find.text('물어보기'));
+    await settle(tester);
+
+    expect(find.text('담당 고객이 아니에요'), findsOneWidget);
+  });
+}

--- a/frontend/flutter_trainer/test/features/clients/client_coach_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_coach_test.dart
@@ -1,0 +1,215 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:oncare_trainer/core/config/app_config.dart';
+import 'package:oncare_trainer/core/errors/app_error.dart';
+import 'package:oncare_trainer/core/network/dio_client.dart';
+import 'package:oncare_trainer/features/clients/data/repositories/client_coach_repository.dart';
+
+class _MockDio extends Mock implements Dio {}
+
+Response<T> _ok<T>(T body) => Response<T>(
+  requestOptions: RequestOptions(path: '/trainer/clients/m1/ai-coach'),
+  statusCode: 200,
+  data: body,
+);
+
+DioException _httpError(int status, {Object? body}) => DioException(
+  requestOptions: RequestOptions(path: '/trainer/clients/m1/ai-coach'),
+  type: DioExceptionType.badResponse,
+  response: Response<Object?>(
+    requestOptions: RequestOptions(path: '/trainer/clients/m1/ai-coach'),
+    statusCode: status,
+    data: body,
+  ),
+);
+
+const AppConfig _demo = AppConfig(
+  environment: Environment.dev,
+  apiBaseUrl: 'http://localhost/v1',
+  useMockApi: true,
+);
+
+const AppConfig _real = AppConfig(
+  environment: Environment.dev,
+  apiBaseUrl: 'http://localhost/v1',
+  useMockApi: false,
+);
+
+void main() {
+  late _MockDio dio;
+  late DioClientCoachRepository repo;
+
+  setUp(() {
+    dio = _MockDio();
+    repo = DioClientCoachRepository(dio);
+  });
+
+  void stubPost(Object answer) {
+    when(
+      () => dio.post<Map<String, Object?>>(
+        '/trainer/clients/m1/ai-coach',
+        data: any(named: 'data'),
+      ),
+    ).thenAnswer((_) async => _ok<Map<String, Object?>>(answer as Map<String, Object?>));
+  }
+
+  group('실 백엔드 저장소', () {
+    test('답변과 근거를 읽는다', () async {
+      stubPost(<String, Object?>{
+        'member_id': 'm1',
+        'reply': '나트륨을 줄이려면 국물을 남기도록 안내해 보세요.',
+        'sources': <Object?>['고혈압 식이 가이드', '회원 최근 7일 식단'],
+      });
+
+      final answer = await repo.ask(memberId: 'm1', message: '나트륨이 높아요');
+
+      expect(answer.reply, contains('국물'));
+      expect(answer.sources, hasLength(2));
+    });
+
+    test('근거가 비어 있어도 답변은 온다', () async {
+      // 회원 기록만으로 답한 경우다 — 근거 목록이 비는 것이 정상이다.
+      stubPost(<String, Object?>{'member_id': 'm1', 'reply': '괜찮아요'});
+
+      final answer = await repo.ask(memberId: 'm1', message: '어때요?');
+
+      expect(answer.reply, '괜찮아요');
+      expect(answer.sources, isEmpty);
+    });
+
+    test('근거 목록의 빈 문자열은 걸러낸다', () async {
+      stubPost(<String, Object?>{
+        'member_id': 'm1',
+        'reply': 'ok',
+        'sources': <Object?>['가이드', '  ', 3],
+      });
+
+      final answer = await repo.ask(memberId: 'm1', message: 'q');
+
+      expect(answer.sources, <String>['가이드']);
+    });
+
+    test('질문을 그대로 실어 보낸다', () async {
+      stubPost(<String, Object?>{'member_id': 'm1', 'reply': 'ok'});
+
+      await repo.ask(memberId: 'm1', message: '나트륨이 높아요');
+
+      final data =
+          verify(
+                () => dio.post<Map<String, Object?>>(
+                  '/trainer/clients/m1/ai-coach',
+                  data: captureAny(named: 'data'),
+                ),
+              ).captured.single
+              as Map<String, Object?>;
+      expect(data['message'], '나트륨이 높아요');
+    });
+
+    test('회원 id 를 경로에 percent-encode 한다', () async {
+      when(
+        () => dio.post<Map<String, Object?>>(
+          '/trainer/clients/a%2Fb/ai-coach',
+          data: any(named: 'data'),
+        ),
+      ).thenAnswer(
+        (_) async => _ok<Map<String, Object?>>(<String, Object?>{'reply': 'ok'}),
+      );
+
+      await repo.ask(memberId: 'a/b', message: 'q');
+
+      verify(
+        () => dio.post<Map<String, Object?>>(
+          '/trainer/clients/a%2Fb/ai-coach',
+          data: any(named: 'data'),
+        ),
+      ).called(1);
+    });
+
+    test('404 는 담당 고객이 아니라는 뜻으로 옮긴다', () async {
+      // 서버가 남의 고객을 404 로 감춘다 — 트레이너에게는 담당이 아니라는
+      // 사실이 필요한 정보다.
+      when(
+        () => dio.post<Map<String, Object?>>(
+          '/trainer/clients/m1/ai-coach',
+          data: any(named: 'data'),
+        ),
+      ).thenThrow(_httpError(404));
+
+      await expectLater(
+        repo.ask(memberId: 'm1', message: 'q'),
+        throwsA(
+          isA<NotFoundError>().having(
+            (e) => e.message,
+            'message',
+            contains('담당 고객'),
+          ),
+        ),
+      );
+    });
+
+    test('400 은 서버 사유를 그대로 보여준다', () async {
+      when(
+        () => dio.post<Map<String, Object?>>(
+          '/trainer/clients/m1/ai-coach',
+          data: any(named: 'data'),
+        ),
+      ).thenThrow(
+        _httpError(400, body: <String, Object?>{'detail': '메시지가 비어 있습니다.'}),
+      );
+
+      await expectLater(
+        repo.ask(memberId: 'm1', message: 'q'),
+        throwsA(
+          isA<ValidationError>().having(
+            (e) => e.message,
+            'message',
+            '메시지가 비어 있습니다.',
+          ),
+        ),
+      );
+    });
+  });
+
+  group('provider 분기', () {
+    test('데모는 물어볼 수 없고 진입점도 숨긴다', () {
+      final container = ProviderContainer(
+        overrides: <Override>[appConfigProvider.overrideWithValue(_demo)],
+      );
+      addTearDown(container.dispose);
+
+      expect(
+        container.read(clientCoachRepositoryProvider),
+        isA<DemoClientCoachRepository>(),
+      );
+      // 데모 고객 상세는 지금과 같아야 한다 — 버튼이 아예 그려지지 않는다.
+      expect(container.read(clientCoachEnabledProvider), isFalse);
+    });
+
+    test('실모드는 백엔드를 쓴다', () {
+      final container = ProviderContainer(
+        overrides: <Override>[
+          appConfigProvider.overrideWithValue(_real),
+          dioProvider.overrideWithValue(dio),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(
+        container.read(clientCoachRepositoryProvider),
+        isA<DioClientCoachRepository>(),
+      );
+      expect(container.read(clientCoachEnabledProvider), isTrue);
+    });
+
+    test('데모 저장소는 요청을 흉내내지 않고 거절한다', () async {
+      const repo = DemoClientCoachRepository();
+
+      await expectLater(
+        repo.ask(memberId: 'm1', message: 'q'),
+        throwsA(isA<ValidationError>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

* 트레이너가 담당 회원에 대해 AI 에게 묻고 **근거와 함께** 답을 받을 수 있습니다.
* 백엔드는 이미 완성돼 있었고 앱만 붙였습니다 — 백엔드 변경 없음.
* 데모 화면은 지금과 동일합니다.

---

## Changes

### ✨ Features

* 고객 상세에 `AI에게 묻기` 액션과 상담 시트를 추가했습니다.
* `ClientCoachRepository` — Dio 구현과 데모 구현, `AppConfig.useMockApi` 로 분기.

### 🎨 UI/UX

* 답변과 함께 **근거 문서**를 보여줍니다.
* 빈 질문은 보내지 않고, 전송 중에는 중복 전송을 막습니다.
* 실패 사유를 시트 안에 표시합니다.

---

## Commits

1. 2783991 feat(trainer): 담당 회원 기반 AI 코칭 상담을 트레이너 앱에 연결

---

## Notes

**왜 지금까지 묻혀 있었나**

`POST /trainer/clients/{member_id}/ai-coach` 가 백엔드에 완성돼 있었지만 트레이너 앱이 한 번도 호출하지 않았습니다.

```
$ grep -rn "ai-coach" frontend/flutter_trainer/lib
(결과 없음)
```

회원 앱의 `/ai-coach/chat` 과 같은 RAG 파이프라인이지만 **검색 스코프가 담당 회원**입니다. 트레이너가 "이 회원 나트륨이 계속 높은데 어떻게 코칭할까?" 를 물으면 그 회원의 식단·운동 기록을 근거로 답합니다. 트레이너 앱의 `AI 코칭` 탭은 루틴 생성만 하고, 이 상담 기능은 닿는 화면이 없었습니다.

**왜 고객 상세이고, 왜 시트인가**

대상이 '이 회원'이라 고객 상세가 맞는 자리입니다. 헤더에 이미 `AI 루틴 만들기`·`주간 리포트` 가 있어 그 아래에 붙였습니다.

탭이 아니라 시트인 이유: 트레이너가 상시로 보는 화면이 아니라 판단이 필요할 때 한 번 여는 도구입니다.

**근거를 함께 보여주는 이유**

근거 없이 답만 보여 주면 트레이너가 그 말을 믿어도 되는지 판단할 수 없습니다. 회원 기록만으로 답해 근거 목록이 비는 경우도 있어, 그때는 근거 영역을 그리지 않습니다.

**404 를 옮기는 이유**

서버는 남의 고객을 404 로 감춥니다(존재조차 드러내지 않음). 앱에서는 '담당 고객이 아니에요' 로 옮깁니다 — 트레이너에게는 담당이 아니라는 사실 자체가 필요한 정보이고, 일반 오류로 덮으면 왜 안 되는지 알 수 없습니다.

**데모 불변**

데모에는 근거로 삼을 회원 기록이 없어 무엇을 물어도 의미 있는 답이 나오지 않습니다. `DemoClientCoachRepository.supportsAsk` 가 false 라 **버튼이 아예 그려지지 않습니다.** 기존 두 액션 행은 건드리지 않고 아래에 별도로 붙여, 데모 고객 상세 헤더가 지금과 같게 남습니다. 위젯 테스트로 고정했습니다.

**범위 밖**

대화 이어가기는 넣지 않았습니다 — 이 엔드포인트는 무상태이고, 회원 앱의 대화 저장(#274)과 별개 도메인입니다. 필요해지면 별건으로 다룹니다.

**다른 작업과의 관계**

`frontend/flutter_trainer/lib/features/clients/**` 만 수정합니다. #492(예약, `features/schedule/**`)와 파일이 겹치지 않습니다.

---

## Test Plan

* [x] 신규 15건 — 답변·근거 파싱, 근거 없음, 빈 근거 필터, 질문 전달, id percent-encode, 404·400 매핑, provider 분기(데모 진입점 숨김 포함), 데모 저장소 거절
* [x] 위젯 5건 — 데모에 버튼 없음, 실모드에 버튼 있음, 질문→답변·근거 표시, 빈 질문 미전송, 실패 사유 표시
* [x] 트레이너 앱 전체 394건 통과, `flutter analyze` 무경고

### Manual Test Steps

1. 백엔드를 띄우고 트레이너 앱을 `USE_MOCK_API=false` 로 실행합니다.
2. 고객 상세에서 `AI에게 묻기` 를 누릅니다.
3. 그 회원의 식단·운동을 근거로 답이 오는지, 근거 목록이 함께 보이는지 확인합니다.
4. 데모(둘러보기) 고객 상세에 버튼이 없는지 확인합니다.

---

## Related Issues

Closes #497

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인
