### PR TITLE
fix(notification): 모바일 Safari 알림 화면 라이트 테마 고정

### DIFF
--- a/frontend/flutter/lib/features/notification/presentation/pages/notification_page.dart
+++ b/frontend/flutter/lib/features/notification/presentation/pages/notification_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:oncare/core/config/app_config.dart';
 import 'package:oncare/design_system/atoms/app_badge.dart';
 import 'package:oncare/design_system/atoms/app_card.dart';
+import 'package:oncare/design_system/theme/app_theme.dart';
 import 'package:oncare/design_system/tokens/spacing.dart';
 import 'package:oncare/features/notification/domain/entities/alert_item.dart';
 import 'package:oncare/features/notification/presentation/controllers/notification_controller.dart';
@@ -28,7 +29,7 @@ class NotificationPage extends ConsumerWidget {
     final state = ref.watch(notificationControllerProvider);
     final notifier = ref.read(notificationControllerProvider.notifier);
 
-    return Scaffold(
+    final Widget page = Scaffold(
       key: const Key('notificationPage'),
       appBar: AppBar(
         title: Text(l.pageNotificationTitle),
@@ -66,6 +67,9 @@ class NotificationPage extends ConsumerWidget {
             )
           : null,
     );
+    // The product currently has a light-only design. Keep this route on the
+    // shared light theme even when ThemeMode.system selects the dark theme.
+    return Theme(data: AppTheme.light(), child: page);
   }
 }
 

--- a/frontend/flutter/test/features/notification/notification_page_test.dart
+++ b/frontend/flutter/test/features/notification/notification_page_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/design_system/theme/app_theme.dart';
+import 'package:oncare/design_system/tokens/colors.dart';
+import 'package:oncare/features/notification/presentation/controllers/notification_controller.dart';
+import 'package:oncare/features/notification/presentation/pages/notification_page.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+const AppConfig _mockConfig = AppConfig(
+  environment: Environment.dev,
+  apiBaseUrl: 'https://dev.api.test',
+  useMockApi: true,
+);
+
+Future<void> _pumpNotificationPage(
+  WidgetTester tester,
+  Brightness platformBrightness,
+) async {
+  tester.platformDispatcher.platformBrightnessTestValue = platformBrightness;
+  addTearDown(
+    tester.platformDispatcher.clearPlatformBrightnessTestValue,
+  );
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[appConfigProvider.overrideWithValue(_mockConfig)],
+      child: MaterialApp(
+        theme: AppTheme.light(),
+        darkTheme: AppTheme.dark(),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: const NotificationPage(),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  for (final Brightness brightness in Brightness.values) {
+    testWidgets(
+      'notification page stays light in ${brightness.name} system mode',
+      (WidgetTester tester) async {
+        await _pumpNotificationPage(tester, brightness);
+
+        final BuildContext pageContext = tester.element(
+          find.byKey(const Key('notificationPage')),
+        );
+        final ThemeData theme = Theme.of(pageContext);
+
+        expect(theme.brightness, Brightness.light);
+        expect(theme.scaffoldBackgroundColor, AppColors.background);
+        expect(theme.colorScheme.onSurface, AppColors.foreground);
+        expect(theme.colorScheme.surfaceContainerHigh, AppColors.accent);
+        expect(find.text('나트륨 섭취 주의'), findsOneWidget);
+        expect(find.text('서비스 점검 안내'), findsOneWidget);
+        expect(find.text('Simulate push'), findsOneWidget);
+      },
+    );
+  }
+
+  testWidgets('notification actions still work inside the light theme', (
+    WidgetTester tester,
+  ) async {
+    await _pumpNotificationPage(tester, Brightness.dark);
+    final BuildContext pageContext = tester.element(
+      find.byKey(const Key('notificationPage')),
+    );
+    final ProviderContainer container = ProviderScope.containerOf(pageContext);
+
+    await tester.tap(find.text('Simulate push'));
+    await tester.pump();
+    expect(find.text('시뮬레이션 알림'), findsOneWidget);
+
+    await tester.tap(find.text('모두 읽음'));
+    await tester.pump();
+    expect(container.read(notificationControllerProvider).unreadCount, 0);
+  });
+}


### PR DESCRIPTION
## Summary

* 모바일 Safari에서 시스템 다크모드를 사용할 때 알림 화면만 어두워지는 문제를 수정했습니다.
* 알림 라우트에 기존 공통 `AppTheme.light()`를 국소 적용해 화면 전체가 라이트 디자인 토큰을 상속하도록 했습니다.
* 시스템 라이트·다크모드와 웹 렌더러에서 색상 및 기존 알림 동작을 검증하는 회귀 테스트를 추가했습니다.

---

## Changes

### ✨ Features

* 해당 없음

### 🔧 Improvements

* 알림 화면이 시스템 밝기 설정과 무관하게 동일한 라이트 테마를 유지하도록 개선

### 🎨 UI/UX

* 알림 화면 배경, AppBar, 카드, 제목·본문·시간 텍스트, badge, `모두 읽음`, `Simulate push` 영역에 기존 라이트 디자인 시스템 적용
* 개별 색상 하드코딩이나 전역 웹 CSS 변경 없이 `AppTheme.light()` 재사용

### 📝 Docs

* 해당 없음

### 🐛 Fixes

* `ThemeMode.system`이 선택한 다크 `ColorScheme`을 알림 화면이 그대로 상속하던 문제 수정

---

## Commits

1. `efccedb` fix(notification): 시스템 다크모드에서도 라이트 테마 유지

---

## Notes

* 웹 `index.html`에는 `prefers-color-scheme: dark`, `color-scheme: dark`, 다크 CSS 변수 또는 Tailwind `dark:` 적용이 없음을 확인했습니다.
* 열린 PR #509는 운동 기록 관련 파일만 수정하여 이번 PR과 파일·기능 범위가 겹치지 않습니다.
* 관련 열린 이슈 #474는 푸시 알림 발송 경로, #503은 트레이너 앱 알림함 신설로 이번 회원 앱 알림 화면 테마 수정과 범위가 겹치지 않습니다.
* 중복 또는 충돌 범위가 없어 다른 이슈·PR에는 별도 댓글을 남기지 않았습니다.
* 홈·식단·운동·MY 등 다른 화면과 전역 테마는 변경하지 않습니다.

---

## Screenshots (Optional)

| Before | After |
| ------ | ----- |
| 시스템 다크모드에서 알림 화면 전체가 어둡게 표시됨 (#508 첨부 화면) | 시스템 밝기와 무관하게 기존 라이트 디자인 유지 |

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 테마 확인
* [x] 웹 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 시스템 밝기를 라이트모드로 설정하고 알림 화면의 라이트 디자인을 확인합니다.
2. 시스템 밝기를 다크모드로 변경하고 알림 화면이 동일한 라이트 디자인을 유지하는지 확인합니다.
3. 알림 항목 읽음 처리, `모두 읽음`, 데모 모드 `Simulate push`를 실행합니다.

자동 검증:

* `dart analyze --fatal-infos`
* `flutter test test/features/notification/notification_controller_test.dart test/features/notification/notification_page_test.dart`
* `flutter test --platform chrome test/features/notification/notification_page_test.dart`
* `flutter build web --release`

---

## Related Issues

Closes #508

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 시스템이 다크 모드인 경우에도 알림 페이지가 라이트 테마로 일관되게 표시되도록 개선했습니다.

* **테스트**
  * 알림 페이지의 테마, 문구 및 색상 표시를 검증하는 테스트를 추가했습니다.
  * 푸시 알림 표시와 ‘모두 읽음’ 처리 후 읽지 않은 알림 수가 0으로 변경되는 동작을 검증합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->