### PR TITLE
feat(trainers): 회원 목표·거리 기반 트레이너 추천 점수 도입

### DIFF
--- a/backend/API_CONTRACT.md
+++ b/backend/API_CONTRACT.md
@@ -131,6 +131,19 @@ category: medical|fitness|healthy_food|pharmacy (생략 가능)
   카테고리로 태깅한다(공급자 간 의미 일치, 빈 category 없음).
 - **검증**: `lat`(-90~90)·`lng`(-180~180)·`category`(허용값)는 위반 시 **422**.
 
+### 트레이너 디렉터리 (회원앱 탐색)
+
+| Method | Path | 응답 |
+|---|---|---|
+| GET | `/trainers` | `[{ id, gym_id, name, role, reason, career, intro, certifications[] }]` |
+| GET | `/trainers/recommended` | 같은 형태 — 홈·운동 탭 추천 레일 |
+| GET | `/trainers/{trainer_id}` | 단건(없으면 404) |
+
+- **노출 조건**: 소속(`gym_id`)이 있고 그 장소가 `category='fitness'` 인 트레이너만. 상담 요청 시의 대상 검증과 같은 조건이라, 목록에 뜬 트레이너는 상담을 걸 수 있다. (#451)
+- **`/trainers/recommended` 순서**: 회원마다 다르다. 회원의 만성질환(`conditions`)·목표(`goals`)·가장 최근 상담의 `exercise_goal`·내 헬스장(`MemberGym`)을 신호로 점수를 매겨 내림차순 정렬한다. 동점은 경력 → id 로 갈라 같은 회원이 새로고침해도 순서가 흔들리지 않는다. (#500)
+- **신호가 없는 회원**(온보딩 전 등)은 운영자가 `recommend_reason` 을 적어 둔 트레이너만 **기존 순서 그대로** 받는다. 빈 목록을 주지 않는다.
+- **`reason`**: 운영자가 쓴 `recommend_reason` 이 우선이고, 비어 있을 때만 점수 근거에서 만든 문구가 채워진다(예: `회원님이 다니는 헬스장 소속 · 체중 감량 지도 경험`).
+
 ### 트레이너 도메인 / 회원측 코치 미러
 
 트레이너 앱 백엔드(`/v1/trainer/*`)와 회원측 "내 담당 코치" 미러(`/v1/me/coach/*`),

--- a/backend/app/api/v1/trainers.py
+++ b/backend/app/api/v1/trainers.py
@@ -33,11 +33,14 @@ def list_recommended_trainers(
     current_user: CurrentUser,
     db: Annotated[Session, Depends(get_db)],
 ) -> list[TrainerOut]:
-    """추천 사유가 붙은 트레이너만 — 홈·운동 탭의 추천 레일.
+    """홈·운동 탭의 추천 레일 — 회원의 목표·거리에 맞춰 줄 세운다. (#500)
+
+    신호가 없는 회원(온보딩 전 등)은 운영자가 사유를 적어 둔 트레이너만 기존
+    순서로 받는다.
 
     `/trainers/{trainer_id}` 보다 먼저 선언해야 "recommended" 가 id 로 잡히지 않는다.
     """
-    return gym_service.list_recommended_trainers(db)
+    return gym_service.list_recommended_trainers(db, current_user.id)
 
 
 @router.get("/trainers/{trainer_id}", response_model=TrainerOut)

--- a/backend/app/services/gym_service.py
+++ b/backend/app/services/gym_service.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import Session
 
 from app.models.models import GymProfile, MemberGym, Place, TrainerProfile, User
 from app.schemas.gym_api import GymOut, TrainerOut
+from app.services import trainer_recommendation
 
 
 def _haversine_m(lat1: float, lng1: float, lat2: float, lng2: float) -> int:
@@ -142,7 +143,9 @@ def unlink_member_gym(db: Session, member_id: str) -> bool:
     return True
 
 
-def _to_trainer(user: User, profile: TrainerProfile) -> TrainerOut:
+def _to_trainer(
+    user: User, profile: TrainerProfile, *, generated_reason: str = ""
+) -> TrainerOut:
     try:
         certs = json.loads(profile.certifications_json or "[]")
     except json.JSONDecodeError:
@@ -152,7 +155,9 @@ def _to_trainer(user: User, profile: TrainerProfile) -> TrainerOut:
         gym_id=profile.gym_id,
         name=user.name,
         role=profile.specialty or None,
-        reason=profile.recommend_reason or None,
+        # 사람이 쓴 사유가 우선. 생성 문구는 그 자리가 비었을 때만 채운다 — 운영자가
+        # 적어 둔 문구가 자동 생성으로 덮이면 큐레이션이 무의미해진다. (#500)
+        reason=profile.recommend_reason or generated_reason or None,
         # 앱은 "7년" 문자열을 그대로 렌더한다. 0 이면 표시할 게 없으므로 None.
         career=f"{profile.career_years}년" if profile.career_years else None,
         intro=profile.intro or None,
@@ -199,10 +204,37 @@ def list_trainers(db: Session, *, gym_id: str | None = None) -> list[TrainerOut]
     return [_to_trainer(user, profile) for user, profile in db.execute(query)]
 
 
-def list_recommended_trainers(db: Session) -> list[TrainerOut]:
-    """추천 사유가 붙은 트레이너만. 사유가 비면 레일에 올리지 않는다."""
-    query = _trainer_query().where(TrainerProfile.recommend_reason != "")
-    return [_to_trainer(user, profile) for user, profile in db.execute(query)]
+def list_recommended_trainers(
+    db: Session, member_id: str | None = None
+) -> list[TrainerOut]:
+    """홈·운동 탭의 추천 레일.
+
+    `member_id` 가 있고 그 회원에게 쓸 신호가 있으면 **회원별로** 줄 세운다
+    (`trainer_recommendation`). 신호가 없으면 — 온보딩 전이거나 만성질환·상담
+    이력·내 헬스장이 모두 없는 회원 — 기존 동작 그대로, 운영자가 사유를 적어 둔
+    트레이너만 원래 순서로 돌려준다.
+
+    점수를 쓸 때 후보는 `큐레이션된 트레이너 ∪ 점수가 붙은 트레이너` 다. 큐레이션
+    목록만 재정렬하면 회원에게 맞는 트레이너가 사유가 없다는 이유만으로 영영
+    레일에 못 오르고, 반대로 점수만 쓰면 운영자가 올린 트레이너가 빠진다.
+
+    사유 문구는 **사람이 쓴 것이 우선**이다(`recommend_reason`). 생성 문구는 그
+    자리가 비었을 때만 채운다.
+    """
+    curated_only = _trainer_query().where(TrainerProfile.recommend_reason != "")
+    if member_id is None:
+        return [_to_trainer(user, profile) for user, profile in db.execute(curated_only)]
+
+    candidates = [(user, profile) for user, profile in db.execute(_trainer_query())]
+    ranked = trainer_recommendation.rank(db, member_id, candidates)
+    if not ranked:  # 신호 없음 → 기존 동작
+        return [_to_trainer(user, profile) for user, profile in db.execute(curated_only)]
+
+    return [
+        _to_trainer(user, profile, generated_reason=scored.reason)
+        for user, profile, scored in ranked
+        if profile.recommend_reason or scored.reason
+    ]
 
 
 def get_trainer(db: Session, trainer_id: str) -> TrainerOut | None:

--- a/backend/app/services/trainer_recommendation.py
+++ b/backend/app/services/trainer_recommendation.py
@@ -1,0 +1,258 @@
+"""회원 신호 기반 트레이너 추천 점수. (#500)
+
+`/trainers/recommended` 는 `TrainerProfile.recommend_reason` 이 비어 있지 않은
+행을 그대로 돌려줬다. 그 사유는 시드에 사람이 써 넣은 문자열이라 **어떤 회원이
+보든 같은 트레이너가 같은 순서로** 나왔다. README 가 말하는 "회원의 목표와 조건에
+맞춘 추천" 이 실제로는 고정 목록이었다.
+
+여기서 쓰는 신호는 전부 이미 DB 에 있다 — 새로 수집하는 것이 없다.
+
+  회원   `HealthProfile.conditions`(온보딩 만성질환) · `goals` ·
+         가장 최근 `ConsultationRequest.exercise_goal` · `MemberGym`(내 헬스장)
+  트레이너 `TrainerProfile.specialty` · `intro` · `career_years` ·
+         `gym_id` → `places.lat/lng`
+
+**왜 점수를 설명 가능하게 두는가.** 추천은 회원이 사람을 고르는 자리다. 순위가
+왜 이렇게 나왔는지 코드에서 답할 수 없으면 화면의 "추천" 이라는 말이 근거를 잃는다.
+그래서 가중치를 상수로 두고, 화면에 붙는 사유 문자열도 **점수를 만든 그 항목에서**
+생성한다.
+
+**한계(의도적).** 트레이너의 전문 분야는 `specialty`·`intro` 자유 텍스트뿐이라
+키워드 매칭에 기댄다. 트레이너 앱이 구조화된 전문 분야를 입력받게 되면 이 매칭은
+그 값을 보도록 바뀌어야 한다 — 그때까지의 근사다.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.models import (
+    ConsultationRequest,
+    HealthProfile,
+    MemberGym,
+    Place,
+    TrainerProfile,
+    User,
+)
+
+#: 가중치. 합이 100 이라 각 항목이 순위에 얼마나 기여하는지 눈으로 읽힌다.
+#:
+#: 같은 헬스장을 가장 크게 둔 이유: 회원이 이미 그곳에 다니고 있다는 뜻이라
+#: 실제로 만나서 지도받을 수 있다. 목표 일치가 그다음이고, 거리는 같은 헬스장이
+#: 아닐 때의 대체 신호다. 경력은 동점을 가르는 정도로만 둔다 — 경력이 길다고 이
+#: 회원에게 맞는 것은 아니다.
+#:
+#: **단일 항목이 아니라 합산이다.** 같은 헬스장이 최대 가중치지만 목표 일치와
+#: 거리의 합이 그것을 넘을 수 있다 — 1km 떨어진 목표 적합 트레이너가 같은
+#: 헬스장의 무관한 트레이너를 앞서는 것은 의도한 동작이다. "같은 헬스장이면 무조건
+#: 1등" 을 원한다면 이 값이 아니라 정렬 자체를 계층으로 바꿔야 한다.
+W_SAME_GYM = 40
+W_GOAL = 30
+W_DISTANCE = 25
+W_CAREER = 5
+
+#: 거리 점수가 0 이 되는 지점(km). 이보다 멀면 거리로는 가점이 없다.
+_DISTANCE_ZERO_KM = 10.0
+
+#: 경력 점수가 만점이 되는 연차. 이보다 길어도 더 오르지 않는다.
+_CAREER_FULL_YEARS = 10
+
+
+@dataclass(frozen=True)
+class _Need:
+    """회원의 관리 needs 하나 — 사유 문구용 라벨과 매칭용 동의어."""
+
+    label: str
+    keywords: tuple[str, ...]
+
+
+#: 온보딩 만성질환(`_conditionOptions`) → needs.
+_CONDITION_NEEDS: dict[str, _Need] = {
+    "고혈압": _Need("혈압 관리", ("혈압", "고혈압")),
+    "당뇨": _Need("혈당 관리", ("혈당", "당뇨")),
+    "고지혈증": _Need("대사 관리", ("콜레스테롤", "고지혈", "대사")),
+    "비만": _Need("체중 감량", ("체중", "감량", "다이어트")),
+}
+
+#: 상담 요청의 `exercise_goal`(Literal) → needs.
+_EXERCISE_GOAL_NEEDS: dict[str, _Need] = {
+    "weight_loss": _Need("체중 감량", ("체중", "감량", "다이어트")),
+    "strength": _Need("근력 향상", ("근력", "근육", "웨이트")),
+    "fitness": _Need("체력 강화", ("체력", "컨디셔닝")),
+    "posture": _Need("자세 교정", ("자세", "체형", "교정")),
+    "health": _Need("건강 관리", ("건강", "재활")),
+    # 'other' 는 무엇을 원하는지 알려주는 바가 없어 needs 로 만들지 않는다.
+}
+
+
+@dataclass
+class MemberSignals:
+    """추천에 쓸 회원 쪽 신호. 하나도 없으면 점수를 낼 수 없다."""
+
+    gym_id: str | None = None
+    lat: float | None = None
+    lng: float | None = None
+    needs: list[_Need] = field(default_factory=list)
+
+    @property
+    def is_empty(self) -> bool:
+        """점수를 낼 근거가 하나도 없는가.
+
+        온보딩 전이거나 만성질환·상담 이력·내 헬스장이 모두 없는 회원이다. 이때는
+        무엇을 기준으로 줄 세워도 근거가 없으므로 기존 동작으로 되돌린다.
+        """
+        return self.gym_id is None and self.lat is None and not self.needs
+
+
+def _haversine_km(lat1: float, lng1: float, lat2: float, lng2: float) -> float:
+    """두 좌표 사이 거리(km). `gym_service._haversine_m` 과 같은 계산."""
+    r = 6371.0
+    p1, p2 = math.radians(lat1), math.radians(lat2)
+    dp = math.radians(lat2 - lat1)
+    dl = math.radians(lng2 - lng1)
+    a = math.sin(dp / 2) ** 2 + math.cos(p1) * math.cos(p2) * math.sin(dl / 2) ** 2
+    return r * 2 * math.asin(math.sqrt(a))
+
+
+def _dedup(needs: list[_Need]) -> list[_Need]:
+    """같은 라벨의 needs 를 하나로. 비만(온보딩)과 weight_loss(상담)는 같은 것이다."""
+    seen: set[str] = set()
+    out: list[_Need] = []
+    for need in needs:
+        if need.label in seen:
+            continue
+        seen.add(need.label)
+        out.append(need)
+    return out
+
+
+def collect_member_signals(db: Session, member_id: str) -> MemberSignals:
+    """회원의 추천 신호를 모은다. 쿼리는 회원당 상수개."""
+    signals = MemberSignals()
+
+    profile = db.scalar(
+        select(HealthProfile).where(HealthProfile.user_id == member_id)
+    )
+    needs: list[_Need] = []
+    if profile is not None:
+        # conditions 는 앱이 ', ' 로 이어 보낸 만성질환 목록이다.
+        for token in (profile.conditions or "").split(","):
+            need = _CONDITION_NEEDS.get(token.strip())
+            if need is not None:
+                needs.append(need)
+        # goals 는 자유 서술이라 키워드가 그대로 들어 있으면 그 needs 로 본다.
+        goals_text = (profile.goals or "").strip()
+        if goals_text:
+            for need in (*_CONDITION_NEEDS.values(), *_EXERCISE_GOAL_NEEDS.values()):
+                if any(k in goals_text for k in need.keywords):
+                    needs.append(need)
+
+    # 가장 최근 상담 요청의 운동 목표 — 회원이 직접 고른 값이라 신뢰도가 높다.
+    goal = db.scalar(
+        select(ConsultationRequest.exercise_goal)
+        .where(ConsultationRequest.member_id == member_id)
+        .order_by(ConsultationRequest.id.desc())
+        .limit(1)
+    )
+    if goal is not None:
+        need = _EXERCISE_GOAL_NEEDS.get(goal)
+        if need is not None:
+            needs.append(need)
+
+    signals.needs = _dedup(needs)
+
+    gym_id = db.scalar(select(MemberGym.gym_id).where(MemberGym.member_id == member_id))
+    if gym_id is not None:
+        signals.gym_id = gym_id
+        place = db.get(Place, gym_id)
+        if place is not None:
+            signals.lat, signals.lng = place.lat, place.lng
+    return signals
+
+
+@dataclass(frozen=True)
+class Scored:
+    """한 트레이너의 점수와 그 근거."""
+
+    score: float
+    #: 점수를 만든 항목에서 뽑은 사유 문구. 근거가 없으면 빈 문자열.
+    reason: str
+
+
+def score_trainer(
+    signals: MemberSignals,
+    profile: TrainerProfile,
+    gym: Place | None,
+) -> Scored:
+    """회원 신호에 대한 트레이너 적합도. 0~100."""
+    score = 0.0
+    reasons: list[str] = []
+
+    if signals.gym_id is not None and profile.gym_id == signals.gym_id:
+        score += W_SAME_GYM
+        reasons.append("회원님이 다니는 헬스장 소속")
+    elif (
+        signals.lat is not None
+        and signals.lng is not None
+        and gym is not None
+        and gym.lat is not None
+        and gym.lng is not None
+    ):
+        km = _haversine_km(signals.lat, signals.lng, gym.lat, gym.lng)
+        if km < _DISTANCE_ZERO_KM:
+            score += W_DISTANCE * (1 - km / _DISTANCE_ZERO_KM)
+            reasons.append(f"{km:.1f}km 거리")
+
+    if signals.needs:
+        # 전문 분야와 소개글을 함께 본다 — 시드처럼 specialty 가 '퍼스널 트레이너'
+        # 로 일반적이고 실제 강점은 intro 에 적혀 있는 경우가 많다.
+        haystack = f"{profile.specialty or ''} {profile.intro or ''}"
+        matched = [
+            need for need in signals.needs
+            if any(k in haystack for k in need.keywords)
+        ]
+        if matched:
+            score += W_GOAL * len(matched) / len(signals.needs)
+            reasons.append(f"{matched[0].label} 지도 경험")
+
+    years = max(profile.career_years or 0, 0)
+    score += W_CAREER * min(years, _CAREER_FULL_YEARS) / _CAREER_FULL_YEARS
+
+    # 경력만으로는 사유가 되지 않는다 — 모든 트레이너에 붙어 회원에게 아무것도
+    # 알려주지 못한다. 회원과 이어지는 근거가 하나라도 있을 때만 문구를 만든다.
+    return Scored(score=score, reason=" · ".join(reasons[:2]))
+
+
+def rank(
+    db: Session,
+    member_id: str,
+    candidates: list[tuple[User, TrainerProfile]],
+) -> list[tuple[User, TrainerProfile, Scored]]:
+    """후보를 회원 적합도 순으로. 신호가 없으면 빈 리스트(호출부가 폴백).
+
+    정렬은 점수 내림차순이고, 동점은 **경력 → id** 로 갈라 같은 입력에 늘 같은
+    순서가 나오게 한다. 동점 순서가 흔들리면 새로고침마다 추천 레일이 바뀐다.
+    """
+    signals = collect_member_signals(db, member_id)
+    if signals.is_empty:
+        return []
+
+    gym_ids = {p.gym_id for _, p in candidates if p.gym_id is not None}
+    gyms: dict[str, Place] = {}
+    if gym_ids:
+        gyms = {
+            place.id: place
+            for place in db.scalars(select(Place).where(Place.id.in_(gym_ids))).all()
+        }
+
+    scored = [
+        (user, profile, score_trainer(signals, profile, gyms.get(profile.gym_id or "")))
+        for user, profile in candidates
+    ]
+    scored.sort(
+        key=lambda row: (-row[2].score, -(row[1].career_years or 0), row[0].id)
+    )
+    return scored

--- a/backend/tests/test_trainer_recommendation.py
+++ b/backend/tests/test_trainer_recommendation.py
@@ -1,0 +1,153 @@
+"""회원 신호 기반 트레이너 추천 순위. (#500) DB 필요.
+
+전에는 `/trainers/recommended` 가 `recommend_reason` 이 비지 않은 행을 그대로
+돌려줘 **어떤 회원이 보든 같은 순서**였다. 여기서 확인하는 것은 두 가지다 —
+목표가 다르면 순서가 달라지는가, 그리고 신호가 없는 회원이 빈 화면을 보지 않는가.
+"""
+from __future__ import annotations
+
+from uuid import uuid4
+
+
+def _register(client, **onboarding) -> dict:
+    """새 회원을 만들고 온보딩까지 마친 뒤 인증 헤더를 준다."""
+    email = f"rec-{uuid4().hex[:8]}@oncare.com"
+    client.post(
+        "/v1/auth/register", json={"email": email, "password": "pw!", "name": "u"}
+    )
+    token = client.post(
+        "/v1/auth/login", data={"username": email, "password": "pw!"}
+    ).json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+    if onboarding:
+        r = client.post("/v1/users/me/onboarding", json=onboarding, headers=headers)
+        assert r.status_code == 200, r.text
+    return headers
+
+
+def _ids(client, headers) -> list[str]:
+    r = client.get("/v1/trainers/recommended", headers=headers)
+    assert r.status_code == 200, r.text
+    return [t["id"] for t in r.json()]
+
+
+def _rank_of(ids: list[str], trainer_id: str) -> int:
+    assert trainer_id in ids, f"{trainer_id} 가 추천 목록에 없다: {ids}"
+    return ids.index(trainer_id)
+
+
+def test_goals_change_the_order(client):
+    """목표가 다른 두 회원은 다른 순서를 받는다 — 이 이슈의 본질."""
+    slimming = _register(client, conditions="비만")
+    strength = _register(client, goals="근력을 키우고 싶어요")
+
+    slimming_ids = _ids(client, slimming)
+    strength_ids = _ids(client, strength)
+
+    assert slimming_ids != strength_ids, "회원이 달라도 순서가 같으면 추천이 아니다"
+
+    # 감량 정체기를 다루는 정트레이너는 '비만' 회원 쪽에서 더 앞이어야 한다.
+    assert _rank_of(slimming_ids, "trainer-demo-jung") < _rank_of(
+        strength_ids, "trainer-demo-jung"
+    )
+    # 근력 전문 윤트레이너는 반대로 '근력' 회원 쪽에서 더 앞이다.
+    assert _rank_of(strength_ids, "trainer-yoon") < _rank_of(
+        slimming_ids, "trainer-yoon"
+    )
+
+
+def test_matched_trainer_outranks_unmatched(client):
+    """목표가 맞는 트레이너가 맞지 않는 트레이너보다 앞선다."""
+    headers = _register(client, conditions="비만")
+    ids = _ids(client, headers)
+
+    # 감량을 다루는 정트레이너 vs 시니어 균형 운동을 다루는 조트레이너.
+    assert _rank_of(ids, "trainer-demo-jung") < _rank_of(ids, "trainer-cho")
+
+
+def test_member_without_signals_still_gets_the_rail(client):
+    """온보딩 전 회원도 빈 화면을 보지 않는다 — 기존 큐레이션 목록으로 폴백."""
+    headers = _register(client)  # 온보딩 없음
+    ids = _ids(client, headers)
+
+    assert ids, "신호가 없다고 추천 레일이 비면 홈 화면에 구멍이 난다"
+    # 폴백은 '사유가 있는 트레이너' 라는 기존 조건 그대로다.
+    body = client.get("/v1/trainers/recommended", headers=headers).json()
+    assert all(t["reason"] for t in body)
+
+
+def test_curated_reason_is_not_overwritten(client):
+    """사람이 쓴 사유가 자동 생성 문구로 덮이지 않는다."""
+    headers = _register(client, conditions="비만")
+    body = client.get("/v1/trainers/recommended", headers=headers).json()
+
+    jung = next(t for t in body if t["id"] == "trainer-demo-jung")
+    assert jung["reason"] == "감량 정체기 식사·운동량 재조정"
+
+
+def test_generated_reason_fills_an_empty_one(client, db_session):
+    """큐레이션 사유가 없는 트레이너는 점수 근거에서 만든 문구를 받는다."""
+    from sqlalchemy import select
+
+    from app.models import models
+
+    yoon = db_session.scalar(
+        select(models.TrainerProfile).where(
+            models.TrainerProfile.trainer_id == "trainer-yoon"
+        )
+    )
+    original = yoon.recommend_reason
+    yoon.recommend_reason = ""
+    db_session.commit()
+    try:
+        headers = _register(client, goals="근력을 키우고 싶어요")
+        body = client.get("/v1/trainers/recommended", headers=headers).json()
+        entry = next((t for t in body if t["id"] == "trainer-yoon"), None)
+        assert entry is not None, "점수가 붙었으면 사유가 비어도 레일에 오른다"
+        assert entry["reason"], "생성 문구가 비면 화면에 근거가 사라진다"
+        assert "근력" in entry["reason"]
+    finally:
+        yoon.recommend_reason = original
+        db_session.commit()
+
+
+def test_joining_a_gym_lifts_its_trainers(client, db_session):
+    """내 헬스장 소속이면 순위가 올라간다.
+
+    같은 헬스장은 단일 항목으로는 가장 큰 가중치지만 **점수는 blend** 라, 목표가
+    맞는 근처 트레이너가 같은 헬스장의 무관한 트레이너를 앞설 수 있다. 그건 의도한
+    동작이다 — 1km 떨어진 전문가가 실제로 더 나은 추천일 수 있다. 그래서 "무조건
+    1등" 이 아니라 **다른 조건을 고정했을 때 순위가 오르는가** 로 확인한다.
+    """
+    from sqlalchemy import select
+
+    from app.models import models
+
+    headers = _register(client, conditions="비만")
+    me = client.get("/v1/users/me", headers=headers).json()["id"]
+
+    # 감량과 무관하고 경력도 짧아 원래 하위인 한트레이너로 확인한다. 이미 상위인
+    # 트레이너를 쓰면 가점을 받아도 순위가 그대로일 수 있어(위쪽이 더 높음) 신호가
+    # 살아 있는지 구분되지 않는다.
+    target = "trainer-demo-han"
+    before = _rank_of(_ids(client, headers), target)
+
+    profile = db_session.scalar(
+        select(models.TrainerProfile).where(
+            models.TrainerProfile.trainer_id == target
+        )
+    )
+    db_session.add(models.MemberGym(member_id=me, gym_id=profile.gym_id))
+    db_session.commit()
+    try:
+        after = _rank_of(_ids(client, headers), target)
+        assert after < before, "내 헬스장 소속인데 순위가 그대로면 신호가 죽은 것"
+    finally:
+        db_session.query(models.MemberGym).filter_by(member_id=me).delete()
+        db_session.commit()
+
+
+def test_order_is_stable_across_calls(client):
+    """같은 회원은 새로고침해도 같은 순서를 본다(동점 정렬이 결정적)."""
+    headers = _register(client, conditions="비만")
+    assert _ids(client, headers) == _ids(client, headers)


### PR DESCRIPTION
## Summary

* `/trainers/recommended` 가 **회원마다 다른 순서**를 돌려줍니다. 전에는 어떤 회원이 보든 같은 트레이너가 같은 순서였습니다.
* 새로 수집하는 데이터가 없습니다 — 이미 DB 에 있는 신호만 씁니다.
* 프론트 변경 없음. 앱은 지금도 `reason` 을 렌더합니다.
* 신호가 없는 회원은 **기존 동작 그대로**입니다.

---

## Changes

### ✨ Features

* `trainer_recommendation` 서비스 신설 — 회원 신호 수집 → 트레이너별 점수 → 정렬.
* 쓰는 신호: 회원의 `conditions`(온보딩 만성질환)·`goals`·가장 최근 상담의 `exercise_goal`·`MemberGym`(내 헬스장) / 트레이너의 `specialty`·`intro`·`career_years`·소속 헬스장 좌표.
* 사유 문구를 **점수를 만든 그 항목에서** 생성합니다(예: `회원님이 다니는 헬스장 소속 · 체중 감량 지도 경험`).

### 🧭 규칙

* **후보는 `큐레이션 ∪ 점수가 붙은 트레이너`** 입니다. 큐레이션 목록만 재정렬하면 회원에게 맞는 트레이너가 사유가 없다는 이유만으로 영영 레일에 못 오르고, 점수만 쓰면 운영자가 올린 트레이너가 빠집니다.
* **사람이 쓴 사유가 우선**입니다. 생성 문구는 `recommend_reason` 이 빈 자리만 채웁니다 — 자동 생성이 큐레이션을 덮으면 큐레이션이 무의미해집니다.
* **신호가 없는 회원은 폴백**합니다(온보딩 전, 만성질환·상담 이력·내 헬스장이 모두 없음). 무엇을 기준으로 줄 세워도 근거가 없으므로 기존 큐레이션 목록을 원래 순서로 줍니다. 빈 목록을 주지 않습니다.
* **동점은 경력 → id** 로 가릅니다. 동점 순서가 흔들리면 새로고침마다 추천 레일이 바뀝니다.

### 📊 가중치

같은 헬스장 40 · 목표 일치 30 · 거리 25 · 경력 5 (합 100). 상수로 두고 고른 이유를 주석에 남겼습니다.

### 🧪 Tests

* 목표가 다른 두 회원이 **다른 순서**를 받는다 (이 이슈의 본질)
* 목표가 맞는 트레이너가 맞지 않는 트레이너보다 앞선다
* 신호 없는 회원도 레일이 비지 않고, 폴백은 기존 조건 그대로다
* 큐레이션 사유가 덮이지 않는다 / 빈 사유는 생성 문구로 채워진다
* 내 헬스장에 연결하면 그 소속 트레이너의 순위가 오른다
* 같은 회원은 새로고침해도 같은 순서를 본다

---

## Commits

1. 318142c feat(trainers): 회원 목표·거리 기반 트레이너 추천 점수 도입

---

## Notes

**같은 헬스장이 "무조건 1등" 은 아닙니다 — 의도한 동작입니다.**

같은 헬스장이 최대 단일 가중치(40)지만 점수는 합산이라, 목표가 맞고 가까운 트레이너(30+25)가 같은 헬스장의 무관한 트레이너를 앞설 수 있습니다. 회원이 다니는 곳에 시니어 균형 운동 전문가만 있고 1km 옆에 체중 감량 전문가가 있다면 **후자가 실제로 더 나은 추천**이라고 봤습니다. "같은 헬스장이면 무조건 위" 를 원하면 가중치가 아니라 정렬을 계층으로 바꿔야 하고, 그 근거도 주석에 적어 뒀습니다.

이 판단 때문에 처음 쓴 테스트 하나를 고쳤습니다. "같은 헬스장이 먼 매칭을 이긴다" 고 단언했는데 설계가 보장하는 것보다 강한 주장이었고, 시드 헬스장이 전부 신촌 인근이라 '먼' 이 1~2km 였습니다. 점수를 왜곡해 테스트를 통과시키는 대신 **테스트를 실제 주장("내 헬스장 소속이면 순위가 오른다")으로** 바꿨습니다.

**알려진 한계 — 후속 과제**

트레이너의 전문 분야가 `specialty`·`intro` 자유 텍스트뿐이라 키워드 매칭에 기댑니다(시드처럼 `specialty` 가 '퍼스널 트레이너' 로 일반적이고 실제 강점은 `intro` 에 적힌 경우가 많아 둘을 함께 봅니다). 트레이너 앱이 **구조화된 전문 분야**를 입력받게 되면 이 매칭은 그 값을 보도록 바뀌어야 합니다. 트레이너 앱 입력 변경이 필요해 이 PR 범위 밖으로 뒀습니다.

거리 항목은 신촌 인근에 시드가 몰려 있어 후보 간 변별력이 크지 않습니다. 지역이 흩어지면 의미가 커집니다.

**검증**

* 백엔드 `pytest`: 523 passed, 1 failed
* 실패한 `test_complete_session_logs_history_and_is_idempotent` 는 이 브랜치와 무관합니다. 로컬 DB 에 이전 실행들의 `sched-hist-*` 이력이 쌓여 `build_client_history` 의 60건 상한을 넘긴 상태로, main 에서도 동일하게 실패하며 CI(매번 새 Postgres)에서는 재현되지 않습니다.

Closes #500
