### PR TITLE
feat(trainer-clients): 데모 고객 데이터를 15명으로 확장

### DIFF
--- a/frontend/flutter_trainer/lib/core/storage/seed_clients.dart
+++ b/frontend/flutter_trainer/lib/core/storage/seed_clients.dart
@@ -1,0 +1,813 @@
+part of 'seed_data.dart';
+
+/// The demo roster: fifteen members whose numbers actually move.
+///
+/// A demo roster is a fixture for the *charts*, not just the list. Three
+/// clients with mild, similar weeks left most of the console's states
+/// unreachable by clicking around: nothing was ever empty, nothing ever
+/// collapsed, no sparkline ever spiked, and the 확인 필요 고객 card never
+/// had to say "+N명". So these are built as a spread across the states
+/// the UI can render, not as fifteen plausible-looking averages.
+///
+/// The thresholds they are aimed at (see `client_alerts.dart`):
+///  * `sodiumMg > 2000` → 나트륨 초과;
+///  * mean of the **non-zero** `weekCompletion` days `< 60` → 이행률 저조
+///    (zero days are "no record", so a client who logged one good day is
+///    not failing — that asymmetry is easy to get wrong by eye, and half
+///    of these exist to pin it down);
+///  * `sugarG > 50` → the 당류 tile warns;
+///  * `threadHandled: false` → 답장 대기.
+///
+/// Coverage this is meant to guarantee, by client:
+///  1  김민수    나트륨 초과, 톱니형 이행률
+///  2  이지수    무알림 (주말만 미기록)
+///  3  박성호    나트륨 초과 + 휴면, 기록 거의 없음
+///  4  정하윤    V자 — 무너졌다 회복, 나트륨 급락 후 반등
+///  5  최우진    완벽 — 알림 0, 7일 100% (대조군)
+///  6  강서연    주말 붕괴 — 평일 완벽, 주말 나트륨 폭등 + 당류 초과
+///  7  임도현    신규 — 식단·기록·추이 전부 비어 있음 (빈 상태 검증)
+///  8  오세라    급성 악화 — 나트륨 우상향, 이행률 우하향, 답장 대기
+///  9  배준혁    야근형 — 이행률 저조 + 나트륨 들쭉날쭉 + 답장 대기
+///  10 신유나    회복 중 — 나트륨 우하향, 이행률 우상향
+///  11 한지호    정체기 — 목표선 위아래로 진동 (경계값)
+///  12 문가영    휴면 — 주 3일치만 기록되고 끊김 (짧은 스파크라인)
+///  13 류태경    극단 — 0↔100, 1200↔3200 지그재그 (최대 진폭)
+///  14 백서진    운동은 완벽한데 나트륨만 계속 초과
+///  15 노은채    단 하루만 기록 (단일 포인트 스파크라인)
+const List<_Client> _clients = <_Client>[
+  _Client(
+    id: 1,
+    name: '김민수',
+    avatar: '김',
+    goal: '혈압 관리 · 체중 감량',
+    lastMessage: '오늘 식단 전송됐어요',
+    lastTime: '방금',
+    threadHandled: true,
+    active: true,
+    calories: 1420,
+    sodiumMg: 2100,
+    sugarG: 45,
+    lastRoutine: '오늘',
+    weekCompletion: <int>[100, 67, 100, 0, 100, 67, 100],
+    sodiumWeek: <int>[2400, 2200, 1900, 2050, 2300, 1850, 2100],
+    diet: <_Meal>[
+      _Meal('아침', '오트밀, 바나나', 315, 380),
+      _Meal('점심', '닭가슴살 샐러드, 현미밥', 620, 890),
+      _Meal('저녁', '두부찌개, 잡곡밥', 485, 830),
+    ],
+    aiRoutine: <_Routine>[
+      _Routine('저강도 유산소 (걷기)', 30, '유산소', '혈압 안정에 효과적'),
+      _Routine('하체 스트레칭', 15, '스트레칭', '혈액순환 개선'),
+      _Routine('코어 강화', 10, '근력', '기초대사량 향상'),
+    ],
+    history: <_History>[
+      _History(
+        dateLabel: '7/12 (오늘)',
+        label: 'PT 세션 · 트레이너 지도',
+        completionRate: 100,
+        exercises: <String>['레그프레스 3세트', '레그컬 3세트', '하체 스트레칭'],
+        clientFeedback: '무릎이 좀 당겼지만 트레이너님 덕분에 잘 마쳤어요 😊',
+        trainerNote: '무릎 가동범위 체크 필요. 다음 세션 중량 조절 예정.',
+      ),
+      _History(
+        dateLabel: '7/10',
+        label: 'AI 루틴 · 자율 운동',
+        completionRate: 67,
+        exercises: <String>['걷기 30분 ✓', '코어 강화 10분 ✓', '스트레칭 ✗ (생략)'],
+        clientFeedback: '스트레칭은 시간이 없어서 못 했어요',
+        trainerNote: '',
+      ),
+      _History(
+        dateLabel: '7/8',
+        label: 'AI 루틴 · 자율 운동',
+        completionRate: 100,
+        exercises: <String>['걷기 30분 ✓', '코어 강화 10분 ✓', '하체 스트레칭 15분 ✓'],
+        clientFeedback: '오늘은 다 했어요! 뿌듯해요 💪',
+        trainerNote: '',
+      ),
+    ],
+    chat: <_Chat>[
+      _Chat(
+        'trainer',
+        '민수님, AI 식단 분석 잘 받았어요 👍 오늘 나트륨이 목표치를 좀 넘었는데 어떠셨어요?',
+        '18:10',
+      ),
+      _Chat('client', '찌개 먹을 때 국물을 많이 마셨나봐요 😅', '18:13'),
+      _Chat('trainer', '그렇군요! 오늘 PT 후에 부상이나 불편한 데는 없으셨나요?', '18:14'),
+      _Chat('client', '무릎이 가볍게 당기긴 했는데 괜찮아요', '18:16'),
+      _Chat(
+        'trainer',
+        '확인했어요. AI가 오늘 식단 기반으로 유산소 루틴을 추천했는데, 무릎 상태 감안해서 런닝 대신 걷기로 조정해서 보낼게요. 다음 PT 때 봐요 💪',
+        '18:18',
+      ),
+    ],
+  ),
+  _Client(
+    id: 2,
+    name: '이지수',
+    avatar: '이',
+    goal: '체력 강화 · 다이어트',
+    lastMessage: '루틴 받았어요, 감사합니다!',
+    lastTime: '1시간 전',
+    active: true,
+    calories: 1680,
+    sodiumMg: 1800,
+    sugarG: 38,
+    lastRoutine: '어제',
+    weekCompletion: <int>[67, 100, 100, 100, 100, 0, 0],
+    sodiumWeek: <int>[1700, 1950, 1600, 1800, 2100, 1750, 1800],
+    diet: <_Meal>[
+      _Meal('아침', '그릭요거트, 과일', 280, 200),
+      _Meal('점심', '현미밥, 불고기, 나물', 750, 980),
+      _Meal('저녁', '연어 샐러드', 650, 620),
+    ],
+    aiRoutine: <_Routine>[
+      _Routine('인터벌 런닝', 25, '유산소', '체지방 연소 효율↑'),
+      _Routine('스쿼트 3세트', 15, '근력', '하체 근력 강화'),
+      _Routine('플랭크', 10, '근력', '코어 안정화'),
+    ],
+    history: <_History>[
+      _History(
+        dateLabel: '7/11 (어제)',
+        label: 'AI 루틴 · 자율 운동',
+        completionRate: 100,
+        exercises: <String>['인터벌 런닝 25분 ✓', '스쿼트 3세트 ✓', '플랭크 10분 ✓'],
+        clientFeedback: '런닝이 힘들었는데 다 했어요! 숨이 많이 찼어요',
+        trainerNote: '심폐지구력 향상 중. 다음 주 런닝 강도 소폭 올릴 예정.',
+      ),
+      _History(
+        dateLabel: '7/9',
+        label: 'PT 세션 · 트레이너 지도',
+        completionRate: 100,
+        exercises: <String>['데드리프트 3세트', '런지 3세트', '코어 서킷'],
+        clientFeedback: '데드리프트 자세 교정 도움 많이 됐어요!',
+        trainerNote: '',
+      ),
+      _History(
+        dateLabel: '7/7',
+        label: 'AI 루틴 · 자율 운동',
+        completionRate: 67,
+        exercises: <String>['런닝 25분 ✓', '스쿼트 ✓', '플랭크 ✗ (피로)'],
+        clientFeedback: '마지막 플랭크는 너무 지쳐서 못 했어요',
+        trainerNote: '',
+      ),
+    ],
+    chat: <_Chat>[
+      _Chat(
+        'trainer',
+        '지수님, AI 운동 데이터 수신했어요 — 오늘 인터벌 런닝 25분 완료! 컨디션은 어때요?',
+        '20:05',
+      ),
+      _Chat('client', '생각보다 괜찮았어요. 숨이 금방 차더라고요 😮‍💨', '20:08'),
+      _Chat(
+        'trainer',
+        '심폐 지구력 올라가는 과정이에요 💪 AI 분석 보니까 당류는 목표 안에 있고, 루틴 다음 주부터 근력 비중 늘려볼게요. 식단도 AI 추천 참고해서 업데이트해 드릴게요',
+        '20:10',
+      ),
+    ],
+  ),
+  _Client(
+    id: 3,
+    name: '박성호',
+    avatar: '박',
+    goal: '근력 향상',
+    lastMessage: '이번 주 운동 못했어요...',
+    lastTime: '3일 전',
+    active: false,
+    calories: 2100,
+    sodiumMg: 2400,
+    sugarG: 55,
+    lastRoutine: '5일 전',
+    weekCompletion: <int>[0, 33, 100, 0, 0, 0, 0],
+    sodiumWeek: <int>[2600, 2500, 2300, 2450, 2200, 2550, 2400],
+    diet: <_Meal>[
+      _Meal('아침', '계란 3개, 토스트', 480, 520),
+      _Meal('점심', '짜장면', 890, 1200),
+      _Meal('저녁', '삼겹살, 쌈채소', 730, 680),
+    ],
+    aiRoutine: <_Routine>[
+      _Routine('벤치프레스 4세트', 20, '근력', '상체 근력 목표'),
+      _Routine('데드리프트 3세트', 15, '근력', '전신 근력 향상'),
+      _Routine('유산소 쿨다운', 10, '유산소', '나트륨 배출 지원'),
+    ],
+    history: <_History>[
+      _History(
+        dateLabel: '7/7',
+        label: 'PT 세션 · 트레이너 지도',
+        completionRate: 100,
+        exercises: <String>['벤치프레스 4세트', '인클라인 덤벨 3세트', '트라이셉스 딥'],
+        clientFeedback: '가슴이 많이 타는 느낌이었어요. 좋았어요!',
+        trainerNote: '벤치 중량 62.5kg → 65kg 도전 가능. 다음 PT 때 시도 예정.',
+      ),
+      _History(
+        dateLabel: '7/5',
+        label: 'AI 루틴 · 자율 운동',
+        completionRate: 33,
+        exercises: <String>['벤치프레스 ✓', '데드리프트 ✗', '유산소 ✗'],
+        clientFeedback: '회사 일이 생겨서 벤치만 하고 나왔어요',
+        trainerNote: '',
+      ),
+      _History(
+        dateLabel: '7/3',
+        label: 'AI 루틴 · 자율 운동',
+        completionRate: 0,
+        exercises: <String>['벤치프레스 ✗', '데드리프트 ✗', '유산소 ✗'],
+        clientFeedback: '못 갔어요 😓',
+        trainerNote: '',
+      ),
+    ],
+    chat: <_Chat>[
+      _Chat('trainer', '성호님, 이번 주 운동 기록이 AI 쪽에서 안 잡히는데 몸은 괜찮으세요?', '월 09:00'),
+      _Chat('client', '이번 주 일이 너무 많아서 못 갔어요 😓', '월 09:03'),
+      _Chat(
+        'trainer',
+        '이해해요! 대신 AI 식단 분석 보니까 나트륨이 좀 높더라고요. 주말에 30분 걷기라도 하면 도움 돼요. AI가 그에 맞는 루틴 다시 짜줬으니까 앱에서 확인해보세요 🙂',
+        '월 09:07',
+      ),
+    ],
+  ),
+
+  // --- V자 회복: 무너졌다가 되돌아온 주 -------------------------------
+  _Client(
+    id: 4,
+    name: '정하윤',
+    avatar: '정',
+    goal: '산후 체력 회복',
+    lastMessage: '이번 주부터 다시 시작했어요!',
+    lastTime: '2시간 전',
+    threadHandled: true,
+    active: true,
+    calories: 1520,
+    sodiumMg: 1650,
+    sugarG: 32,
+    lastRoutine: '오늘',
+    // 주 중반에 완전히 끊겼다가 후반에 되돌아온다 — 막대가 V를 그린다.
+    weekCompletion: <int>[100, 25, 0, 0, 50, 100, 100],
+    // 나트륨도 같이 급락했다 반등: 외식이 끊긴 구간이 그대로 보인다.
+    sodiumWeek: <int>[2900, 2600, 1500, 1250, 1400, 1900, 1650],
+    diet: <_Meal>[
+      _Meal('아침', '통밀토스트, 아보카도', 340, 290),
+      _Meal('점심', '닭가슴살 도시락', 520, 640),
+      _Meal('저녁', '채소 스프, 두부, 현미밥', 660, 720),
+    ],
+    aiRoutine: <_Routine>[
+      _Routine('저강도 걷기', 25, '유산소', '회복기 심박 관리'),
+      _Routine('골반 안정화', 15, '스트레칭', '산후 코어 재활'),
+      _Routine('밴드 로우', 12, '근력', '상체 자세 교정'),
+    ],
+    history: <_History>[
+      _History(
+        dateLabel: '7/12 (오늘)',
+        label: 'AI 루틴 · 자율 운동',
+        completionRate: 100,
+        exercises: <String>['걷기 25분 ✓', '골반 안정화 15분 ✓', '밴드 로우 12분 ✓'],
+        clientFeedback: '컨디션 돌아온 게 느껴져요. 다 했습니다!',
+        trainerNote: '2주 공백 후 복귀 성공. 다음 주부터 강도 10% 상향.',
+      ),
+      _History(
+        dateLabel: '7/9',
+        label: 'AI 루틴 · 자율 운동',
+        completionRate: 50,
+        exercises: <String>['걷기 25분 ✓', '골반 안정화 ✗ (아이 컨디션)'],
+        clientFeedback: '아이가 아파서 절반만 했어요',
+        trainerNote: '',
+      ),
+      _History(
+        dateLabel: '7/6',
+        label: 'AI 루틴 · 자율 운동',
+        completionRate: 0,
+        exercises: <String>['걷기 ✗', '골반 안정화 ✗', '밴드 로우 ✗'],
+        clientFeedback: '한 주 통째로 쉬었어요',
+        trainerNote: '',
+      ),
+    ],
+    chat: <_Chat>[
+      _Chat('trainer', '하윤님, 지난주 공백 뒤에 오늘 세 개 다 채우셨네요 👏', '14:20'),
+      _Chat('client', '몸이 다시 붙는 느낌이에요. 나트륨도 신경 썼어요!', '14:26'),
+      _Chat('trainer', '추이 보니 확실히 내려왔어요. 이 페이스로 한 주만 더 가보죠 🙂', '14:31'),
+    ],
+  ),
+
+  // --- 대조군: 알림이 하나도 없는 고객 --------------------------------
+  _Client(
+    id: 5,
+    name: '최우진',
+    avatar: '최',
+    goal: '마라톤 완주 준비',
+    lastMessage: '내일 장거리 뜁니다',
+    lastTime: '어제',
+    threadHandled: true,
+    active: true,
+    calories: 1750,
+    sodiumMg: 1180,
+    sugarG: 22,
+    lastRoutine: '오늘',
+    weekCompletion: <int>[100, 100, 100, 100, 100, 100, 100],
+    // 거의 평평한 스파크라인 — 목표선 근처에서 흔들리는 다른 고객과 대비된다.
+    sodiumWeek: <int>[1300, 1250, 1100, 1200, 1150, 1090, 1180],
+    diet: <_Meal>[
+      _Meal('아침', '오트밀, 블루베리', 360, 150),
+      _Meal('점심', '현미밥, 흰살생선, 나물', 640, 520),
+      _Meal('저녁', '닭가슴살, 고구마', 750, 510),
+    ],
+    aiRoutine: <_Routine>[
+      _Routine('LSD 러닝', 45, '유산소', '유산소 기반 다지기'),
+      _Routine('힙 힌지 드릴', 12, '근력', '러닝 이코노미 개선'),
+      _Routine('종아리 스트레칭', 10, '스트레칭', '부상 예방'),
+    ],
+    history: <_History>[
+      _History(
+        dateLabel: '7/12 (오늘)',
+        label: 'AI 루틴 · 자율 운동',
+        completionRate: 100,
+        exercises: <String>['LSD 러닝 45분 ✓', '힙 힌지 12분 ✓', '스트레칭 10분 ✓'],
+        clientFeedback: '페이스 안정적이었어요',
+        trainerNote: '7일 연속 100%. 과훈련 신호 없는지 다음 주 확인.',
+      ),
+      _History(
+        dateLabel: '7/11 (어제)',
+        label: 'AI 루틴 · 자율 운동',
+        completionRate: 100,
+        exercises: <String>['인터벌 8세트 ✓', '코어 서킷 ✓', '스트레칭 ✓'],
+        clientFeedback: '인터벌 끝나고 다리가 후들거렸어요 😅',
+        trainerNote: '',
+      ),
+    ],
+    chat: <_Chat>[
+      _Chat('trainer', '우진님, 이번 주 7일 전부 100% 나왔어요. 무리는 없으세요?', '21:00'),
+      _Chat('client', '아직은 괜찮아요! 주말 장거리만 잘 넘기면 될 것 같아요', '21:04'),
+      _Chat('trainer', '좋아요. 대신 수요일은 회복 루틴으로 잡아둘게요 🙂', '21:06'),
+    ],
+  ),
+
+  // --- 주말 붕괴형: 평일과 주말이 완전히 다른 사람 ---------------------
+  _Client(
+    id: 6,
+    name: '강서연',
+    avatar: '강',
+    goal: '체지방 감량',
+    lastMessage: '주말엔 약속이 많아서요 😅',
+    lastTime: '5시간 전',
+    threadHandled: true,
+    active: true,
+    calories: 2260,
+    sodiumMg: 2750,
+    sugarG: 68,
+    lastRoutine: '금요일',
+    // 평일 완벽, 주말 0 — 막대가 절벽처럼 끊긴다.
+    weekCompletion: <int>[100, 100, 100, 100, 100, 0, 0],
+    // 같은 주말에 나트륨이 두 배로 뛴다.
+    sodiumWeek: <int>[1400, 1350, 1500, 1420, 1380, 3100, 2750],
+    diet: <_Meal>[
+      _Meal('아침', '거름', 0, 0),
+      _Meal('점심', '마라탕', 980, 1850),
+      _Meal('저녁', '치킨, 맥주', 1280, 900),
+    ],
+    aiRoutine: <_Routine>[
+      _Routine('주말 회복 걷기', 30, '유산소', '주말 나트륨 배출'),
+      _Routine('전신 서킷', 20, '근력', '평일 루틴 유지'),
+      _Routine('상체 스트레칭', 10, '스트레칭', '피로 해소'),
+    ],
+    history: <_History>[
+      _History(
+        dateLabel: '7/11 (어제)',
+        label: 'AI 루틴 · 자율 운동',
+        completionRate: 0,
+        exercises: <String>['걷기 ✗', '전신 서킷 ✗', '스트레칭 ✗'],
+        clientFeedback: '주말은 약속이 계속 있었어요 😅',
+        trainerNote: '평일 100% / 주말 0% 패턴 5주째. 주말용 15분 루틴으로 분리 검토.',
+      ),
+      _History(
+        dateLabel: '7/9',
+        label: 'AI 루틴 · 자율 운동',
+        completionRate: 100,
+        exercises: <String>['전신 서킷 20분 ✓', '걷기 30분 ✓', '스트레칭 10분 ✓'],
+        clientFeedback: '평일엔 루틴대로 잘 되고 있어요',
+        trainerNote: '',
+      ),
+    ],
+    chat: <_Chat>[
+      _Chat('trainer', '서연님, 평일은 완벽한데 주말에 나트륨이 3100까지 올라갔어요', '16:40'),
+      _Chat('client', '주말엔 약속이 많아서요 😅 마라탕이 문제였나봐요', '16:45'),
+      _Chat(
+        'trainer',
+        '주말만 따로 15분짜리 가벼운 루틴으로 잡아드릴게요. 안 하는 것보다 훨씬 나아요 🙂',
+        '16:48',
+      ),
+    ],
+  ),
+
+  // --- 신규: 아직 아무 데이터도 없는 고객 (빈 상태 검증) ----------------
+  _Client(
+    id: 7,
+    name: '임도현',
+    avatar: '임',
+    goal: '목표 설정 전',
+    lastMessage: '아직 대화가 없어요',
+    lastTime: '-',
+    threadHandled: true,
+    active: true,
+    calories: 0,
+    sodiumMg: 0,
+    sugarG: 0,
+    lastRoutine: '-',
+    // 기록이 하나도 없다. `isLowCompletion` 이 0 만 있는 주를 실패로 세지
+    // 않는다는 규칙이 여기서 눈으로 확인된다 — 배지가 뜨면 안 된다.
+    weekCompletion: <int>[0, 0, 0, 0, 0, 0, 0],
+    sodiumWeek: <int>[],
+    diet: <_Meal>[],
+    aiRoutine: <_Routine>[
+      _Routine('체력 측정 걷기', 20, '유산소', '기초 체력 파악'),
+      _Routine('맨몸 스쿼트', 10, '근력', '하체 기준선 측정'),
+      _Routine('전신 스트레칭', 10, '스트레칭', '가동범위 확인'),
+    ],
+    history: <_History>[],
+    chat: <_Chat>[],
+  ),
+
+  // --- 급성 악화: 모든 지표가 같은 방향으로 나빠진다 --------------------
+  _Client(
+    id: 8,
+    name: '오세라',
+    avatar: '오',
+    goal: '고혈압 관리',
+    lastMessage: '요즘 너무 바빠서 못 하고 있어요',
+    lastTime: '어제',
+    active: true,
+    calories: 2480,
+    sodiumMg: 3250,
+    sugarG: 82,
+    lastRoutine: '6일 전',
+    // 이행률은 계단식으로 떨어지고…
+    weekCompletion: <int>[80, 60, 40, 33, 20, 0, 0],
+    // …나트륨은 같은 기간 계속 올라간다. 두 그래프가 정확히 반대로 간다.
+    sodiumWeek: <int>[1900, 2150, 2400, 2650, 2900, 3050, 3250],
+    diet: <_Meal>[
+      _Meal('아침', '편의점 삼각김밥 2개', 420, 780),
+      _Meal('점심', '부대찌개, 공기밥', 920, 1650),
+      _Meal('저녁', '족발, 소주', 1140, 820),
+    ],
+    aiRoutine: <_Routine>[
+      _Routine('저강도 걷기', 20, '유산소', '혈압 우선 안정'),
+      _Routine('호흡 이완', 10, '스트레칭', '교감신경 완화'),
+      _Routine('의자 스쿼트', 8, '근력', '최소 부하로 재시작'),
+    ],
+    history: <_History>[
+      _History(
+        dateLabel: '7/8',
+        label: 'AI 루틴 · 자율 운동',
+        completionRate: 20,
+        exercises: <String>['걷기 ✓ (10분만)', '호흡 이완 ✗', '의자 스쿼트 ✗'],
+        clientFeedback: '10분 걷다가 회사에서 전화 와서 끊었어요',
+        trainerNote: '나트륨 3000 돌파 + 이행률 20%. 이번 주 안에 전화 상담 필요.',
+      ),
+      _History(
+        dateLabel: '7/6',
+        label: 'AI 루틴 · 자율 운동',
+        completionRate: 33,
+        exercises: <String>['걷기 ✓', '호흡 이완 ✗', '의자 스쿼트 ✗'],
+        clientFeedback: '피곤해서 걷기만 했어요',
+        trainerNote: '',
+      ),
+    ],
+    chat: <_Chat>[
+      _Chat('trainer', '세라님, 나트륨이 6일 연속 올라서 3250까지 왔어요. 혈압은 재보셨어요?', '09:10'),
+      _Chat('client', '요즘 너무 바빠서 못 하고 있어요', '09:34'),
+      _Chat('client', '주말엔 꼭 재볼게요...', '09:35'),
+    ],
+  ),
+
+  // --- 야근형: 이행률이 낮고 나트륨이 널뛴다 ---------------------------
+  _Client(
+    id: 9,
+    name: '배준혁',
+    avatar: '배',
+    goal: '수면 · 컨디션 개선',
+    lastMessage: '오늘도 야근이라 못 갈 것 같아요',
+    lastTime: '30분 전',
+    active: true,
+    calories: 2050,
+    sodiumMg: 2280,
+    sugarG: 47,
+    lastRoutine: '4일 전',
+    // 0 이 아닌 날 평균 36% — 이행률 저조 배지가 뜨는 쪽.
+    weekCompletion: <int>[50, 0, 33, 0, 25, 0, 0],
+    // 야근 여부에 따라 위아래로 튄다.
+    sodiumWeek: <int>[2100, 2600, 1800, 2900, 2200, 1600, 2280],
+    diet: <_Meal>[
+      _Meal('아침', '커피만', 20, 10),
+      _Meal('점심', '김치찌개, 공기밥', 780, 1420),
+      _Meal('저녁', '야근 도시락, 편의점 야식', 1250, 850),
+    ],
+    aiRoutine: <_Routine>[
+      _Routine('퇴근 후 걷기', 15, '유산소', '짧게라도 유지'),
+      _Routine('목·어깨 스트레칭', 10, '스트레칭', '장시간 착석 보완'),
+      _Routine('플랭크', 5, '근력', '최소 코어 유지'),
+    ],
+    history: <_History>[
+      _History(
+        dateLabel: '7/10',
+        label: 'AI 루틴 · 자율 운동',
+        completionRate: 25,
+        exercises: <String>['목·어깨 스트레칭 ✓', '걷기 ✗', '플랭크 ✗'],
+        clientFeedback: '자기 전에 스트레칭만 겨우 했어요',
+        trainerNote: '15분 루틴도 못 채우는 주가 반복. 5분 버전으로 낮춰볼 것.',
+      ),
+      _History(
+        dateLabel: '7/8',
+        label: 'AI 루틴 · 자율 운동',
+        completionRate: 33,
+        exercises: <String>['걷기 15분 ✓', '스트레칭 ✗', '플랭크 ✗'],
+        clientFeedback: '',
+        trainerNote: '',
+      ),
+    ],
+    chat: <_Chat>[
+      _Chat('trainer', '준혁님, 이번 주도 야근이 이어지네요. 5분짜리로 줄여볼까요?', '19:50'),
+      _Chat('client', '오늘도 야근이라 못 갈 것 같아요', '20:12'),
+    ],
+  ),
+
+  // --- 회복 중: 나쁜 데서 좋은 쪽으로 -----------------------------------
+  _Client(
+    id: 10,
+    name: '신유나',
+    avatar: '신',
+    goal: '재활 후 복귀',
+    lastMessage: '이번 주는 다 지켰어요 :)',
+    lastTime: '3시간 전',
+    threadHandled: true,
+    active: true,
+    calories: 1590,
+    sodiumMg: 1720,
+    sugarG: 35,
+    lastRoutine: '오늘',
+    // 주 초반 공백 → 후반 완주. 우상향 계단.
+    weekCompletion: <int>[0, 0, 33, 67, 100, 100, 100],
+    // 나트륨은 반대로 꾸준히 내려온다.
+    sodiumWeek: <int>[2800, 2500, 2200, 1950, 1800, 1750, 1720],
+    diet: <_Meal>[
+      _Meal('아침', '두유, 삶은 계란', 260, 240),
+      _Meal('점심', '비빔밥 (고추장 절반)', 680, 780),
+      _Meal('저녁', '샐러드, 닭가슴살, 현미밥', 650, 700),
+    ],
+    aiRoutine: <_Routine>[
+      _Routine('실내 자전거', 20, '유산소', '무릎 부담 없는 유산소'),
+      _Routine('레그 익스텐션', 12, '근력', '대퇴사두 재건'),
+      _Routine('무릎 가동범위', 10, '스트레칭', '재활 프로토콜'),
+    ],
+    history: <_History>[
+      _History(
+        dateLabel: '7/12 (오늘)',
+        label: 'AI 루틴 · 자율 운동',
+        completionRate: 100,
+        exercises: <String>['실내 자전거 20분 ✓', '레그 익스텐션 12분 ✓', '가동범위 10분 ✓'],
+        clientFeedback: '무릎 통증 없이 다 했어요!',
+        trainerNote: '3주 연속 개선. 다음 주 러닝머신 걷기 추가 검토.',
+      ),
+      _History(
+        dateLabel: '7/10',
+        label: 'AI 루틴 · 자율 운동',
+        completionRate: 67,
+        exercises: <String>['실내 자전거 ✓', '레그 익스텐션 ✓', '가동범위 ✗'],
+        clientFeedback: '마지막에 시간이 부족했어요',
+        trainerNote: '',
+      ),
+    ],
+    chat: <_Chat>[
+      _Chat('trainer', '유나님, 나트륨 추이가 2800에서 1700까지 내려왔어요 👏', '13:15'),
+      _Chat('client', '이번 주는 다 지켰어요 :)', '13:22'),
+      _Chat('trainer', '무릎 상태 괜찮으면 다음 주에 걷기 조금 얹어볼게요', '13:25'),
+    ],
+  ),
+
+  // --- 정체기: 목표선 위아래로만 진동 (경계값) -------------------------
+  _Client(
+    id: 11,
+    name: '한지호',
+    avatar: '한',
+    goal: '현 체중 유지',
+    lastMessage: '똑같은 것 같아요',
+    lastTime: '어제',
+    threadHandled: true,
+    active: true,
+    calories: 1880,
+    sodiumMg: 2010,
+    sugarG: 50,
+    lastRoutine: '어제',
+    // 매일 같은 값 — 완전히 평평한 막대.
+    weekCompletion: <int>[67, 67, 67, 67, 67, 67, 67],
+    // 목표선(2000) 바로 위아래에서만 흔들린다. 경계 판정 확인용.
+    sodiumWeek: <int>[1990, 2010, 1995, 2005, 1998, 2015, 2010],
+    diet: <_Meal>[
+      _Meal('아침', '시리얼, 우유', 380, 320),
+      _Meal('점심', '백반 정식', 720, 980),
+      _Meal('저녁', '된장찌개, 공기밥', 780, 710),
+    ],
+    aiRoutine: <_Routine>[
+      _Routine('트레드밀 경사 걷기', 25, '유산소', '정체 구간 자극 변화'),
+      _Routine('풀업 어시스트', 12, '근력', '상체 자극 전환'),
+      _Routine('전신 스트레칭', 10, '스트레칭', '회복'),
+    ],
+    history: <_History>[
+      _History(
+        dateLabel: '7/11 (어제)',
+        label: 'AI 루틴 · 자율 운동',
+        completionRate: 67,
+        exercises: <String>['경사 걷기 ✓', '풀업 어시스트 ✓', '스트레칭 ✗'],
+        clientFeedback: '늘 하던 만큼 했어요',
+        trainerNote: '7주째 같은 이행률·같은 나트륨. 자극 변화 필요.',
+      ),
+    ],
+    chat: <_Chat>[
+      _Chat('trainer', '지호님, 몇 주째 수치가 거의 안 움직여요. 루틴을 좀 바꿔볼까요?', '22:00'),
+      _Chat('client', '똑같은 것 같아요', '22:11'),
+      _Chat('trainer', '다음 주는 경사·중량 쪽으로 자극을 바꿔서 보내드릴게요 🙂', '22:14'),
+    ],
+  ),
+
+  // --- 휴면: 주 중반에 기록이 끊겼다 (짧은 스파크라인) ------------------
+  _Client(
+    id: 12,
+    name: '문가영',
+    avatar: '문',
+    goal: '체력 회복',
+    lastMessage: '당분간 쉬려고요',
+    lastTime: '3주 전',
+    active: false,
+    calories: 770,
+    sodiumMg: 1030,
+    sugarG: 29,
+    lastRoutine: '3주 전',
+    // 0 이 아닌 날이 하나(33%)뿐 — 이행률 저조로 잡힌다.
+    weekCompletion: <int>[33, 0, 0, 0, 0, 0, 0],
+    // 3일치만 남기고 끊긴다. 7개 미만 스파크라인 렌더링 확인용.
+    sodiumWeek: <int>[2100, 1950, 1030],
+    diet: <_Meal>[
+      _Meal('아침', '토스트, 커피', 290, 310),
+      _Meal('점심', '샌드위치', 480, 720),
+      _Meal('저녁', '기록 없음', 0, 0),
+    ],
+    aiRoutine: <_Routine>[
+      _Routine('가벼운 걷기', 20, '유산소', '복귀 준비'),
+      _Routine('전신 스트레칭', 15, '스트레칭', '휴식기 유연성 유지'),
+      _Routine('맨몸 스쿼트', 8, '근력', '최소 근력 유지'),
+    ],
+    history: <_History>[
+      _History(
+        dateLabel: '6/21',
+        label: 'AI 루틴 · 자율 운동',
+        completionRate: 33,
+        exercises: <String>['걷기 20분 ✓', '스트레칭 ✗', '스쿼트 ✗'],
+        clientFeedback: '당분간 쉬려고요',
+        trainerNote: '3주째 기록 없음. 휴면 전환. 복귀 의사 확인 필요.',
+      ),
+    ],
+    chat: <_Chat>[
+      _Chat('trainer', '가영님, 3주째 기록이 없어서요. 복귀 계획 있으실까요?', '6/21 10:00'),
+      _Chat('client', '당분간 쉬려고요', '6/21 12:40'),
+    ],
+  ),
+
+  // --- 극단 변동: 최대 진폭 --------------------------------------------
+  _Client(
+    id: 13,
+    name: '류태경',
+    avatar: '류',
+    goal: '벌크업',
+    lastMessage: '오늘은 제대로 했습니다',
+    lastTime: '1시간 전',
+    active: true,
+    calories: 3120,
+    sodiumMg: 3100,
+    sugarG: 91,
+    lastRoutine: '오늘',
+    // 하루 걸러 전부 또는 전무 — 막대가 톱니로 꽂힌다.
+    weekCompletion: <int>[100, 0, 100, 0, 100, 0, 0],
+    // 1200 ↔ 3200. 스파크라인 최대 진폭 케이스.
+    sodiumWeek: <int>[1200, 3100, 1350, 2950, 1100, 3200, 3100],
+    diet: <_Meal>[
+      _Meal('아침', '계란 5개, 오트밀', 720, 480),
+      _Meal('점심', '치킨마요 덮밥 곱빼기', 1180, 1640),
+      _Meal('저녁', '프로틴, 고구마, 야식 라면', 1220, 980),
+    ],
+    aiRoutine: <_Routine>[
+      _Routine('스쿼트 5세트', 25, '근력', '하체 볼륨 확보'),
+      _Routine('벤치프레스 5세트', 25, '근력', '상체 볼륨 확보'),
+      _Routine('유산소 쿨다운', 10, '유산소', '나트륨 배출'),
+    ],
+    history: <_History>[
+      _History(
+        dateLabel: '7/12 (오늘)',
+        label: 'PT 세션 · 트레이너 지도',
+        completionRate: 100,
+        exercises: <String>['스쿼트 5세트', '벤치프레스 5세트', '유산소 쿨다운'],
+        clientFeedback: '오늘은 제대로 했습니다',
+        trainerNote: '하는 날과 안 하는 날 편차가 큼. 주 4회 고정 스케줄 제안.',
+      ),
+      _History(
+        dateLabel: '7/11 (어제)',
+        label: 'AI 루틴 · 자율 운동',
+        completionRate: 0,
+        exercises: <String>['스쿼트 ✗', '벤치프레스 ✗', '쿨다운 ✗'],
+        clientFeedback: '어제는 아예 못 갔어요',
+        trainerNote: '',
+      ),
+    ],
+    chat: <_Chat>[
+      _Chat('trainer', '태경님, 하는 날은 100%인데 격일로 완전히 비네요', '11:20'),
+      _Chat('client', '오늘은 제대로 했습니다', '11:48'),
+      _Chat('client', '근데 식단은 자신이 없네요 😅', '11:49'),
+    ],
+  ),
+
+  // --- 운동은 완벽, 나트륨만 계속 초과 ---------------------------------
+  _Client(
+    id: 14,
+    name: '백서진',
+    avatar: '백',
+    goal: '식습관 개선',
+    lastMessage: '국물을 못 끊겠어요',
+    lastTime: '어제',
+    threadHandled: true,
+    active: true,
+    calories: 1920,
+    sodiumMg: 2680,
+    sugarG: 44,
+    lastRoutine: '오늘',
+    // 운동은 흠잡을 데가 없다.
+    weekCompletion: <int>[100, 100, 100, 100, 100, 100, 100],
+    // 그런데 나트륨은 7일 내내 목표선 위 — 높은 자리에서 평평하다.
+    sodiumWeek: <int>[2400, 2550, 2700, 2600, 2800, 2650, 2680],
+    diet: <_Meal>[
+      _Meal('아침', '북엇국, 공기밥', 520, 1120),
+      _Meal('점심', '칼국수', 880, 1260),
+      _Meal('저녁', '닭가슴살 샐러드', 520, 300),
+    ],
+    aiRoutine: <_Routine>[
+      _Routine('러닝머신', 30, '유산소', '나트륨 배출 지원'),
+      _Routine('전신 근력 서킷', 25, '근력', '현 루틴 유지'),
+      _Routine('스트레칭', 10, '스트레칭', '회복'),
+    ],
+    history: <_History>[
+      _History(
+        dateLabel: '7/12 (오늘)',
+        label: 'AI 루틴 · 자율 운동',
+        completionRate: 100,
+        exercises: <String>['러닝머신 30분 ✓', '근력 서킷 25분 ✓', '스트레칭 10분 ✓'],
+        clientFeedback: '운동은 빠짐없이 하고 있어요',
+        trainerNote: '이행률 100%인데 나트륨 7일 연속 초과. 식단 상담으로 전환.',
+      ),
+    ],
+    chat: <_Chat>[
+      _Chat('trainer', '서진님, 운동은 7일 다 채우셨어요. 다만 나트륨이 계속 2500 위예요', '20:30'),
+      _Chat('client', '국물을 못 끊겠어요', '20:41'),
+      _Chat('trainer', '국물만 절반 남기셔도 400~500은 빠져요. 그것부터 해보죠 🙂', '20:44'),
+    ],
+  ),
+
+  // --- 단 하루만 기록 (단일 포인트 스파크라인) --------------------------
+  _Client(
+    id: 15,
+    name: '노은채',
+    avatar: '노',
+    goal: '운동 습관 만들기',
+    lastMessage: '첫 운동 했어요!',
+    lastTime: '어제',
+    threadHandled: true,
+    active: true,
+    calories: 1280,
+    sodiumMg: 1450,
+    sugarG: 18,
+    lastRoutine: '어제',
+    // 하루만 100%. 0 인 날은 세지 않으므로 평균 100 — 배지가 뜨면 안 된다.
+    weekCompletion: <int>[100, 0, 0, 0, 0, 0, 0],
+    // 측정값이 하나뿐인 스파크라인.
+    sodiumWeek: <int>[1450],
+    diet: <_Meal>[
+      _Meal('아침', '바나나, 우유', 220, 130),
+      _Meal('점심', '샐러드 볼', 430, 610),
+      _Meal('저녁', '두부 스테이크, 잡곡밥', 630, 710),
+    ],
+    aiRoutine: <_Routine>[
+      _Routine('걷기', 20, '유산소', '습관 형성 우선'),
+      _Routine('맨몸 스쿼트', 8, '근력', '부담 없는 시작'),
+      _Routine('전신 스트레칭', 10, '스트레칭', '운동 후 회복'),
+    ],
+    history: <_History>[
+      _History(
+        dateLabel: '7/11 (어제)',
+        label: 'AI 루틴 · 자율 운동',
+        completionRate: 100,
+        exercises: <String>['걷기 20분 ✓', '맨몸 스쿼트 8분 ✓', '스트레칭 10분 ✓'],
+        clientFeedback: '첫 운동 했어요! 생각보다 할 만했어요',
+        trainerNote: '첫 기록. 다음 주까지 주 3회 유지가 목표.',
+      ),
+    ],
+    chat: <_Chat>[
+      _Chat('trainer', '은채님, 첫 루틴 완주 축하해요 🎉', '18:00'),
+      _Chat('client', '첫 운동 했어요!', '18:05'),
+      _Chat('trainer', '이번 주는 3번만 채워보죠. 무리 안 하는 게 더 중요해요 🙂', '18:07'),
+    ],
+  ),
+];

