### PR TITLE
fix(trainer-i18n): 알림함 문구를 arb 로 옮겨 main 컴파일 복구

### DIFF
--- a/frontend/flutter_trainer/lib/app/shell/nav_destinations.dart
+++ b/frontend/flutter_trainer/lib/app/shell/nav_destinations.dart
@@ -61,7 +61,15 @@ class NavDestination {
 /// 운영 / 코칭 groups with headings; the headings named the obvious and
 /// the extra gap made the five rows read as two lists instead of one.
 /// 사이드바 라벨 키. 값이 아니라 키인 이유는 [NavDestination.label] 참고.
-enum NavLabel { dashboard, clients, schedule, coaching, reports, consultations }
+enum NavLabel {
+  dashboard,
+  clients,
+  schedule,
+  coaching,
+  reports,
+  consultations,
+  notifications,
+}
 
 /// 라벨 키 → 현재 로케일의 문구.
 String navLabel(AppLocalizations l, NavLabel label) => switch (label) {
@@ -71,6 +79,7 @@ String navLabel(AppLocalizations l, NavLabel label) => switch (label) {
   NavLabel.coaching => l.navCoaching,
   NavLabel.reports => l.navReports,
   NavLabel.consultations => l.navConsultations,
+  NavLabel.notifications => l.navNotifications,
 };
 
 const List<NavDestination> navDestinations = <NavDestination>[
@@ -126,7 +135,7 @@ const NavDestination consultationsDestination = NavDestination(
 /// 알림함 — [consultationsDestination] 과 같은 이유로 [navDestinations] 밖에
 /// 둔다. 실 API 빌드에서만 보이고, 브랜치 인덱스를 사이드바가 직접 넘긴다. (#503)
 const NavDestination notificationsDestination = NavDestination(
-  label: '알림',
+  label: NavLabel.notifications,
   icon: Icons.notifications_none,
   activeIcon: Icons.notifications,
   route: AppRoutes.notifications,

--- a/frontend/flutter_trainer/lib/features/notifications/presentation/pages/notifications_page.dart
+++ b/frontend/flutter_trainer/lib/features/notifications/presentation/pages/notifications_page.dart
@@ -9,9 +9,10 @@ import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/features/notifications/data/repositories/notification_repository.dart';
 import 'package:oncare_trainer/features/notifications/domain/entities/trainer_notification.dart';
+import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 import 'package:oncare_trainer/shared/widgets/action_button.dart';
-import 'package:oncare_trainer/shared/widgets/section_card.dart';
 import 'package:oncare_trainer/shared/widgets/page_scaffold.dart';
+import 'package:oncare_trainer/shared/widgets/section_card.dart';
 
 /// 알림함 — 트레이너가 놓친 변화를 나중에 확인하는 자리. (#503)
 ///
@@ -59,12 +60,12 @@ class NotificationsPage extends ConsumerWidget {
 
   Future<void> _readAll(BuildContext context, WidgetRef ref) async {
     final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    // messenger 와 같이 await 전에 잡아 둔다.
+    final AppLocalizations l = AppLocalizations.of(context);
     try {
       await ref.read(trainerNotificationRepositoryProvider).markAllRead();
     } catch (_) {
-      messenger.showSnackBar(
-        const SnackBar(content: Text('읽음 처리에 실패했어요. 잠시 후 다시 시도해 주세요')),
-      );
+      messenger.showSnackBar(SnackBar(content: Text(l.notifReadAllFailed)));
       return;
     }
     ref
@@ -74,18 +75,19 @@ class NotificationsPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final AppLocalizations l = AppLocalizations.of(context);
     final notifications = ref.watch(trainerNotificationsProvider);
     final unread = ref.watch(trainerUnreadNotificationsProvider).valueOrNull;
 
     return PageScaffold(
-      title: '알림',
+      title: l.notifTitle,
       subtitle: unread == null
           ? null
-          : (unread > 0 ? '읽지 않은 알림 $unread건' : '모두 확인했어요'),
+          : (unread > 0 ? l.notifUnreadCount(unread) : l.notifAllRead),
       actions: <Widget>[
         if (unread != null && unread > 0)
           ActionButton(
-            label: '모두 읽음',
+            label: l.notifReadAll,
             icon: Icons.done_all,
             onPressed: () => _readAll(context, ref),
           ),
@@ -100,16 +102,16 @@ class NotificationsPage extends ConsumerWidget {
           child: EmptyHint(
             message:
                 (error is AppError ? error.message : null) ??
-                '알림을 불러오지 못했어요',
+                l.notifLoadFailed,
             icon: Icons.error_outline,
           ),
         ),
         data: (rows) {
           if (rows.isEmpty) {
-            return const Padding(
+            return Padding(
               padding: EdgeInsets.only(top: AppSpacing.xxl),
               child: EmptyHint(
-                message: '아직 받은 알림이 없어요',
+                message: l.notifEmpty,
                 icon: Icons.notifications_none,
               ),
             );

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
@@ -3265,6 +3265,54 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'On - Care Trainer'**
   String get appTitleSpaced;
+
+  /// No description provided for @navNotifications.
+  ///
+  /// In en, this message translates to:
+  /// **'Notifications'**
+  String get navNotifications;
+
+  /// No description provided for @notifTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Notifications'**
+  String get notifTitle;
+
+  /// No description provided for @notifReadAll.
+  ///
+  /// In en, this message translates to:
+  /// **'Mark all read'**
+  String get notifReadAll;
+
+  /// No description provided for @notifEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'No notifications yet'**
+  String get notifEmpty;
+
+  /// No description provided for @notifLoadFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t load notifications'**
+  String get notifLoadFailed;
+
+  /// No description provided for @notifAllRead.
+  ///
+  /// In en, this message translates to:
+  /// **'All caught up'**
+  String get notifAllRead;
+
+  /// No description provided for @notifReadAllFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t mark them read. Please try again in a moment'**
+  String get notifReadAllFailed;
+
+  /// No description provided for @notifUnreadCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} unread'**
+  String notifUnreadCount(int count);
 }
 
 class _AppLocalizationsDelegate

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
@@ -1805,4 +1805,31 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get appTitleSpaced => 'On - Care Trainer';
+
+  @override
+  String get navNotifications => 'Notifications';
+
+  @override
+  String get notifTitle => 'Notifications';
+
+  @override
+  String get notifReadAll => 'Mark all read';
+
+  @override
+  String get notifEmpty => 'No notifications yet';
+
+  @override
+  String get notifLoadFailed => 'Couldn\'t load notifications';
+
+  @override
+  String get notifAllRead => 'All caught up';
+
+  @override
+  String get notifReadAllFailed =>
+      'Couldn\'t mark them read. Please try again in a moment';
+
+  @override
+  String notifUnreadCount(int count) {
+    return '$count unread';
+  }
 }

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
@@ -1756,4 +1756,30 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get appTitleSpaced => 'On - Care 트레이너';
+
+  @override
+  String get navNotifications => '알림';
+
+  @override
+  String get notifTitle => '알림';
+
+  @override
+  String get notifReadAll => '모두 읽음';
+
+  @override
+  String get notifEmpty => '아직 받은 알림이 없어요';
+
+  @override
+  String get notifLoadFailed => '알림을 불러오지 못했어요';
+
+  @override
+  String get notifAllRead => '모두 확인했어요';
+
+  @override
+  String get notifReadAllFailed => '읽음 처리에 실패했어요. 잠시 후 다시 시도해 주세요';
+
+  @override
+  String notifUnreadCount(int count) {
+    return '읽지 않은 알림 $count건';
+  }
 }

--- a/frontend/flutter_trainer/lib/l10n/app_en.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_en.arb
@@ -1230,5 +1230,20 @@
   "appTitleSpaced": "On - Care Trainer",
   "@appTitleSpaced": {
     "description": "Login screen wordmark with the spaced hyphen used in the visual design."
+  },
+  "navNotifications": "Notifications",
+  "notifTitle": "Notifications",
+  "notifReadAll": "Mark all read",
+  "notifEmpty": "No notifications yet",
+  "notifLoadFailed": "Couldn't load notifications",
+  "notifAllRead": "All caught up",
+  "notifReadAllFailed": "Couldn't mark them read. Please try again in a moment",
+  "notifUnreadCount": "{count} unread",
+  "@notifUnreadCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   }
 }

--- a/frontend/flutter_trainer/lib/l10n/app_ko.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_ko.arb
@@ -527,5 +527,13 @@
   "schedHourLabel": "{hour}시",
   "schedMinuteLabel": "{minute}분",
   "progDefaultReps": "10회",
-  "appTitleSpaced": "On - Care 트레이너"
+  "appTitleSpaced": "On - Care 트레이너",
+  "navNotifications": "알림",
+  "notifTitle": "알림",
+  "notifReadAll": "모두 읽음",
+  "notifEmpty": "아직 받은 알림이 없어요",
+  "notifLoadFailed": "알림을 불러오지 못했어요",
+  "notifAllRead": "모두 확인했어요",
+  "notifReadAllFailed": "읽음 처리에 실패했어요. 잠시 후 다시 시도해 주세요",
+  "notifUnreadCount": "읽지 않은 알림 {count}건"
 }

--- a/frontend/flutter_trainer/test/features/notifications/notifications_page_test.dart
+++ b/frontend/flutter_trainer/test/features/notifications/notifications_page_test.dart
@@ -14,6 +14,10 @@ import 'package:oncare_trainer/features/notifications/data/repositories/notifica
 import 'package:oncare_trainer/features/notifications/domain/entities/trainer_notification.dart';
 
 import '../../helpers/pump_app.dart';
+import 'package:oncare_trainer/gen/l10n/app_localizations_ko.dart';
+
+/// 라벨 기대값은 로케일을 명시해 읽는다.
+final AppLocalizationsKo _ko = AppLocalizationsKo();
 
 TrainerNotification _notification({
   String id = 'noti-1',
@@ -78,7 +82,7 @@ void main() {
     await withWideSurface(tester, () async {
       await pumpTrainerApp(tester, token: 'demo-token');
 
-      expect(find.text(notificationsDestination.label), findsNothing);
+      expect(find.text(navLabel(_ko, notificationsDestination.label)), findsNothing);
     });
   });
 
@@ -94,7 +98,7 @@ void main() {
         ],
       );
 
-      expect(find.text(notificationsDestination.label), findsOneWidget);
+      expect(find.text(navLabel(_ko, notificationsDestination.label)), findsOneWidget);
     });
   });
 


### PR DESCRIPTION
## Summary

**main 이 컴파일되지 않는 상태였습니다.** #515(다국어)와 #518(알림함)이 **텍스트 충돌 없이** 자동 병합되면서 타입 오류만 남았습니다.

* #515 가 `NavDestination.label` 을 `String` → `NavLabel` enum 으로 바꿨습니다.
* #518 이 추가한 `notificationsDestination` 은 `label: '알림'` 로 String 을 넘깁니다.
* 서로 다른 줄이라 git 은 충돌로 보지 않았고, 머지 후에야 `flutter analyze` 에서 드러났습니다.

## Changes

* `NavLabel` 에 `notifications` 추가 + `navLabel` 매핑.
* 알림함 화면의 한국어 하드코딩(제목·모두 읽음·빈 상태·실패 문구·미읽음 수)을 **arb 로 이관** — #515 가 세운 파이프라인에 #518 의 문구를 얹습니다.
* 테스트도 로케일을 명시해 라벨을 읽습니다(다른 nav 테스트와 같은 방식).
* '모두 읽음' 실패 경로의 `l` 을 await 전에 확보(async gap).

## Notes

**왜 생겼나.** 두 PR 을 각각 열 때 이 충돌을 예상해 "#515 를 먼저 머지하면 나머지 문구를 한 번에 정리할 수 있다"고 적어 뒀는데, 실제 머지 순서가 #515 → #518 로 갔음에도 **git 이 충돌로 잡지 못하는 형태**여서 사후 복구가 됐습니다. 타입 시스템이 잡아 준 것이 다행이고, CI 가 main push 에는 돌지 않아 머지 직후에는 드러나지 않았습니다.

**남은 트레이너 앱 PR(#519·#522)도 같은 정리가 필요합니다** — 각 PR 에서 arb 이관까지 함께 하겠습니다.

## 검증

* `flutter analyze` 무이슈, `flutter test` **410 passed**
* 영어 로케일 회귀 테스트 통과(한글 잔존 없음)