### PR TITLE
fix(member): 홈 그래프 축 라벨 겹침과 추천 식단 부제 잘림 수정

### DIFF
--- a/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
@@ -1149,7 +1149,11 @@ _demoNutritionHistory = <_NutTabKind, _NutData>{
     cur: <double>[1650, 2100, 1480, 1720, 1390, 1860, 967],
     unit: 'kcal',
     goal: 2000,
-    ticks: <double>[1000, 1500, 2000, 2500],
+    // 눈금 2개. 라벨 칸은 16px 인데 네 개(1000·1500·2000·2500)를 68px 축에
+    // 값 비례로 놓으면 칸 간격이 16px 을 밑돌아 아래쪽 라벨끼리 겹쳐 숫자를
+    // 읽을 수 없었다. 목표선은 따로 그리지 않으므로(상단 '목표 N' 라벨과
+    // 데이터 포인트 상태색으로만 표현) 2000 을 빼도 잃는 정보가 없다.
+    ticks: <double>[1500, 2500],
     color: FigmaColors.primary,
     warn: false,
   ),
@@ -1761,10 +1765,15 @@ class _RecMealCard extends StatelessWidget {
                       meal.reason,
                       maxLines: 2,
                       overflow: TextOverflow.ellipsis,
+                      // 카드 폭이 130px 고정이라 12.5px 로는 "나트륨 조절에
+                      // 좋아요" 가 한 줄에 못 들어가 두 줄이 되고, 카드 높이가
+                      // 158px 로 고정이라 그 둘째 줄이 잘렸다. 가독성
+                      // 개선(3299f996)에서 키운 값을 이 카드만 되돌린다 —
+                      // 제목이 진한 14px 이라 부제는 작은 회색이어야 위계도 산다.
                       style: const TextStyle(
-                        fontSize: 12.5,
+                        fontSize: 11,
                         fontWeight: FontWeight.w500,
-                        color: AppColors.foreground,
+                        color: FigmaColors.textMuted,
                         height: 1.4,
                       ),
                     ),