--- a/frontend/flutter_trainer/lib/core/storage/seed_data.dart
+++ b/frontend/flutter_trainer/lib/core/storage/seed_data.dart
@@ -6,9 +6,14 @@ import 'package:oncare_trainer/core/storage/app_database.dart';
 import 'package:oncare_trainer/core/utils/date_format.dart';
 import 'package:oncare_trainer/features/schedule/domain/entities/schedule_status.dart';
 
+// The roster itself is bulky enough to drown the seeding logic, so it
+// lives next door. `part` keeps the `_Client` family private to this
+// library rather than making the shapes public just to split a file.
+part 'seed_clients.dart';
+
 /// Idempotent seeder for the trainer app's local DB. Runs at bootstrap.
 ///
-/// **Flag.** `AppKeyValues['trainer_seeded_v3']` stores the date string
+/// **Flag.** `AppKeyValues['trainer_seeded_v4']` stores the date string
 /// (`YYYY-MM-DD`) the seed last ran with. Bump the version suffix
 /// whenever the seeded *content* changes — otherwise a browser that
 /// already seeded today keeps the old data until the date rolls over.
@@ -21,24 +26,25 @@ import 'package:oncare_trainer/features/schedule/domain/entities/schedule_status
 ///   `seed-`-prefixed row and re-insert, sliding the trainer's schedule
 ///   onto today so the 스케줄 탭 is never empty on a later calendar day.
 ///
