### PR TITLE
docs(trainer-my): 설정 화면 주석이 실제 구현과 어긋남

### DIFF
--- a/frontend/flutter_trainer/lib/features/my/presentation/pages/my_page.dart
+++ b/frontend/flutter_trainer/lib/features/my/presentation/pages/my_page.dart
@@ -33,11 +33,14 @@ import 'package:oncare_trainer/shared/widgets/section_card.dart';
 ///
 ///  * **내 정보** — profile, certifications, this month's stats, gym.
 ///    Edits persist through `PUT /v1/trainer/me` and the gym affiliation
-///    endpoints; mock mode follows the same repository contract.
-///  * **설정** — notifications, account, app info, 로그아웃. Most rows
-///    are placeholders today; they are shown (disabled, with a reason)
-///    rather than hidden so the shape of the screen doesn't change when
-///    the endpoints arrive.
+///    endpoints; mock mode follows the same repository contract (#477, #452).
+///    이름·이메일 입력은 비활성이다 — 값이 없어서가 아니라 **계정 소관**이라
+///    여기서 바꾸지 않는다.
+///  * **설정** — 알림 수신 설정은 `GET/PUT /v1/trainer/me/settings`(#379),
+///    비밀번호 변경은 `POST /v1/trainer/me/password` 로 서버에 저장된다.
+///    비밀번호 변경만 **데모에서 비활성**이고(바꿀 계정이 없다) 그 사유를 함께
+///    보여 준다 — 미구현이 아니라 그 빌드에서만 막히는 것이다.
+///    앱 정보(서비스·버전·문의)는 표시 전용이다.
 ///
 /// The Figma mock's "역할 전환" section is intentionally omitted — the
 /// trainer and member apps use fully separate accounts (CLAUDE.local.md).


### PR DESCRIPTION
## Summary

* `my_page.dart` 클래스 주석이 설정 섹션을 **"Most rows are placeholders today"** 라고 설명하는데 사실이 아닙니다. 실제 동작에 맞게 고쳤습니다.
* **동작 변경 없음** — 주석만 바뀝니다.

---

## Changes

### 📝 고친 것

주석은 이렇게 말하고 있었습니다.

> **설정** — notifications, account, app info, 로그아웃. Most rows are placeholders today; they are shown (disabled, with a reason) rather than hidden…

실제로는 서버에 저장됩니다.

| 행 | 실제 |
|---|---|
| 알림 수신 설정 | `GET/PUT /v1/trainer/me/settings` (#379) |
| 비밀번호 변경 | `POST /v1/trainer/me/password` |
| 로그인 계정 · 앱 정보 | 표시 전용 |
| 로그아웃 | 동작 |

### 🔍 확인하다 함께 바로잡은 두 가지

* **비활성인 것은 설정이 아니라 '내 정보' 의 이름·이메일 입력입니다.** 그리고 미구현이라서가 아니라 **계정 소관**이라 여기서 바꾸지 않는 것입니다. 주석은 "placeholder 라서 disabled" 라고 읽히게 두 사실을 뒤섞고 있었습니다.
* **비밀번호 변경만 데모에서 막힙니다.** 그 빌드에 바꿀 계정이 없어서지 기능이 없어서가 아닙니다 — **조건부로 막히는 것과 미구현은 다릅니다.**

---

## Notes

**왜 주석 하나가 이슈가 됐나.** 주석이 코드를 잘못 설명하면 다음 사람이 "어차피 placeholder" 로 읽고 실제 호출 경로를 지나칩니다. 실제로 미구현 항목을 훑는 작업에서 이 파일이 잘못 걸렸고, 그래서 이슈로 남겼습니다.

**인용한 이슈 번호를 한 번 고쳤습니다.** 처음에는 설정 엔드포인트 옆에 #477·#452 를 적었는데 그 둘은 프로필·소속 헬스장 편집 건입니다. `git log -S` 로 확인해 알림 설정은 #379, 프로필·헬스장은 #477·#452 로 각각 제자리에 붙였습니다.

**#515·#522 와 같은 파일을 건드립니다.** 주석 블록만 바뀌므로 충돌이 나더라도 해소는 간단합니다.

**검증**

* `flutter analyze` 무이슈, `flutter test` **394 passed** (동작이 바뀌지 않았으니 그대로여야 정상입니다)

Closes #506