--- a/frontend/flutter/test/features/dashboard/home_nutrition_axis_test.dart
+++ b/frontend/flutter/test/features/dashboard/home_nutrition_axis_test.dart
@@ -1,0 +1,147 @@
+/// 홈 "주간 추이" 그래프의 세로축 눈금 라벨.
+///
+/// 라벨은 값에 비례한 위치에 `Positioned` 로 겹쳐 놓이고 높이는 16px 로 고정이다.
+/// 축 높이가 68px 뿐이라 눈금을 촘촘히 두면 라벨끼리 물리적으로 겹쳐 숫자를 읽을
+/// 수 없다 — 실제로 칼로리 축이 1,000·1,500·2,000·2,500 네 개일 때 그렇게 겹쳤다.
+/// 여기서는 "겹치지 않는다"를 좌표로 못박는다. 눈금을 다시 늘리면 이 테스트가
+/// 먼저 깨진다.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/account/domain/entities/user_profile.dart';
+import 'package:oncare/features/account/presentation/controllers/account_controller.dart';
+import 'package:oncare/features/dashboard/domain/entities/dashboard_summary.dart';
+import 'package:oncare/features/dashboard/presentation/controllers/dashboard_controller.dart';
+import 'package:oncare/features/dashboard/presentation/widgets/dashboard_content.dart';
+import 'package:oncare/features/diet/domain/entities/diet_day.dart';
+import 'package:oncare/features/member_coach/data/repositories/mock_member_coach_repository.dart';
+import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+void main() {
+  const DashboardSummary summary = DashboardSummary(
+    indicators: <HealthIndicator>[
+      HealthIndicator(label: '칼로리', current: 1860, max: 2000, unit: 'kcal'),
+      HealthIndicator(
+        label: '나트륨',
+        current: 2329,
+        max: 2000,
+        unit: 'mg',
+        overBudget: true,
+      ),
+      HealthIndicator(label: '당류', current: 43, max: 50, unit: 'g'),
+    ],
+    macros: DietMacros(
+      carbsG: 203.6,
+      proteinG: 109.3,
+      fatG: 66.5,
+      carbsPct: 44,
+      proteinPct: 24,
+      fatPct: 32,
+    ),
+    dietEntries: 4,
+    exerciseMinutes: 45,
+    exerciseCalories: 520,
+    exerciseCount: 4,
+    todaySchedule: <ScheduleItem>[],
+    weekScore: 85,
+    weekScoreDelta: 12,
+    sodiumWarning: null,
+  );
+
+  Future<void> pumpHome(WidgetTester tester) async {
+    await tester.binding.setSurfaceSize(const Size(800, 1600));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          profileProvider.overrideWith(
+            (ref) async => const UserProfile(
+              id: 'member',
+              name: '테스트',
+              email: 'member@example.com',
+            ),
+          ),
+          dashboardSummaryProvider.overrideWith((ref) async => summary),
+          memberCoachRepositoryProvider.overrideWithValue(
+            MockMemberCoachRepository(),
+          ),
+        ],
+        child: const MaterialApp(
+          locale: Locale('ko'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: DashboardContent()),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  /// 세로축 라벨 칸 — 폭 38 · 높이 68 의 `SizedBox` 하나뿐이다.
+  final Finder axis = find.descendant(
+    of: find.byKey(const ValueKey<String>('dashboard-nutrition-chart')),
+    matching: find.byWidgetPredicate(
+      (Widget w) => w is SizedBox && w.width == 38 && w.height == 68,
+    ),
+  );
+
+  /// 축 라벨을 위에서 아래 순서로 (문구, 사각형) 으로 읽는다.
+  ///
+  /// 사각형은 글자가 아니라 라벨이 차지한 16px 짜리 칸을 잰다 — 글꼴에 따라
+  /// 글자 높이는 달라져도 칸 높이는 레이아웃이 정한 값이라, 겹침 판정이
+  /// 테스트 글꼴의 자간에 흔들리지 않는다.
+  List<({String text, Rect rect})> axisLabels(WidgetTester tester) {
+    final Finder slots = find.descendant(
+      of: axis,
+      matching: find.byWidgetPredicate(
+        (Widget w) => w is SizedBox && w.height == 16,
+      ),
+    );
+    return <({String text, Rect rect})>[
+      for (final Element e in slots.evaluate())
+        (
+          text: (find
+                      .descendant(of: find.byWidget(e.widget), matching: find.byType(Text))
+                      .evaluate()
+                      .single
+                      .widget
+                  as Text)
+              .data!,
+          rect: tester.getRect(find.byWidget(e.widget)),
+        ),
+    ]..sort((a, b) => a.rect.top.compareTo(b.rect.top));
+  }
+
+  testWidgets('칼로리 축은 1,500·2,500 두 눈금만 그린다', (WidgetTester tester) async {
+    await pumpHome(tester);
+
+    expect(
+      <String>[for (final label in axisLabels(tester)) label.text],
+      <String>['2,500', '1,500'],
+    );
+  });
+
+  testWidgets('지표를 바꿔도 축 라벨끼리 겹치지 않는다', (WidgetTester tester) async {
+    await pumpHome(tester);
+
+    for (final String tab in <String>['칼로리', '나트륨', '당류']) {
+      await tester.tap(find.text(tab).first);
+      await tester.pumpAndSettle();
+
+      final List<({String text, Rect rect})> labels = axisLabels(tester);
+      expect(labels.length, greaterThan(1), reason: '$tab 축에 눈금이 없다');
+      for (int i = 1; i < labels.length; i++) {
+        expect(
+          labels[i].rect.top,
+          greaterThanOrEqualTo(labels[i - 1].rect.bottom),
+          reason:
+              '$tab 축: "${labels[i - 1].text}" 와 "${labels[i].text}" 가 겹친다',
+        );
+      }
+    }
+  });
+}

--- a/frontend/flutter/test/features/dashboard/home_recommended_meals_test.dart
+++ b/frontend/flutter/test/features/dashboard/home_recommended_meals_test.dart
@@ -16,6 +16,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:oncare/design_system/figma/figma_kit.dart';
 import 'package:oncare/features/account/domain/entities/user_profile.dart';
 import 'package:oncare/features/account/presentation/controllers/account_controller.dart';
 import 'package:oncare/features/dashboard/domain/entities/dashboard_summary.dart';
@@ -224,5 +225,27 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(renderedMealNames(tester).length, demoOrder.length);
+  });
+
+  testWidgets('이유 문구는 제목보다 작은 회색으로 남는다', (WidgetTester tester) async {
+    // 카드 폭이 130px 고정이라, 앱 전역 가독성 개선(3299f996)에서 이 문구까지
+    // 12.5px 로 키웠더니 "나트륨 조절에 좋아요" 가 두 줄로 밀려 아래가 잘렸다.
+    // 카드 안 높이는 이유 한 줄만 감당한다 — 크기를 다시 올리면 같은 잘림이
+    // 재발하므로 여기서 값을 못박는다.
+    await pumpHome(
+      tester,
+      recommendations: () async => MealRecommendations.fallback,
+    );
+    await tester.pumpAndSettle();
+
+    final TextStyle reason = tester
+        .widget<Text>(find.text('나트륨 조절에 좋아요'))
+        .style!;
+    final TextStyle name = tester.widget<Text>(find.text('닭가슴살 샐러드')).style!;
+
+    expect(reason.fontSize, 11);
+    expect(reason.fontSize, lessThan(name.fontSize!));
+    expect(reason.color, FigmaColors.textMuted);
+    expect(name.color, FigmaColors.ink);
   });
 }