-/// The flag is `_v2` (was `_v1`): the schema-v2 migration adds
-/// `sodiumWeekJson` with an empty default, so a client who upgrades and
-/// re-opens the SAME day would keep blank sodium trends until the date
-/// rolled over (`_v1` flag already == today ⇒ re-seed skipped). Bumping
-/// the key forces exactly one re-seed on upgrade, backfilling the seed
-/// clients' real weekly sodium while runtime rows are preserved (245→247,
-/// review PR 247).
+/// The flag is `_v4` (was `_v3`): the roster grew from three clients to
+/// fifteen. Without the bump, anyone who already opened the app today
+/// would keep the old three until the date rolled over — the same reason
+/// `_v2` existed (it backfilled `sodiumWeekJson` after that column was
+/// added, review PR 247).
 ///
 /// **User data is preserved.** Only rows whose `id` starts with `seed-`
 /// are wiped, so anything added at runtime (e.g. a trainer's chat reply,
 /// which gets a non-`seed-` id) survives re-seeding.
 ///
-/// Source data mirrors the On-Care Figma trainer mock
-/// (`TRAINER_CLIENTS` / `TRAINER_SCHEDULE`).
+/// The schedule mirrors the On-Care Figma trainer mock
+/// (`TRAINER_SCHEDULE`); the roster started there and was extended into
+/// the spread documented in `seed_clients.dart`. Note the schedule stays
+/// at six slots on purpose: fifteen clients on the books does not mean
+/// fifteen sessions in one day.
 Future<void> seedIfEmpty(AppDatabase db) async {
   final today = ymd(DateTime.now());
 
-  if (await db.readValue('trainer_seeded_v3') == today) return;
+  if (await db.readValue('trainer_seeded_v4') == today) return;
 
   // A fixed, ancient anchor for seed chat timestamps. Using a constant
   // (not DateTime.now()) keeps seed messages ordered before ANY reply
@@ -199,7 +205,7 @@ Future<void> seedIfEmpty(AppDatabase db) async {
     });
 
     // ---- Mark seeded (inside the txn so it commits atomically) ----
