### PR TITLE
feat(trainer-notification): 트레이너 앱 알림함 신설

### DIFF
--- a/backend/API_CONTRACT.md
+++ b/backend/API_CONTRACT.md
@@ -144,7 +144,22 @@ category: medical|fitness|healthy_food|pharmacy (생략 가능)
 - **취소 마감**: 슬롯 시작 시각까지. 이미 시작한 수업은 **409** — 자리를 비우는 게 아니라 기록을 지우는 일이라 트레이너가 판단할 몫입니다.
 - **남의 예약·없는 예약은 404** 로 같습니다. 존재 여부조차 드러내지 않습니다(상담 요청과 같은 규칙).
 - `cancellable` 은 **서버 판단**입니다. 앱이 자기 시계로 다시 계산하면 시각이 어긋난 기기에서 버튼은 눌리는데 서버가 409 를 주는 상태가 됩니다.
-- 취소는 트레이너에게 알림 행을 남깁니다(`notifications`). 트레이너가 그 행을 **읽는 경로는 아직 없습니다** — `/notifications` 는 회원 전용이라 트레이너는 403 입니다(#503).
+- 취소는 트레이너에게 알림 행을 남깁니다(`notifications`). 트레이너는 `/trainer/notifications` 로 읽습니다(#503).
+
+### 트레이너 알림함
+
+| Method | Path | 응답 |
+|---|---|---|
+| GET | `/trainer/notifications` | `[{ id, title, body, category, read, created_at, time_ago }]` (최신순, 최대 100건) |
+| GET | `/trainer/notifications/unread-count` | `{ unread(int) }` |
+| POST | `/trainer/notifications/{id}/read` | `{ id, read: true }` |
+| POST | `/trainer/notifications/read-all` | `{ marked_read(int) }` |
+
+- **회원용 `/notifications` 를 재사용하지 않습니다.** `get_current_user` 가 트레이너 계정을 **403** 으로 막는 회원 전용 경로입니다(역할 분리). 저장되는 행은 같은 `notifications` 테이블이고 `user_id` 가 일반 사용자 FK라 스키마 변경은 없습니다. (#503)
+- `category` 는 트레이너 전용 값입니다 — `message`|`consultation`|`reservation`. 회원 알림의 집합(`reminder|health_check|achievement|system`)과 겹치지 않습니다. 한 테이블을 공유하지만 읽는 화면과 이동할 곳이 다릅니다.
+- **생성 지점**: 회원의 새 메시지(`POST /me/coach/chat`), 새 상담 요청(`POST /consultations` — 트레이너 지정이면 그 사람, 헬스장이면 소속 트레이너 전원), 새 예약·예약 취소.
+- **수신 설정**: 메시지 알림만 `trainer_profiles.notify_new_message` 로 끌 수 있습니다. 상담 요청·예약은 끄는 스위치가 설정 화면에 없고, 놓쳐도 되는 종류가 아니라 항상 남깁니다.
+- 남의 알림 읽음 처리는 **404** 입니다.
 
 ### 트레이너 도메인 / 회원측 코치 미러
 

--- a/backend/app/api/v1/notifications.py
+++ b/backend/app/api/v1/notifications.py
@@ -40,18 +40,8 @@ def _action_for(category: str) -> NotificationAction | None:
     return _ACTION_BY_CATEGORY.get(category)
 
 
-def _time_ago(dt: datetime) -> str:
-    now = datetime.now(timezone.utc)
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    sec = (now - dt).total_seconds()
-    if sec < 60:
-        return "방금 전"
-    if sec < 3600:
-        return f"{int(sec // 60)}분 전"
-    if sec < 86400:
-        return f"{int(sec // 3600)}시간 전"
-    return f"{int(sec // 86400)}일 전"
+#: 회원·트레이너 알림함이 같은 문구를 써야 해서 서비스로 옮겼다. (#503)
+_time_ago = notification_service.time_ago
 
 
 @router.get("/notifications", response_model=list[NotificationOut])

--- a/backend/app/api/v1/trainer.py
+++ b/backend/app/api/v1/trainer.py
@@ -16,13 +16,13 @@ from datetime import datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import select
+from sqlalchemy import func, select, update
 from sqlalchemy.orm import Session
 
 from app.api.deps import RequireTrainer
 from app.core.security import hash_password, verify_password
 from app.db.session import get_db
-from app.models.models import TrainerClient, TrainerProfile
+from app.models.models import Notification, TrainerClient, TrainerProfile
 from app.schemas.consultation_api import (
     ConsultationDecision,
     ConsultationStatusFilter,
@@ -34,7 +34,7 @@ from app.schemas.trainer_api import (
     RoutineOptionsOut, RoutineOptionsRequest,
     ScheduleCompleteRequest, ScheduleCreateRequest, ScheduleSessionOut, ScheduleUpdateRequest,
     TrainerClientOut, TrainerGymAffiliation, TrainerMe, TrainerMeUpdate,
-    TrainerNotificationSettings, TrainerNotificationSettingsUpdate,
+    TrainerNotificationOut, TrainerNotificationSettings, TrainerNotificationSettingsUpdate,
     TrainerPasswordChange, WeeklyReportOut,
 )
 from app.services import (
@@ -46,6 +46,10 @@ from app.services import (
 from app.services.coach.chat import answer as coach_answer
 
 router = APIRouter(tags=["trainer"])
+
+#: 알림함이 한 번에 내려주는 최대 건수. 회원 이력과 같은 이유로 상한을 둔다 —
+#: 오래된 알림 무제한 로드를 막는다.
+_NOTIFICATION_LIMIT = 100
 
 # 계약 형식은 정확히 YYYY-MM-DD. date.fromisoformat 는 3.11+ 에서 basic ISO·주 날짜도 받으므로
 # 정규식으로 먼저 좁힌 뒤 달력 유효성을 확인한다(schedule 라우트와 동일 규약).
@@ -642,3 +646,84 @@ def trainer_reject_consultation(
 ) -> TrainerConsultationOut:
     """상담을 거절한다. 사유는 회원 알림 본문에 그대로 실린다."""
     return _decide(consultation_service.reject, db, trainer.id, consultation_id, payload)
+
+
+# ---- 알림함 (#503) ----
+#
+# 회원용 `/notifications` 를 재사용할 수 없다 — `get_current_user` 가 트레이너
+# 계정을 403 으로 막는 **회원 전용** 경로다(역할 분리). 저장되는 행은 같은
+# `notifications` 테이블이고 `user_id` 가 일반 사용자 FK라 스키마 변경은 없다.
+
+def _notification_out(row: Notification) -> TrainerNotificationOut:
+    return TrainerNotificationOut(
+        id=row.id,
+        title=row.title,
+        body=row.body,
+        category=row.category,
+        read=row.read,
+        created_at=row.created_at,
+        time_ago=notification_service.time_ago(row.created_at),
+    )
+
+
+@router.get("/trainer/notifications", response_model=list[TrainerNotificationOut])
+def trainer_notifications(
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> list[TrainerNotificationOut]:
+    """트레이너가 받은 알림(최신순)."""
+    rows = db.scalars(
+        select(Notification)
+        .where(Notification.user_id == trainer.id)
+        .order_by(Notification.created_at.desc())
+        .limit(_NOTIFICATION_LIMIT)
+    ).all()
+    return [_notification_out(row) for row in rows]
+
+
+@router.get("/trainer/notifications/unread-count", response_model=dict)
+def trainer_unread_notifications(
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> dict:
+    """사이드바 배지가 읽는 값."""
+    count = db.scalar(
+        select(func.count())
+        .select_from(Notification)
+        .where(Notification.user_id == trainer.id, Notification.read.is_(False))
+    )
+    return {"unread": int(count or 0)}
+
+
+@router.post("/trainer/notifications/read-all")
+def trainer_read_all_notifications(
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> dict:
+    marked = db.execute(
+        update(Notification)
+        .where(Notification.user_id == trainer.id, Notification.read.is_(False))
+        .values(read=True)
+    ).rowcount
+    db.commit()
+    return {"marked_read": int(marked or 0)}
+
+
+@router.post("/trainer/notifications/{notification_id}/read")
+def trainer_read_notification(
+    notification_id: str,
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> dict:
+    row = db.scalar(
+        select(Notification).where(
+            Notification.id == notification_id,
+            # 남의 알림은 존재조차 드러내지 않는다.
+            Notification.user_id == trainer.id,
+        )
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="알림을 찾을 수 없습니다.")
+    row.read = True
+    db.commit()
+    return {"id": row.id, "read": True}

--- a/backend/app/schemas/trainer_api.py
+++ b/backend/app/schemas/trainer_api.py
@@ -378,6 +378,23 @@ class TrainerPasswordChange(BaseModel):
 REMINDER_LEAD_OPTIONS: tuple[int, ...] = (10, 30, 60)
 
 
+class TrainerNotificationOut(BaseModel):
+    """트레이너 알림함 항목. (#503)
+
+    `category` 는 회원 알림의 집합(reminder|health_check|achievement|system)이 아니라
+    트레이너 전용 값이다 — `message`|`consultation`|`reservation`. 한 테이블을
+    공유하지만 읽는 화면과 이동할 곳이 다르다.
+    """
+
+    id: str
+    title: str
+    body: str
+    category: str
+    read: bool
+    created_at: _datetime
+    time_ago: str
+
+
 class TrainerNotificationSettings(BaseModel):
     """트레이너 알림 수신 설정."""
     notify_new_message: bool

--- a/backend/app/services/consultation_service.py
+++ b/backend/app/services/consultation_service.py
@@ -22,6 +22,7 @@ from app.schemas.consultation_api import (
     ConsultationStatusFilter,
     TrainerConsultationOut,
 )
+from app.services import notification_service
 
 
 class InvalidConsultationRequest(Exception):
@@ -124,6 +125,7 @@ def create_consultation(
         status="pending",
     )
     db.add(consultation)
+    _notify_trainers_of_new_request(db, consultation, member_id)
     try:
         db.commit()
     except IntegrityError:
@@ -135,6 +137,39 @@ def create_consultation(
         raise
     db.refresh(consultation)
     return attach_target_names(db, [consultation])[0]
+
+
+def _notify_trainers_of_new_request(
+    db: Session, consultation: ConsultationRequest, member_id: str
+) -> None:
+    """새 상담 요청을 받을 트레이너(들)에게 알림을 남긴다. 커밋은 호출자가 한다. (#503)
+
+    대상이 트레이너면 그 사람에게만, 헬스장이면 **그 헬스장 소속 트레이너 전원**에게
+    남긴다 — 헬스장으로 온 요청은 소속 누구나 받을 수 있고(#467), 아무에게도
+    알리지 않으면 인박스를 열어 보는 사람만 우연히 발견하게 된다.
+    """
+    if consultation.trainer_id is not None:
+        trainer_ids = [consultation.trainer_id]
+    elif consultation.gym_id is not None:
+        trainer_ids = list(
+            db.scalars(
+                select(TrainerProfile.trainer_id).where(
+                    TrainerProfile.gym_id == consultation.gym_id
+                )
+            ).all()
+        )
+    else:
+        return
+
+    member_name = db.scalar(select(User.name).where(User.id == member_id)) or "회원"
+    for trainer_id in trainer_ids:
+        notification_service.queue_for_trainer(
+            db,
+            trainer_id=trainer_id,
+            kind=notification_service.TRAINER_CONSULTATION_KIND,
+            title="새 상담 요청이 도착했어요",
+            body=f"{member_name} 회원 · {consultation.preferred_date}",
+        )
 
 
 def attach_target_names(db: Session, rows: list[ConsultationRequest]) -> list[ConsultationOut]:

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -11,11 +11,16 @@
 from __future__ import annotations
 
 import uuid
+from datetime import datetime, timezone
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.models.models import MemberNotificationSetting, Notification
+from app.models.models import (
+    MemberNotificationSetting,
+    Notification,
+    TrainerProfile,
+)
 
 #: 알림 종류 → 회원 설정 키. 키는 사용자 앱이 이미 쓰던 것 그대로다
 #: (`my_flows.dart` 의 `_notifItems`) — 앱이 로컬에 저장하던 값을 서버로 옮기는
@@ -44,6 +49,21 @@ _CATEGORY: dict[str, str] = {
     DIET_LOG: "reminder",
     AI_COACHING: "system",
 }
+
+
+def time_ago(dt: datetime) -> str:
+    """알림 목록의 상대 시각 문구. 회원·트레이너 알림함이 함께 쓴다. (#503)"""
+    now = datetime.now(timezone.utc)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    sec = (now - dt).total_seconds()
+    if sec < 60:
+        return "방금 전"
+    if sec < 3600:
+        return f"{int(sec // 60)}분 전"
+    if sec < 86400:
+        return f"{int(sec // 3600)}시간 전"
+    return f"{int(sec // 86400)}일 전"
 
 
 def get_settings(db: Session, member_id: str) -> dict[str, bool]:
@@ -158,31 +178,65 @@ def unread_count(db: Session, member_id: str) -> int:
     return len(rows)
 
 
+#: 트레이너 알림의 종류. `Notification.category` 에 그대로 저장되고, 트레이너 앱이
+#: 이 값으로 어디로 이동할지 정한다. 회원 알림의 category 집합
+#: (reminder|health_check|achievement|system)과 겹치지 않게 둔다 — 한 컬럼을
+#: 공유하지만 읽는 화면이 다르다. (#503)
+TRAINER_MESSAGE_KIND = "message"
+TRAINER_CONSULTATION_KIND = "consultation"
+TRAINER_RESERVATION_KIND = "reservation"
+
+#: 종류별 트레이너 수신 설정 컬럼. 없으면 항상 보낸다 — 상담 요청·예약은 끄면
+#: 트레이너가 놓쳐도 되는 종류가 아니고, 설정 화면에도 그 스위치가 없다.
+_TRAINER_SETTING_COLUMN: dict[str, str] = {
+    TRAINER_MESSAGE_KIND: "notify_new_message",
+}
+
+
+def trainer_wants(db: Session, trainer_id: str, kind: str) -> bool:
+    """트레이너가 이 종류의 알림을 받기로 했는가.
+
+    회원용 [wants] 와 갈라 두는 이유는 설정이 있는 자리가 다르기 때문이다.
+    회원은 `member_notification_settings`, 트레이너는 `trainer_profiles.notify_*`.
+    한쪽 함수로 둘 다 보면 트레이너에게 회원 기본값이 적용된다.
+    """
+    column = _TRAINER_SETTING_COLUMN.get(kind)
+    if column is None:
+        return True
+    value = db.scalar(
+        select(getattr(TrainerProfile, column)).where(
+            TrainerProfile.trainer_id == trainer_id
+        )
+    )
+    # 프로필이 없으면(아직 안 만든 계정) 기본값은 '받는다'. 알림이 조용히
+    # 사라지는 쪽보다 오는 쪽이 낫다.
+    return True if value is None else bool(value)
+
+
 def queue_for_trainer(
     db: Session,
     *,
     trainer_id: str,
+    kind: str,
     title: str,
     body: str = "",
-    category: str = "system",
-) -> Notification:
-    """트레이너에게 남기는 알림. **커밋하지 않는다**([queue] 와 같은 이유).
+) -> Notification | None:
+    """트레이너에게 남기는 알림. 꺼져 있으면 None. **커밋하지 않는다**.
 
-    회원용 [queue] 와 갈라 두는 이유는 수신 설정이다. `wants` 가 보는
-    `MemberNotificationSetting` 은 회원 계정의 설정이라, 트레이너에게 회원 기본값을
-    적용하는 꼴이 된다. 트레이너 설정은 `trainer_profiles.notify_*` 에 따로 있고
-    종류별 게이트는 인박스 작업에서 붙인다(#503).
+    커밋하지 않는 이유는 [queue] 와 같다 — 호출부의 트랜잭션에 얹는다.
 
-    `Notification.user_id` 는 일반 사용자 FK 이고 `GET /notifications` 는
-    `CurrentUser` 기준이라, 이 행은 트레이너가 로그인하면 그대로 읽힌다 —
-    스키마 변경이 필요 없다.
+    `Notification.user_id` 는 일반 사용자 FK 라 트레이너 계정에도 그대로 달린다.
+    다만 읽는 경로는 회원용 `/notifications` 가 아니라 `/trainer/notifications` 다.
+    회원용은 `get_current_user` 가 트레이너를 403 으로 막는 **회원 전용** 경로다.
     """
+    if not trainer_wants(db, trainer_id, kind):
+        return None
     notification = Notification(
         id=f"noti-{uuid.uuid4().hex[:12]}",
         user_id=trainer_id,
         title=title,
         body=body,
-        category=category,
+        category=kind,
         read=False,
     )
     db.add(notification)

--- a/backend/app/services/reservation_service.py
+++ b/backend/app/services/reservation_service.py
@@ -302,6 +302,15 @@ def reserve(
     try:
         db.flush()
         db.add(reservation)
+        # 트레이너는 회원이 잡은 자리를 스케줄을 다시 열어야만 안다. (#503)
+        # 일정→예약 순서 불변식과 무관하므로 그 뒤에 얹는다.
+        notification_service.queue_for_trainer(
+            db,
+            trainer_id=slot.trainer_id,
+            kind=notification_service.TRAINER_RESERVATION_KIND,
+            title="새 예약이 들어왔어요",
+            body=f"{member.name} 회원 · {local:%m월 %d일 %H:%M}",
+        )
         db.commit()
     except IntegrityError as exc:
         db.rollback()
@@ -390,6 +399,7 @@ def cancel(
         notification_service.queue_for_trainer(
             db,
             trainer_id=trainer_id,
+            kind=notification_service.TRAINER_RESERVATION_KIND,
             title="예약이 취소되었습니다",
             body=(
                 f"{member_name} 회원 · {local:%m월 %d일 %H:%M}"

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -361,8 +361,8 @@ def send_message(
     종류를 호출자가 정하는 이유: 주간 리포트도 이 함수로 나가므로, 여기서 판단하면
     일반 메시지와 구분할 수 없다.
 
-    회원이 보낸 메시지에는 알림을 만들지 않는다 — 트레이너 앱은 unread 배지를 따로
-    쓰고, 알림함은 회원 것이다.
+    회원이 보낸 메시지에는 **트레이너 알림**을 남긴다(#503). 사이드바 미읽음 배지는
+    지금 보고 있을 때만 눈에 들어오고, 지나가면 다시 볼 자리가 없었다.
     """
     msg = ChatMessage(
         id=f"chat-{uuid.uuid4().hex[:12]}",
@@ -373,6 +373,15 @@ def send_message(
         created_at=datetime.now(timezone.utc),
     )
     db.add(msg)
+    if sender == "member":
+        member_name = db.scalar(select(User.name).where(User.id == member_id))
+        notification_service.queue_for_trainer(
+            db,
+            trainer_id=trainer_id,
+            kind=notification_service.TRAINER_MESSAGE_KIND,
+            title=f"{member_name or '회원'} 회원의 메시지",
+            body=text,
+        )
     if notify is not None and sender == "trainer":
         trainer_name = db.scalar(select(User.name).where(User.id == trainer_id))
         notification_service.queue(

--- a/backend/tests/test_trainer_notifications.py
+++ b/backend/tests/test_trainer_notifications.py
@@ -1,0 +1,189 @@
+"""트레이너 알림함. (#503) DB 필요.
+
+전에는 트레이너가 받은 알림을 볼 자리가 없었다. 사이드바 배지는 지금 보고 있을
+때만 눈에 들어오고, 지나가면 다시 볼 수 없었다.
+
+회원용 `/notifications` 를 쓰지 못하는 이유도 함께 확인한다 — `get_current_user`
+가 트레이너 계정을 403 으로 막는 회원 전용 경로다.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+
+
+def _login(client, email: str, password: str = "oncare123") -> str:
+    res = client.post(
+        "/v1/auth/login", data={"username": email, "password": password}
+    )
+    assert res.status_code == 200, res.text
+    return res.json()["access_token"]
+
+
+def _h(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture()
+def trainer_token(client) -> str:
+    return _login(client, "trainer@oncare.com")
+
+
+def test_member_only_notifications_reject_a_trainer(client, trainer_token):
+    """회원용 알림 경로는 트레이너를 막는다 — 그래서 별도 경로가 필요했다."""
+    assert client.get("/v1/notifications", headers=_h(trainer_token)).status_code == 403
+
+
+def test_member_message_lands_in_the_trainer_inbox(client, trainer_token):
+    """회원이 보낸 메시지는 트레이너 알림함에 남는다."""
+    member_token = _login(client, "jisu@oncare.com")
+
+    text = f"안녕하세요 {uuid4().hex[:6]}"
+    sent = client.post(
+        "/v1/me/coach/chat", json={"text": text}, headers=_h(member_token)
+    )
+    assert sent.status_code == 201, sent.text
+
+    # 총 개수가 아니라 **맨 앞 항목**을 본다. 목록은 최신순 상한이 있어, 오래
+    # 돌린 DB 에서는 개수 비교가 상한에 걸려 의미를 잃는다.
+    newest = client.get(
+        "/v1/trainer/notifications", headers=_h(trainer_token)
+    ).json()[0]
+    assert newest["category"] == "message"
+    assert newest["body"] == text
+    assert newest["read"] is False
+
+
+def test_message_notification_respects_the_trainer_setting(client, trainer_token):
+    """설정에서 끄면 만들지 않는다 — 서버가 설정을 모르면 끌 수가 없다."""
+    member_token = _login(client, "jisu@oncare.com")
+    client.put(
+        "/v1/trainer/me/settings",
+        json={"notify_new_message": False},
+        headers=_h(trainer_token),
+    )
+    try:
+        text = f"꺼진 상태 {uuid4().hex[:6]}"
+        client.post(
+            "/v1/me/coach/chat", json={"text": text}, headers=_h(member_token)
+        )
+        newest = client.get(
+            "/v1/trainer/notifications", headers=_h(trainer_token)
+        ).json()
+        # 이 메시지로 만들어진 알림이 하나도 없어야 한다.
+        assert all(row["body"] != text for row in newest)
+    finally:
+        client.put(
+            "/v1/trainer/me/settings",
+            json={"notify_new_message": True},
+            headers=_h(trainer_token),
+        )
+
+
+def test_new_reservation_lands_in_the_trainer_inbox(client, trainer_token):
+    """회원이 잡은 자리를 트레이너가 스케줄을 다시 열어야만 아는 상태를 없앤다."""
+    member_token = _login(client, "jisu@oncare.com")
+    slot = client.post(
+        "/v1/trainer/reservation-slots",
+        headers=_h(trainer_token),
+        json={
+            "starts_at": (
+                datetime.now(timezone.utc) + timedelta(days=4)
+            ).isoformat(),
+            "capacity": 1,
+        },
+    )
+    assert slot.status_code == 201, slot.text
+
+    booked = client.post(
+        "/v1/reservations",
+        headers=_h(member_token),
+        json={"slot_id": slot.json()["id"]},
+    )
+    assert booked.status_code == 201, booked.text
+
+    newest = client.get(
+        "/v1/trainer/notifications", headers=_h(trainer_token)
+    ).json()[0]
+    assert newest["category"] == "reservation"
+    assert "새 예약" in newest["title"]
+
+    # 취소도 같은 인박스로 온다(#502 가 남기는 행).
+    client.delete(
+        f"/v1/reservations/{booked.json()['id']}", headers=_h(member_token)
+    )
+    cancelled = client.get(
+        "/v1/trainer/notifications", headers=_h(trainer_token)
+    ).json()[0]
+    assert cancelled["category"] == "reservation"
+    assert "취소" in cancelled["title"]
+
+
+def test_unread_count_and_read_actions(client, trainer_token):
+    member_token = _login(client, "jisu@oncare.com")
+    client.post(
+        "/v1/me/coach/chat",
+        json={"text": f"읽음 테스트 {uuid4().hex[:6]}"},
+        headers=_h(member_token),
+    )
+
+    unread = client.get(
+        "/v1/trainer/notifications/unread-count", headers=_h(trainer_token)
+    )
+    assert unread.status_code == 200, unread.text
+    assert unread.json()["unread"] >= 1
+
+    newest = client.get(
+        "/v1/trainer/notifications", headers=_h(trainer_token)
+    ).json()[0]
+    read = client.post(
+        f"/v1/trainer/notifications/{newest['id']}/read", headers=_h(trainer_token)
+    )
+    assert read.status_code == 200, read.text
+    assert read.json()["read"] is True
+
+    all_read = client.post(
+        "/v1/trainer/notifications/read-all", headers=_h(trainer_token)
+    )
+    assert all_read.status_code == 200, all_read.text
+    assert (
+        client.get(
+            "/v1/trainer/notifications/unread-count", headers=_h(trainer_token)
+        ).json()["unread"]
+        == 0
+    )
+
+
+def test_reading_someone_elses_notification_is_404(client, trainer_token, db_session):
+    """남의 알림은 존재조차 드러내지 않는다."""
+    from app.models import models
+
+    other = models.Notification(
+        id=f"noti-{uuid4().hex[:12]}",
+        user_id="user-jisu",
+        title="회원 알림",
+        body="",
+        category="system",
+        read=False,
+    )
+    db_session.add(other)
+    db_session.commit()
+    try:
+        res = client.post(
+            f"/v1/trainer/notifications/{other.id}/read", headers=_h(trainer_token)
+        )
+        assert res.status_code == 404
+    finally:
+        db_session.delete(other)
+        db_session.commit()
+
+
+def test_trainer_notifications_require_a_trainer(client):
+    """회원 토큰으로는 트레이너 알림함을 볼 수 없다."""
+    member_token = _login(client, "jisu@oncare.com")
+    assert (
+        client.get("/v1/trainer/notifications", headers=_h(member_token)).status_code
+        == 403
+    )

--- a/frontend/flutter_trainer/lib/app/router/app_router.dart
+++ b/frontend/flutter_trainer/lib/app/router/app_router.dart
@@ -13,6 +13,7 @@ import 'package:oncare_trainer/features/coaching/presentation/pages/coaching_pag
 import 'package:oncare_trainer/features/consultations/presentation/pages/consultations_page.dart';
 import 'package:oncare_trainer/features/dashboard/presentation/pages/dashboard_page.dart';
 import 'package:oncare_trainer/features/my/presentation/pages/my_page.dart';
+import 'package:oncare_trainer/features/notifications/presentation/pages/notifications_page.dart';
 import 'package:oncare_trainer/features/reports/presentation/pages/reports_page.dart';
 import 'package:oncare_trainer/features/schedule/presentation/pages/schedule_page.dart';
 
@@ -150,6 +151,15 @@ GoRouter buildAppRouter({
               GoRoute(
                 path: AppRoutes.consultations,
                 builder: (context, state) => const ConsultationsPage(),
+              ),
+            ],
+          ),
+          // 알림함도 같은 이유로 맨 뒤에 붙인다. (#503)
+          StatefulShellBranch(
+            routes: <RouteBase>[
+              GoRoute(
+                path: AppRoutes.notifications,
+                builder: (context, state) => const NotificationsPage(),
               ),
             ],
           ),

--- a/frontend/flutter_trainer/lib/app/router/routes.dart
+++ b/frontend/flutter_trainer/lib/app/router/routes.dart
@@ -43,6 +43,12 @@ class AppRoutes {
   /// The route itself is always registered so a deep link still resolves.
   static const String consultations = '/consultations';
 
+  /// 알림함 — 놓친 변화를 나중에 확인하는 자리. (#503)
+  ///
+  /// 상담 요청과 같은 이유로 nav 행은 실 API 빌드에서만 보인다(데모에는 알림을
+  /// 만드는 회원 백엔드가 없다). 라우트 자체는 항상 등록해 딥링크가 살아 있다.
+  static const String notifications = '/notifications';
+
   // --- Client detail ---
 
   /// Every addressable sub-section of a client's detail panel.

--- a/frontend/flutter_trainer/lib/app/shell/app_shell.dart
+++ b/frontend/flutter_trainer/lib/app/shell/app_shell.dart
@@ -36,6 +36,10 @@ class AppShell extends StatelessWidget {
   /// could not shift any existing branch. (#467)
   static int get consultationsBranchIndex => myBranchIndex + 1;
 
+  /// Branch index of 알림함. 상담 요청과 같은 이유로 맨 뒤에 붙인다 — 앞에
+  /// 끼우면 `myBranchIndex` 가 밀려 푸터 선택이 조용히 깨진다. (#503)
+  static int get notificationsBranchIndex => consultationsBranchIndex + 1;
+
   void _goBranch(int index) {
     // Tapping the active destination resets it to its branch root (e.g.
     // 고객 상세에서 '고객'을 다시 누르면 목록으로) — the standard console

--- a/frontend/flutter_trainer/lib/app/shell/app_sidebar.dart
+++ b/frontend/flutter_trainer/lib/app/shell/app_sidebar.dart
@@ -11,6 +11,7 @@ import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/features/auth/presentation/controllers/session_controller.dart';
 import 'package:oncare_trainer/features/consultations/data/repositories/consultation_repository.dart';
+import 'package:oncare_trainer/features/notifications/data/repositories/notification_repository.dart';
 import 'package:oncare_trainer/shared/models/trainer_profile.dart';
 import 'package:oncare_trainer/shared/services/chat_repository.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
@@ -73,6 +74,12 @@ class AppSidebar extends ConsumerWidget {
     final pendingConsultations = inbox
         ? ref.watch(consultationPendingCountProvider).valueOrNull
         : null;
+    // 알림함도 실 API 빌드에서만 — 데모에는 알림을 만드는 회원 백엔드가 없어
+    // 늘 비어 있는 행이 하나 더 생길 뿐이다. (#503)
+    final notificationInbox = ref.watch(notificationInboxEnabledProvider);
+    final unreadNotifications = notificationInbox
+        ? ref.watch(trainerUnreadNotificationsProvider).valueOrNull
+        : null;
 
     return Container(
       width: expanded ? AppLayout.sidebarWidth : AppLayout.sidebarRailWidth,
@@ -105,6 +112,7 @@ class AppSidebar extends ConsumerWidget {
                         // navDestinations and is rendered below with its
                         // count passed in directly.
                         NavBadge.pendingConsultations => null,
+                        NavBadge.unreadNotifications => null,
                         NavBadge.none => null,
                       },
                       onTap: () {
@@ -121,6 +129,18 @@ class AppSidebar extends ConsumerWidget {
                       badgeCount: pendingConsultations,
                       onTap: () {
                         onSelect(AppShell.consultationsBranchIndex);
+                        onNavigate?.call();
+                      },
+                    ),
+                  if (notificationInbox)
+                    _NavTile(
+                      destination: notificationsDestination,
+                      selected:
+                          currentIndex == AppShell.notificationsBranchIndex,
+                      expanded: expanded,
+                      badgeCount: unreadNotifications,
+                      onTap: () {
+                        onSelect(AppShell.notificationsBranchIndex);
                         onNavigate?.call();
                       },
                     ),

--- a/frontend/flutter_trainer/lib/app/shell/nav_destinations.dart
+++ b/frontend/flutter_trainer/lib/app/shell/nav_destinations.dart
@@ -17,6 +17,10 @@ enum NavBadge {
   /// rather than looked up from [navDestinations] — this destination is
   /// conditional, so it is not in that list. (#467)
   pendingConsultations,
+
+  /// Unread trainer notifications. Supplied by the sidebar directly for the
+  /// same reason as [pendingConsultations]. (#503)
+  unreadNotifications,
 }
 
 /// One entry in the sidebar. The order of [navDestinations] is the tab
@@ -101,4 +105,14 @@ const NavDestination consultationsDestination = NavDestination(
   activeIcon: Icons.mark_email_unread,
   route: AppRoutes.consultations,
   badge: NavBadge.pendingConsultations,
+);
+
+/// 알림함 — [consultationsDestination] 과 같은 이유로 [navDestinations] 밖에
+/// 둔다. 실 API 빌드에서만 보이고, 브랜치 인덱스를 사이드바가 직접 넘긴다. (#503)
+const NavDestination notificationsDestination = NavDestination(
+  label: '알림',
+  icon: Icons.notifications_none,
+  activeIcon: Icons.notifications,
+  route: AppRoutes.notifications,
+  badge: NavBadge.unreadNotifications,
 );

--- a/frontend/flutter_trainer/lib/features/notifications/data/repositories/notification_repository.dart
+++ b/frontend/flutter_trainer/lib/features/notifications/data/repositories/notification_repository.dart
@@ -1,0 +1,142 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare_trainer/core/config/app_config.dart';
+import 'package:oncare_trainer/core/errors/app_error.dart';
+import 'package:oncare_trainer/core/network/dio_client.dart';
+import 'package:oncare_trainer/features/notifications/domain/entities/trainer_notification.dart';
+
+/// 트레이너 알림함을 읽고 읽음 처리한다. (#503)
+///
+/// 두 구현이 [trainerNotificationRepositoryProvider] 뒤에 있고
+/// [AppConfig.useMockApi] 로 갈린다.
+///
+///  * [DemoNotificationRepository] — 데모. 알림을 만드는 회원 백엔드가 없어
+///    항상 비어 있다. 상담 인박스(#467)와 같은 이유로, 늘 "없어요"만 말하는
+///    진입점을 데모에 남기지 않는다.
+///  * [DioNotificationRepository] — 실 백엔드(`/trainer/notifications`).
+///
+/// 회원용 `/notifications` 를 쓰지 않는 이유: 그 경로는 트레이너 계정을 403 으로
+/// 막는 **회원 전용**이다(역할 분리). 저장되는 행은 같은 테이블이다.
+abstract interface class TrainerNotificationRepository {
+  /// 이 빌드에서 알림함을 쓸 수 있는가. 데모에서는 진입점을 감춘다.
+  bool get supportsInbox;
+
+  /// 받은 알림(최신순).
+  Future<List<TrainerNotification>> fetch();
+
+  /// 사이드바 배지가 읽는 미읽음 수.
+  Future<int> unreadCount();
+
+  /// 한 건 읽음 처리.
+  Future<void> markRead(String id);
+
+  /// 전체 읽음 처리. 읽음으로 바뀐 건수를 돌려준다.
+  Future<int> markAllRead();
+}
+
+/// 데모: 알림함이 없다. 읽기는 빈 결과로 성공해, 딥링크로 들어와도 오류가
+/// 아니라 빈 화면이 된다.
+class DemoNotificationRepository implements TrainerNotificationRepository {
+  const DemoNotificationRepository();
+
+  @override
+  bool get supportsInbox => false;
+
+  @override
+  Future<List<TrainerNotification>> fetch() async =>
+      const <TrainerNotification>[];
+
+  @override
+  Future<int> unreadCount() async => 0;
+
+  @override
+  Future<void> markRead(String id) async {}
+
+  @override
+  Future<int> markAllRead() async => 0;
+}
+
+/// 실 백엔드 구현.
+class DioNotificationRepository implements TrainerNotificationRepository {
+  const DioNotificationRepository(this._dio);
+
+  final Dio _dio;
+
+  @override
+  bool get supportsInbox => true;
+
+  @override
+  Future<List<TrainerNotification>> fetch() async {
+    try {
+      final res = await _dio.get<List<dynamic>>('/trainer/notifications');
+      return (res.data ?? const <dynamic>[])
+          .whereType<Map<String, Object?>>()
+          .map(TrainerNotification.fromJson)
+          .toList();
+    } on DioException catch (e) {
+      throw AppError.fromDio(e);
+    }
+  }
+
+  @override
+  Future<int> unreadCount() async {
+    try {
+      final res = await _dio.get<Map<String, Object?>>(
+        '/trainer/notifications/unread-count',
+      );
+      final value = res.data?['unread'];
+      return value is num ? value.toInt() : 0;
+    } on DioException catch (e) {
+      throw AppError.fromDio(e);
+    }
+  }
+
+  @override
+  Future<void> markRead(String id) async {
+    try {
+      await _dio.post<void>('/trainer/notifications/$id/read');
+    } on DioException catch (e) {
+      throw AppError.fromDio(e);
+    }
+  }
+
+  @override
+  Future<int> markAllRead() async {
+    try {
+      final res = await _dio.post<Map<String, Object?>>(
+        '/trainer/notifications/read-all',
+      );
+      final value = res.data?['marked_read'];
+      return value is num ? value.toInt() : 0;
+    } on DioException catch (e) {
+      throw AppError.fromDio(e);
+    }
+  }
+}
+
+/// 현재 모드에 맞는 저장소.
+final trainerNotificationRepositoryProvider =
+    Provider<TrainerNotificationRepository>((ref) {
+      if (ref.watch(appConfigProvider).useMockApi) {
+        return const DemoNotificationRepository();
+      }
+      return DioNotificationRepository(ref.watch(dioProvider));
+    }, name: 'trainerNotificationRepository');
+
+/// 알림함에 들어갈 수 있는 빌드인가 — 사이드바 진입점 노출 조건.
+final notificationInboxEnabledProvider = Provider<bool>(
+  (ref) => ref.watch(trainerNotificationRepositoryProvider).supportsInbox,
+  name: 'notificationInboxEnabled',
+);
+
+/// 받은 알림 목록.
+final trainerNotificationsProvider =
+    FutureProvider<List<TrainerNotification>>((ref) {
+      return ref.watch(trainerNotificationRepositoryProvider).fetch();
+    }, name: 'trainerNotifications');
+
+/// 미읽음 수 — 사이드바 배지.
+final trainerUnreadNotificationsProvider = FutureProvider<int>((ref) {
+  return ref.watch(trainerNotificationRepositoryProvider).unreadCount();
+}, name: 'trainerUnreadNotifications');

--- a/frontend/flutter_trainer/lib/features/notifications/domain/entities/trainer_notification.dart
+++ b/frontend/flutter_trainer/lib/features/notifications/domain/entities/trainer_notification.dart
@@ -1,0 +1,51 @@
+/// 트레이너가 받은 알림 한 건. `GET /trainer/notifications`. (#503)
+library;
+
+/// 알림 종류. 서버 `category` 값과 1:1이고, 어디로 이동할지를 정한다.
+///
+/// 회원 알림의 category 집합(reminder|health_check|achievement|system)과 다르다 —
+/// 같은 테이블을 쓰지만 읽는 화면과 갈 곳이 다르다.
+enum TrainerNotificationKind { message, consultation, reservation, other }
+
+TrainerNotificationKind _kindFrom(String? raw) => switch (raw) {
+  'message' => TrainerNotificationKind.message,
+  'consultation' => TrainerNotificationKind.consultation,
+  'reservation' => TrainerNotificationKind.reservation,
+  // 서버가 새 종류를 추가했는데 앱이 모르는 경우. 목록에서 빼지 않고 이동만
+  // 하지 않는다 — 안 보이는 알림보다 갈 곳 없는 알림이 낫다.
+  _ => TrainerNotificationKind.other,
+};
+
+class TrainerNotification {
+  const TrainerNotification({
+    required this.id,
+    required this.title,
+    required this.body,
+    required this.kind,
+    required this.read,
+    required this.createdAt,
+    required this.timeAgo,
+  });
+
+  final String id;
+  final String title;
+  final String body;
+  final TrainerNotificationKind kind;
+  final bool read;
+  final DateTime createdAt;
+
+  /// 서버가 만든 상대 시각 문구("3분 전"). 회원 알림함과 같은 규칙을 쓰도록
+  /// 서버 판단을 그대로 받는다.
+  final String timeAgo;
+
+  factory TrainerNotification.fromJson(Map<String, Object?> json) =>
+      TrainerNotification(
+        id: json['id']! as String,
+        title: (json['title'] as String?) ?? '',
+        body: (json['body'] as String?) ?? '',
+        kind: _kindFrom(json['category'] as String?),
+        read: (json['read'] as bool?) ?? false,
+        createdAt: DateTime.parse(json['created_at']! as String).toLocal(),
+        timeAgo: (json['time_ago'] as String?) ?? '',
+      );
+}

--- a/frontend/flutter_trainer/lib/features/notifications/presentation/pages/notifications_page.dart
+++ b/frontend/flutter_trainer/lib/features/notifications/presentation/pages/notifications_page.dart
@@ -1,0 +1,212 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:oncare_trainer/app/router/routes.dart';
+import 'package:oncare_trainer/core/errors/app_error.dart';
+import 'package:oncare_trainer/design_system/tokens/colors.dart';
+import 'package:oncare_trainer/design_system/tokens/radius.dart';
+import 'package:oncare_trainer/design_system/tokens/spacing.dart';
+import 'package:oncare_trainer/features/notifications/data/repositories/notification_repository.dart';
+import 'package:oncare_trainer/features/notifications/domain/entities/trainer_notification.dart';
+import 'package:oncare_trainer/shared/widgets/action_button.dart';
+import 'package:oncare_trainer/shared/widgets/section_card.dart';
+import 'package:oncare_trainer/shared/widgets/page_scaffold.dart';
+
+/// 알림함 — 트레이너가 놓친 변화를 나중에 확인하는 자리. (#503)
+///
+/// 전에는 사이드바 배지와 대시보드 강조뿐이라, 그 순간을 지나가면 다시 볼
+/// 방법이 없었다. 회원의 메시지·상담 요청·예약은 트레이너가 그 화면에 직접
+/// 들어가야만 알 수 있었다.
+///
+/// 데모 빌드는 이 화면에 닿지 않는다 — 저장소가 인박스 없음을 보고하고
+/// 사이드바 진입점이 그려지지 않는다([notificationInboxEnabledProvider]).
+class NotificationsPage extends ConsumerWidget {
+  /// Creates the inbox page.
+  const NotificationsPage({super.key});
+
+  /// 알림 종류별 이동할 곳. 모르는 종류는 이동하지 않는다.
+  static String? _targetOf(TrainerNotificationKind kind) => switch (kind) {
+    TrainerNotificationKind.message => AppRoutes.clients,
+    TrainerNotificationKind.consultation => AppRoutes.consultations,
+    TrainerNotificationKind.reservation => AppRoutes.schedule,
+    TrainerNotificationKind.other => null,
+  };
+
+  Future<void> _open(
+    BuildContext context,
+    WidgetRef ref,
+    TrainerNotification notification,
+  ) async {
+    final String? target = _targetOf(notification.kind);
+    // 읽음 처리는 이동과 무관하게 먼저 한다 — 갈 곳이 없는 알림도 확인하면
+    // 배지에서 빠져야 한다.
+    if (!notification.read) {
+      try {
+        await ref
+            .read(trainerNotificationRepositoryProvider)
+            .markRead(notification.id);
+        ref
+          ..invalidate(trainerNotificationsProvider)
+          ..invalidate(trainerUnreadNotificationsProvider);
+      } catch (_) {
+        // 읽음 처리 실패로 이동까지 막지 않는다. 다음 조회에서 다시 미읽음으로
+        // 보이는 편이, 누른 알림이 아무 반응도 없는 것보다 낫다.
+      }
+    }
+    if (target != null && context.mounted) context.go(target);
+  }
+
+  Future<void> _readAll(BuildContext context, WidgetRef ref) async {
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    try {
+      await ref.read(trainerNotificationRepositoryProvider).markAllRead();
+    } catch (_) {
+      messenger.showSnackBar(
+        const SnackBar(content: Text('읽음 처리에 실패했어요. 잠시 후 다시 시도해 주세요')),
+      );
+      return;
+    }
+    ref
+      ..invalidate(trainerNotificationsProvider)
+      ..invalidate(trainerUnreadNotificationsProvider);
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final notifications = ref.watch(trainerNotificationsProvider);
+    final unread = ref.watch(trainerUnreadNotificationsProvider).valueOrNull;
+
+    return PageScaffold(
+      title: '알림',
+      subtitle: unread == null
+          ? null
+          : (unread > 0 ? '읽지 않은 알림 $unread건' : '모두 확인했어요'),
+      actions: <Widget>[
+        if (unread != null && unread > 0)
+          ActionButton(
+            label: '모두 읽음',
+            icon: Icons.done_all,
+            onPressed: () => _readAll(context, ref),
+          ),
+      ],
+      child: notifications.when(
+        loading: () => const Padding(
+          padding: EdgeInsets.only(top: AppSpacing.xxl),
+          child: Center(child: CircularProgressIndicator()),
+        ),
+        error: (error, _) => Padding(
+          padding: const EdgeInsets.only(top: AppSpacing.xxl),
+          child: EmptyHint(
+            message:
+                (error is AppError ? error.message : null) ??
+                '알림을 불러오지 못했어요',
+            icon: Icons.error_outline,
+          ),
+        ),
+        data: (rows) {
+          if (rows.isEmpty) {
+            return const Padding(
+              padding: EdgeInsets.only(top: AppSpacing.xxl),
+              child: EmptyHint(
+                message: '아직 받은 알림이 없어요',
+                icon: Icons.notifications_none,
+              ),
+            );
+          }
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              for (final TrainerNotification row in rows) ...<Widget>[
+                _NotificationTile(
+                  notification: row,
+                  onTap: () => _open(context, ref, row),
+                ),
+                const SizedBox(height: AppSpacing.sm),
+              ],
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _NotificationTile extends StatelessWidget {
+  const _NotificationTile({required this.notification, required this.onTap});
+
+  final TrainerNotification notification;
+  final VoidCallback onTap;
+
+  IconData get _icon => switch (notification.kind) {
+    TrainerNotificationKind.message => Icons.chat_bubble_outline,
+    TrainerNotificationKind.consultation => Icons.mark_email_unread_outlined,
+    TrainerNotificationKind.reservation => Icons.event_available_outlined,
+    TrainerNotificationKind.other => Icons.notifications_none,
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    final bool unread = !notification.read;
+    return Material(
+      // 미읽음은 배경으로 구분한다 — 점 하나보다 목록에서 먼저 눈에 들어온다.
+      color: unread ? AppColors.accent : AppColors.card,
+      borderRadius: const BorderRadius.all(AppRadius.md),
+      child: InkWell(
+        key: ValueKey<String>('notification-${notification.id}'),
+        onTap: onTap,
+        borderRadius: const BorderRadius.all(AppRadius.md),
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.md),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Icon(
+                _icon,
+                size: 18,
+                color: unread ? AppColors.primary : AppColors.mutedForeground,
+              ),
+              const SizedBox(width: AppSpacing.md),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      notification.title,
+                      style: TextStyle(
+                        fontSize: 13.5,
+                        fontWeight: unread ? FontWeight.w700 : FontWeight.w600,
+                        color: AppColors.foreground,
+                      ),
+                    ),
+                    if (notification.body.isNotEmpty) ...<Widget>[
+                      const SizedBox(height: 2),
+                      Text(
+                        notification.body,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          fontSize: 12.5,
+                          color: AppColors.mutedForeground,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+              const SizedBox(width: AppSpacing.sm),
+              Text(
+                notification.timeAgo,
+                style: const TextStyle(
+                  fontSize: 11.5,
+                  fontWeight: FontWeight.w600,
+                  color: AppColors.subtleForeground,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/flutter_trainer/test/features/notifications/notifications_page_test.dart
+++ b/frontend/flutter_trainer/test/features/notifications/notifications_page_test.dart
@@ -1,0 +1,173 @@
+/// 트레이너 알림함. (#503)
+///
+/// 데모는 지금 그대로여야 한다 — 알림을 만드는 회원 백엔드가 없어 늘 비어 있을
+/// 행을 사이드바에 더하지 않는다(상담 요청과 같은 규칙).
+library;
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare_trainer/app/router/routes.dart';
+import 'package:oncare_trainer/app/shell/nav_destinations.dart';
+import 'package:oncare_trainer/features/notifications/data/repositories/notification_repository.dart';
+import 'package:oncare_trainer/features/notifications/domain/entities/trainer_notification.dart';
+
+import '../../helpers/pump_app.dart';
+
+TrainerNotification _notification({
+  String id = 'noti-1',
+  String title = '이지수 회원의 메시지',
+  String body = '오늘 수업 시간 조정 가능할까요?',
+  TrainerNotificationKind kind = TrainerNotificationKind.message,
+  bool read = false,
+}) => TrainerNotification(
+  id: id,
+  title: title,
+  body: body,
+  kind: kind,
+  read: read,
+  createdAt: DateTime.utc(2026, 8, 9, 10),
+  timeAgo: '3분 전',
+);
+
+/// 실 API 처럼 동작하는 페이크 — 읽음 처리 호출을 기록한다.
+class _FakeNotificationRepository implements TrainerNotificationRepository {
+  _FakeNotificationRepository(this._rows);
+
+  List<TrainerNotification> _rows;
+  final List<String> readCalls = <String>[];
+  int readAllCalls = 0;
+
+  @override
+  bool get supportsInbox => true;
+
+  @override
+  Future<List<TrainerNotification>> fetch() async => _rows;
+
+  @override
+  Future<int> unreadCount() async =>
+      _rows.where((TrainerNotification r) => !r.read).length;
+
+  @override
+  Future<void> markRead(String id) async {
+    readCalls.add(id);
+    _rows = <TrainerNotification>[
+      for (final TrainerNotification r in _rows)
+        if (r.id == id)
+          _notification(id: r.id, title: r.title, body: r.body, kind: r.kind, read: true)
+        else
+          r,
+    ];
+  }
+
+  @override
+  Future<int> markAllRead() async {
+    readAllCalls++;
+    final int n = _rows.where((TrainerNotification r) => !r.read).length;
+    _rows = <TrainerNotification>[
+      for (final TrainerNotification r in _rows)
+        _notification(id: r.id, title: r.title, body: r.body, kind: r.kind, read: true),
+    ];
+    return n;
+  }
+}
+
+void main() {
+  testWidgets('데모 콘솔에는 알림 행이 없다', (tester) async {
+    await withWideSurface(tester, () async {
+      await pumpTrainerApp(tester, token: 'demo-token');
+
+      expect(find.text(notificationsDestination.label), findsNothing);
+    });
+  });
+
+  testWidgets('실 API 콘솔에는 알림 행이 보인다', (tester) async {
+    await withWideSurface(tester, () async {
+      await pumpTrainerApp(
+        tester,
+        token: 'demo-token',
+        extraOverrides: <Override>[
+          trainerNotificationRepositoryProvider.overrideWithValue(
+            _FakeNotificationRepository(<TrainerNotification>[_notification()]),
+          ),
+        ],
+      );
+
+      expect(find.text(notificationsDestination.label), findsOneWidget);
+    });
+  });
+
+  testWidgets('받은 알림이 목록에 그려진다', (tester) async {
+    await pumpTrainerApp(
+      tester,
+      token: 'demo-token',
+      at: AppRoutes.notifications,
+      extraOverrides: <Override>[
+        trainerNotificationRepositoryProvider.overrideWithValue(
+          _FakeNotificationRepository(<TrainerNotification>[_notification()]),
+        ),
+      ],
+    );
+
+    expect(find.text('이지수 회원의 메시지'), findsOneWidget);
+    expect(find.text('오늘 수업 시간 조정 가능할까요?'), findsOneWidget);
+    expect(find.textContaining('읽지 않은 알림'), findsOneWidget);
+  });
+
+  testWidgets('알림이 없으면 빈 상태를 보여 준다', (tester) async {
+    await pumpTrainerApp(
+      tester,
+      token: 'demo-token',
+      at: AppRoutes.notifications,
+      extraOverrides: <Override>[
+        trainerNotificationRepositoryProvider.overrideWithValue(
+          _FakeNotificationRepository(const <TrainerNotification>[]),
+        ),
+      ],
+    );
+
+    expect(find.text('아직 받은 알림이 없어요'), findsOneWidget);
+  });
+
+  testWidgets('알림을 누르면 읽음 처리된다', (tester) async {
+    final repo = _FakeNotificationRepository(<TrainerNotification>[
+      _notification(),
+    ]);
+    await pumpTrainerApp(
+      tester,
+      token: 'demo-token',
+      at: AppRoutes.notifications,
+      extraOverrides: <Override>[
+        trainerNotificationRepositoryProvider.overrideWithValue(repo),
+      ],
+    );
+
+    await tester.tap(find.byKey(const ValueKey<String>('notification-noti-1')));
+    await settle(tester);
+
+    // 갈 곳이 있든 없든 확인한 알림은 배지에서 빠져야 한다.
+    expect(repo.readCalls, <String>['noti-1']);
+  });
+
+  testWidgets('모두 읽음이 전체를 읽음 처리한다', (tester) async {
+    final repo = _FakeNotificationRepository(<TrainerNotification>[
+      _notification(),
+      _notification(id: 'noti-2', title: '새 예약이 들어왔어요'),
+    ]);
+    await pumpTrainerApp(
+      tester,
+      token: 'demo-token',
+      at: AppRoutes.notifications,
+      extraOverrides: <Override>[
+        trainerNotificationRepositoryProvider.overrideWithValue(repo),
+      ],
+    );
+
+    await tester.tap(find.text('모두 읽음'));
+    await settle(tester);
+
+    expect(repo.readAllCalls, 1);
+    expect(find.text('모두 확인했어요'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
> **이 PR 은 #517(예약 취소) 위에 쌓여 있습니다.** base 가 `feat/issue-502-member-reservation-cancel` 이라, #517 을 먼저 머지하면 GitHub 가 이 PR 의 base 를 main 으로 자동 전환합니다. `queue_for_trainer` 를 #502 가 추가했고 이 PR 이 확장하기 때문입니다.

## Summary

* 트레이너가 **받은 알림을 보는 자리**가 생겼습니다. 전에는 사이드바 배지와 대시보드 강조뿐이라, 지나가면 다시 볼 방법이 없었습니다.
* `/trainer/notifications` 계열을 신설했습니다 — 회원용 경로는 **트레이너를 403 으로 막습니다.**
* 데모 콘솔은 지금 그대로입니다(진입점이 생기지 않습니다).

---

## Changes

### 🔌 백엔드

* `GET /trainer/notifications` · `/unread-count` · `POST /{id}/read` · `POST /read-all`.
* **생성 지점**: 회원의 새 메시지, 새 상담 요청, 새 예약. (취소는 #502 가 이미 남깁니다.)
  * 상담 요청이 헬스장으로 오면 **그 헬스장 소속 트레이너 전원**에게 남깁니다 — 누구나 받을 수 있는 요청이라(#467), 아무에게도 알리지 않으면 인박스를 여는 사람만 우연히 발견합니다.
* 메시지 알림만 `trainer_profiles.notify_new_message` 로 끕니다. 회원 설정을 보는 `wants()` 를 그대로 쓰면 **트레이너에게 회원 기본값이 적용**되므로 `trainer_wants` 로 갈랐습니다.
* 상대 시각 문구(`3분 전`)를 서비스로 옮겨 회원·트레이너 알림함이 같은 규칙을 씁니다.

### 📱 트레이너 앱

* 알림함 화면(목록·읽음·모두 읽음·빈 상태), 사이드바 진입점과 미읽음 배지.
* 종류별 이동: 메시지 → 고객, 상담 → 상담 요청, 예약 → 스케줄. 모르는 종류는 목록에는 남기고 이동만 하지 않습니다 — 안 보이는 알림보다 갈 곳 없는 알림이 낫습니다.
* 읽음 처리는 이동과 **분리**했습니다. 갈 곳이 없는 알림도 확인하면 배지에서 빠져야 합니다.

---

## Notes

**이슈 본문의 잘못된 전제를 이미 정정했습니다.**

#503 을 열 때 "`GET /notifications` 를 트레이너가 그대로 읽는다" 고 적었는데 사실이 아니었습니다. `get_current_user` 가 트레이너 계정을 **403** 으로 막습니다(회원 전용, 트레이너는 `/trainer/*` — 역할 분리). #502 작업 중 확인해 이슈 본문을 고쳤고, 이 PR 이 그 정정된 범위대로 `/trainer/notifications` 를 만듭니다.

바뀌지 않은 부분: **스키마 변경은 여전히 없습니다.** `Notification.user_id` 가 일반 사용자 FK 라 트레이너 행이 그대로 저장됩니다. 회귀 테스트로 403 사실 자체를 박아 뒀습니다(`test_member_only_notifications_reject_a_trainer`).

**#515(다국어)와 겹치는 파일이 있습니다.** 이 PR 은 #502 위에 쌓여 있어 트레이너 앱이 아직 한국어 하드코딩 상태입니다. 새로 추가한 문구(`알림`, `모두 읽음`, `아직 받은 알림이 없어요`, `읽지 않은 알림 N건`, `모두 확인했어요`, `알림을 불러오지 못했어요`, `읽음 처리에 실패했어요…`)는 **#515 머지 후 arb 로 옮겨야 합니다.** `app_sidebar.dart`·`nav_destinations.dart` 는 양쪽이 함께 건드려 충돌이 예상됩니다 — 머지 순서에 따라 한 번 해소가 필요합니다.

**검증**

* 백엔드 `pytest`: 530 passed, 1 failed — 실패한 `test_complete_session_logs_history_and_is_idempotent` 는 이 브랜치와 무관합니다(로컬 DB 누적, main 에서도 동일하게 실패하며 CI 에서는 재현되지 않습니다).
* 트레이너 앱: `flutter analyze` 무이슈, `flutter test` **400 passed**
* 새 테스트: 백엔드 7건(403 확인 · 메시지/예약/취소 인박스 유입 · 설정 게이트 · 읽음·미읽음 · 남의 알림 404 · 회원 토큰 거부), 앱 6건(데모 진입점 없음 · 실 API 진입점 · 목록 · 빈 상태 · 읽음 · 모두 읽음)

Closes #503
