### PR TITLE
feat(landing): 소개 페이지에 트레이너 웹 진입 추가하고 데모 표기 정리

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,11 @@
   <meta property="og:title" content="On-Care · HealthMate AI" />
   <meta property="og:description" content="흩어진 트레이너–회원 대화를 데이터 기반 코칭으로 — 트레이너 연계 식단·운동 코칭 플랫폼" />
   <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="On-Care" />
+  <meta property="og:url" content="https://ewhasudo.zapto.org/" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="theme-color" content="#0b2236" />
+  <link rel="canonical" href="https://ewhasudo.zapto.org/" />
   <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAT6klEQVR42u1dCXAcV5lW2ABLUYQru7CbylKwSxZSBQRsS7I9Mz0jJ8aJCctlKnHtcgQIm4UlEBZYTnME2E1VSIU7RSBAICHjOSVZsZw4SoLjOMSJiXHs6JjpmdHolmzZlmVbmunH/72j1RqPNNM9PaMj6qpXGs10v37v///3/dc76upWrpVr5Vq5Vq7yLnZeHaOyjb0AZZul8O+Y/H3lqvjiRN4SZH+jdXScj7+2CEv3imeZeBbMqVthTHlE29Zx/lzEvn4/e6HW3HehpzX9Bk8wdakvmngLSlMsdWkgkv7nteGev99yiL1orvpRt21mLndJ3xIMcim3fglI8d7bfbE3nNjsjST+1xtJ/orKo1S6fBF90BvVT9Lfs96IPk3f5XxR+hxNTtDfIfqu2xdJ7vFFk3fTb1/TIol3eaPdF+M91neAEfK75yUzuDQKaFAEybxEi+p+IuD/EfEeJ+JN+Hf0s6YHjhpNu8ZY4P4hhv+15l6mxTPMF0vNKlo8zX/zt/bze5vaR/mzgbYBRgw5RUz7E/29jerdeEU7e+mskcEF4PkxKs6bBQGQ9Eii3htN3UrS3uNv7WNNu45yAoLI9JshpJxKVCdJT+aJiIZZorLM/i6Pe6lgdEz7qA4whzNl15gBJvrCyQz99hNPKLWeC4IFApctI2aUYV3dKmB5VH8PEfghrTmTa3pgjEs3iElQIojNiakzdwrVGwFjwJCkIRg9RiMmYxDj9xFM/bvWof+tEgrBiOVybdtmdghWiRbuuYY6fQASGbh/GETmUs6l2zWCl2QIRgneaVA7jMDOYYy2I6RXrtPuEozg+sECkUtY6rfxTgh8T+xDZwmXAReQyJyAkVoRvsjIoDZgxNEINKA3qF3PeEhxz4alJWpScsI3n7jQF+6509+azUPqJT7nFo7oxYuEqFygbZAFAIeRxL3eaPZiU5CWjOlqwVBfqPMqXyyd2kCKlSyVHDq52AhflBHUVq4j4ukhbXvPtaJb0uNe3LSXSvaO/S/0hBO3kLLjCo+gZ4GhxnYx0GZ/SxY6gqymxM8ayUw2R8OixXsOOX0XatFkG9ngzBdP5WqrXF0uZML6YnpuA0ZDLPVoIPTs6xYlE2Yg59k3EtQcwvAVNviSkvr5TNjppvYR5o9ndE+wZ5Ww6GZ77wt2qYasDyffRp5oiitaDjlLnfCFuoEgibxqf0vvyNpQp48LHlvgkWDCTrDzMq05m4UFIWMzbDkW9A06jZhwzBtKciaYnnTtiS+CW2QzX8Ilf5kTv5AJvtbekXXbj6xeGJ0gnauGew6+hoh/cLnCzrxMEHCke0Kdb1AR3Jo5WXVMRDPJTt7RtGtUKNznCfGtOiGwcwTxpMfW3XnkZSZtambxRPVbhLWjP++IbxkJ0zC3KZr7S6sfVH2lG+p+D8dBcliWh6lZmefMw+cx/aPV1QdyeHnDh//B19yrCw93CTtZLjprPBFE5qnn3sOXqHBM1cIM9LI7TUfLpU74YzoLzFHw22Krt5hSRiSV9EG4KrpAmZxauHuT1tLLJOxUBD0UnuaEwOfGUJK9I5goWhpCCcLYJL9Xs1EvnsGzc9WLd/rkvZorI4GgqA1QlLnGZSgS3ESAjdKEe0VI2bm9rwi0NiyIjv//48Es+8afhtnPDh1lv+8aZ/d0j7NfHD7Gbt4/wj72EOV4KeeLe/HMXAQrrBfP4FnUgbpQJ+rGO/AuvBPPlKrXji7w7xhAXvpZV60ixUlvPP1hkTlyjvvopCciCLSlPcPuPHyUdY+fZdN5g8114af0iSn2u85xds2uXv4sWV6zIASf8R1+wz24F8/MUy1/J96NNqAteBZtC1QATRBMQBHFjD7v0igQHPyXtq4X++LpA3A+nDIAHavfnmRXNKfYPSSJp6bznBCGSWiD5YoU6z2npw12NxEXBAeE+CWWq8/4DfdYnylWZ76gXrQFbULb0EbnTKBR0JJlvuaMviZy+NUVjwLT5o9nPyi8XefEX709wa7r6GPpk1Nm5wUxZggx3yjIGcyU6MNHz7L33Z/h0IGCz/iu2L1zXYZ5r2G+H21DG9FWp0xQo4Cyfp91TReQdt9NCXRH2I+OrKIOfW7PIEmaYUplKaLPRTQFV70T02zzjjQv+KxgxWm9arShjWjrKodMMHVBLP3MJkIOK5I4MzsjCQ+FHAwVG7drBtYTPHz8oT4TcvJOKFRw5WQdTw5N8mL9rpJLtQ1tRZvrJbTZzaZxKKK8sj+W2my1Ip3BTyz9I2n35+xaO1BqGwhXoezcIr4ptRK6DPnZrUu1EW1G29EHzQkMUYyMaHePsxCFVBzrYkdeRhUmRNjBHv5j+MKyuOPZoybsuH0ZgLIq1KvairYLk9a2T2CIKZTpYa116LW2lbFpekaT7+TEtxnvgcSsJ8m5sjXNBk9NmxK7VC7VVrQdfVjvZBTAMSOz3ZFjZgbdaM4mhx+byldJ//efGjFNzKV2qTajD05GgYChMUzH+bVdBphDhSp6Qma68nZHwDoyD58aOb3kGYA+oC+aE58AE7xiqc7GW/e+pHwYktkubzz1eszDx8xiOxCEhsI2/8DOzIyztfTob7YZfUBf1tpmgkkzQ4tmLytbGc+K+ZM9a1f5+qXT9bnHBmZ5m0vxUm1HX9AnvxMYouks3mjiY2Un8E0FHO75usB/exkvhf/f2T9SNeunVpdqO/riSA9QthDrHejv7WXrAeU0UAV3C5e6MgVcKQPyMnaT5ybnwjCgEkUMS4hmjuy0wntZF5YJOVHAigE3uzACjAIIM2oMaartNzscAaYijujPWWbSnVeeAxZJJp04YEoHfGHvYEUKWHmkvRQg+/oTQ+wHfx5lx87kaqpXVNvRFyc6QDlkJMQjWlAvwyGTPza2ZC6i4TOGh+06YWhkA8VQPkQJDxU4MxwqvwmyQD60O8ve+oce9tb7etgnH+5np3O1sawMS94AfWlwEhcC7SgxRDrgDI2CN5fOF8sf1wWP/CtJ/iTFMuwzQHiBbCPFUQYcesFK+tXQvyKe4rH6y+5L8JFQC99CVY8+oC/okz/qJDCncyZQdHR1SVNUze4ie/cyoXxTZUdANUsAjp4hwvWw3b0TtvWAujecOM6J3yTTjI1IG8YRXU2wBxzU6xT/H6R3vZ1GH00+5kzQ7EdH8xpBOdFFKxkZVdzxx5INRRyKks4XPEZIy5WtKSgedvvBMVvSqiT/mdEzol7q7BrC3v8k6LnpsUH+Gcn2TS1plpGJnXyVeKDa/JO/jPERCGdsY0uKsm8JWw6ZNyryA95IemPZDNDCeiNfAD0zjEqGHd6/s5ftG5xk/TRkUQYnp9lRqTTLwVtFyHF6BnldMJR8EA49IPbo6RzbTIExMABpw089OmDmAAyH1lU5z01M5dlJKvCIR6gNnydBsKMPTAZQYLNsBnjDqXf4TPNz/hEA0+ztBBW/pJkHxRIjPG5frMxBhC/vG+LQsyEupL89M2H+9kj/KZ7/bYoLU/enh8ZsQZFRkIlTjLf6GnmDmcUoAkkP902QANiyiPLcmgx1B0onZ5QOaNbfRBw7zUdBCSXsl8n2L5BkOLV6lPT/lpLqIOzlJPVg6g8PzhBY3fNjggSuG+IC9vYMnCoLiqyJG6dW2RS95FtPDnM9VD4Dknylvmd7sqF0PEgF4qJ8o4xjlAsuywriOkCanl8jm/3Ljw+xLz0+yO1nDNkv7hVF/X8T5Vxv/OMA+69H+nm5gQpMTDW3B5KP76csDLUS4YZHBni6EAr/39oybGhyel4mKMKnaKoK8r3XP9zH/psg7NNU0K5vUJvR7q/S6PvKPtH+L+4dot/7uf65nhL1n6ACmFUTuuyYofR3ykM7upQ2Q6UfUN82egHZrik7jpgmZ7itIulEQnt1kQKiNVhKY0GhbWe4kruKsL7v1LlEzVsI+c4WoaNQ7/88NmhCzFzSe4aw8TrK876FfAqMHNUGwMkaS0F9qv34H6Mb7UbhEdGYfUeMaDi2Lpb+RzuZsfMIgvb7bYYi1DydYiUgE/SrCzq8xtJRMA8WzpPDp+eUaGWdtGdOcuIpffCb58aL6iBVx23PjJI5KeANRkN9ESFo4ESemTtaWDQnoQjavQVb6FwaVPsYlWKAHCLEgDAWIFQyDVEVD5mkME9/33WcxZLHWYRs/GgS5QT9L0qcSkvqBA89lDJdlUL8/6dHzRgN3vHU8OQsos8ozlOcuE0yTALY2UMKHf7Ebllg73dkJ9iO1EnHachzLSA9x9cZR5IdZUv/TDpS/5ZbCzCEok7wuZmliKuspHKUIkzDj+7u49K7jgi2hTBamb6K+H00Z+hdNHcIThQg5IPtvUVjSqpNmNa4xkncZ85wNEL6iTtshKPVbDj9fU6ioXNPUUGiXmcHR0+byrT4tEF7jlLnsbMEQylOMGA3lKl1FHx2z4A50w1teHrk3PcrZX+QHEDcg+LGjGnkUnhIP5z6VPlriyUEYfWjMEXtx4Pmm6T1EZLYyWnDlaimkvIIwRmIDN8BTAh2H+ffwzeBOXt5XJi1dx0511dRH9EmtM3hZKy5dIDY3Suir7UxP0jgFPb2oSF0ULjR7qyEUbmCWw64F1BTkv5Nss+hxPGeK0mRA+6A+X5pKd2kLKU5RhLa5CzmP48D1oIpPXqmvq3rAltzg2ZmxaV+zldBRt1b/6vyBVDAbgTU1OPHz+bZtRTCaJSmIqwqFSaBDig2P0m9G21Z7RLuz8qGYf+hqL7d9uy4GQbo78WUdDc33OD6ICqI87Q0Nyud16mk+M+kX9R7mqTpC+uno+/c6Kl6J9pgbZObDODLlqKZj9ufJS2Hiqet/+9Imvo1zHl3cTWkX4aYN+/IsJQ0OysdCYqggJ633SekGU7Xj8yI7LmSj3ejDWiLm9LPHTBgfzx9AtN7HC3cU0OGKvmV2zBkLtggrxewMTyZcyW0rIJr335yhBMVYYUzOaNgIYj4i3fi3WhDIObuykkBP7SIO55qtp2MP2dhXlzfZJkfarjNBL5wg0IE42dzrsX3ERTMkv0/VVCZGfKmd+GdlSzEKMkAWk/hi2a2VrBIQy5Pur3txRTNe9pNa8hauHdK1geCXeNn865YR0aRWRSqTrwD71ots23V2JERAqvFexNklb28omVKplfckvq0kzlCdpiwSo4EJF7cUMyGYV0nJv6ibrwD76oO8eWaYbHf3DcrX6KkZkkED72KQtNJbtdWaQsyBUdbCZezE1Ou5XxVHagTdVcLdqzKl1ZJjlweTPyTK0tVLStlbgpUcRT4LLmAd5NlcmjsjCBg3tmMODyTk6CPulDnmmoS3yL95D99z73F2pbJWliEXC1dYGWCWjg9M/vBXtjCsMAO6rDWWc3deLFElbA/qwUPvdbVLQsUJwPNma2B+weZr8qbdPhl4AxxGSwTUjBSDiRZ78WzInPm7t4Q8zlevnDqM9XZNUVyk/aKaOZ5gipvT6ZJRiA+g4jmoEw7zrXE1brUFPfiGTzrd2sviDLMTkKIR6u3h5xK2If0N9EGfWPl5ovd2NADihPrgVVIwbAwwihgCu7BvUrZalXfrkbkfSlaMOkNdtZXdeMm0yyN6DcE2keqqpAL9YJKI36XpoqrpIs1eYPv8BvuWVd1vC+yFiye/kptNvBTIYpo+ndu7xtUas6pgqR300yItvRJM6GCz/hOQY4/WsMtyxBwi2faeLihJht8K11w14FX+OKZp/gWBjXcrlKNBpiU1+7K8oLPtZR6JfmIFBMUdzX++sBFjmM+leye5QkeupRMr36R+U/UbPsyTe2SIiftOpuxUNneQKQHgfvjCvdrvneouZaMtvGl2McJhKxryQTrjOxab9JHkGNQf6d8ocTVC7p7rkoy+0I9V2mt2VOQilozofbETxvU1xwRf+ui2D9aMYGG4maygyfkborLb/NuYH4LjsnqO+sLdm1dUMk/lwnsfKETujQansPLbStjvkuu2A/u+PpQ19WLavt6kwlSGjAJlRyTv5hrjJf0xq445EfM7aElRknP9s6GRUn8QsW8gfZLIxgKyr0080sRkqDLCO/z3MkKJ9obg50XLSrYmTeVKX0FUs430i67E3y3ReE1L34FHRFHW/GjE1uyp2ln3K8qiXe081XdgpzdZjlJiU47pbUGHXw7RzrUZ9EyAoQnrCdLTpwnFk0+gWMWFeGrvjF3NQ5fNmNHNGxpMcUnCE97McPC39wrD1Bb+L2n0QaEFLRmCTfR9KAvlLxRbbi39M+XxInXUno27sy8iiRtG0nXMDpLHrTBCYBRUUtlLWGG4zwdVSWyWOkJTyhxm9YqVrRvs7S7bjkcRW49ja4pnngNMeFLVHoQS6LIKl9HJY8VnK4KRCmiU+Gnq+4c5mdI0vd9VH7giWQvmXUK4LI89LngyFi+JwV5lMSIFtoe7QQ/A5iYwXefxWFqUX6M7eyjbOddtamOtNVnjrSVh3aizqadI4YwKVOTBDsPemjPf4zKWQZErQJqi+OE1Rkp8wafox26kp8kAoaoZGlmgTiUWR3mzOfaZGaSIAK78/IMyLyCMD4rAScd0doGwVAeLsb9/TTbu5nOEv7MBiXtVvN5+cCNgxFRMG+SAmyvwDFRRNQbaXr3L3BEOeF1iv6e4Ev/SZr5xqg4SAdlBw7UkaMmkjxJf1PYbocmF/8WWwhrkbTH03rwlUXPvFw5X36GIIXHnFsXDdbf3XUBJrp6oj2raDevJkQicSi0L6y/l0zdqz3R1IYA/baBTjXaRKs8i1ou879j5SocGSCWcylFHUFZR3BF0l3JxEnTEAQFY2YX6SxBuleIvXKtXCvXylXO9VfyYHMe21r1zAAAAABJRU5ErkJggg==" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -94,6 +99,9 @@
     .btn-primary:hover { background: var(--brand-3); transform: translateY(-2px); box-shadow: 0 12px 26px rgba(21,128,189,.34); }
     .btn-ghost { background: rgba(255,255,255,.08); color: #fff; border-color: rgba(255,255,255,.25); }
     .btn-ghost:hover { background: rgba(255,255,255,.16); transform: translateY(-2px); }
+    /* light-background counterpart of .btn-ghost — used in the nav and on cards */
+    .btn-outline { background: #fff; color: var(--brand-3); border-color: #c3deef; }
+    .btn-outline:hover { background: var(--brand-tint); border-color: var(--brand-2); transform: translateY(-2px); }
 
     .pill { display: inline-flex; align-items: center; gap: 5px; font-size: .72rem; font-weight: 800; padding: 4px 11px; border-radius: 999px; white-space: nowrap; }
     .pill-green { background: var(--green-soft); color: var(--green); }
@@ -152,6 +160,27 @@
     .ico.g { background: var(--green-soft); color: var(--green); }
     .card h3 { font-size: 1.12rem; font-weight: 800; color: var(--ink); letter-spacing: -.01em; margin-bottom: 9px; display: flex; align-items: center; gap: 9px; flex-wrap: wrap; }
     .card p { color: var(--muted); font-size: .94rem; }
+
+    /* ── app entry cards (회원 앱 / 트레이너 웹) ── */
+    .apps { display: grid; grid-template-columns: repeat(2, 1fr); gap: 22px; }
+    .app-card {
+      position: relative; overflow: hidden;
+      background: var(--card); border: 1px solid var(--line); border-radius: var(--radius);
+      padding: 32px 30px 30px; box-shadow: var(--shadow);
+      display: flex; flex-direction: column; gap: 14px;
+      transition: transform .18s ease, box-shadow .2s ease, border-color .2s;
+    }
+    .app-card:hover { transform: translateY(-4px); box-shadow: var(--shadow-lg); border-color: #d4e6f1; }
+    .app-card::before { content: ''; position: absolute; top: 0; left: 0; right: 0; height: 4px; background: linear-gradient(90deg, var(--brand), var(--brand-2)); }
+    .app-card.trainer::before { background: linear-gradient(90deg, var(--amber), #f3c081); }
+    .app-role { font-size: .72rem; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; color: var(--brand); }
+    .app-card.trainer .app-role { color: var(--amber); }
+    .app-card h3 { font-size: 1.22rem; font-weight: 800; color: var(--ink); letter-spacing: -.01em; }
+    .app-card > p { color: var(--muted); font-size: .94rem; }
+    .app-card ul { list-style: none; display: grid; gap: 8px; }
+    .app-card li { position: relative; padding-left: 21px; font-size: .92rem; color: var(--text); }
+    .app-card li::before { content: '✓'; position: absolute; left: 0; top: 0; color: var(--green); font-weight: 800; }
+    .app-card .btn { align-self: flex-start; margin-top: 8px; }
 
     .alt { background: linear-gradient(180deg, #fff 0%, var(--brand-tint) 100%); border-top: 1px solid var(--line-soft); border-bottom: 1px solid var(--line-soft); }
     .callout { margin-top: 24px; background: var(--ink); color: #cfe0ec; border-radius: 16px; padding: 24px 28px; box-shadow: var(--shadow-lg); font-size: .98rem; }
@@ -239,9 +268,11 @@
         border-bottom: 1px solid var(--line); gap: 16px;
       }
       .nav-links.open { display: flex; }
-      .nav-cta .btn span { display: none; }
+      /* Two app buttons do not fit next to the logo on phones. The trainer entry
+         stays reachable through the "앱" menu item and the #apps section. */
+      .nav-cta .btn-outline { display: none; }
       .nav-toggle { display: inline-flex; }
-      .g-2, .g-3, .stats-grid { grid-template-columns: 1fr; }
+      .g-2, .g-3, .stats-grid, .apps { grid-template-columns: 1fr; }
       .cta-band { padding: 40px 24px; }
       .foot-grid { flex-direction: column; }
       .pad { padding: 68px 0; }
@@ -258,6 +289,7 @@
       <div class="nav-links" id="navLinks">
         <a href="#overview">개요</a>
         <a href="#problem">문제</a>
+        <a href="#apps">서비스</a>
         <a href="#features">기능</a>
         <a href="#architecture">구조</a>
         <a href="#business">비즈니스</a>
@@ -265,14 +297,15 @@
       </div>
       <div class="nav-cta">
         <a href="https://github.com/CSE-Sudo-26/sudo-capstone-project" target="_blank" rel="noopener" class="icon-link" aria-label="GitHub">
-          <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 0 0 .5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.53-1.34-1.3-1.7-1.3-1.7-1.06-.72.08-.71.08-.71 1.17.08 1.79 1.2 1.79 1.2 1.04 1.79 2.73 1.27 3.4.97.1-.76.41-1.27.74-1.56-2.55-.29-5.23-1.28-5.23-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.8 0c2.2-1.5 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.25 5.69.42.36.8 1.08.8 2.18v3.23c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12 11.5 11.5 0 0 0 12 .5Z"/></svg>
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 0 0 .5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.53-1.34-1.3-1.7-1.3-1.7-1.06-.72.08-.71.08-.71 1.17.08 1.79 1.2 1.79 1.2 1.04 1.79 2.73 1.27 3.4.97.1-.76.41-1.27.74-1.56-2.55-.29-5.23-1.28-5.23-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.8 0c2.2-1.5 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.25 5.69.42.36.8 1.08.8 2.18v3.23c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12 11.5 11.5 0 0 0 12 .5Z"/></svg>
         </a>
-        <a href="https://ewhasudo.zapto.org/frontend/#/dashboard" target="_blank" rel="noopener" class="btn btn-primary" aria-label="웹 데모">
-          <span>웹 데모</span>
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+        <a href="https://ewhasudo.zapto.org/trainer/" target="_blank" rel="noopener" class="btn btn-outline">트레이너 웹</a>
+        <a href="https://ewhasudo.zapto.org/frontend/#/dashboard" target="_blank" rel="noopener" class="btn btn-primary">
+          <span>회원 앱</span>
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
         </a>
         <button class="nav-toggle" id="navToggle" aria-label="메뉴" aria-controls="navLinks" aria-expanded="false">
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><path d="M4 7h16M4 12h16M4 17h16"/></svg>
+          <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><path d="M4 7h16M4 12h16M4 17h16"/></svg>
         </button>
       </div>
     </div>
@@ -287,11 +320,15 @@
       <p class="hero-sub">회원이 음식 사진 한 장·간단한 입력만 하면, 앱이 식단과 운동을 회원별·날짜별로 정리해 트레이너에게 전달합니다. 트레이너는 흩어진 메시지 대신 정리된 리포트 위에서 코칭하고, 그 코칭은 다시 회원에게 돌아옵니다.</p>
       <div class="hero-cta">
         <a href="https://ewhasudo.zapto.org/frontend/#/dashboard" target="_blank" rel="noopener" class="btn btn-primary">
-          서비스 바로가기
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+          회원 앱 바로가기
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+        </a>
+        <a href="https://ewhasudo.zapto.org/trainer/" target="_blank" rel="noopener" class="btn btn-ghost">
+          트레이너 웹 바로가기
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
         </a>
         <a href="https://youtu.be/C4ivM_dlAww?si=8iOWmOpSxcpQmlU3" target="_blank" rel="noopener" class="btn btn-ghost">
-          <svg viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>
           데모 영상
         </a>
         <a href="https://github.com/CSE-Sudo-26/sudo-capstone-project" target="_blank" rel="noopener" class="btn btn-ghost">GitHub</a>
@@ -339,12 +376,12 @@
       </div>
       <div class="grid g-2">
         <div class="card" data-reveal>
-          <div class="ico a">🏋️</div>
+          <div class="ico a" aria-hidden="true">🏋️</div>
           <h3>트레이너</h3>
           <p>회원 30~40명의 식사·운동을 개별 메신저로 일일이 확인하느라 하루 한 시간 넘게 쓰지만, 대화가 흩어져 회원별 흐름이 한눈에 보이지 않습니다. 회원이 늘수록 관리 품질이 떨어져 <b>확장이 어렵습니다.</b></p>
         </div>
         <div class="card" data-reveal>
-          <div class="ico a">🧍</div>
+          <div class="ico a" aria-hidden="true">🧍</div>
           <h3>회원</h3>
           <p>매 끼 검색·입력하는 번거로움에 기록을 며칠 만에 포기하고, 어렵게 남긴 기록도 <b>“그래서 무엇을 바꿔야 하는지”</b>로 이어지지 않습니다.</p>
         </div>
@@ -387,8 +424,51 @@
     </div>
   </section>
 
+  <!-- APPS -->
+  <section class="pad" id="apps">
+    <div class="wrap">
+      <div class="section-head center" data-reveal>
+        <span class="eyebrow">Apps</span>
+        <h2>회원 앱과 트레이너 웹, 하나의 서비스</h2>
+        <p>On-Care는 회원 앱과 트레이너 웹이 같은 백엔드를 공유합니다. 회원이 남긴 기록은 트레이너 웹의 리포트로, 트레이너의 코칭은 회원 앱의 알림·채팅으로 이어집니다. 둘 다 설치 없이 웹에서 바로 열어볼 수 있습니다.</p>
+      </div>
+      <div class="apps">
+        <div class="app-card" data-reveal>
+          <span class="app-role">For members · 회원</span>
+          <h3>회원 앱</h3>
+          <p>기록은 최소한으로, 관리는 트레이너와 함께.</p>
+          <ul>
+            <li>사진 한 장으로 끝내는 식단 기록과 영양 추정</li>
+            <li>운동·활동·목표를 한 화면에서 확인하는 홈 대시보드</li>
+            <li>트레이너·헬스장 찾기와 상담 요청, 담당 트레이너 연결</li>
+            <li>담당 트레이너와의 채팅, AI 코치 추천</li>
+          </ul>
+          <a href="https://ewhasudo.zapto.org/frontend/#/dashboard" target="_blank" rel="noopener" class="btn btn-primary">
+            회원 앱 열기
+            <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+          </a>
+        </div>
+        <div class="app-card trainer" data-reveal>
+          <span class="app-role">For trainers · 트레이너</span>
+          <h3>트레이너 웹</h3>
+          <p>흩어진 메시지 대신, 정리된 리포트 위에서 코칭.</p>
+          <ul>
+            <li>담당 회원의 식단·운동·활동 요약 리포트</li>
+            <li>회원별·날짜별 기록 열람과 피드백 작성</li>
+            <li>세션 일정과 운동 프로그램 관리, 회원 기록에 자동 반영</li>
+            <li>상담 요청 수락·거절과 회원 채팅</li>
+          </ul>
+          <a href="https://ewhasudo.zapto.org/trainer/" target="_blank" rel="noopener" class="btn btn-outline">
+            트레이너 웹 열기
+            <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <!-- FEATURES -->
-  <section class="pad" id="features">
+  <section class="pad alt" id="features">
     <div class="wrap">
       <div class="section-head center" data-reveal>
         <span class="eyebrow">Features</span>
@@ -396,27 +476,27 @@
       </div>
       <div class="grid g-3">
         <div class="card" data-reveal>
-          <div class="ico b">📷</div>
+          <div class="ico b" aria-hidden="true">📷</div>
           <h3>간편 식단 기록</h3>
           <p>음식 사진을 찍으면 Vision(VLM)이 음식과 양을 추정하고, 식약처 공공 DB의 영양성분 참고값으로 나트륨·칼로리·당 추정치를 제공합니다. 완벽한 자동 계산이 아니라 기록 부담을 없애는 것이 목적이며, 최종 값은 회원·트레이너가 확인·보정합니다.</p>
         </div>
         <div class="card" data-reveal>
-          <div class="ico b">🏋️</div>
+          <div class="ico b" aria-hidden="true">🏋️</div>
           <h3>운동 기록 자동 연동</h3>
           <p>트레이너가 세션에서 입력한 프로그램·수행이 회원 기록에 자동 반영되어, 회원이 일일이 적지 않아도 데이터가 쌓입니다.</p>
         </div>
         <div class="card" data-reveal>
-          <div class="ico b">📊</div>
+          <div class="ico b" aria-hidden="true">📊</div>
           <h3>자동 요약 리포트</h3>
           <p>식단·운동·활동을 회원별·날짜별로 묶어 트레이너에게 전달합니다. “이 회원, 이번 주 나트륨 과다 · 유산소 부족”을 한눈에 파악합니다.</p>
         </div>
         <div class="card" data-reveal>
-          <div class="ico b">🔗</div>
+          <div class="ico b" aria-hidden="true">🔗</div>
           <h3>데이터 기반 매칭</h3>
           <p>회원의 목표와 조건(위치·시간·성향)에 맞춰 트레이너·헬스장을 추천하고 앱 안에서 연결합니다.</p>
         </div>
         <div class="card" data-reveal>
-          <div class="ico b">🎯</div>
+          <div class="ico b" aria-hidden="true">🎯</div>
           <h3>목표·미션 관리</h3>
           <p>만성질환 위험군에 맞춘 나트륨·활동량 목표와 일일 미션. 많이 먹은 날은 활동량을, 적게 먹은 날은 식단을 조정하는 <b>식단↔운동 연동 코칭</b>을 제공합니다.</p>
         </div>
@@ -425,7 +505,7 @@
   </section>
 
   <!-- DIET PIPELINE -->
-  <section class="pad alt" id="pipeline">
+  <section class="pad" id="pipeline">
     <div class="wrap">
       <div class="section-head center" data-reveal>
         <span class="eyebrow">Pipeline</span>
@@ -439,7 +519,7 @@
   </section>
 
   <!-- ARCHITECTURE -->
-  <section class="pad" id="architecture">
+  <section class="pad alt" id="architecture">
     <div class="wrap">
       <div class="section-head center" data-reveal>
         <span class="eyebrow">Architecture</span>
@@ -453,7 +533,7 @@
   </section>
 
   <!-- TECH -->
-  <section class="pad alt" id="tech">
+  <section class="pad" id="tech">
     <div class="wrap">
       <div class="section-head center" data-reveal>
         <span class="eyebrow">Tech Stack</span>
@@ -518,7 +598,7 @@
   </section>
 
   <!-- COMPETITIVE -->
-  <section class="pad" id="compare">
+  <section class="pad alt" id="compare">
     <div class="wrap">
       <div class="section-head" data-reveal>
         <span class="eyebrow">Positioning</span>
@@ -528,7 +608,7 @@
       <div class="table-wrap" data-reveal>
         <table>
           <thead>
-            <tr><th>항목</th><th>필라이즈</th><th>밀리그램·인아웃</th><th class="oc">On-Care</th></tr>
+            <tr><th scope="col">항목</th><th scope="col">필라이즈</th><th scope="col">밀리그램·인아웃</th><th scope="col" class="oc">On-Care</th></tr>
           </thead>
           <tbody>
             <tr><td>식단 기록</td><td>사진 AI 인식</td><td>사진·빠른 입력</td><td class="oc">사진 → 공공 영양 DB 매칭</td></tr>
@@ -543,7 +623,7 @@
   </section>
 
   <!-- BUSINESS -->
-  <section class="pad alt" id="business">
+  <section class="pad" id="business">
     <div class="wrap">
       <div class="section-head center" data-reveal>
         <span class="eyebrow">Business</span>
@@ -552,17 +632,17 @@
       </div>
       <div class="grid g-3">
         <div class="card" data-reveal>
-          <div class="ico g">💳</div>
+          <div class="ico g" aria-hidden="true">💳</div>
           <h3>메인</h3>
           <p>트레이너·헬스장 <b>중개 수수료 / 구매 전환 커미션</b>, 트레이너용 고도화 기능 <b>구독</b>.</p>
         </div>
         <div class="card" data-reveal>
-          <div class="ico b">✨</div>
+          <div class="ico b" aria-hidden="true">✨</div>
           <h3>프리미엄</h3>
           <p>기본 기능은 무료로 진입장벽을 낮추고, 가치를 체감한 사용자가 고도화 기능을 결제합니다.</p>
         </div>
         <div class="card" data-reveal>
-          <div class="ico a">📣</div>
+          <div class="ico a" aria-hidden="true">📣</div>
           <h3>부수</h3>
           <p>광고(상위 노출 등)는 보조 수입으로만 활용합니다.</p>
         </div>
@@ -572,7 +652,7 @@
   </section>
 
   <!-- TEAM -->
-  <section class="pad" id="team">
+  <section class="pad alt" id="team">
     <div class="wrap">
       <div class="section-head center" data-reveal>
         <span class="eyebrow">Team</span>
@@ -583,19 +663,19 @@
         <div class="member" data-reveal>
           <b>최지수</b>
           <a class="gh" href="https://github.com/aJISUa" target="_blank" rel="noopener">
-            <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 0 0 .5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.53-1.34-1.3-1.7-1.3-1.7-1.06-.72.08-.71.08-.71 1.17.08 1.79 1.2 1.79 1.2 1.04 1.79 2.73 1.27 3.4.97.1-.76.41-1.27.74-1.56-2.55-.29-5.23-1.28-5.23-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.8 0c2.2-1.5 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.25 5.69.42.36.8 1.08.8 2.18v3.23c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12 11.5 11.5 0 0 0 12 .5Z"/></svg>@aJISUa
+            <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 0 0 .5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.53-1.34-1.3-1.7-1.3-1.7-1.06-.72.08-.71.08-.71 1.17.08 1.79 1.2 1.79 1.2 1.04 1.79 2.73 1.27 3.4.97.1-.76.41-1.27.74-1.56-2.55-.29-5.23-1.28-5.23-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.8 0c2.2-1.5 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.25 5.69.42.36.8 1.08.8 2.18v3.23c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12 11.5 11.5 0 0 0 12 .5Z"/></svg>@aJISUa
           </a>
         </div>
         <div class="member" data-reveal>
           <b>박서연</b>
           <a class="gh" href="https://github.com/seoyeon0516" target="_blank" rel="noopener">
-            <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 0 0 .5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.53-1.34-1.3-1.7-1.3-1.7-1.06-.72.08-.71.08-.71 1.17.08 1.79 1.2 1.79 1.2 1.04 1.79 2.73 1.27 3.4.97.1-.76.41-1.27.74-1.56-2.55-.29-5.23-1.28-5.23-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.8 0c2.2-1.5 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.25 5.69.42.36.8 1.08.8 2.18v3.23c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12 11.5 11.5 0 0 0 12 .5Z"/></svg>@seoyeon0516
+            <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 0 0 .5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.53-1.34-1.3-1.7-1.3-1.7-1.06-.72.08-.71.08-.71 1.17.08 1.79 1.2 1.79 1.2 1.04 1.79 2.73 1.27 3.4.97.1-.76.41-1.27.74-1.56-2.55-.29-5.23-1.28-5.23-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.8 0c2.2-1.5 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.25 5.69.42.36.8 1.08.8 2.18v3.23c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12 11.5 11.5 0 0 0 12 .5Z"/></svg>@seoyeon0516
           </a>
         </div>
         <div class="member" data-reveal>
           <b>신수빈</b>
           <a class="gh" href="https://github.com/subin21cc" target="_blank" rel="noopener">
-            <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 0 0 .5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.53-1.34-1.3-1.7-1.3-1.7-1.06-.72.08-.71.08-.71 1.17.08 1.79 1.2 1.79 1.2 1.04 1.79 2.73 1.27 3.4.97.1-.76.41-1.27.74-1.56-2.55-.29-5.23-1.28-5.23-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.8 0c2.2-1.5 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.25 5.69.42.36.8 1.08.8 2.18v3.23c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12 11.5 11.5 0 0 0 12 .5Z"/></svg>@subin21cc
+            <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 0 0 .5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.53-1.34-1.3-1.7-1.3-1.7-1.06-.72.08-.71.08-.71 1.17.08 1.79 1.2 1.79 1.2 1.04 1.79 2.73 1.27 3.4.97.1-.76.41-1.27.74-1.56-2.55-.29-5.23-1.28-5.23-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.8 0c2.2-1.5 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.25 5.69.42.36.8 1.08.8 2.18v3.23c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12 11.5 11.5 0 0 0 12 .5Z"/></svg>@subin21cc
           </a>
         </div>
       </div>
@@ -608,13 +688,16 @@
     <div class="wrap">
       <div class="cta-band" data-reveal>
         <h2>지금, On-Care를 직접 사용해 보세요</h2>
-        <p>별도 설치 없이 웹에서 바로 체험할 수 있습니다. 전체 구동 흐름은 데모 영상에서 확인하세요.</p>
+        <p>별도 설치 없이 웹에서 바로 사용할 수 있습니다. 회원 앱과 트레이너 웹을 나란히 열어 양쪽 흐름을 함께 확인해 보세요.</p>
         <div class="hero-cta">
-          <a href="https://ewhasudo.zapto.org/frontend/#/dashboard" target="_blank" rel="noopener" class="btn btn-primary">서비스 바로가기
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+          <a href="https://ewhasudo.zapto.org/frontend/#/dashboard" target="_blank" rel="noopener" class="btn btn-primary">회원 앱 바로가기
+            <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+          </a>
+          <a href="https://ewhasudo.zapto.org/trainer/" target="_blank" rel="noopener" class="btn btn-ghost">트레이너 웹 바로가기
+            <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
           </a>
           <a href="https://youtu.be/C4ivM_dlAww?si=8iOWmOpSxcpQmlU3" target="_blank" rel="noopener" class="btn btn-ghost">
-            <svg viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>데모 영상
+            <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>데모 영상
           </a>
         </div>
       </div>
@@ -631,7 +714,8 @@
         </div>
         <div class="foot-col">
           <h5>Product</h5>
-          <a href="https://ewhasudo.zapto.org/frontend/#/dashboard" target="_blank" rel="noopener">웹 서비스</a>
+          <a href="https://ewhasudo.zapto.org/frontend/#/dashboard" target="_blank" rel="noopener">회원 앱</a>
+          <a href="https://ewhasudo.zapto.org/trainer/" target="_blank" rel="noopener">트레이너 웹</a>
           <a href="https://youtu.be/C4ivM_dlAww?si=8iOWmOpSxcpQmlU3" target="_blank" rel="noopener">데모 영상</a>
           <a href="#features">기능</a>
           <a href="#architecture">시스템 구조</a>


### PR DESCRIPTION
Closes #544

## Summary

소개 페이지에 **트레이너 웹 진입 동선이 전혀 없던 문제**를 해결하고, 서비스 단계에 맞지 않는 "웹 데모" 표기를 정리했다. `/trainer/` 는 Pages 배포 워크플로가 이미 함께 게시하고 README 배지에도 걸려 있었지만, 소개 페이지는 회원 앱(`/frontend/`)만 가리키고 있었다.

트레이너 클라이언트는 웹으로만 배포되므로 페이지 표기는 "트레이너 웹"으로 통일했다.

## Changes

**트레이너 웹 진입 추가**
- 네비게이션에 `트레이너 웹` 버튼과 `서비스` 메뉴 항목 추가
- 히어로 CTA를 `회원 앱 바로가기` + `트레이너 웹 바로가기`로 분리
- `#apps` 섹션 신설 — 회원 앱 / 트레이너 웹이 각각 무엇을 하는 화면인지 정리하고 각 카드에서 바로 열 수 있게 함
- 하단 CTA 밴드와 푸터 Product 목록에 트레이너 웹 추가
- 모바일에서는 네비게이션 폭이 부족해 트레이너 웹 버튼을 숨기고, `서비스` 메뉴와 `#apps` 섹션으로 도달하게 함

**표기 정리**
- 네비게이션 `웹 데모` → `회원 앱`, 하단 CTA 문구를 "체험" → "사용"으로 조정
- 유튜브 `데모 영상` 표기는 실제 영상 이름이라 유지

**전반 점검에서 함께 고친 것**
- 접근성: 장식용 이모지·SVG 아이콘 `aria-hidden`, 경쟁 분석 표 헤더 `scope="col"`
- 공유 메타: `og:url` · `og:site_name` · `canonical` · `theme-color` 보강
- 섹션이 하나 늘어난 만큼 배경 교차(`alt`) 순서를 다시 맞춰 같은 배경이 연달아 붙지 않게 정리

## Notes

- 로컬에서 렌더링 확인 (데스크톱 폭 기준, 신규 섹션·버튼·링크 동작 확인). 링크 대상 `/trainer/`·`/frontend/` 는 현재 배포본에서 200 응답 확인.
- 트레이너 웹 로그인 화면의 `로그인 없이 데모 둘러보기` 등 **앱 내부 문구는 이 PR 범위 밖**이다. 별도로 정리 필요.
- README·Flutter 패키지 설명에 남아 있는 "트레이너 앱" 표현은 코드베이스 자체를 가리키는 문맥이라 건드리지 않았다.