-    await db.putValue('trainer_seeded_v3', today);
+    await db.putValue('trainer_seeded_v4', today);
   });
 }
 
@@ -314,200 +320,6 @@ class _Slot {
   final String note;
   final List<Map<String, Object?>> program; // {name,sets,reps,weight}
 }
-
-const List<_Client> _clients = <_Client>[
-  _Client(
-    id: 1,
-    name: '김민수',
-    avatar: '김',
-    goal: '혈압 관리 · 체중 감량',
-    lastMessage: '오늘 식단 전송됐어요',
-    lastTime: '방금',
-    threadHandled: true,
-    active: true,
-    calories: 1420,
-    sodiumMg: 2100,
-    sugarG: 45,
-    lastRoutine: '오늘',
-    weekCompletion: <int>[100, 67, 100, 0, 100, 67, 100],
-    sodiumWeek: <int>[2400, 2200, 1900, 2050, 2300, 1850, 2100],
-    diet: <_Meal>[
-      _Meal('아침', '오트밀, 바나나', 315, 380),
-      _Meal('점심', '닭가슴살 샐러드, 현미밥', 620, 890),
-      _Meal('저녁', '두부찌개, 잡곡밥', 485, 830),
-    ],
-    aiRoutine: <_Routine>[
-      _Routine('저강도 유산소 (걷기)', 30, '유산소', '혈압 안정에 효과적'),
-      _Routine('하체 스트레칭', 15, '스트레칭', '혈액순환 개선'),
-      _Routine('코어 강화', 10, '근력', '기초대사량 향상'),
-    ],
-    history: <_History>[
-      _History(
-        dateLabel: '7/12 (오늘)',
-        label: 'PT 세션 · 트레이너 지도',
-        completionRate: 100,
-        exercises: <String>['레그프레스 3세트', '레그컬 3세트', '하체 스트레칭'],
-        clientFeedback: '무릎이 좀 당겼지만 트레이너님 덕분에 잘 마쳤어요 😊',
-        trainerNote: '무릎 가동범위 체크 필요. 다음 세션 중량 조절 예정.',
-      ),
-      _History(
-        dateLabel: '7/10',
-        label: 'AI 루틴 · 자율 운동',
-        completionRate: 67,
-        exercises: <String>['걷기 30분 ✓', '코어 강화 10분 ✓', '스트레칭 ✗ (생략)'],
-        clientFeedback: '스트레칭은 시간이 없어서 못 했어요',
-        trainerNote: '',
-      ),
-      _History(
-        dateLabel: '7/8',
-        label: 'AI 루틴 · 자율 운동',
-        completionRate: 100,
-        exercises: <String>['걷기 30분 ✓', '코어 강화 10분 ✓', '하체 스트레칭 15분 ✓'],
-        clientFeedback: '오늘은 다 했어요! 뿌듯해요 💪',
-        trainerNote: '',
-      ),
-    ],
-    chat: <_Chat>[
-      _Chat(
-        'trainer',
-        '민수님, AI 식단 분석 잘 받았어요 👍 오늘 나트륨이 목표치를 좀 넘었는데 어떠셨어요?',
-        '18:10',
-      ),
-      _Chat('client', '찌개 먹을 때 국물을 많이 마셨나봐요 😅', '18:13'),
-      _Chat('trainer', '그렇군요! 오늘 PT 후에 부상이나 불편한 데는 없으셨나요?', '18:14'),
-      _Chat('client', '무릎이 가볍게 당기긴 했는데 괜찮아요', '18:16'),
-      _Chat(
-        'trainer',
-        '확인했어요. AI가 오늘 식단 기반으로 유산소 루틴을 추천했는데, 무릎 상태 감안해서 런닝 대신 걷기로 조정해서 보낼게요. 다음 PT 때 봐요 💪',
-        '18:18',
-      ),
-    ],
-  ),
-  _Client(
-    id: 2,
-    name: '이지수',
-    avatar: '이',
-    goal: '체력 강화 · 다이어트',
-    lastMessage: '루틴 받았어요, 감사합니다!',
-    lastTime: '1시간 전',
-    active: true,
-    calories: 1680,
-    sodiumMg: 1800,
-    sugarG: 38,
-    lastRoutine: '어제',
-    weekCompletion: <int>[67, 100, 100, 100, 100, 0, 0],
-    sodiumWeek: <int>[1700, 1950, 1600, 1800, 2100, 1750, 1800],
-    diet: <_Meal>[
-      _Meal('아침', '그릭요거트, 과일', 280, 200),
-      _Meal('점심', '현미밥, 불고기, 나물', 750, 980),
-      _Meal('저녁', '연어 샐러드', 650, 620),
-    ],
-    aiRoutine: <_Routine>[
-      _Routine('인터벌 런닝', 25, '유산소', '체지방 연소 효율↑'),
-      _Routine('스쿼트 3세트', 15, '근력', '하체 근력 강화'),
-      _Routine('플랭크', 10, '근력', '코어 안정화'),
-    ],
-    history: <_History>[
-      _History(
-        dateLabel: '7/11 (어제)',
-        label: 'AI 루틴 · 자율 운동',
-        completionRate: 100,
-        exercises: <String>['인터벌 런닝 25분 ✓', '스쿼트 3세트 ✓', '플랭크 10분 ✓'],
-        clientFeedback: '런닝이 힘들었는데 다 했어요! 숨이 많이 찼어요',
-        trainerNote: '심폐지구력 향상 중. 다음 주 런닝 강도 소폭 올릴 예정.',
-      ),
-      _History(
-        dateLabel: '7/9',
-        label: 'PT 세션 · 트레이너 지도',
-        completionRate: 100,
-        exercises: <String>['데드리프트 3세트', '런지 3세트', '코어 서킷'],
-        clientFeedback: '데드리프트 자세 교정 도움 많이 됐어요!',
-        trainerNote: '',
-      ),
-      _History(
-        dateLabel: '7/7',
-        label: 'AI 루틴 · 자율 운동',
-        completionRate: 67,
-        exercises: <String>['런닝 25분 ✓', '스쿼트 ✓', '플랭크 ✗ (피로)'],
-        clientFeedback: '마지막 플랭크는 너무 지쳐서 못 했어요',
-        trainerNote: '',
-      ),
-    ],
-    chat: <_Chat>[
-      _Chat(
-        'trainer',
-        '지수님, AI 운동 데이터 수신했어요 — 오늘 인터벌 런닝 25분 완료! 컨디션은 어때요?',
-        '20:05',
-      ),
-      _Chat('client', '생각보다 괜찮았어요. 숨이 금방 차더라고요 😮‍💨', '20:08'),
-      _Chat(
-        'trainer',
-        '심폐 지구력 올라가는 과정이에요 💪 AI 분석 보니까 당류는 목표 안에 있고, 루틴 다음 주부터 근력 비중 늘려볼게요. 식단도 AI 추천 참고해서 업데이트해 드릴게요',
-        '20:10',
-      ),
-    ],
-  ),
-  _Client(
-    id: 3,
-    name: '박성호',
-    avatar: '박',
-    goal: '근력 향상',
-    lastMessage: '이번 주 운동 못했어요...',
-    lastTime: '3일 전',
-    active: false,
-    calories: 2100,
-    sodiumMg: 2400,
-    sugarG: 55,
-    lastRoutine: '5일 전',
-    weekCompletion: <int>[0, 33, 100, 0, 0, 0, 0],
-    sodiumWeek: <int>[2600, 2500, 2300, 2450, 2200, 2550, 2400],
-    diet: <_Meal>[
-      _Meal('아침', '계란 3개, 토스트', 480, 520),
-      _Meal('점심', '짜장면', 890, 1200),
-      _Meal('저녁', '삼겹살, 쌈채소', 730, 680),
-    ],
-    aiRoutine: <_Routine>[
-      _Routine('벤치프레스 4세트', 20, '근력', '상체 근력 목표'),
-      _Routine('데드리프트 3세트', 15, '근력', '전신 근력 향상'),
-      _Routine('유산소 쿨다운', 10, '유산소', '나트륨 배출 지원'),
-    ],
-    history: <_History>[
-      _History(
-        dateLabel: '7/7',
-        label: 'PT 세션 · 트레이너 지도',
-        completionRate: 100,
-        exercises: <String>['벤치프레스 4세트', '인클라인 덤벨 3세트', '트라이셉스 딥'],
-        clientFeedback: '가슴이 많이 타는 느낌이었어요. 좋았어요!',
-        trainerNote: '벤치 중량 62.5kg → 65kg 도전 가능. 다음 PT 때 시도 예정.',
-      ),
-      _History(
-        dateLabel: '7/5',
-        label: 'AI 루틴 · 자율 운동',
-        completionRate: 33,
-        exercises: <String>['벤치프레스 ✓', '데드리프트 ✗', '유산소 ✗'],
-        clientFeedback: '회사 일이 생겨서 벤치만 하고 나왔어요',
-        trainerNote: '',
-      ),
-      _History(
-        dateLabel: '7/3',
-        label: 'AI 루틴 · 자율 운동',
-        completionRate: 0,
-        exercises: <String>['벤치프레스 ✗', '데드리프트 ✗', '유산소 ✗'],
-        clientFeedback: '못 갔어요 😓',
-        trainerNote: '',
-      ),
-    ],
-    chat: <_Chat>[
-      _Chat('trainer', '성호님, 이번 주 운동 기록이 AI 쪽에서 안 잡히는데 몸은 괜찮으세요?', '월 09:00'),
-      _Chat('client', '이번 주 일이 너무 많아서 못 갔어요 😓', '월 09:03'),
-      _Chat(
-        'trainer',
-        '이해해요! 대신 AI 식단 분석 보니까 나트륨이 좀 높더라고요. 주말에 30분 걷기라도 하면 도움 돼요. AI가 그에 맞는 루틴 다시 짜줬으니까 앱에서 확인해보세요 🙂',
-        '월 09:07',
-      ),
-    ],
-  ),
-];
 
 const List<_Slot> _schedule = <_Slot>[
   _Slot(

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/diet_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/diet_view.dart
@@ -11,7 +11,9 @@ import 'package:oncare_trainer/features/clients/domain/entities/client_diet_entr
 import 'package:oncare_trainer/shared/models/trainer_client.dart';
 import 'package:oncare_trainer/shared/widgets/metric_tile.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
-import 'package:oncare_trainer/features/dashboard/domain/dashboard_summary.dart' show weekdayLabels;
+import 'package:oncare_trainer/features/dashboard/domain/dashboard_summary.dart'
+    show weekdayLabels;
+import 'package:oncare_trainer/shared/widgets/section_card.dart' show EmptyHint;
 
 /// The 식단 sub-tab: today's nutrition summary (칼로리/나트륨/당류),
 /// per-meal records, and a conditional AI comment.
@@ -44,12 +46,20 @@ class DietView extends ConsumerWidget {
             _SodiumTrendCard(client: client),
           ],
           const SizedBox(height: AppSpacing.md),
-          for (final meal in meals) ...<Widget>[
-            _MealCard(entry: meal),
-            const SizedBox(height: AppSpacing.sm),
+          // Nothing logged yet: say so, and withhold the verdict. The
+          // summary tiles read 0 either way, and `_AiComment` would call
+          // a blank day "균형이 잘 맞아요" — praise for a member who has
+          // not recorded a single meal.
+          if (meals.isEmpty)
+            EmptyHint(message: l.dietEmpty, icon: Icons.restaurant_outlined)
+          else ...<Widget>[
+            for (final meal in meals) ...<Widget>[
+              _MealCard(entry: meal),
+              const SizedBox(height: AppSpacing.sm),
+            ],
+            const SizedBox(height: AppSpacing.xs),
+            _AiComment(client: client),
           ],
-          const SizedBox(height: AppSpacing.xs),
-          _AiComment(client: client),
         ],
       ),
     );

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
@@ -1220,6 +1220,12 @@ abstract class AppLocalizations {
   /// **'Couldn\'t load meals'**
   String get dietLoadFailed;
 
+  /// No description provided for @dietEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'No meals logged yet'**
+  String get dietEmpty;
+
   /// No description provided for @dietTodaySummary.
   ///
   /// In en, this message translates to:

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
@@ -625,6 +625,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get dietLoadFailed => 'Couldn\'t load meals';
 
   @override
+  String get dietEmpty => 'No meals logged yet';
+
+  @override
   String get dietTodaySummary => 'Today\'s nutrition';
 
   @override

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
@@ -613,6 +613,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get dietLoadFailed => '식단을 불러오지 못했어요';
 
   @override
+  String get dietEmpty => '아직 기록된 식단이 없어요';
+
+  @override
   String get dietTodaySummary => '오늘 영양 요약';
 
   @override

--- a/frontend/flutter_trainer/lib/l10n/app_en.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_en.arb
@@ -386,6 +386,7 @@
   "clientFeedback": "Client feedback",
   "trainerNote": "Trainer's note",
   "dietLoadFailed": "Couldn't load meals",
+  "dietEmpty": "No meals logged yet",
   "dietTodaySummary": "Today's nutrition",
   "dietSodiumTrend": "Sodium over the last 7 days",
   "dietAverageMg": "Avg {value}mg",

--- a/frontend/flutter_trainer/lib/l10n/app_ko.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_ko.arb
@@ -187,6 +187,7 @@
   "clientFeedback": "고객 피드백",
   "trainerNote": "트레이너 메모",
   "dietLoadFailed": "식단을 불러오지 못했어요",
+  "dietEmpty": "아직 기록된 식단이 없어요",
   "dietTodaySummary": "오늘 영양 요약",
   "dietSodiumTrend": "최근 7일 나트륨 추이",
   "dietAverageMg": "평균 {value}mg",

--- a/frontend/flutter_trainer/test/core/storage/seed_data_test.dart
+++ b/frontend/flutter_trainer/test/core/storage/seed_data_test.dart
@@ -25,28 +25,109 @@ void main() {
   });
 
   group('seedIfEmpty', () {
-    test('first run seeds 3 clients with their related data', () async {
+    test('first run seeds the roster with its related data', () async {
       await seedIfEmpty(db);
 
       final clients = await db.select(db.trainerClients).get();
-      expect(clients.length, 3);
-      expect(clients.map((c) => c.name).toSet(), <String>{'김민수', '이지수', '박성호'});
+      expect(clients.length, 15);
+      expect(
+        clients.map((c) => c.name).toSet().length,
+        15,
+        reason: '이름이 겹치면 addClient 의 중복 검사와 스케줄 폴백이 어긋난다',
+      );
 
-      // Each client has 3 meals, 3 AI routines, 3 history entries, chat.
-      final diet = await db.select(db.clientDietEntries).get();
-      final routines = await db.select(db.clientAiRoutines).get();
-      final history = await db.select(db.clientRoutineHistory).get();
-      final chat = await db.select(db.clientChatMessages).get();
-      expect(diet.length, 9);
-      expect(routines.length, 9);
-      expect(history.length, 9);
-      expect(chat, isNotEmpty);
+      // Every client must be coachable and chartable, whatever else their
+      // fixture is demonstrating: the 코칭 탭 reads the routine list and
+      // the completion bars index all seven days.
+      for (final c in clients) {
+        final routines = await (db.select(
+          db.clientAiRoutines,
+        )..where((t) => t.clientId.equals(c.id))).get();
+        expect(routines, isNotEmpty, reason: '${c.name}: AI 루틴이 없으면 코칭 탭이 빈다');
+        expect(
+          (jsonDecode(c.weekCompletionJson) as List<Object?>).length,
+          7,
+          reason: '${c.name}: 완료율 막대는 7일을 인덱싱한다',
+        );
+      }
 
-      // weekCompletion is stored as a 7-length JSON array.
-      final minsu = clients.firstWhere((c) => c.name == '김민수');
-      expect((jsonDecode(minsu.weekCompletionJson) as List<Object?>).length, 7);
+      expect(await db.select(db.clientChatMessages).get(), isNotEmpty);
+      expect(await db.readValue('trainer_seeded_v4'), _todayString());
+    });
 
-      expect(await db.readValue('trainer_seeded_v3'), _todayString());
+    // The roster is a fixture for the *charts*, not just the list — its
+    // whole point is that every state the console can render is reachable
+    // by clicking around the demo. Assert that spread directly, so
+    // flattening the data back out to fifteen similar weeks fails here
+    // rather than silently making half the UI unreachable.
+    test('the roster covers the states the console has to render', () async {
+      await seedIfEmpty(db);
+      final clients = await db.select(db.trainerClients).get();
+
+      List<int> sodiumWeek(TrainerClientRow c) =>
+          (jsonDecode(c.sodiumWeekJson) as List<Object?>)
+              .map((e) => (e! as num).toInt())
+              .toList();
+      List<int> week(TrainerClientRow c) =>
+          (jsonDecode(c.weekCompletionJson) as List<Object?>)
+              .map((e) => e! as int)
+              .toList();
+      bool low(TrainerClientRow c) {
+        final recorded = week(c).where((d) => d > 0).toList();
+        if (recorded.isEmpty) return false;
+        return recorded.reduce((a, b) => a + b) / recorded.length < 60;
+      }
+
+      // Sparkline shapes: a full week, a partial week, a single point, and
+      // nothing at all must all exist — each takes a different path.
+      expect(clients.where((c) => sodiumWeek(c).length == 7), isNotEmpty);
+      expect(
+        clients.where((c) {
+          final n = sodiumWeek(c).length;
+          return n > 1 && n < 7;
+        }),
+        isNotEmpty,
+        reason: '7일 미만 추이 (기록이 끊긴 고객)',
+      );
+      expect(clients.where((c) => sodiumWeek(c).length == 1), isNotEmpty);
+      expect(clients.where((c) => sodiumWeek(c).isEmpty), isNotEmpty);
+
+      // Alert combinations, including the two that are easy to lose.
+      expect(
+        clients.where((c) => c.sodiumMg > 2000 && !low(c)),
+        isNotEmpty,
+        reason: '나트륨만 초과',
+      );
+      expect(
+        clients.where((c) => c.sodiumMg <= 2000 && low(c)),
+        isNotEmpty,
+        reason: '이행률만 저조',
+      );
+      expect(
+        clients.where((c) => c.sodiumMg > 2000 && low(c)),
+        isNotEmpty,
+        reason: '복합 — 확인 필요 목록 맨 위에 오는 케이스',
+      );
+      expect(
+        clients.where((c) => c.sodiumMg <= 2000 && !low(c) && c.sugarG <= 50),
+        isNotEmpty,
+        reason: '무알림 대조군이 없으면 배지가 항상 켜진 화면만 보게 된다',
+      );
+      expect(clients.where((c) => c.sugarG > 50), isNotEmpty, reason: '당류 경고');
+      expect(clients.where((c) => !c.active), isNotEmpty, reason: '휴면');
+
+      // A brand-new client: no meals, no history. `isLowCompletion` must
+      // NOT flag an all-zero week, or day one reads as failure.
+      final blank = clients.where((c) => sodiumWeek(c).isEmpty).first;
+      expect(low(blank), isFalse);
+      final meals = await (db.select(
+        db.clientDietEntries,
+      )..where((t) => t.clientId.equals(blank.id))).get();
+      final history = await (db.select(
+        db.clientRoutineHistory,
+      )..where((t) => t.clientId.equals(blank.id))).get();
+      expect(meals, isEmpty, reason: '식단 빈 상태 렌더링 경로');
+      expect(history, isEmpty, reason: '운동 기록 빈 상태 렌더링 경로');
     });
 
     test('schedule seeds onto today (never empty on a later day)', () async {
@@ -76,13 +157,13 @@ void main() {
 
     test('stale flag (different date) re-seeds schedule onto today', () async {
       await seedIfEmpty(db);
-      await db.putValue('trainer_seeded_v3', '2020-01-01');
+      await db.putValue('trainer_seeded_v4', '2020-01-01');
 
       await seedIfEmpty(db);
 
       final schedule = await db.select(db.trainerScheduleEntries).get();
       expect(schedule.every((s) => s.date == _todayString()), isTrue);
-      expect(await db.readValue('trainer_seeded_v3'), _todayString());
+      expect(await db.readValue('trainer_seeded_v4'), _todayString());
     });
 
     test(
@@ -151,7 +232,7 @@ void main() {
     });
 
     test(
-      'a same-day v1→v2 upgrade re-seeds to backfill sodium trends',
+      'a same-day upgrade under an older flag re-seeds exactly once',
       () async {
         final today = _todayString();
 
@@ -191,7 +272,7 @@ void main() {
         expect(week.length, 7);
         expect(week.any((v) => (v as num) > 0), isTrue);
 
-        expect(await db.readValue('trainer_seeded_v3'), today);
+        expect(await db.readValue('trainer_seeded_v4'), today);
       },
     );
 
@@ -213,7 +294,7 @@ void main() {
           );
 
       // Force a re-seed.
-      await db.putValue('trainer_seeded_v3', '2020-01-01');
+      await db.putValue('trainer_seeded_v4', '2020-01-01');
       await seedIfEmpty(db);
 
       final chat = await db.select(db.clientChatMessages).get();

--- a/frontend/flutter_trainer/test/features/clients/client_detail_diet_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_diet_test.dart
@@ -13,6 +13,8 @@ const Map<String, String> seedClientIds = <String, String>{
   '김민수': 'seed-client-1',
   '이지수': 'seed-client-2',
   '박성호': 'seed-client-3',
+  // The brand-new client: no meals, no history, no sodium series.
+  '임도현': 'seed-client-7',
 };
 
 void main() {
@@ -43,13 +45,22 @@ void main() {
       expect(seongho[1].items, '짜장면'); // 점심
     });
 
-    test('client rows carry a 7-day sodium history ending at today', () async {
+    test('client rows carry a sodium history ending at today', () async {
       final clients = await DriftClientRepository(db).watchClients().first;
       for (final c in clients) {
-        expect(c.sodiumWeek.length, 7);
-        // The last entry mirrors today's total shown elsewhere.
-        expect(c.sodiumWeek.last, c.sodiumMg);
+        // At most a week, and never more — the sparkline draws what it
+        // is given. A client who only started logging this week has
+        // fewer points, and one who has not started has none.
+        expect(c.sodiumWeek.length, lessThanOrEqualTo(7), reason: c.name);
+        // Whatever its length, the last entry mirrors today's total
+        // shown on the metric tile beside it.
+        if (c.sodiumWeek.isNotEmpty) {
+          expect(c.sodiumWeek.last, c.sodiumMg, reason: c.name);
+        }
       }
+      // The fixture must keep covering the full-week case too, or the
+      // seven-point sparkline stops being exercised at all.
+      expect(clients.where((c) => c.sodiumWeek.length == 7), isNotEmpty);
       final minsu = clients.firstWhere((c) => c.name == '김민수');
       expect(minsu.sodiumOverDays, greaterThan(0)); // 2400/2200/2300… over
       expect(minsu.sodiumWeekAvg, isNotNull);
@@ -110,6 +121,24 @@ void main() {
       expect(find.text('최근 7일 나트륨 추이'), findsOneWidget);
       expect(find.textContaining('평균'), findsOneWidget);
       expect(find.textContaining('목표(2000mg)를 초과했어요'), findsOneWidget);
+    });
+
+    testWidgets('a client with no logged meals gets a hint, not a verdict', (
+      tester,
+    ) async {
+      // 임도현 has not recorded anything yet. The tiles read 0 either
+      // way, so without this the tab silently praised a blank day.
+      await pumpTrainerApp(
+        tester,
+        token: 'demo-trainer-token',
+        at: AppRoutes.clientDetail(seedClientIds['임도현']!, section: 'diet'),
+      );
+
+      expect(find.text('아직 기록된 식단이 없어요'), findsOneWidget);
+      expect(find.textContaining('균형이 잘 맞아요'), findsNothing);
+      expect(find.textContaining('나트륨이 목표치를'), findsNothing);
+      // The trend card is skipped too — there is no series to draw.
+      expect(find.text('최근 7일 나트륨 추이'), findsNothing);
     });
 
     testWidgets('이지수 (sodium under target) shows the balanced AI comment', (

--- a/frontend/flutter_trainer/test/features/clients/clients_page_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/clients_page_test.dart
@@ -8,6 +8,7 @@ import 'package:oncare_trainer/core/storage/app_database.dart';
 import 'package:oncare_trainer/core/storage/seed_data.dart';
 import 'package:oncare_trainer/features/schedule/data/repositories/schedule_repository.dart';
 import 'package:oncare_trainer/features/schedule/domain/entities/schedule_session.dart';
+import 'package:oncare_trainer/features/clients/presentation/widgets/client_card.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
 
 import '../../helpers/pump_app.dart';
@@ -29,29 +30,36 @@ void main() {
     });
     tearDown(() => db.close());
 
-    test('watchClients returns the 3 seeded clients in order', () async {
+    test('watchClients returns the seeded clients in sortOrder', () async {
       final clients = await DriftClientRepository(db).watchClients().first;
-      expect(clients.map((c) => c.name).toList(), <String>[
+      // Unprioritised order is the seeded order, so the first three are
+      // still the original roster the rest of these tests address.
+      expect(clients.take(3).map((c) => c.name).toList(), <String>[
         '김민수',
         '이지수',
         '박성호',
       ]);
+      expect(clients.length, 15);
     });
 
     test('sodiumOverBudget flags only clients above 2000mg', () async {
       final clients = await DriftClientRepository(db).watchClients().first;
-      expect(
-        clients.where((c) => c.sodiumOverBudget).map((c) => c.name).toSet(),
-        <String>{'김민수', '박성호'}, // 2100, 2400; 이지수 1800 is under
-      );
+      // The rule, not a name list — the roster is a fixture that grows.
+      for (final c in clients) {
+        expect(c.sodiumOverBudget, c.sodiumMg > 2000, reason: c.name);
+      }
+      // …and the fixture must keep exercising both sides of it.
+      expect(clients.where((c) => c.sodiumOverBudget), isNotEmpty);
+      expect(clients.where((c) => !c.sodiumOverBudget), isNotEmpty);
     });
 
     test('addClient appends a fresh profile after the seeded roster', () async {
       final repo = DriftClientRepository(db);
+      final seeded = (await repo.watchClients().first).length;
       await repo.addClient(name: '  최수진  ', goal: '체중 감량');
 
       final clients = await repo.watchClients().first;
-      expect(clients.length, 4);
+      expect(clients.length, seeded + 1);
       final added = clients.last; // large sortOrder appends
       expect(added.name, '최수진'); // trimmed
       expect(added.avatar, '최');
@@ -66,8 +74,9 @@ void main() {
       'addClient ignores an empty name and defaults an empty goal',
       () async {
         final repo = DriftClientRepository(db);
+        final seeded = (await repo.watchClients().first).length;
         expect(await repo.addClient(name: '   ', goal: '아무거나'), isFalse);
-        expect((await repo.watchClients().first).length, 3);
+        expect((await repo.watchClients().first).length, seeded);
 
         expect(await repo.addClient(name: '박도윤', goal: '  '), isTrue);
         final clients = await repo.watchClients().first;
@@ -77,18 +86,19 @@ void main() {
 
     test('addClient rejects a duplicate name', () async {
       final repo = DriftClientRepository(db);
+      final seeded = (await repo.watchClients().first).length;
 
       // Schedules resolve their client by NAME, so a second 김민수 could
       // receive the first one's chat/운동기록 (review PR 243).
       expect(await repo.addClient(name: '김민수', goal: '중복'), isFalse);
       expect(await repo.addClient(name: '  김민수  ', goal: '공백 차이'), isFalse);
       expect(await repo.addClient(name: '김민수 ', goal: '후행 공백'), isFalse);
-      expect((await repo.watchClients().first).length, 3); // nothing added
+      expect((await repo.watchClients().first).length, seeded); // nothing added
 
       // A genuinely new name still registers, and is then itself taken.
       expect(await repo.addClient(name: '최수진', goal: '체중 감량'), isTrue);
       expect(await repo.addClient(name: '최수진', goal: '또'), isFalse);
-      expect((await repo.watchClients().first).length, 4);
+      expect((await repo.watchClients().first).length, seeded + 1);
 
       expect(await repo.clientNameExists('김민수'), isTrue);
       expect(await repo.clientNameExists('없는사람'), isFalse);
@@ -163,7 +173,7 @@ void main() {
   });
 
   group('ClientsPage', () {
-    testWidgets('renders the 3 clients, AI summary count, and badge', (
+    testWidgets('renders the roster with its size and priority order', (
       tester,
     ) async {
       await pumpTrainerApp(
@@ -175,10 +185,10 @@ void main() {
       // The roster header states the size; the coaching signals
       // (나트륨 초과, 오늘 예약) now live on the 대시보드, not here.
       expect(find.text('고객'), findsWidgets);
-      expect(find.text('3명 · 활성 2명'), findsOneWidget);
+      expect(find.text('15명 · 활성 13명'), findsOneWidget);
 
-      // Priority order: sodium-over clients (김민수, 박성호) come first;
-      // 이지수 is last and lazily built, so scroll to reach her.
+      // Priority order: sodium-over clients come first, so a client who
+      // is under target is further down a now-long, lazily built list.
       expect(find.text('김민수'), findsOneWidget);
       expect(find.text('박성호'), findsOneWidget);
       await tester.scrollUntilVisible(find.text('이지수'), 150);
@@ -194,12 +204,23 @@ void main() {
         at: AppRoutes.clients,
       );
 
-      // 이지수와 박성호가 각각 1건씩 답장을 기다린다. 김민수의 스레드는
-      // 이미 답장·읽음 처리된 상태로 시드된다.
-      expect(find.text('1'), findsNWidgets(2));
+      // Scoped to each card rather than counting '1' across the roster:
+      // several members are waiting on a reply now, and the list is long
+      // enough that what is built depends on scroll position.
+      Finder badgeOf(String name) => find.descendant(
+        of: find.ancestor(
+          of: find.text(name),
+          matching: find.byType(ClientCard),
+        ),
+        matching: find.text('1'),
+      );
 
-      // Open 박성호's chat, then come back — his badge cleared, 이지수's
-      // stays. The badge clears once the messages are on screen.
+      // 박성호 is waiting; 김민수's thread is seeded already answered.
+      expect(badgeOf('박성호'), findsOneWidget);
+      expect(badgeOf('김민수'), findsNothing);
+
+      // Open 박성호's chat, then come back — his badge cleared. The badge
+      // clears once the messages are on screen.
       await goTo(
         tester,
         AppRoutes.clientDetail('seed-client-3', section: 'chat'),
@@ -207,7 +228,7 @@ void main() {
       await tester.tap(find.byIcon(Icons.arrow_back_ios_new));
       await settle(tester);
 
-      expect(find.text('1'), findsOneWidget);
+      expect(badgeOf('박성호'), findsNothing);
     });
 
     testWidgets('tapping a client card opens the detail screen', (
@@ -248,9 +269,20 @@ void main() {
       await settle(tester);
 
       // New client appended at the end of the list (0 data, no badge).
+      // Scoped to her own card: a seeded brand-new client carries the
+      // same "아직 대화가 없어요" placeholder.
       await tester.scrollUntilVisible(find.text('최수진'), 150);
       expect(find.text('최수진'), findsOneWidget);
-      expect(find.text('아직 대화가 없어요'), findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.ancestor(
+            of: find.text('최수진'),
+            matching: find.byType(ClientCard),
+          ),
+          matching: find.text('아직 대화가 없어요'),
+        ),
+        findsOneWidget,
+      );
     });
 
     testWidgets('registering a duplicate name is blocked with an error', (

--- a/frontend/flutter_trainer/test/features/clients/clients_split_view_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/clients_split_view_test.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import 'package:oncare_trainer/app/router/routes.dart';
 import 'package:oncare_trainer/design_system/tokens/layout.dart';
+import 'package:oncare_trainer/features/clients/presentation/widgets/client_card.dart';
 
 import '../../helpers/pump_app.dart';
 
@@ -27,6 +28,29 @@ void main() {
 
   /// The client's name in the roster card (the panel header shows it too).
   Finder card(String name) => find.text(name).first;
+
+  /// Brings a roster card into view before tapping it. The roster is
+  /// fifteen clients and lazily built, so anyone ranked below the fold
+  /// simply does not exist yet.
+  ///
+  /// The scrollable is located through a card rather than by index — the
+  /// sidebar and the open detail panel are scrollables too, and which
+  /// one comes first in the tree is not this test's business.
+  Future<void> scrollToCard(WidgetTester tester, String name) async {
+    // Check the raw finder, not `card()` — `.first` throws rather than
+    // reporting empty when nothing matched.
+    if (find.text(name).evaluate().isNotEmpty) return;
+    await tester.scrollUntilVisible(
+      find.text(name),
+      160,
+      scrollable: find
+          .ancestor(
+            of: find.byType(ClientCard).first,
+            matching: find.byType(Scrollable),
+          )
+          .first,
+    );
+  }
 
   testWidgets('wide viewport starts as a plain list; picking a client '
       'opens the side panel', (tester) async {
@@ -74,6 +98,7 @@ void main() {
     );
     expect(find.textContaining('AI가 김민수님의'), findsOneWidget);
 
+    await scrollToCard(tester, '이지수');
     await tester.tap(card('이지수'));
     await settle(tester);
 
@@ -93,6 +118,7 @@ void main() {
     await tester.enterText(find.byType(TextField), '민수님 오늘 어땠어요?');
     await tester.pump();
 
+    await scrollToCard(tester, '이지수');
     await tester.tap(card('이지수'));
     await settle(tester);
 
@@ -119,17 +145,31 @@ void main() {
     expect(find.text('2400'), findsWidgets);
   });
 
-  testWidgets('the list is ordered by priority: sodium-over first, then '
-      'recent chat', (tester) async {
+  testWidgets('the list is ordered by priority: sodium-over first', (
+    tester,
+  ) async {
     await openWide(tester);
 
-    // 김민수(2100mg)·박성호(2400mg) are over the 2000mg target and rank
-    // above 이지수(1800mg); 김민수 has the most recent chat of the two.
-    final kim = tester.getTopLeft(card('김민수')).dy;
-    final park = tester.getTopLeft(card('박성호')).dy;
-    final lee = tester.getTopLeft(card('이지수')).dy;
-    expect(kim, lessThan(park));
-    expect(park, lessThan(lee));
+    // Read the rendered order rather than three clients' Y positions:
+    // the roster is long enough now that not every name is built, so
+    // measuring specific ones would depend on where the list happens to
+    // sit. Every over-target client must precede every under-target one.
+    final rendered = tester
+        .widgetList<ClientCard>(find.byType(ClientCard))
+        .toList();
+    expect(rendered.length, greaterThan(2));
+    final firstUnderTarget = rendered.indexWhere(
+      (c) => !c.client.sodiumOverBudget,
+    );
+    if (firstUnderTarget >= 0) {
+      expect(
+        rendered.skip(firstUnderTarget).every((c) => !c.client.sodiumOverBudget),
+        isTrue,
+        reason: '나트륨 초과 고객이 목표 이내 고객보다 아래에 오면 안 된다',
+      );
+    }
+    // The top of the list is where the trainer looks first.
+    expect(rendered.first.client.sodiumOverBudget, isTrue);
   });
 
   testWidgets('the panel location is a path that encodes the section', (

--- a/frontend/flutter_trainer/test/features/dashboard/dashboard_page_test.dart
+++ b/frontend/flutter_trainer/test/features/dashboard/dashboard_page_test.dart
@@ -47,10 +47,10 @@ void main() {
     expect(find.text('답장 필요'), findsOneWidget);
     expect(find.text('주의 고객'), findsOneWidget);
 
-    // 2 of 3 clients active. 이지수·박성호 are waiting on a reply;
-    // 김민수's thread is seeded already answered.
-    expect(find.text('휴면 1명'), findsOneWidget);
-    expect(find.text('고객 2명 대기 중'), findsOneWidget);
+    // 13 of the 15 seeded clients are active; 박성호 and 문가영 are the
+    // two 휴면 fixtures. Six threads are waiting on a reply.
+    expect(find.text('휴면 2명'), findsOneWidget);
+    expect(find.text('고객 6명 대기 중'), findsOneWidget);
   });
 
   testWidgets('주의 고객 counts health signals, not the reply backlog', (
@@ -58,14 +58,15 @@ void main() {
   ) async {
     await openDashboard(tester);
 
-    // All three seeded clients are waiting on a reply, but only 김민수
-    // (2100mg) and 박성호 (2400mg) are over the sodium target. 답장 대기
-    // still shows in the list; it just isn't 주의. If the two ever merge
-    // again the card reads 3 and stops meaning anything.
+    // Six threads are waiting on a reply, but 주의 counts only health
+    // signals: 8 clients over the sodium target plus 문가영, who is under
+    // it and flagged for 이행률 alone — nine. 답장 대기 still shows in the
+    // list; it just isn't 주의. If the two ever merge again the card
+    // would read higher and stop meaning anything.
     final attention = tester.widget<StatCard>(
       find.ancestor(of: find.text('주의 고객'), matching: find.byType(StatCard)),
     );
-    expect(attention.value, '2');
+    expect(attention.value, '9');
     expect(find.text('나트륨·이행률 확인'), findsOneWidget);
   });
 
@@ -93,12 +94,17 @@ void main() {
     await openDashboard(tester);
 
     expect(find.text('확인 필요 고객'), findsOneWidget);
-    // All three seeded clients are waiting on a reply, but 김민수(2100mg)
-    // and 박성호(2400mg) are also over the sodium target — and the badge
-    // is the client's first alert, so theirs must be the health one.
-    // 이지수 is within target, so their row stays 답장 대기.
-    expect(find.text('나트륨 초과'), findsNWidgets(2));
-    expect(find.text('답장 대기'), findsOneWidget);
+    // Ten clients carry an alert of some kind — note this list is wider
+    // than the 주의 고객 count above it, which is health signals only and
+    // reads 9. The card shows five, so the overflow link into the
+    // filtered roster is finally reachable; with the old three-client
+    // roster it could never appear.
+    expect(find.text('+5명'), findsOneWidget);
+
+    // The badge is a client's FIRST alert, and health reasons sort ahead
+    // of 답장 대기, so every visible row leads with a health one.
+    expect(find.text('나트륨 초과'), findsWidgets);
+    expect(find.text('답장 대기'), findsNothing);
 
     await tester.tap(find.text('나트륨 초과').first);
     await settle(tester);

--- a/frontend/flutter_trainer/test/features/my/my_page_test.dart
+++ b/frontend/flutter_trainer/test/features/my/my_page_test.dart
@@ -83,7 +83,7 @@ void main() {
       expect(find.text('생활스포츠지도사 2급'), findsOneWidget);
 
       await tester.scrollUntilVisible(find.text('담당 고객'), 150);
-      expect(find.text('3'), findsOneWidget); // live client count
+      expect(find.text('15'), findsOneWidget); // live client count
       expect(find.text('완료 세션'), findsOneWidget);
 
       await tester.scrollUntilVisible(find.text('온케어짐 신촌점'), 150);


### PR DESCRIPTION
## Summary

* 데모 고객을 3명 → 15명으로 확장. "그럴듯한 평균값 15개"가 아니라 **콘솔이 그릴 수 있는 상태의 스펙트럼**을 덮도록 설계했습니다.
* V자 회복, 주말 절벽, 나트륨↑/이행률↓ 동시 악화, 극단 지그재그(0↔100 · 1200↔3200), 완전 평탄한 정체기 등 그래프 형태를 의도적으로 분산.
* 스파크라인 길이 7일 / 3일(기록 끊김) / 1개 / 0개를 모두 포함해, 지금까지 도달 불가능했던 렌더링 경로를 열었습니다.
* 이 과정에서 **식단 기록이 없는 고객에게 "균형이 잘 맞아요"라고 칭찬하던 결함**을 발견해 함께 고쳤습니다.
* 로스터는 별도 `part` 파일로 분리했고, 오늘 스케줄(`_schedule`)은 건드리지 않았습니다.

---

## Changes

### ✨ Features

* `lib/core/storage/seed_clients.dart` 신설 — 15명 로스터를 `part` 파일로 분리. 시드 로직(`seed_data.dart`)이 데이터에 묻히지 않게 하고, `_Client` 계열 타입을 public 으로 열지 않고도 파일을 나눴습니다.
* 12명 추가. 각자 덮는 상태를 파일 상단 주석에 표로 명시했습니다 (정하윤 V자 회복 / 최우진 무알림 대조군 / 강서연 주말 붕괴 / 임도현 신규·빈 상태 / 오세라 급성 악화 / 배준혁 야근형 / 신유나 회복 중 / 한지호 경계값 정체 / 문가영 휴면·기록 끊김 / 류태경 극단 변동 / 백서진 나트륨만 초과 / 노은채 단일 기록).

### 🔧 Improvements

* 시드 플래그 `trainer_seeded_v3` → `v4`. 오늘 이미 접속한 브라우저도 한 번 재시드됩니다.
* 로스터 크기에 하드코딩돼 있던 테스트들을 **규칙 검증**으로 전환했습니다. 예: "나트륨 초과 = 김민수·박성호" → "모든 고객에 대해 `sodiumOverBudget == sodiumMg > 2000` 이고, 양쪽 사례가 모두 존재한다". 다음 확장 때 또 깨지지 않습니다.
* 시드 픽스처의 **커버리지 자체를 검증하는 테스트**를 추가했습니다. 데이터를 다시 평평하게 만들면 여기서 실패합니다.

### 🐛 Fixes

* `diet_view.dart`: 끼니 기록이 하나도 없을 때 `0 kcal / 0 mg` 타일 뒤에 AI 판정을 그대로 붙여 "오늘 식단은 균형이 잘 맞아요"라고 출력하던 문제. 빈 상태 힌트를 띄우고 판정을 보류합니다. (바로 위 나트륨 추이 카드는 이미 `isNotEmpty` 가드가 있었는데 끼니 목록에만 없었습니다.)

---

## Commits

1. `39af5f6` feat(trainer-clients): grow the demo roster to 15 clients that move

---

## Notes

* **백엔드 무관**입니다. 이 데이터는 클라이언트 로컬 Drift(데모 모드) 전용이고, 실서버 모드는 `client_repository.dart:261`에서 `DioClientRepository`로 분기됩니다. Neon 전환과 충돌하지 않습니다.
* **오늘 스케줄은 의도적으로 6칸 유지**했습니다. 고객 15명이 곧 오늘 세션 15개는 아니고, `_schedule` 을 건드리면 `feat/issue-501-trainer-i18n`(같은 리스트를 상수화 중)과 정면으로 충돌합니다.
* 머지 충돌 확인 결과: 시드 파일은 미머지 브랜치들과 **충돌 없음**. `feat/issue-501-trainer-i18n` 과 `diet_view.dart` 한 훅만 겹치며, 나중에 머지하는 쪽이 간단히 해소 가능합니다. `feat/issue-504-trainer-routine-crud` 는 clean.
* 대시보드 수치가 바뀝니다: 주의 고객 2 → 9, 답장 대기 2 → 6, 휴면 1 → 2. `확인 필요 고객` 카드에 `+5명` 오버플로 링크가 **처음으로** 표시됩니다(알림 보유 10명 중 5행만 노출).
* 별도 이슈 제안: `bootstrap.dart:30` 의 `seedIfEmpty` 가 `useMockApi` 게이트 없이 실행되고, `ai_routine_repository.dart:124` · `schedule_repository.dart:392` 는 게이트가 아예 없습니다. 실서버 모드에서도 AI 코칭 탭 추천 루틴과 스케줄 탭이 로컬 데모 데이터를 읽습니다 — Neon 연결 후 "왜 데모 데이터가 보이지?" 로 드러날 수 있습니다.

---

## Test Plan

* [ ] 기능 정상 동작 확인
* [ ] 예외 케이스 확인
* [ ] UI 확인
* [ ] 빌드 성공
* [ ] 관련 테스트 통과

### Manual Test Steps

1. 고객 탭 — 15명, 나트륨 초과 고객이 상단에 정렬되는지 확인
2. 임도현(신규) 열기 — 식단 탭에 "아직 기록된 식단이 없어요" 가 뜨고 AI 판정 문구가 **없는지**, 운동 탭도 빈 상태인지 확인
3. 노은채(단일 기록) · 문가영(3일치) — 스파크라인이 점 1개 / 짧은 막대로 정상 렌더되는지 확인
4. 류태경 열기 — 나트륨 추이가 1200↔3200 으로 크게 요동치는지 확인
5. 대시보드 — `확인 필요 고객` 카드 하단 `+5명` 링크 클릭 시 필터된 고객 목록으로 이동하는지 확인

---

## Related Issues

Closes #529

## Checklist

* [ ] 코드 리뷰 준비 완료
* [ ] 불필요한 코드 제거
* [ ] 하드코딩 값 점검
* [ ] Merge 충돌 없음
* [ ] 데모 시나리오 영향 확인