### PR DESCRIPTION
Closes #535

## Summary

사용자앱 홈에서 읽히지 않던 두 곳을 고친다 — 주간 칼로리 추이의 세로축 숫자 겹침, 그리고 "이번 주 AI 추천 식단" 카드의 이유 문구 잘림.

## Changes

- **칼로리 축 눈금 2개로 축소** — 축 높이는 68px 고정이고 라벨 칸은 16px 인데, 눈금 네 개(1,000·1,500·2,000·2,500)를 값 비례로 놓으면 아래쪽 칸 간격이 16px 을 밑돌아 라벨이 서로 겹쳤다. 목표선은 따로 그리지 않고 상단 '목표 N' 라벨과 데이터 포인트 상태색으로 표현하므로 2,000 을 빼도 잃는 정보가 없다. 나트륨·당류 축은 겹치지 않아 그대로 둔다.
- **추천 식단 부제를 이전의 작은 회색으로 복귀** — 앱 전역 가독성 개선(3299f996)에서 이 문구까지 커졌는데, 카드 폭이 130px 고정이라 "나트륨 조절에 좋아요" 가 한 줄에 들어가지 못해 두 줄이 되고 카드 높이(158px) 안에서 둘째 줄이 잘렸다. 이 카드만 되돌린다 — 제목이 진한 14px 이라 부제가 작은 회색일 때 둘의 위계도 함께 산다.
- **회귀 테스트 추가** — 축 테스트는 라벨이 차지한 16px 칸의 좌표로 겹침을 직접 판정하고(글꼴 자간에 흔들리지 않는다), 세 지표를 모두 훑는다. 추천 카드 테스트는 부제가 제목보다 작고 회색인지 못박는다.

## Commits

- `678802ec` fix(member): 홈 그래프 축 라벨 겹침과 추천 식단 부제 잘림 수정

## Notes

- 눈금을 되돌리면 새 테스트가 먼저 깨지는지 확인했다 — 옛 값(1,000·1,500·2,000·2,500)으로 되돌려 실행하면 라벨 목록 비교와 겹침 판정이 모두 실패한다.
- `flutter analyze` 통과, 사용자앱 전체 테스트 통과.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 영양 주간 추이 그래프의 칼로리 눈금을 `1,500`과 `2,500` 두 개로 간소화했습니다.
  * 추천 식단 카드의 이유 문구를 더 작고 muted 색상으로 조정해 제목과 시각적으로 구분했습니다.

* **테스트**
  * 그래프 축 라벨의 표시 내용과 겹침 여부를 검증하는 테스트를 추가했습니다.
  * 추천 식단 카드의 텍스트 크기와 색상 스타일 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->