### PR TITLE
feat(exercise): PT 완료를 회원 운동 기록에 자동 반영

### DIFF
--- a/backend/API_CONTRACT.md
+++ b/backend/API_CONTRACT.md
@@ -67,8 +67,9 @@
 | POST | `/exercise/sessions` | 입력 `{ type, minutes(>0), calories, intensity(light\|moderate\|high), day_label? }` → 생성된 `sessions[]` 항목 |
 | PUT | `/exercise/sessions/{id}` | 입력 동일(부분 갱신) → 갱신된 항목 |
 
-`sessions[]`: `{ id(str), day_label, type(cardio|strength|yoga|walking), minutes, calories, intensity(light|moderate|high), date_label, time_label, items[str] }`
+`sessions[]`: `{ id(str), day_label, type(cardio|strength|yoga|walking), minutes, calories, intensity(light|moderate|high), source(member|trainer_pt), date_label, time_label, items[str] }`
 `intensity`: 생략 시 `moderate`. 수정 시트가 저장된 강도로 복원되고 칼로리 추정 배수(0.85/1.0/1.2)의 근거가 된다.
+`source`: 생략 시 `member`. `trainer_pt` 는 트레이너가 PT 세션을 완료 처리해 서버가 파생시킨 기록(id 는 `sched-ex-{session_id}`)으로, 근거가 트레이너에게 있어 **회원의 PUT/DELETE 는 409** 로 거절된다. 지우려면 트레이너가 그 세션을 삭제해야 하고 그러면 이 기록도 함께 사라진다. (#499)
 `day_labels`: `["월","화","수","목","금","토","일"]`
 `daily_calories`: 요일별 소모 칼로리(합 = `total_calories`). 홈 '주간 추이' 차트가 이 시리즈를 읽으며, 비어 있으면 클라이언트가 데모 상수로 폴백한다.
 

--- a/backend/app/api/v1/exercise.py
+++ b/backend/app/api/v1/exercise.py
@@ -30,6 +30,20 @@ _ALLOWED_TYPES = {"cardio", "strength", "yoga", "walking", "stretching", "other"
 _ALLOWED_INTENSITIES = {"light", "moderate", "high"}
 
 
+def _reject_if_derived(row: ExerciseSession) -> None:
+    """트레이너 PT 완료로 파생된 기록은 회원이 고칠 수 없다. (#499)
+
+    404 가 아니라 409 다 — 기록은 분명히 존재하고 회원 것이며, 화면에도 보인다.
+    없는 척하면 앱이 목록에서 사라진 줄 알고 잘못 갱신한다. 삭제하려면 트레이너가
+    그 세션을 지워야 하고, 그러면 이 기록도 함께 사라진다.
+    """
+    if row.source != "member":
+        raise HTTPException(
+            status_code=409,
+            detail="트레이너가 완료 처리한 PT 기록은 수정하거나 삭제할 수 없습니다.",
+        )
+
+
 @router.get("/exercise/weeks/current", response_model=ExerciseWeekResponse)
 def current_week(
     current_user: CurrentUser,
@@ -104,6 +118,7 @@ def update_session(
     )
     if row is None:
         raise HTTPException(status_code=404, detail="운동 기록을 찾을 수 없습니다.")
+    _reject_if_derived(row)
 
     day_label = payload.day_label or row.day_label
     if day_label not in WEEKDAY_LABELS:
@@ -135,6 +150,7 @@ def delete_session(
     )
     if row is None:
         raise HTTPException(status_code=404, detail="운동 기록을 찾을 수 없습니다.")
+    _reject_if_derived(row)
     db.delete(row)
     db.commit()
     return {"status": "deleted"}

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -198,6 +198,12 @@ class ExerciseSession(Base):
     intensity: Mapped[str] = mapped_column(
         String(20), default="moderate", server_default="moderate"
     )
+    #: 이 기록을 누가 만들었나. member=회원이 직접 남김, trainer_pt=트레이너가 PT
+    #: 세션을 완료 처리해 파생된 기록. 파생 기록은 근거가 트레이너에게 있어 회원이
+    #: 고칠 수 없고(#499), 화면에서도 수기 기록과 구분해 보여준다.
+    source: Mapped[str] = mapped_column(
+        String(20), default="member", server_default="member"
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/backend/app/schemas/exercise_api.py
+++ b/backend/app/schemas/exercise_api.py
@@ -13,6 +13,10 @@ class ExerciseSessionOut(BaseModel):
     date_label: str
     time_label: str
     items: list[str]
+    # 이 기록을 누가 만들었나. member=회원이 직접 남김, trainer_pt=트레이너가 PT
+    # 세션을 완료해 파생된 기록. 앱은 이 값으로 배지를 붙이고 수정·삭제를 감춘다.
+    # 기본값이 있어야 이 필드를 모르는 기존 클라이언트가 깨지지 않는다. (#499)
+    source: str = "member"
 
 
 class ExerciseWeekResponse(BaseModel):

--- a/backend/app/services/exercise_service.py
+++ b/backend/app/services/exercise_service.py
@@ -13,15 +13,60 @@
 """
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 
 WEEKDAY_LABELS = ["월", "화", "수", "목", "금", "토", "일"]
+
+#: 운동 타입별 분당 소모 칼로리. 회원 앱의 `_estimateCalories`
+#: (`exercise_flows.dart`) 표를 그대로 옮긴 값이다 — 수기 입력은 앱이 계산해
+#: 보내고 PT 완료분은 서버가 계산하므로, 두 값이 다르면 같은 운동인데 회원
+#: 화면에서 칼로리가 갈린다.
+_KCAL_PER_MIN = {
+    "cardio": 9.0,
+    "strength": 6.0,
+    "walking": 4.0,
+    "stretching": 3.0,
+    "yoga": 3.0,
+    "other": 5.0,
+}
+
+#: 강도 배수 — 회원 앱 `_intensityFactor` 와 같다.
+_INTENSITY_FACTOR = {"light": 0.85, "moderate": 1.0, "high": 1.2}
 
 
 def monday_of_this_week_str() -> str:
     now = datetime.now()
     monday = now - timedelta(days=now.weekday())
     return monday.strftime("%Y-%m-%d")
+
+
+def monday_of_str(day: str) -> str:
+    """`day`(YYYY-MM-DD) 가 속한 주의 월요일.
+
+    지난 주 세션을 오늘 완료 처리할 수 있으므로, 파생 기록의 주차는 완료 시점이
+    아니라 **세션 날짜** 기준이어야 한다. 형식이 깨진 값은 이번 주로 떨어뜨린다.
+    """
+    try:
+        d = date.fromisoformat(day)
+    except (TypeError, ValueError):
+        return monday_of_this_week_str()
+    return (d - timedelta(days=d.weekday())).isoformat()
+
+
+def weekday_label_of(day: str) -> str:
+    """`day`(YYYY-MM-DD) 의 요일 라벨(월~일). 형식이 깨지면 오늘 요일."""
+    try:
+        d = date.fromisoformat(day)
+    except (TypeError, ValueError):
+        return WEEKDAY_LABELS[datetime.now().weekday()]
+    return WEEKDAY_LABELS[d.weekday()]
+
+
+def estimate_calories(type_: str, minutes: int, intensity: str) -> int:
+    """분·강도로 소모 칼로리 추정. 회원 앱과 같은 표를 쓴다."""
+    per_min = _KCAL_PER_MIN.get(type_, _KCAL_PER_MIN["other"])
+    factor = _INTENSITY_FACTOR.get(intensity, 1.0)
+    return round(per_min * max(minutes, 0) * factor)
 
 
 def _date_label_for_day(day_label: str) -> str:
@@ -103,6 +148,7 @@ def build_current_week(rows: list) -> dict:
             "id": r.id, "day_label": r.day_label, "type": r.type,
             "minutes": r.minutes, "calories": r.calories,
             "intensity": getattr(r, "intensity", "moderate") or "moderate",
+            "source": getattr(r, "source", "member") or "member",
             "date_label": _date_label_for_day(r.day_label),
             "time_label": _default_time_label(r.type),
             "items": _default_items(r.type),

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -16,15 +16,16 @@ from sqlalchemy import func, or_, select, tuple_, update
 from sqlalchemy.orm import Session
 
 from app.models.models import (
-    ChatMessage, DietEntry, GymProfile, Place, RoutineHistory, TrainerClient,
-    TrainerProfile, TrainerReservation, TrainerRoutine, TrainerSchedule, User,
+    ChatMessage, DietEntry, ExerciseSession, GymProfile, Place, RoutineHistory,
+    TrainerClient, TrainerProfile, TrainerReservation, TrainerRoutine,
+    TrainerSchedule, User,
 )
 from app.schemas.trainer_api import (
     ChatMessageOut, ClientDietEntryOut, MemberCoachOut, ProgramItem, RoutineHistoryOut,
     RoutineOut, ScheduleSessionOut, TrainerClientOut, TrainerGymOut, TrainerMe,
     TrainerNotificationSettings, WeeklyReportOut,
 )
-from app.services import notification_service
+from app.services import exercise_service, notification_service
 
 # 일일 나트륨 목표(mg). 프론트 `sodiumTargetMg` 와 같은 값 — 리포트의
 # '초과 N일'이 앱 화면의 경고와 어긋나면 안 된다.
@@ -701,27 +702,84 @@ def delete_session(db: Session, trainer_id: str, session_id: str) -> bool:
         raise ScheduleConflict(
             "예약으로 생성된 일정은 일반 일정 화면에서 삭제할 수 없습니다."
         )
-    # 완료 세션은 완료 시 파생된 운동기록(sched-hist-{id})을 갖는다. 세션을 지우면 그
-    # 파생 기록도 함께 지워 고아 레코드가 회원 이력에 남지 않게 한다(완료 시 적재의 역연산).
+    # 완료 세션은 완료 시 파생된 기록을 갖는다 — 트레이너 이력(sched-hist-{id})과
+    # 회원 운동 기록(sched-ex-{id}) 두 개다. 세션을 지우면 둘 다 함께 지워 고아
+    # 레코드가 남지 않게 한다(완료 시 적재의 역연산). 회원 쪽을 빠뜨리면 회원의
+    # 주간 집계에만 지워진 PT 가 계속 잡힌다.
     if s.status == "완료":
         hist = db.get(RoutineHistory, f"sched-hist-{s.id}")
         if hist is not None:
             db.delete(hist)
+        derived = db.get(ExerciseSession, _derived_exercise_id(s.id))
+        if derived is not None:
+            db.delete(derived)
     db.delete(s)
     db.commit()
     return True
 
 
+#: PT 완료가 파생시키는 회원 운동 기록의 종류. `TrainerSchedule.type` 은 화면용
+#: 한국어 라벨('1:1 PT'|'상담')이고 `ExerciseSession.type` 은 계약 값이라 매핑이
+#: 필요하다. 여기 없는 종류는 **운동이 아니므로 기록을 만들지 않는다** — 상담
+#: 한 시간이 회원 주간 운동량으로 잡히면 집계가 거짓이 된다.
+_SESSION_EXERCISE_TYPE = {"1:1 PT": "strength"}
+
+#: PT 는 트레이너가 붙어서 끌고 가는 시간이라 수기 입력의 '보통'보다 낮게 볼
+#: 이유가 없다. 강도를 따로 입력받는 자리가 트레이너 앱에 없으므로 기본값을 쓴다.
+_PT_INTENSITY = "moderate"
+
+
+def _derived_exercise_id(session_id: str) -> str:
+    """PT 완료가 파생시킨 운동 기록의 id — 슬롯 기준 결정론적.
+
+    `sched-hist-{id}` 와 같은 이유다. 동시 완료나 재호출에도 같은 id 가 나와
+    중복 행이 생기지 않는다.
+    """
+    return f"sched-ex-{session_id}"
+
+
+def _add_member_exercise_log(
+    db: Session, s: TrainerSchedule
+) -> ExerciseSession | None:
+    """완료된 PT 세션을 회원 쪽 운동 기록으로 적재. 대상이 아니면 None.
+
+    `RoutineHistory` 는 트레이너 화면 전용이라(`/trainer/clients/{id}/history`)
+    회원 앱에서는 읽지 않는다. 회원의 운동 탭·홈 대시보드 주간 집계는 전부
+    `ExerciseSession` 에서 나오므로, 두 곳 모두에 남겨야 회원이 받은 PT 가
+    자기 기록에 잡힌다. (#499)
+    """
+    ex_type = _SESSION_EXERCISE_TYPE.get(s.type)
+    if s.member_id is None or ex_type is None or s.duration_minutes <= 0:
+        return None
+    row = ExerciseSession(
+        id=_derived_exercise_id(s.id),
+        user_id=s.member_id,
+        # 주차·요일은 완료 시점이 아니라 **세션 날짜** 기준이다. 지난 주 세션을
+        # 오늘 완료 처리해도 그 주의 집계로 들어가야 한다.
+        week_start=exercise_service.monday_of_str(s.date),
+        day_label=exercise_service.weekday_label_of(s.date),
+        type=ex_type,
+        minutes=s.duration_minutes,
+        calories=exercise_service.estimate_calories(
+            ex_type, s.duration_minutes, _PT_INTENSITY
+        ),
+        intensity=_PT_INTENSITY,
+        source="trainer_pt",
+    )
+    db.add(row)
+    return row
+
+
 def complete_session(
     db: Session, trainer_id: str, session_id: str, note: str
 ) -> ScheduleSessionOut | None:
-    """예정→완료. 매칭된 회원이 있으면 운동기록(RoutineHistory)으로 적재해
-    '예약→수업→기록' 루프를 닫는다.
+    """예정→완료. 매칭된 회원이 있으면 트레이너 쪽 기록(RoutineHistory)과 회원 쪽
+    기록(ExerciseSession)으로 함께 적재해 '예약→수업→기록' 루프를 닫는다.
 
     - 소유 슬롯 아님 → None(404).
     - 공백/미래 일정 → ScheduleError(400).
     - 이미 완료 → 그대로 반환(멱등, 중복 기록 없음).
-    기록 id 는 슬롯 기준 결정론적(sched-hist-{id})이라 동시/재호출에도 중복되지 않는다.
+    두 기록 모두 id 가 슬롯 기준 결정론적이라 동시/재호출에도 중복되지 않는다.
     """
     s = _get_owned_session(db, trainer_id, session_id)
     if s is None:
@@ -764,6 +822,7 @@ def complete_session(
             exercises_json=json.dumps(exercises, ensure_ascii=False),
             trainer_note=note,
         ))
+        _add_member_exercise_log(db, s)
     db.commit()
     db.refresh(s)
     return _schedule_out(s)

--- a/backend/migrations/versions/0027_exercise_session_source.py
+++ b/backend/migrations/versions/0027_exercise_session_source.py
@@ -1,0 +1,41 @@
+"""운동 기록의 출처 표시
+
+트레이너가 PT 세션을 완료 처리하면 회원 쪽 운동 기록(`exercise_sessions`)이
+파생 생성된다(#499). 그 기록은 근거가 트레이너에게 있어 회원이 수정·삭제할 수
+없고 화면에서도 수기 입력과 구분돼야 하는데, 지금 스키마로는 둘을 구별할 방법이
+없다.
+
+기존 행은 전부 회원이 직접 남긴 것이므로 server_default 로 'member' 가 채워진다.
+백필 쿼리가 따로 필요 없다.
+
+Revision ID: 0027_exercise_source
+Revises: 0026_trainer_reservations
+Create Date: 2026-08-09
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0027_exercise_source"
+down_revision: str | Sequence[str] | None = "0026_trainer_reservations"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "exercise_sessions",
+        sa.Column(
+            "source",
+            sa.String(length=20),
+            server_default="member",
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("exercise_sessions", "source")

--- a/backend/tests/test_trainer_schedule.py
+++ b/backend/tests/test_trainer_schedule.py
@@ -457,3 +457,169 @@ def test_schedule_rejects_a_malformed_date(client):
         headers=_sched_auth(token),
     )
     assert r.status_code == 422
+
+
+# ---- PT 완료 → 회원 쪽 운동 기록 파생 (#499) ----
+
+def _member_h(client) -> dict:
+    """회원(user-jisu) 헤더. 시드가 demo_login_password 로 만든 계정."""
+    token = client.post(
+        "/v1/auth/login",
+        data={"username": "jisu@oncare.com", "password": "oncare123"},
+    ).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture()
+def make_pt_session(client):
+    """PT 세션을 만들고 테스트 끝에 지우는 팩토리.
+
+    정리하지 않으면 회원 이력이 테스트마다 쌓여, 최신 60건만 내려주는
+    `build_client_history` 의 상한에 닿는 순간 **다른 테스트**가 깨진다
+    (#484 와 같은 누적 데이터 취약성). 세션을 지우면 파생 기록도 함께
+    사라지므로 회원의 주간 집계도 원래대로 돌아온다.
+    """
+    created: list[tuple[str, str]] = []
+
+    def _make(token: str, **over) -> str:
+        body = {
+            "date": _today(), "time": "20:00", "client_name": "이지수",
+            "member_id": "user-jisu", "type": "1:1 PT", "duration_minutes": 60,
+        }
+        body.update(over)
+        r = client.post("/v1/trainer/schedule", json=body, headers=_h(token))
+        assert r.status_code == 201, r.text
+        sid = r.json()["id"]
+        created.append((sid, token))
+        return sid
+
+    yield _make
+
+    for sid, token in created:
+        client.delete(f"/v1/trainer/schedule/{sid}", headers=_h(token))
+
+
+def test_complete_session_adds_member_exercise_log(client, make_pt_session):
+    """PT 완료가 트레이너 이력뿐 아니라 **회원 쪽** 운동 기록으로도 잡힌다.
+
+    RoutineHistory 는 트레이너 화면 전용이라, 이것만으로는 회원의 운동 탭·홈
+    대시보드 주간 집계에 아무것도 늘지 않았다.
+    """
+    token = _tok(client)
+    mh = _member_h(client)
+
+    before = client.get("/v1/exercise/weeks/current", headers=mh).json()
+    sid = make_pt_session(token, time="20:05", duration_minutes=45)
+
+    done = client.post(f"/v1/trainer/schedule/{sid}/complete", json={}, headers=_h(token))
+    assert done.status_code == 200, done.text
+
+    after = client.get("/v1/exercise/weeks/current", headers=mh).json()
+    assert after["total_minutes"] == before["total_minutes"] + 45
+    # 칼로리는 회원 앱과 같은 표(strength=6kcal/분, moderate=1.0)로 추정한다.
+    assert after["total_calories"] == before["total_calories"] + 270
+
+    derived = [s for s in after["sessions"] if s["id"] == f"sched-ex-{sid}"]
+    assert len(derived) == 1
+    assert derived[0]["source"] == "trainer_pt"
+    assert derived[0]["type"] == "strength"
+
+
+def test_complete_session_exercise_log_is_idempotent(client, make_pt_session):
+    """재호출해도 회원 기록이 중복되지 않는다(결정론적 id)."""
+    token = _tok(client)
+    mh = _member_h(client)
+    sid = make_pt_session(token, time="20:10", duration_minutes=30)
+
+    client.post(f"/v1/trainer/schedule/{sid}/complete", json={}, headers=_h(token))
+    once = client.get("/v1/exercise/weeks/current", headers=mh).json()["total_minutes"]
+    client.post(f"/v1/trainer/schedule/{sid}/complete", json={}, headers=_h(token))
+    twice = client.get("/v1/exercise/weeks/current", headers=mh).json()["total_minutes"]
+
+    assert once == twice
+
+
+def test_completed_consultation_makes_no_exercise_log(client, db_session, make_pt_session):
+    """상담은 운동이 아니다 — 회원 주간 운동량으로 잡히면 집계가 거짓이 된다."""
+    from app.models import models
+
+    token = _tok(client)
+    sid = make_pt_session(token, time="20:15", type="상담", duration_minutes=30)
+    client.post(f"/v1/trainer/schedule/{sid}/complete", json={}, headers=_h(token))
+
+    db_session.expire_all()
+    assert db_session.get(models.ExerciseSession, f"sched-ex-{sid}") is None
+    # 트레이너 쪽 이력은 기존대로 남는다 — 이 변경은 회원 기록만 다룬다.
+    assert db_session.get(models.RoutineHistory, f"sched-hist-{sid}") is not None
+
+
+def test_past_session_lands_in_its_own_week(client, db_session, make_pt_session):
+    """지난 주 세션을 오늘 완료해도 그 주의 집계로 들어간다.
+
+    완료 시점의 월요일을 쓰면 지난 주 PT 가 이번 주 운동량으로 잡힌다.
+    """
+    from datetime import date, timedelta
+
+    from app.models import models
+
+    token = _tok(client)
+    past = date.today() - timedelta(days=9)
+    sid = make_pt_session(token, date=past.isoformat(), time="20:20")
+    client.post(f"/v1/trainer/schedule/{sid}/complete", json={}, headers=_h(token))
+
+    db_session.expire_all()
+    row = db_session.get(models.ExerciseSession, f"sched-ex-{sid}")
+    assert row is not None
+    assert row.week_start == (past - timedelta(days=past.weekday())).isoformat()
+    assert row.day_label == ["월", "화", "수", "목", "금", "토", "일"][past.weekday()]
+
+
+def test_delete_completed_session_removes_member_exercise_log(client, db_session, make_pt_session):
+    """세션을 지우면 회원 쪽 파생 기록도 사라진다 — 회원 집계에만 유령 PT 가 남지 않도록."""
+    from app.models import models
+
+    token = _tok(client)
+    sid = make_pt_session(token, time="20:25")
+    client.post(f"/v1/trainer/schedule/{sid}/complete", json={}, headers=_h(token))
+    db_session.expire_all()
+    assert db_session.get(models.ExerciseSession, f"sched-ex-{sid}") is not None
+
+    assert client.delete(f"/v1/trainer/schedule/{sid}", headers=_h(token)).status_code == 200
+    db_session.expire_all()
+    assert db_session.get(models.ExerciseSession, f"sched-ex-{sid}") is None
+
+
+def test_member_cannot_edit_or_delete_derived_log(client, make_pt_session):
+    """파생 기록의 근거는 트레이너에게 있다 — 회원이 고치면 리포트가 딛고 선 값이 흔들린다."""
+    token = _tok(client)
+    mh = _member_h(client)
+    sid = make_pt_session(token, time="20:30")
+    client.post(f"/v1/trainer/schedule/{sid}/complete", json={}, headers=_h(token))
+
+    ex_id = f"sched-ex-{sid}"
+    put = client.put(
+        f"/v1/exercise/sessions/{ex_id}",
+        json={"type": "cardio", "minutes": 5, "calories": 10, "intensity": "light"},
+        headers=mh,
+    )
+    assert put.status_code == 409, put.text
+    assert client.delete(f"/v1/exercise/sessions/{ex_id}", headers=mh).status_code == 409
+
+
+def test_member_own_log_still_editable(client):
+    """회원이 직접 남긴 기록은 그대로 수정·삭제된다(가드가 과잉 적용되지 않는다)."""
+    mh = _member_h(client)
+    sid = client.post(
+        "/v1/exercise/sessions",
+        json={"type": "cardio", "minutes": 20, "calories": 180, "day_label": "월"},
+        headers=mh,
+    ).json()["id"]
+
+    put = client.put(
+        f"/v1/exercise/sessions/{sid}",
+        json={"type": "cardio", "minutes": 25, "calories": 200, "intensity": "moderate"},
+        headers=mh,
+    )
+    assert put.status_code == 200, put.text
+    assert put.json()["source"] == "member"
+    assert client.delete(f"/v1/exercise/sessions/{sid}", headers=mh).status_code == 200

--- a/frontend/flutter/lib/features/exercise/domain/entities/exercise_week.dart
+++ b/frontend/flutter/lib/features/exercise/domain/entities/exercise_week.dart
@@ -35,6 +35,22 @@ ExerciseIntensity _exerciseIntensityFromString(String? s) =>
       orElse: () => ExerciseIntensity.moderate,
     );
 
+/// 이 기록을 누가 만들었는가.
+///
+/// [ExerciseSource.trainerPt] 는 트레이너가 PT 세션을 완료 처리해 서버가 파생시킨
+/// 기록이다(#499). 근거가 트레이너에게 있어 회원이 고칠 수 없고, 서버도 수정·삭제를
+/// 409 로 거절한다 — 화면에서 편집 동작을 감추는 것은 그 규칙을 앞당겨 보여주는 것뿐이다.
+enum ExerciseSource { member, trainerPt }
+
+/// 서버 계약값(`member`|`trainer_pt`) → [ExerciseSource].
+///
+/// 모르는 값과 누락은 [ExerciseSource.member] 로 떨어뜨린다. 이 필드를 모르는
+/// 예전 응답(그리고 데모/목 경로)에서 기록이 통째로 잠기면 안 된다.
+ExerciseSource _exerciseSourceFromString(String? s) => switch (s) {
+  'trainer_pt' => ExerciseSource.trainerPt,
+  _ => ExerciseSource.member,
+};
+
 class ExerciseSession {
   const ExerciseSession({
     this.id,
@@ -46,6 +62,7 @@ class ExerciseSession {
     this.dateLabel,
     this.timeLabel,
     this.items = const <String>[],
+    this.source = ExerciseSource.member,
   });
 
   final String? id;
@@ -70,6 +87,12 @@ class ExerciseSession {
   /// Optional; empty for the legacy mock rows.
   final List<String> items;
 
+  /// 기록의 출처. 기본값은 회원이 직접 남긴 것.
+  final ExerciseSource source;
+
+  /// 회원이 이 기록을 고칠 수 있는가. 트레이너가 완료 처리한 PT 기록은 불가.
+  bool get isEditable => source == ExerciseSource.member;
+
   factory ExerciseSession.fromJson(Map<String, Object?> json) =>
       ExerciseSession(
         id: json['id'] as String?,
@@ -83,6 +106,7 @@ class ExerciseSession {
         items: ((json['items'] as List<Object?>?) ?? const <Object?>[])
             .cast<String>()
             .toList(),
+        source: _exerciseSourceFromString(json['source'] as String?),
       );
 }
 

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/workout_record_tab.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/workout_record_tab.dart
@@ -174,7 +174,9 @@ class _Body extends ConsumerWidget {
         const SizedBox(height: AppSpacing.lg),
 
         for (final s in week.sessions) ...<Widget>[
-          if (s.id == null)
+          // 트레이너가 완료 처리한 PT 기록은 스와이프 삭제도 편집 시트도 열지
+          // 않는다. 서버가 409 로 거절하므로(#499) 열어 봐야 실패로 끝난다.
+          if (s.id == null || !s.isEditable)
             _SessionCard(session: s)
           else
             SwipeToDelete(
@@ -385,6 +387,30 @@ class _SessionCard extends StatelessWidget {
                         ),
                       ),
                     ),
+                    // 트레이너가 완료 처리해 들어온 기록임을 밝힌다. 이 배지가
+                    // 없으면 회원은 자기가 넣지 않은 기록이 왜 있는지 알 수 없고,
+                    // 눌러도 편집이 열리지 않는 이유도 설명되지 않는다.
+                    if (session.source == ExerciseSource.trainerPt) ...<Widget>[
+                      const SizedBox(width: 6),
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 8,
+                          vertical: 2,
+                        ),
+                        decoration: BoxDecoration(
+                          color: AppColors.primary.withValues(alpha: 0.12),
+                          borderRadius: const BorderRadius.all(AppRadius.pill),
+                        ),
+                        child: Text(
+                          AppLocalizations.of(context).exSourceTrainerPt,
+                          style: const TextStyle(
+                            fontSize: 12.5,
+                            fontWeight: FontWeight.w600,
+                            color: AppColors.primary,
+                          ),
+                        ),
+                      ),
+                    ],
                   ],
                 ),
               ),

--- a/frontend/flutter/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations.dart
@@ -1316,6 +1316,12 @@ abstract class AppLocalizations {
   /// **'Other'**
   String get exTypeOtherChip;
 
+  /// Badge on an exercise record the trainer created by completing a PT session. Read-only for the member.
+  ///
+  /// In en, this message translates to:
+  /// **'Trainer PT'**
+  String get exSourceTrainerPt;
+
   /// No description provided for @exLevelLight.
   ///
   /// In en, this message translates to:

--- a/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
@@ -671,6 +671,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get exTypeOtherChip => 'Other';
 
   @override
+  String get exSourceTrainerPt => 'Trainer PT';
+
+  @override
   String get exLevelLight => 'Light';
 
   @override

--- a/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
@@ -663,6 +663,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get exTypeOtherChip => '기타';
 
   @override
+  String get exSourceTrainerPt => '트레이너 PT';
+
+  @override
   String get exLevelLight => '가벼움';
 
   @override

--- a/frontend/flutter/lib/l10n/app_en.arb
+++ b/frontend/flutter/lib/l10n/app_en.arb
@@ -342,6 +342,10 @@
   "exTypeStretching": "Stretching",
   "exTypeOther": "Exercise",
   "exTypeOtherChip": "Other",
+  "exSourceTrainerPt": "Trainer PT",
+  "@exSourceTrainerPt": {
+    "description": "Badge on an exercise record the trainer created by completing a PT session. Read-only for the member."
+  },
   "exLevelLight": "Light",
   "exLevelModerate": "Moderate",
   "exLevelHigh": "High",

--- a/frontend/flutter/lib/l10n/app_ko.arb
+++ b/frontend/flutter/lib/l10n/app_ko.arb
@@ -225,6 +225,7 @@
   "exTypeStretching": "스트레칭",
   "exTypeOther": "운동",
   "exTypeOtherChip": "기타",
+  "exSourceTrainerPt": "트레이너 PT",
   "exLevelLight": "가벼움",
   "exLevelModerate": "보통",
   "exLevelHigh": "높음",

--- a/frontend/flutter/test/features/exercise/exercise_week_test.dart
+++ b/frontend/flutter/test/features/exercise/exercise_week_test.dart
@@ -157,4 +157,39 @@ void main() {
     });
     expect(week.sessions.first.intensity, ExerciseIntensity.high);
   });
+
+  group('ExerciseSession.source (#499)', () {
+    ExerciseSession parse(Map<String, Object?> extra) =>
+        ExerciseSession.fromJson(<String, Object?>{
+          'id': 'ex-1',
+          'day_label': '월',
+          'type': 'strength',
+          'minutes': 60,
+          'calories': 360,
+          ...extra,
+        });
+
+    test('trainer_pt 기록은 회원이 고칠 수 없다', () {
+      final s = parse(<String, Object?>{'source': 'trainer_pt'});
+      expect(s.source, ExerciseSource.trainerPt);
+      expect(s.isEditable, isFalse);
+    });
+
+    test('회원이 남긴 기록은 그대로 편집 가능하다', () {
+      final s = parse(<String, Object?>{'source': 'member'});
+      expect(s.source, ExerciseSource.member);
+      expect(s.isEditable, isTrue);
+    });
+
+    test('필드가 없거나 모르는 값이면 회원 기록으로 본다', () {
+      // 이 필드를 모르는 예전 응답과 데모/목 경로에서 기록이 통째로
+      // 잠기면 안 된다 — 안전한 쪽은 '편집 가능'이다.
+      expect(parse(<String, Object?>{}).isEditable, isTrue);
+      expect(
+        parse(<String, Object?>{'source': 'something-new'}).isEditable,
+        isTrue,
+      );
+    });
+  });
+
 }

--- a/frontend/flutter/test/features/exercise/workout_record_source_test.dart
+++ b/frontend/flutter/test/features/exercise/workout_record_source_test.dart
@@ -1,0 +1,100 @@
+/// 트레이너가 완료 처리한 PT 기록의 화면 규칙. (#499)
+///
+/// 서버가 파생시킨 기록은 회원이 고칠 수 없고(PUT/DELETE 409), 화면은 그 규칙을
+/// 앞당겨 보여준다 — 배지를 붙이고 편집·스와이프 삭제를 감춘다. 눌러도 실패로
+/// 끝나는 동작을 열어 두면 회원은 자기 앱이 고장 난 것으로 읽는다.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
+import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
+import 'package:oncare/features/exercise/presentation/widgets/workout_record_tab.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+import 'package:oncare/shared/widgets/swipe_to_delete.dart';
+
+const AppConfig _config = AppConfig(
+  environment: Environment.dev,
+  apiBaseUrl: 'https://dev.api.test',
+  useMockApi: true,
+);
+
+ExerciseWeek _weekWith(List<ExerciseSession> sessions) => ExerciseWeek(
+  sessions: sessions,
+  dailyMinutes: const <double>[60, 0, 0, 0, 0, 0, 0],
+  dayLabels: const <String>['월', '화', '수', '목', '금', '토', '일'],
+  totalMinutes: 60,
+  totalCalories: 360,
+  streakDays: 1,
+  aiCoachMessage: '이번 주도 좋아요',
+);
+
+const ExerciseSession _memberLog = ExerciseSession(
+  id: 'ex-own',
+  dayLabel: '월',
+  type: ExerciseType.cardio,
+  minutes: 30,
+  calories: 270,
+);
+
+const ExerciseSession _trainerLog = ExerciseSession(
+  id: 'sched-ex-1',
+  dayLabel: '월',
+  type: ExerciseType.strength,
+  minutes: 60,
+  calories: 360,
+  source: ExerciseSource.trainerPt,
+);
+
+Future<void> _pump(WidgetTester tester, List<ExerciseSession> sessions) async {
+  // 세션 카드는 차트·통계 아래에 쌓인다. 기본 테스트 창(600dp)에서는 두 번째
+  // 카드가 뷰포트 밖이라 아예 빌드되지 않아, "없다" 와 "안 보인다" 가 구분되지
+  // 않는다. 목록 전체가 한 화면에 들어오도록 창을 키운다.
+  tester.view.physicalSize = const Size(1200, 3600);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        appConfigProvider.overrideWithValue(_config),
+        exerciseWeekProvider.overrideWith((ref) async => _weekWith(sessions)),
+      ],
+      child: const MaterialApp(
+        locale: Locale('ko'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(body: WorkoutRecordTab()),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('PT 파생 기록은 배지를 달고 스와이프 삭제를 열지 않는다', (
+    WidgetTester tester,
+  ) async {
+    await _pump(tester, const <ExerciseSession>[_trainerLog]);
+
+    expect(find.text('트레이너 PT'), findsOneWidget);
+    expect(find.byType(SwipeToDelete), findsNothing);
+  });
+
+  testWidgets('회원이 남긴 기록은 배지 없이 삭제·편집이 열린다', (WidgetTester tester) async {
+    await _pump(tester, const <ExerciseSession>[_memberLog]);
+
+    expect(find.text('트레이너 PT'), findsNothing);
+    expect(find.byType(SwipeToDelete), findsOneWidget);
+  });
+
+  testWidgets('둘이 섞여 있어도 회원 기록만 편집 가능하다', (WidgetTester tester) async {
+    await _pump(tester, const <ExerciseSession>[_trainerLog, _memberLog]);
+
+    // 배지는 파생 기록 하나에만, 스와이프 삭제는 회원 기록 하나에만 붙는다.
+    expect(find.text('트레이너 PT'), findsOneWidget);
+    expect(find.byType(SwipeToDelete), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

* 트레이너가 PT 를 완료 처리하면 **회원의 운동 탭·홈 대시보드 주간 집계에도** 반영됩니다.
* 파생 기록은 '트레이너 PT' 배지가 붙고, 회원은 고칠 수 없습니다(서버가 409 로 거절).
* 데모(둘러보기) 화면은 지금과 동일합니다 — 데모에는 트레이너가 없어 파생 기록이 생기지 않습니다.

---

## Changes

### ✨ Features

* `complete_session` 이 트레이너 이력(`RoutineHistory`)과 함께 회원 기록(`ExerciseSession`)도 적재합니다. 기존 조건부 전환 블록 안에서, 결정론적 id(`sched-ex-{session_id}`)로 — 동시·재호출에도 중복되지 않습니다.
* 세션을 삭제하면 파생된 회원 기록도 함께 사라집니다(트레이너 이력 정리와 같은 자리).
* 회원 앱이 파생 기록에 배지를 붙이고 편집·스와이프 삭제를 감춥니다.

### 🔒 규칙

* `exercise_sessions.source` 신설(`member`|`trainer_pt`). 파생 기록에 대한 회원의 `PUT`/`DELETE` 는 **409** 입니다 — 404 가 아닌 이유는 기록이 분명히 존재하고 화면에도 보이기 때문입니다. 없는 척하면 앱이 목록에서 사라진 줄 알고 잘못 갱신합니다.
* 마이그레이션 `0027`. 기존 행은 `server_default='member'` 로 채워져 백필이 필요 없습니다.

### 🧮 계산 규칙

* **주차·요일은 완료 시점이 아니라 세션 날짜 기준**입니다. 지난 주 세션을 오늘 완료해도 그 주의 집계로 들어갑니다.
* **상담은 기록을 만들지 않습니다.** 상담 한 시간이 주간 운동량으로 잡히면 집계가 거짓이 됩니다.
* 칼로리는 회원 앱 `_estimateCalories` 의 kcal/분 표를 서버로 옮겨 추정합니다. 수기 입력과 값이 갈리면 같은 운동인데 화면에서 달라 보입니다.

### 🧪 Tests

* 백엔드: 완료 → 기록 생성 / 멱등 / 상담 제외 / 지난 주 주차 / 세션 삭제 시 정리 / 회원 수정·삭제 409 / 회원 자기 기록은 그대로 편집 가능
* 회원 앱: `source` 파싱(누락·미지 값은 `member` 폴백) + 배지와 스와이프 삭제 노출 규칙

---

## Commits

1. a8d1cd0 feat(exercise): PT 완료를 회원 운동 기록에 자동 반영

---

## Notes

**이슈 본문을 착수 후 정정했습니다.**

#499 를 열 때 "PT 완료는 세션 상태만 바꾼다" 고 적었는데 사실이 아니었습니다. 완료는 이미 `RoutineHistory` 를 남기고 있었습니다. 다만 그것을 읽는 곳이 `GET /trainer/clients/{member_id}/history` 뿐이라 **트레이너 화면 전용**이고, 회원 앱에는 닿지 않았습니다. 빠져 있던 것은 회원 쪽 기록이며, 이 PR 은 그것만 채웁니다. 이슈 본문도 그에 맞게 고쳤습니다.

**범위를 좁힌 것**

* 루틴 배정은 그대로 둡니다 — 배정은 "할 예정" 이지 "했다" 가 아닙니다.
* `RoutineHistory` 를 회원에게 노출하지 않았습니다. 트레이너 화면 계약이라 별건입니다.
* 완료 되돌리기는 원래 없습니다(상태는 예정→완료 단방향). 그래서 정리 경로는 세션 삭제 하나입니다.

**읽기 전용으로 정한 이유**

파생 기록의 근거는 트레이너에게 있습니다. 회원이 분·칼로리를 고치면 트레이너 주간 리포트가 딛고 선 값이 흔들립니다. 지우려면 트레이너가 그 세션을 삭제해야 하고, 그러면 이 기록도 함께 사라집니다.

**테스트 픽스처 정리**

새 테스트가 회원 이력을 영구히 불리면 최신 60건만 내려주는 `build_client_history` 의 상한에 닿아 **다른 테스트**가 깨집니다(#484 와 같은 누적 데이터 취약성). PT 세션 픽스처가 만든 세션을 테스트 끝에 지웁니다.

**검증**

* 백엔드 `pytest`: 523 passed, 1 failed
* 실패한 `test_complete_session_logs_history_and_is_idempotent` 는 **이 브랜치 변경을 stash 하고 main 상태에서 돌려도 똑같이 실패**합니다. 로컬 DB 에 이전 실행들의 `sched-hist-*` 이력이 쌓여 60건 상한을 넘긴 상태라, CI(매번 새 Postgres)에서는 재현되지 않습니다. 이 PR 이 만든 회귀가 아닙니다.
* 회원 앱 `flutter analyze` 무이슈, `flutter test` 410 passed

Closes #499


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 완료된 트레이너 PT 세션에서 회원 운동 기록이 자동 생성됩니다.
  * 운동 기록에 생성 출처(회원 기록 또는 트레이너 PT)가 표시됩니다.
  * 주간 운동 시간, 요일, 강도 및 예상 칼로리가 자동으로 집계됩니다.

* **개선 사항**
  * 트레이너 PT에서 생성된 기록은 회원이 수정하거나 삭제할 수 없습니다.
  * 원본 PT 세션 삭제 시 연결된 운동 기록도 함께 삭제됩니다.
  * 기존 출처 정보가 없는 기록은 회원 기록으로 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->