### PR TITLE
fix(trainer): AI 코칭 추천·스케줄을 실제 데이터 경로와 연동

### DIFF
--- a/backend/app/api/v1/trainer.py
+++ b/backend/app/api/v1/trainer.py
@@ -32,7 +32,8 @@ from app.schemas.trainer_api import (
     ChatMessageOut, ChatSendRequest, ClientCoachOut, ClientCoachRequest, ClientDietEntryOut,
     ReportSendRequest, RoutineAssignRequest, RoutineOut, RoutineHistoryOut,
     RoutineOptionsOut, RoutineOptionsRequest, RoutineUpdateRequest,
-    ScheduleCompleteRequest, ScheduleCreateRequest, ScheduleSessionOut, ScheduleUpdateRequest,
+    ScheduleCompleteRequest, ScheduleCreateRequest, ScheduleProgramRegisterOut,
+    ScheduleProgramRegisterRequest, ScheduleSessionOut, ScheduleUpdateRequest,
     TrainerClientOut, TrainerGymAffiliation, TrainerMe, TrainerMeUpdate,
     TrainerNotificationOut, TrainerNotificationSettings, TrainerNotificationSettingsUpdate,
     TrainerPasswordChange, WeeklyReportOut,
@@ -521,6 +522,35 @@ def trainer_create_session(
         member_id=payload.member_id, type_=payload.type,
         duration_minutes=payload.duration_minutes, note=payload.note,
         program=payload.program,
+    )
+
+
+@router.put(
+    "/trainer/clients/{member_id}/schedule-program",
+    response_model=ScheduleProgramRegisterOut,
+)
+def trainer_register_schedule_program(
+    member_id: str,
+    payload: ScheduleProgramRegisterRequest,
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> ScheduleProgramRegisterOut:
+    """Atomically attach an AI program or create the member's PT session."""
+    result = trainer_service.register_program(
+        db,
+        trainer.id,
+        member_id,
+        date=payload.date,
+        time=payload.time,
+        client_name=payload.client_name,
+        program=payload.program,
+    )
+    if result is None:
+        raise HTTPException(status_code=404, detail="담당 고객을 찾을 수 없습니다.")
+    session, attached_to_existing = result
+    return ScheduleProgramRegisterOut(
+        session=session,
+        attached_to_existing=attached_to_existing,
     )
 
 

--- a/backend/app/schemas/trainer_api.py
+++ b/backend/app/schemas/trainer_api.py
@@ -256,6 +256,23 @@ class ScheduleCreateRequest(BaseModel):
     _v_time = field_validator("time")(_validate_hhmm)
 
 
+class ScheduleProgramRegisterRequest(BaseModel):
+    """AI coaching command to attach a program or create its PT session."""
+
+    date: str = Field(max_length=10)
+    time: str = Field(max_length=10)
+    client_name: str = Field(default="", max_length=100)
+    program: list[ProgramItem] = Field(min_length=1, max_length=30)
+
+    _v_date = field_validator("date")(_validate_ymd)
+    _v_time = field_validator("time")(_validate_hhmm)
+
+
+class ScheduleProgramRegisterOut(BaseModel):
+    session: ScheduleSessionOut
+    attached_to_existing: bool
+
+
 class ScheduleUpdateRequest(PartialUpdate):
     """부분 수정 — 제공된 필드만 반영."""
     time: str | None = Field(default=None, max_length=10)

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -813,6 +813,67 @@ def create_session(
     return _schedule_out(s)
 
 
+def register_program(
+    db: Session,
+    trainer_id: str,
+    member_id: str,
+    *,
+    date: str,
+    time: str,
+    client_name: str,
+    program: list[ProgramItem],
+) -> tuple[ScheduleSessionOut, bool] | None:
+    """Atomically attach a program to a planned session or create one.
+
+    Locking the trainer-client link serializes this command for one
+    trainer/member pair. A concurrent request therefore cannot observe the
+    same empty schedule state and create a duplicate session: the second
+    request waits, then sees and updates the row committed by the first.
+    """
+    client_link = db.scalar(
+        select(TrainerClient)
+        .where(
+            TrainerClient.trainer_id == trainer_id,
+            TrainerClient.member_id == member_id,
+        )
+        .with_for_update()
+    )
+    if client_link is None:
+        return None
+
+    session = db.scalar(
+        select(TrainerSchedule)
+        .where(
+            TrainerSchedule.trainer_id == trainer_id,
+            TrainerSchedule.member_id == member_id,
+            TrainerSchedule.date == date,
+            TrainerSchedule.status == "예정",
+        )
+        .order_by(TrainerSchedule.time, TrainerSchedule.id)
+        .limit(1)
+        .with_for_update()
+    )
+    if session is None:
+        created = create_session(
+            db,
+            trainer_id,
+            date=date,
+            time=time,
+            client_name=client_name,
+            member_id=member_id,
+            type_="1:1 PT",
+            duration_minutes=60,
+            note="",
+            program=program,
+        )
+        return created, False
+
+    session.program_json = _dump_program(program)
+    db.commit()
+    db.refresh(session)
+    return _schedule_out(session), True
+
+
 def update_session(
     db: Session, trainer_id: str, session_id: str, fields: dict
 ) -> ScheduleSessionOut | None:

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -806,7 +806,13 @@ def update_session(
     s = _get_owned_session(db, trainer_id, session_id)
     if s is None:
         return None
-    if _is_reservation_schedule(db, session_id):
+    # A reservation owns the booking coordinates and lifecycle, so changing
+    # its time/member/type/duration through the general schedule API would
+    # desynchronise the slot and remaining count. The trainer may still add
+    # the PT plan and memo: those fields do not alter the reservation.
+    if _is_reservation_schedule(db, session_id) and not set(fields).issubset(
+        {"program", "note"}
+    ):
         raise ScheduleConflict(
             "예약으로 생성된 일정은 일반 일정 화면에서 수정할 수 없습니다."
         )

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import uuid
+from collections.abc import Mapping, Sequence
 from collections import defaultdict
 from datetime import date, datetime, timedelta, timezone
 
@@ -760,6 +761,23 @@ def _is_reservation_schedule(db: Session, session_id: str) -> bool:
     ) is not None
 
 
+def _dump_program(
+    program: Sequence[ProgramItem | Mapping[str, object]],
+) -> str:
+    """Serialize validated program items from create and partial-update paths.
+
+    Schedule creation passes ``ProgramItem`` instances, while
+    ``ScheduleUpdateRequest.model_dump()`` recursively converts the same items
+    to dictionaries before calling the service.  Supporting both forms keeps
+    the service boundary consistent for API and direct service callers.
+    """
+    items = [
+        item.model_dump() if isinstance(item, ProgramItem) else dict(item)
+        for item in program
+    ]
+    return json.dumps(items, ensure_ascii=False)
+
+
 def create_session(
     db: Session, trainer_id: str, *, date: str, time: str, client_name: str,
     member_id: str | None, type_: str, duration_minutes: int, note: str,
@@ -776,7 +794,7 @@ def create_session(
         duration_minutes=duration_minutes,
         status="예정",
         note=note,
-        program_json=json.dumps([p.model_dump() for p in program], ensure_ascii=False),
+        program_json=_dump_program(program),
         sort_order=0,
     )
     db.add(s)
@@ -832,9 +850,7 @@ def update_session(
     if "note" in fields:
         s.note = fields["note"]
     if "program" in fields and fields["program"] is not None:
-        s.program_json = json.dumps(
-            [p.model_dump() for p in fields["program"]], ensure_ascii=False
-        )
+        s.program_json = _dump_program(fields["program"])
     db.commit()
     db.refresh(s)
     return _schedule_out(s)

--- a/backend/tests/test_reservations.py
+++ b/backend/tests/test_reservations.py
@@ -253,6 +253,51 @@ def test_reserved_schedule_cannot_be_updated_or_deleted_as_regular_schedule(
     assert persisted_slot.remaining == 0
 
 
+def test_reserved_schedule_accepts_program_without_changing_booking(
+    client, db_session, created_slots
+):
+    trainer_token = _login(client, "trainer@oncare.com")
+    member_token = _login(client, "jisu@oncare.com")
+    slot = _create_slot(client, trainer_token, created_slots, capacity=1)
+    booked = client.post(
+        "/v1/reservations",
+        headers=_headers(member_token),
+        json={"slot_id": slot["id"]},
+    )
+    assert booked.status_code == 201, booked.text
+
+    schedule_id = booked.json()["schedule_id"]
+    before = db_session.get(TrainerSchedule, schedule_id)
+    assert before is not None
+    original_time = before.time
+
+    updated = client.put(
+        f"/v1/trainer/schedule/{schedule_id}",
+        headers=_headers(trainer_token),
+        json={
+            "program": [
+                {
+                    "name": "저강도 걷기",
+                    "sets": 1,
+                    "reps": "30분",
+                    "weight": "-",
+                }
+            ]
+        },
+    )
+
+    assert updated.status_code == 200, updated.text
+    assert updated.json()["program"][0]["name"] == "저강도 걷기"
+    db_session.expire_all()
+    persisted = db_session.get(TrainerSchedule, schedule_id)
+    assert persisted is not None
+    assert persisted.time == original_time
+    assert "저강도 걷기" in persisted.program_json
+    persisted_slot = db_session.get(TrainerReservationSlot, slot["id"])
+    assert persisted_slot is not None
+    assert persisted_slot.remaining == 0
+
+
 def test_member_account_deletion_restores_slot_and_removes_schedule(
     client, db_session
 ):

--- a/backend/tests/test_trainer_schedule.py
+++ b/backend/tests/test_trainer_schedule.py
@@ -1,7 +1,15 @@
 """트레이너 스케줄 CRUD + 예약→수업→기록 완료 루프(#252). DB 필요."""
 from __future__ import annotations
 
+import time
+from concurrent.futures import ThreadPoolExecutor
+from datetime import date, timedelta
+from threading import Barrier
+
 import pytest
+from sqlalchemy import select
+
+from app.models.models import TrainerClient, TrainerSchedule
 
 
 def _tok(client) -> str:
@@ -32,6 +40,126 @@ def test_schedule_seeded_timeline(client):
     # 공백 슬롯 + program 포함 슬롯 존재
     assert any(s["status"] == "공백" for s in slots)
     assert any(len(s["program"]) > 0 for s in slots)
+
+
+def _program_command_body(day: str, exercise: str) -> dict:
+    return {
+        "date": day,
+        "time": "16:00",
+        "client_name": "이지수",
+        "program": [
+            {"name": exercise, "sets": 1, "reps": "20분", "weight": "-"}
+        ],
+    }
+
+
+def _delete_program_test_sessions(db_session, day: str) -> None:
+    rows = db_session.scalars(
+        select(TrainerSchedule).where(
+            TrainerSchedule.trainer_id == "trainer-demo",
+            TrainerSchedule.member_id == "user-jisu",
+            TrainerSchedule.date == day,
+        )
+    ).all()
+    for row in rows:
+        db_session.delete(row)
+    db_session.commit()
+
+
+def test_schedule_program_command_reuses_the_created_session(client, db_session):
+    token = _tok(client)
+    day = (date.today() + timedelta(days=61)).isoformat()
+    url = "/v1/trainer/clients/user-jisu/schedule-program"
+    _delete_program_test_sessions(db_session, day)
+
+    try:
+        first = client.put(
+            url,
+            json=_program_command_body(day, "걷기"),
+            headers=_h(token),
+        )
+        second = client.put(
+            url,
+            json=_program_command_body(day, "플랭크"),
+            headers=_h(token),
+        )
+
+        assert first.status_code == 200, first.text
+        assert second.status_code == 200, second.text
+        assert first.json()["attached_to_existing"] is False
+        assert second.json()["attached_to_existing"] is True
+        assert first.json()["session"]["id"] == second.json()["session"]["id"]
+        assert second.json()["session"]["program"][0]["name"] == "플랭크"
+
+        db_session.expire_all()
+        rows = db_session.scalars(
+            select(TrainerSchedule).where(
+                TrainerSchedule.trainer_id == "trainer-demo",
+                TrainerSchedule.member_id == "user-jisu",
+                TrainerSchedule.date == day,
+                TrainerSchedule.status == "예정",
+            )
+        ).all()
+        assert len(rows) == 1
+    finally:
+        _delete_program_test_sessions(db_session, day)
+
+
+def test_concurrent_schedule_program_commands_create_one_session(
+    client, db_session
+):
+    token = _tok(client)
+    day = (date.today() + timedelta(days=62)).isoformat()
+    url = "/v1/trainer/clients/user-jisu/schedule-program"
+    _delete_program_test_sessions(db_session, day)
+
+    # Hold the same row used as the service's mutex until both HTTP requests
+    # have started. Once released, they must serialize and converge on one row.
+    link = db_session.scalar(
+        select(TrainerClient)
+        .where(
+            TrainerClient.trainer_id == "trainer-demo",
+            TrainerClient.member_id == "user-jisu",
+        )
+        .with_for_update()
+    )
+    assert link is not None
+    barrier = Barrier(3)
+
+    def register(exercise: str):
+        barrier.wait()
+        return client.put(
+            url,
+            json=_program_command_body(day, exercise),
+            headers=_h(token),
+        )
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            futures = [pool.submit(register, name) for name in ("걷기", "플랭크")]
+            barrier.wait()
+            time.sleep(0.2)
+            db_session.commit()
+            responses = [future.result(timeout=10) for future in futures]
+
+        assert [response.status_code for response in responses] == [200, 200]
+        assert sorted(
+            response.json()["attached_to_existing"] for response in responses
+        ) == [False, True]
+
+        db_session.expire_all()
+        rows = db_session.scalars(
+            select(TrainerSchedule).where(
+                TrainerSchedule.trainer_id == "trainer-demo",
+                TrainerSchedule.member_id == "user-jisu",
+                TrainerSchedule.date == day,
+                TrainerSchedule.status == "예정",
+            )
+        ).all()
+        assert len(rows) == 1
+    finally:
+        db_session.rollback()
+        _delete_program_test_sessions(db_session, day)
 
 
 def test_schedule_crud(client):

--- a/frontend/flutter_trainer/lib/features/coaching/data/repositories/ai_routine_repository.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/data/repositories/ai_routine_repository.dart
@@ -1,17 +1,24 @@
-import 'dart:convert';
-
 import 'package:drift/drift.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:oncare_trainer/core/config/app_config.dart';
 import 'package:oncare_trainer/core/storage/app_database.dart';
-import 'package:oncare_trainer/core/utils/date_format.dart';
 import 'package:oncare_trainer/features/coaching/domain/entities/ai_routine_item.dart';
-import 'package:oncare_trainer/features/schedule/domain/entities/schedule_status.dart';
 
-/// Reads a client's AI-suggested routine from the local drift DB.
-class AiRoutineRepository {
+/// Supplies the initial AI-suggested exercises shown before a trainer asks
+/// the backend to generate fresh A/B options.
+abstract interface class AiRoutineRepository {
+  /// Watches the initial suggestions for one client.
+  Stream<List<AiRoutineItem>> watchRoutine(
+    String clientId, {
+    String? clientName,
+  });
+}
+
+/// Reads the bundled demo suggestions from the local drift DB.
+class DriftAiRoutineRepository implements AiRoutineRepository {
   /// Creates the repository over [_db].
-  const AiRoutineRepository(this._db);
+  const DriftAiRoutineRepository(this._db);
 
   final AppDatabase _db;
 
@@ -20,6 +27,7 @@ class AiRoutineRepository {
   /// Real API clients use backend ids (`user-demo`) while the bundled
   /// suggestions use demo ids (`seed-client-1`). [clientName] lets a live
   /// roster resolve the corresponding local suggestion set.
+  @override
   Stream<List<AiRoutineItem>> watchRoutine(
     String clientId, {
     String? clientName,
@@ -55,75 +63,30 @@ class AiRoutineRepository {
           .toList();
     });
   }
-
-  /// Registers the composed routine as [clientName]'s PT program on
-  /// [date]'s schedule (스케줄 탭 watches the same table, so it updates
-  /// live). Attaches to the client's earliest 예정 session on that date
-  /// when one exists; otherwise books a new one-hour 예정 slot.
-  /// Returns `true` when attached to an existing session.
-  ///
-  /// [program] entries follow the schedule programJson shape
-  /// (`{name, sets, reps, weight}`).
-  Future<bool> registerToSchedule({
-    required String date,
-    required String clientName,
-    required List<Map<String, Object?>> program,
-  }) async {
-    final table = _db.trainerScheduleEntries;
-    final existing =
-        await (_db.select(table)
-              ..where(
-                (t) =>
-                    t.date.equals(date) &
-                    t.clientName.equals(clientName) &
-                    t.status.equals(ScheduleStatus.upcoming),
-              )
-              ..orderBy(<OrderingTerm Function($TrainerScheduleEntriesTable)>[
-                (t) => OrderingTerm(expression: t.time),
-              ])
-              ..limit(1))
-            .getSingleOrNull();
-
-    if (existing != null) {
-      await (_db.update(table)..where((t) => t.id.equals(existing.id))).write(
-        TrainerScheduleEntriesCompanion(
-          programJson: Value(jsonEncode(program)),
-        ),
-      );
-      return true;
-    }
-
-    final now = DateTime.now();
-    // For today, the next full hour capped at the 23:00 slot: an evening
-    // registration stays in the future (22:xx → 23:00) where the previous
-    // cap of 22 produced a past 22:00. It does NOT cover 23:00–23:59 —
-    // there is no later slot today, so that books an already-past 23:00;
-    // register after 23:00 against the next day using the date picker.
-    // A complete fix needs a server clock (review PR 220).
-    // Other dates start at 10:00.
-    final hour = date == ymd(now) ? (now.hour + 1).clamp(6, 23) : 10;
-    await _db
-        .into(table)
-        .insert(
-          TrainerScheduleEntriesCompanion.insert(
-            id: 'sched-${now.microsecondsSinceEpoch}',
-            date: date,
-            time: '${hour.toString().padLeft(2, '0')}:00',
-            clientName: Value(clientName),
-            type: const Value(SessionType.personalTraining),
-            durationMinutes: const Value(60),
-            status: ScheduleStatus.upcoming,
-            programJson: Value(jsonEncode(program)),
-          ),
-        );
-    return false;
-  }
 }
 
-/// Provides the [AiRoutineRepository].
+/// Real mode deliberately starts without bundled suggestions. Fresh options
+/// come from `POST /trainer/clients/{id}/routine-options`; falling back to
+/// drift here would make a live member look as if they had demo recommendations.
+class EmptyAiRoutineRepository implements AiRoutineRepository {
+  /// Creates the real-mode empty initial source.
+  const EmptyAiRoutineRepository();
+
+  @override
+  Stream<List<AiRoutineItem>> watchRoutine(
+    String clientId, {
+    String? clientName,
+  }) => Stream<List<AiRoutineItem>>.value(const <AiRoutineItem>[]);
+}
+
+/// Selects bundled suggestions only for mock mode. Real mode never touches
+/// [appDatabaseProvider] through this provider.
 final aiRoutineRepositoryProvider = Provider<AiRoutineRepository>((ref) {
-  return AiRoutineRepository(ref.watch(appDatabaseProvider));
-});
+  if (ref.watch(appConfigProvider).useMockApi) {
+    return DriftAiRoutineRepository(ref.watch(appDatabaseProvider));
+  }
+  return const EmptyAiRoutineRepository();
+}, name: 'aiRoutineRepository');
 
 /// A stable key for local suggestions when the live and demo ids differ.
 typedef AiRoutineClientKey = ({String id, String name});

--- a/frontend/flutter_trainer/lib/features/coaching/presentation/pages/coaching_page.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/pages/coaching_page.dart
@@ -20,6 +20,8 @@ import 'package:oncare_trainer/features/coaching/domain/program_template.dart';
 import 'package:oncare_trainer/features/coaching/presentation/pages/ai_routine_options_flow.dart';
 import 'package:oncare_trainer/features/coaching/presentation/widgets/routine_form_fields.dart';
 import 'package:oncare_trainer/features/schedule/data/repositories/schedule_repository.dart';
+import 'package:oncare_trainer/features/schedule/domain/entities/schedule_session.dart';
+import 'package:oncare_trainer/features/schedule/domain/entities/schedule_status.dart';
 import 'package:oncare_trainer/shared/widgets/icon_label.dart';
 import 'package:oncare_trainer/shared/models/trainer_client.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
@@ -28,7 +30,6 @@ import 'package:oncare_trainer/shared/widgets/metric_tile.dart';
 import 'package:oncare_trainer/shared/widgets/page_scaffold.dart';
 import 'package:oncare_trainer/shared/widgets/section_card.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
-import 'package:oncare_trainer/features/schedule/domain/entities/schedule_status.dart';
 
 /// A trainer-added exercise (kept in-memory like the mock).
 class _CustomExercise {
@@ -214,25 +215,25 @@ class _CoachingPageState extends ConsumerState<CoachingPage> {
   }
 
   /// The composed routine (edited AI items minus removed, plus custom)
-  /// in the schedule programJson shape.
-  List<Map<String, Object?>> _composeProgram(List<AiRoutineItem> items) {
+  /// in the shared schedule API/domain shape.
+  List<ProgramItem> _composeProgram(List<AiRoutineItem> items) {
     final AppLocalizations l = AppLocalizations.of(context);
-    return <Map<String, Object?>>[
+    return <ProgramItem>[
       for (final item in items)
         if (!_removed.contains(item.id))
-          <String, Object?>{
-            'name': _nameEdits[item.id] ?? item.name,
-            'sets': 1,
-            'reps': l.minutesShort(_minuteEdits[item.id] ?? item.minutes),
-            'weight': '-',
-          },
+          ProgramItem(
+            name: _nameEdits[item.id] ?? item.name,
+            sets: 1,
+            reps: l.minutesShort(_minuteEdits[item.id] ?? item.minutes),
+            weight: '-',
+          ),
       for (final c in _custom)
-        <String, Object?>{
-          'name': c.name,
-          'sets': 1,
-          'reps': l.minutesShort(c.minutes),
-          'weight': '-',
-        },
+        ProgramItem(
+          name: c.name,
+          sets: 1,
+          reps: l.minutesShort(c.minutes),
+          weight: '-',
+        ),
     ];
   }
 
@@ -289,6 +290,11 @@ class _CoachingPageState extends ConsumerState<CoachingPage> {
       return;
     }
     final date = ymd(DateTime.now().add(Duration(days: _registerOffset)));
+    final now = DateTime.now();
+    // Today uses the next full hour (capped at the final 23:00 slot); a
+    // future date starts at 10:00, preserving the existing coaching UX.
+    final hour = date == ymd(now) ? (now.hour + 1).clamp(6, 23) : 10;
+    final time = '${hour.toString().padLeft(2, '0')}:00';
     // Remember who this write is for — the trainer can switch clients
     // while it saves, and the result must not be attributed to the new
     // one (review PR 220).
@@ -296,10 +302,12 @@ class _CoachingPageState extends ConsumerState<CoachingPage> {
     setState(() => _registeringClientId = registeredFor);
     try {
       await ref
-          .read(aiRoutineRepositoryProvider)
-          .registerToSchedule(
+          .read(scheduleRepositoryProvider)
+          .registerProgram(
             date: date,
+            clientId: client.id,
             clientName: client.name,
+            time: time,
             program: program,
           );
     } catch (_) {

--- a/frontend/flutter_trainer/lib/features/coaching/presentation/pages/coaching_page.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/pages/coaching_page.dart
@@ -89,11 +89,9 @@ class _CoachingPageState extends ConsumerState<CoachingPage> {
 
   /// A schedule registration just succeeded (drives the 3s flash).
   bool _registered = false;
-  // The client whose registration is in flight (null when none). Tracked
-  // per-client — not a plain bool — so switching away and back can't let
-  // the SAME client's registration be triggered twice while the first is
-  // still saving (review PR 220).
-  String? _registeringClientId;
+  // Every client whose registration is in flight. Multiple clients may save
+  // concurrently, but each client may have only one pending write.
+  final Set<String> _registeringClientIds = <String>{};
   Timer? _registerTimer;
 
   /// Day offset (0 = 오늘 … 6) the routine gets registered on.
@@ -133,9 +131,8 @@ class _CoachingPageState extends ConsumerState<CoachingPage> {
       _sending = false;
       _registered = false;
       _registerOffset = 0;
-      // NOTE: _registeringClientId is intentionally NOT cleared — a
-      // registration in flight for another client keeps being tracked,
-      // so returning to it still blocks a duplicate (review PR 220).
+      // NOTE: _registeringClientIds is intentionally NOT cleared — writes
+      // for other clients keep being tracked while the selection changes.
     });
     _sentTimer?.cancel();
     _registerTimer?.cancel();
@@ -277,7 +274,7 @@ class _CoachingPageState extends ConsumerState<CoachingPage> {
   ) async {
     // Block a duplicate for THIS client — either just registered, or one
     // is already in flight for them.
-    if (_registered || _registeringClientId == client.id) return;
+    if (_registered || _registeringClientIds.contains(client.id)) return;
     final messenger = ScaffoldMessenger.of(context);
     final program = _composeProgram(items);
     if (program.isEmpty) {
@@ -299,7 +296,7 @@ class _CoachingPageState extends ConsumerState<CoachingPage> {
     // while it saves, and the result must not be attributed to the new
     // one (review PR 220).
     final registeredFor = client.id;
-    setState(() => _registeringClientId = registeredFor);
+    setState(() => _registeringClientIds.add(registeredFor));
     try {
       await ref
           .read(scheduleRepositoryProvider)
@@ -313,8 +310,8 @@ class _CoachingPageState extends ConsumerState<CoachingPage> {
     } catch (_) {
       if (!mounted) return;
       // Clear the guard for this client so it can be retried.
-      if (_registeringClientId == registeredFor) {
-        setState(() => _registeringClientId = null);
+      if (_registeringClientIds.contains(registeredFor)) {
+        setState(() => _registeringClientIds.remove(registeredFor));
       }
       // Only surface the error if that client is still on screen.
       if (_isStillSelected(registeredFor)) {
@@ -326,8 +323,8 @@ class _CoachingPageState extends ConsumerState<CoachingPage> {
       return;
     }
     if (!mounted) return;
-    if (_registeringClientId == registeredFor) {
-      setState(() => _registeringClientId = null);
+    if (_registeringClientIds.contains(registeredFor)) {
+      setState(() => _registeringClientIds.remove(registeredFor));
     }
     // Attribute the success flash only to the client it was started for.
     if (!_isStillSelected(registeredFor)) return;
@@ -708,7 +705,8 @@ class _CoachingPageState extends ConsumerState<CoachingPage> {
                     // registration is in flight, so a second tap can't queue a
                     // duplicate session (review PR 220).
                     registered:
-                        _registered || _registeringClientId == client.id,
+                        _registered ||
+                        _registeringClientIds.contains(client.id),
                     icon: _registered
                         ? Icons.check_rounded
                         : Icons.calendar_today_outlined,

--- a/frontend/flutter_trainer/lib/features/schedule/data/repositories/dio_schedule_repository.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/data/repositories/dio_schedule_repository.dart
@@ -7,6 +7,7 @@ import 'package:oncare_trainer/core/utils/date_format.dart';
 import 'package:oncare_trainer/features/schedule/data/dtos/schedule_dtos.dart';
 import 'package:oncare_trainer/features/schedule/data/repositories/schedule_repository.dart';
 import 'package:oncare_trainer/features/schedule/domain/entities/schedule_session.dart';
+import 'package:oncare_trainer/features/schedule/domain/entities/schedule_status.dart';
 
 /// The trainer's timeline against the FastAPI backend
 /// (`/v1/trainer/schedule*`). Selected when `USE_MOCK_API=false`.
@@ -178,6 +179,52 @@ class DioScheduleRepository implements ScheduleRepository {
         },
       ),
     );
+  }
+
+  @override
+  Future<bool> registerProgram({
+    required String date,
+    required String clientId,
+    required String clientName,
+    required String time,
+    required List<ProgramItem> program,
+  }) async {
+    final sessions = await _fetch(<String, String>{
+      'date': date,
+      'member_id': clientId,
+    });
+    final upcoming =
+        sessions
+            .where((session) => session.status == ScheduleStatus.upcoming)
+            .toList()
+          ..sort((a, b) => a.time.compareTo(b.time));
+
+    if (upcoming.isNotEmpty) {
+      final id = Uri.encodeComponent(upcoming.first.id);
+      await _mutate(
+        () => _dio.put<Map<String, dynamic>>(
+          '/trainer/schedule/$id',
+          data: <String, Object?>{'program': programToJson(program)},
+        ),
+      );
+      return true;
+    }
+
+    await _mutate(
+      () => _dio.post<Map<String, dynamic>>(
+        '/trainer/schedule',
+        data: <String, Object?>{
+          'date': date,
+          'time': time,
+          'client_name': clientName,
+          'member_id': clientId,
+          'type': SessionType.personalTraining,
+          'duration_minutes': 60,
+          'program': programToJson(program),
+        },
+      ),
+    );
+    return false;
   }
 
   @override

--- a/frontend/flutter_trainer/lib/features/schedule/data/repositories/dio_schedule_repository.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/data/repositories/dio_schedule_repository.dart
@@ -7,7 +7,6 @@ import 'package:oncare_trainer/core/utils/date_format.dart';
 import 'package:oncare_trainer/features/schedule/data/dtos/schedule_dtos.dart';
 import 'package:oncare_trainer/features/schedule/data/repositories/schedule_repository.dart';
 import 'package:oncare_trainer/features/schedule/domain/entities/schedule_session.dart';
-import 'package:oncare_trainer/features/schedule/domain/entities/schedule_status.dart';
 
 /// The trainer's timeline against the FastAPI backend
 /// (`/v1/trainer/schedule*`). Selected when `USE_MOCK_API=false`.
@@ -189,42 +188,28 @@ class DioScheduleRepository implements ScheduleRepository {
     required String time,
     required List<ProgramItem> program,
   }) async {
-    final sessions = await _fetch(<String, String>{
-      'date': date,
-      'member_id': clientId,
-    });
-    final upcoming =
-        sessions
-            .where((session) => session.status == ScheduleStatus.upcoming)
-            .toList()
-          ..sort((a, b) => a.time.compareTo(b.time));
-
-    if (upcoming.isNotEmpty) {
-      final id = Uri.encodeComponent(upcoming.first.id);
-      await _mutate(
-        () => _dio.put<Map<String, dynamic>>(
-          '/trainer/schedule/$id',
-          data: <String, Object?>{'program': programToJson(program)},
-        ),
-      );
-      return true;
-    }
-
-    await _mutate(
-      () => _dio.post<Map<String, dynamic>>(
-        '/trainer/schedule',
+    late bool attachedToExisting;
+    final memberId = Uri.encodeComponent(clientId);
+    await _mutate(() async {
+      final response = await _dio.put<Map<String, dynamic>>(
+        '/trainer/clients/$memberId/schedule-program',
         data: <String, Object?>{
           'date': date,
           'time': time,
           'client_name': clientName,
-          'member_id': clientId,
-          'type': SessionType.personalTraining,
-          'duration_minutes': 60,
           'program': programToJson(program),
         },
-      ),
-    );
-    return false;
+      );
+      final attached = response.data?['attached_to_existing'];
+      if (attached is! bool) {
+        throw const FormatException(
+          'schedule-program response is missing attached_to_existing',
+        );
+      }
+      attachedToExisting = attached;
+      return response;
+    });
+    return attachedToExisting;
   }
 
   @override

--- a/frontend/flutter_trainer/lib/features/schedule/data/repositories/schedule_repository.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/data/repositories/schedule_repository.dart
@@ -73,6 +73,21 @@ abstract interface class ScheduleRepository {
     required String note,
   });
 
+  /// Attaches [program] to the client's earliest upcoming PT session on
+  /// [date], or creates a new one at [time] when none exists.
+  ///
+  /// Returns `true` when an existing session was updated and `false` when a
+  /// new session was created. Both mock and real implementations expose the
+  /// same operation so AI coaching cannot accidentally write to a different
+  /// data source than the schedule screen.
+  Future<bool> registerProgram({
+    required String date,
+    required String clientId,
+    required String clientName,
+    required String time,
+    required List<ProgramItem> program,
+  });
+
   /// Removes a session from the timeline.
   Future<void> deleteSession(String id);
 
@@ -257,6 +272,77 @@ class DriftScheduleRepository implements ScheduleRepository {
         note: Value(note),
       ),
     );
+  }
+
+  @override
+  Future<bool> registerProgram({
+    required String date,
+    required String clientId,
+    required String clientName,
+    required String time,
+    required List<ProgramItem> program,
+  }) {
+    final table = _db.trainerScheduleEntries;
+    return _db.transaction(() async {
+      final candidates =
+          await (_db.select(table)
+                ..where(
+                  (t) =>
+                      t.date.equals(date) &
+                      t.status.equals(ScheduleStatus.upcoming),
+                )
+                ..orderBy(<OrderingTerm Function($TrainerScheduleEntriesTable)>[
+                  (t) => OrderingTerm(expression: t.time),
+                ]))
+              .get();
+
+      TrainerScheduleRow? existing;
+      final normalizedName = clientName.trim().toLowerCase();
+      for (final candidate in candidates) {
+        if (candidate.clientId == clientId ||
+            (candidate.clientId == null &&
+                candidate.clientName.trim().toLowerCase() == normalizedName)) {
+          existing = candidate;
+          break;
+        }
+      }
+
+      final encodedProgram = jsonEncode(<Map<String, Object?>>[
+        for (final item in program)
+          <String, Object?>{
+            'name': item.name,
+            'sets': item.sets,
+            'reps': item.reps,
+            'weight': item.weight,
+          },
+      ]);
+      if (existing != null) {
+        await (_db.update(
+          table,
+        )..where((t) => t.id.equals(existing!.id))).write(
+          TrainerScheduleEntriesCompanion(programJson: Value(encodedProgram)),
+        );
+        return true;
+      }
+
+      final now = DateTime.now();
+      await _db
+          .into(table)
+          .insert(
+            TrainerScheduleEntriesCompanion.insert(
+              id: 'sched-${now.microsecondsSinceEpoch}',
+              date: date,
+              time: time,
+              clientId: Value(clientId),
+              clientName: Value(clientName),
+              type: const Value(SessionType.personalTraining),
+              durationMinutes: const Value(60),
+              status: ScheduleStatus.upcoming,
+              programJson: Value(encodedProgram),
+            ),
+          );
+      return false;
+    });
   }
 
   /// Removes a session from the timeline.

--- a/frontend/flutter_trainer/test/features/coaching/coaching_data_source_provider_test.dart
+++ b/frontend/flutter_trainer/test/features/coaching/coaching_data_source_provider_test.dart
@@ -1,0 +1,56 @@
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare_trainer/core/config/app_config.dart';
+import 'package:oncare_trainer/core/storage/app_database.dart';
+import 'package:oncare_trainer/features/coaching/data/repositories/ai_routine_repository.dart';
+import 'package:oncare_trainer/features/schedule/data/repositories/dio_schedule_repository.dart';
+import 'package:oncare_trainer/features/schedule/data/repositories/schedule_repository.dart';
+
+ProviderContainer _containerFor({required bool useMockApi}) {
+  final db = AppDatabase.forTesting(NativeDatabase.memory());
+  addTearDown(db.close);
+  final container = ProviderContainer(
+    overrides: <Override>[
+      appConfigProvider.overrideWithValue(
+        AppConfig(
+          environment: Environment.dev,
+          apiBaseUrl: 'http://localhost/v1',
+          useMockApi: useMockApi,
+        ),
+      ),
+      appDatabaseProvider.overrideWithValue(db),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  test('mock mode selects drift for recommendations and schedule', () {
+    final container = _containerFor(useMockApi: true);
+
+    expect(
+      container.read(aiRoutineRepositoryProvider),
+      isA<DriftAiRoutineRepository>(),
+    );
+    expect(
+      container.read(scheduleRepositoryProvider),
+      isA<DriftScheduleRepository>(),
+    );
+  });
+
+  test('real mode never selects drift for recommendations or schedule', () {
+    final container = _containerFor(useMockApi: false);
+
+    expect(
+      container.read(aiRoutineRepositoryProvider),
+      isA<EmptyAiRoutineRepository>(),
+    );
+    expect(
+      container.read(scheduleRepositoryProvider),
+      isA<DioScheduleRepository>(),
+    );
+  });
+}

--- a/frontend/flutter_trainer/test/features/coaching/coaching_page_test.dart
+++ b/frontend/flutter_trainer/test/features/coaching/coaching_page_test.dart
@@ -11,6 +11,7 @@ import 'package:oncare_trainer/core/storage/seed_data.dart';
 import 'package:oncare_trainer/core/utils/date_format.dart';
 import 'package:oncare_trainer/features/coaching/data/repositories/ai_routine_repository.dart';
 import 'package:oncare_trainer/features/coaching/data/repositories/trainer_routine_repository.dart';
+import 'package:oncare_trainer/features/coaching/domain/entities/ai_routine_item.dart';
 import 'package:oncare_trainer/features/coaching/domain/entities/assigned_routine.dart';
 import 'package:oncare_trainer/features/auth/data/repositories/dio_trainer_auth_repository.dart'
     show trainerAuthRepositoryProvider;
@@ -19,6 +20,7 @@ import 'package:oncare_trainer/features/auth/domain/repositories/trainer_auth_re
 import 'package:oncare_trainer/features/clients/domain/entities/client_diet_entry.dart';
 import 'package:oncare_trainer/features/clients/domain/entities/routine_history_entry.dart';
 import 'package:oncare_trainer/features/schedule/data/repositories/schedule_repository.dart';
+import 'package:oncare_trainer/features/schedule/domain/entities/schedule_session.dart';
 import 'package:oncare_trainer/shared/models/client_chat_message.dart';
 import 'package:oncare_trainer/shared/models/trainer_client.dart';
 import 'package:oncare_trainer/shared/models/trainer_profile.dart';
@@ -55,26 +57,68 @@ class _SlowChatRepository extends DriftChatRepository {
 
 /// Counts registration calls and delays them, to test the in-flight
 /// double-tap guard.
-class _SlowCountingRoutineRepository extends AiRoutineRepository {
-  _SlowCountingRoutineRepository(super.db);
+class _SlowCountingScheduleRepository extends DriftScheduleRepository {
+  _SlowCountingScheduleRepository(super.db);
 
   int registerCalls = 0;
 
   @override
-  Future<bool> registerToSchedule({
+  Future<bool> registerProgram({
     required String date,
+    required String clientId,
     required String clientName,
-    required List<Map<String, Object?>> program,
+    required String time,
+    required List<ProgramItem> program,
   }) async {
     registerCalls++;
     // Keep the write in flight across client-switching/scroll animations.
     await Future<void>.delayed(const Duration(seconds: 5));
-    return super.registerToSchedule(
+    return super.registerProgram(
       date: date,
+      clientId: clientId,
       clientName: clientName,
+      time: time,
       program: program,
     );
   }
+}
+
+/// Captures the schedule operation selected by the coaching page without
+/// performing a local write. Dio behavior is covered by its repository test.
+class _CapturingScheduleRepository extends DriftScheduleRepository {
+  _CapturingScheduleRepository(super.db);
+
+  int registerCalls = 0;
+  String? clientId;
+  List<ProgramItem>? program;
+
+  @override
+  Future<bool> registerProgram({
+    required String date,
+    required String clientId,
+    required String clientName,
+    required String time,
+    required List<ProgramItem> program,
+  }) async {
+    registerCalls++;
+    this.clientId = clientId;
+    this.program = program;
+    return true;
+  }
+}
+
+/// Supplies explicit non-drift suggestions to tests that focus on real API
+/// assignment behavior rather than on the initial recommendation source.
+class _FixedAiRoutineRepository implements AiRoutineRepository {
+  const _FixedAiRoutineRepository(this.items);
+
+  final List<AiRoutineItem> items;
+
+  @override
+  Stream<List<AiRoutineItem>> watchRoutine(
+    String clientId, {
+    String? clientName,
+  }) => Stream<List<AiRoutineItem>>.value(items);
 }
 
 /// A fixed one-client roster for real-API-mode tests (real
@@ -216,7 +260,33 @@ class _FakeTrainerAuthRepository implements TrainerAuthRepository {
 }
 
 void main() {
-  group('AiRoutineRepository.watchRoutine', () {
+  test('real API mode never exposes bundled drift recommendations', () async {
+    final container = ProviderContainer(
+      overrides: <Override>[
+        appConfigProvider.overrideWithValue(
+          const AppConfig(
+            environment: Environment.dev,
+            apiBaseUrl: 'http://localhost/v1',
+            useMockApi: false,
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    expect(
+      container.read(aiRoutineRepositoryProvider),
+      isA<EmptyAiRoutineRepository>(),
+    );
+    expect(
+      await container.read(
+        aiRoutineProvider((id: 'real-client-1', name: '김민수')).future,
+      ),
+      isEmpty,
+    );
+  });
+
+  group('demo coaching repositories', () {
     late AppDatabase db;
 
     setUp(() async {
@@ -226,7 +296,7 @@ void main() {
     tearDown(() => db.close());
 
     test('returns the 3 seeded suggestions in order per client', () async {
-      final repo = AiRoutineRepository(db);
+      final repo = DriftAiRoutineRepository(db);
       final minsu = await repo.watchRoutine('seed-client-1').first;
       expect(minsu.length, 3);
       expect(minsu.first.name, '저강도 유산소 (걷기)');
@@ -240,7 +310,7 @@ void main() {
     test(
       'resolves live backend ids through the matching client name',
       () async {
-        final repo = AiRoutineRepository(db);
+        final repo = DriftAiRoutineRepository(db);
 
         final minsu = await repo
             .watchRoutine('user-demo', clientName: '김민수')
@@ -254,18 +324,15 @@ void main() {
     test(
       'registerToTodaySchedule attaches to an existing 예정 session',
       () async {
-        final repo = AiRoutineRepository(db);
+        final repo = DriftScheduleRepository(db);
         // 박성호 has a seeded 15:00 예정 session.
-        final attached = await repo.registerToSchedule(
+        final attached = await repo.registerProgram(
           date: ymd(DateTime.now()),
+          clientId: 'seed-client-3',
           clientName: '박성호',
-          program: <Map<String, Object?>>[
-            <String, Object?>{
-              'name': '저강도 유산소',
-              'sets': 1,
-              'reps': '30분',
-              'weight': '-',
-            },
+          time: '10:00',
+          program: const <ProgramItem>[
+            ProgramItem(name: '저강도 유산소', sets: 1, reps: '30분', weight: '-'),
           ],
         );
         expect(attached, isTrue);
@@ -280,18 +347,15 @@ void main() {
     test(
       'registerToTodaySchedule books a new slot when no 예정 exists',
       () async {
-        final repo = AiRoutineRepository(db);
+        final repo = DriftScheduleRepository(db);
         // 김민수's only session today is 완료 — a new slot gets booked.
-        final attached = await repo.registerToSchedule(
+        final attached = await repo.registerProgram(
           date: ymd(DateTime.now()),
+          clientId: 'seed-client-1',
           clientName: '김민수',
-          program: <Map<String, Object?>>[
-            <String, Object?>{
-              'name': '코어 강화',
-              'sets': 1,
-              'reps': '10분',
-              'weight': '-',
-            },
+          time: '10:00',
+          program: const <ProgramItem>[
+            ProgramItem(name: '코어 강화', sets: 1, reps: '10분', weight: '-'),
           ],
         );
         expect(attached, isFalse);
@@ -621,10 +685,9 @@ void main() {
         tester,
         token: 'demo-trainer-token',
         extraOverrides: <Override>[
-          // Shares the app's seeded DB so the AI suggestions load.
-          aiRoutineRepositoryProvider.overrideWith(
+          scheduleRepositoryProvider.overrideWith(
             (ref) =>
-                _SlowCountingRoutineRepository(ref.watch(appDatabaseProvider)),
+                _SlowCountingScheduleRepository(ref.watch(appDatabaseProvider)),
           ),
         ],
       );
@@ -648,8 +711,8 @@ void main() {
       await settle(tester);
 
       final repo =
-          container.read(aiRoutineRepositoryProvider)
-              as _SlowCountingRoutineRepository;
+          container.read(scheduleRepositoryProvider)
+              as _SlowCountingScheduleRepository;
       expect(repo.registerCalls, 1);
       await tester.pump(const Duration(seconds: 5));
       await settle(tester);
@@ -661,9 +724,9 @@ void main() {
         tester,
         token: 'demo-trainer-token',
         extraOverrides: <Override>[
-          aiRoutineRepositoryProvider.overrideWith(
+          scheduleRepositoryProvider.overrideWith(
             (ref) =>
-                _SlowCountingRoutineRepository(ref.watch(appDatabaseProvider)),
+                _SlowCountingScheduleRepository(ref.watch(appDatabaseProvider)),
           ),
         ],
       );
@@ -740,9 +803,9 @@ void main() {
         tester,
         token: 'demo-trainer-token',
         extraOverrides: <Override>[
-          aiRoutineRepositoryProvider.overrideWith(
+          scheduleRepositoryProvider.overrideWith(
             (ref) =>
-                _SlowCountingRoutineRepository(ref.watch(appDatabaseProvider)),
+                _SlowCountingScheduleRepository(ref.watch(appDatabaseProvider)),
           ),
         ],
       );
@@ -785,8 +848,8 @@ void main() {
       await settle(tester);
 
       final repo =
-          container.read(aiRoutineRepositoryProvider)
-              as _SlowCountingRoutineRepository;
+          container.read(scheduleRepositoryProvider)
+              as _SlowCountingScheduleRepository;
       expect(repo.registerCalls, 1);
       await tester.pump(const Duration(seconds: 5));
       await settle(tester);
@@ -887,9 +950,6 @@ void main() {
   });
 
   group('CoachingPage — real API mode (subin21cc review)', () {
-    // Matches a seeded drift client by NAME so aiRoutineProvider's
-    // clientName fallback still resolves local AI suggestions for a
-    // client id the real API (not drift) issued.
     const realClient = TrainerClient(
       id: 'real-client-1',
       name: '김민수',
@@ -906,6 +966,30 @@ void main() {
       sodiumWeek: <int>[],
     );
 
+    const realSuggestions = <AiRoutineItem>[
+      AiRoutineItem(
+        id: 'real-suggestion-1',
+        name: '저강도 유산소 (걷기)',
+        minutes: 30,
+        type: '유산소',
+        reason: '실 API 배정 테스트',
+      ),
+      AiRoutineItem(
+        id: 'real-suggestion-2',
+        name: '코어 스트레칭',
+        minutes: 15,
+        type: '스트레칭',
+        reason: '실 API 배정 테스트',
+      ),
+      AiRoutineItem(
+        id: 'real-suggestion-3',
+        name: '스쿼트',
+        minutes: 15,
+        type: '근력',
+        reason: '실 API 배정 테스트',
+      ),
+    ];
+
     const realConfig = AppConfig(
       environment: Environment.dev,
       apiBaseUrl: 'http://localhost/v1',
@@ -916,6 +1000,8 @@ void main() {
       WidgetTester tester, {
       bool chatFails = false,
       Object? assignError,
+      bool includeInitialSuggestions = true,
+      void Function(_CapturingScheduleRepository repo)? captureSchedule,
     }) async {
       final routineRepo = _SpyTrainerRoutineRepository(
         throwOnAssign: assignError,
@@ -932,6 +1018,18 @@ void main() {
             const _FakeTrainerAuthRepository(),
           ),
           trainerRoutineRepositoryProvider.overrideWithValue(routineRepo),
+          if (includeInitialSuggestions)
+            aiRoutineRepositoryProvider.overrideWithValue(
+              const _FixedAiRoutineRepository(realSuggestions),
+            ),
+          if (captureSchedule != null)
+            scheduleRepositoryProvider.overrideWith((ref) {
+              final repo = _CapturingScheduleRepository(
+                ref.watch(appDatabaseProvider),
+              );
+              captureSchedule(repo);
+              return repo;
+            }),
           chatRepositoryProvider.overrideWithValue(
             _FakeRealChatRepository(failSend: chatFails),
           ),
@@ -952,6 +1050,33 @@ void main() {
       await tester.tap(find.textContaining('님에게 전송'));
       await settle(tester);
     }
+
+    testWidgets(
+      'real-API schedule registration uses the selected member id and the '
+      'shared schedule repository',
+      (tester) async {
+        late _CapturingScheduleRepository scheduleRepo;
+        await openRealApiTab(
+          tester,
+          captureSchedule: (repo) => scheduleRepo = repo,
+        );
+
+        await tester.scrollUntilVisible(
+          find.text('오늘 PT 스케줄에 등록'),
+          150,
+          scrollable: find.byType(Scrollable).first,
+        );
+        await tester.ensureVisible(find.text('오늘 PT 스케줄에 등록'));
+        await tester.pump();
+        await tester.tap(find.text('오늘 PT 스케줄에 등록'));
+        await settle(tester);
+
+        expect(scheduleRepo.registerCalls, 1);
+        expect(scheduleRepo.clientId, 'real-client-1');
+        expect(scheduleRepo.program, isNotEmpty);
+        expect(find.text('오늘 스케줄에 등록됨'), findsOneWidget);
+      },
+    );
 
     testWidgets(
       'real-API assign delivery does not depend on the chat repository '

--- a/frontend/flutter_trainer/test/features/coaching/coaching_page_test.dart
+++ b/frontend/flutter_trainer/test/features/coaching/coaching_page_test.dart
@@ -838,9 +838,11 @@ void main() {
         await tester.pump(const Duration(milliseconds: 30));
       }
 
-      // Start 김민수's (slow) registration, hop to 이지수 and back.
+      // Start 김민수 and 이지수 independently, then return to 김민수 while
+      // both writes are still pending.
       await tapRegister();
       await selectClient('이지수');
+      await tapRegister();
       await selectClient('김민수');
       // Back on 김민수 while the first write is still in flight — the
       // button stays disabled, so this tap must NOT start a second one.
@@ -850,7 +852,7 @@ void main() {
       final repo =
           container.read(scheduleRepositoryProvider)
               as _SlowCountingScheduleRepository;
-      expect(repo.registerCalls, 1);
+      expect(repo.registerCalls, 2);
       await tester.pump(const Duration(seconds: 5));
       await settle(tester);
     });

--- a/frontend/flutter_trainer/test/features/reports/weekly_report_test.dart
+++ b/frontend/flutter_trainer/test/features/reports/weekly_report_test.dart
@@ -195,6 +195,7 @@ void main() {
         client: makeClient(name: '김민수'),
         sessions: <ScheduleSession>[session(date: ymd(monday), status: '완료')],
         weekStart: wednesday,
+        today: wednesday,
       );
 
       final message = reportMessage(_ko, report);

--- a/frontend/flutter_trainer/test/features/schedule/dio_schedule_repository_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/dio_schedule_repository_test.dart
@@ -15,12 +15,14 @@ Response<List<dynamic>> _okList(List<dynamic> body, String path) =>
       data: body,
     );
 
-Response<Map<String, dynamic>> _okMap(String path) =>
-    Response<Map<String, dynamic>>(
-      requestOptions: RequestOptions(path: path),
-      statusCode: 200,
-      data: <String, dynamic>{},
-    );
+Response<Map<String, dynamic>> _okMap(
+  String path, [
+  Map<String, dynamic> body = const <String, dynamic>{},
+]) => Response<Map<String, dynamic>>(
+  requestOptions: RequestOptions(path: path),
+  statusCode: 200,
+  data: body,
+);
 
 DioException _httpError(int status, String path) => DioException(
   requestOptions: RequestOptions(path: path),
@@ -230,16 +232,15 @@ void main() {
   );
 
   test(
-    'registerProgram updates the earliest upcoming session for the member',
+    'registerProgram delegates lookup and write to one atomic command',
     () async {
-      stubGet(<dynamic>[
-        _session(id: 'done', time: '09:00', status: '완료'),
-        _session(id: 'late', time: '15:00'),
-        _session(id: 'early', time: '11:00'),
-      ]);
+      const path = '/trainer/clients/m1/schedule-program';
       when(
-        () => dio.put<Map<String, dynamic>>(any(), data: any(named: 'data')),
-      ).thenAnswer((_) async => _okMap('$_schedulePath/early'));
+        () => dio.put<Map<String, dynamic>>(path, data: any(named: 'data')),
+      ).thenAnswer(
+        (_) async =>
+            _okMap(path, <String, dynamic>{'attached_to_existing': true}),
+      );
 
       final attached = await repo.registerProgram(
         date: '2026-08-06',
@@ -252,32 +253,46 @@ void main() {
       );
 
       expect(attached, isTrue);
-      expect(capturedQuery(), <String, String>{
-        'date': '2026-08-06',
-        'member_id': 'm1',
+      final body =
+          verify(
+                () => dio.put<Map<String, dynamic>>(
+                  path,
+                  data: captureAny(named: 'data'),
+                ),
+              ).captured.single
+              as Map<String, Object?>;
+      expect(body.keys.toSet(), <String>{
+        'date',
+        'time',
+        'client_name',
+        'program',
       });
-      final verification = verify(
-        () => dio.put<Map<String, dynamic>>(
-          captureAny(),
-          data: captureAny(named: 'data'),
+      expect(body['client_name'], '김민수');
+      expect((body['program'] as List<Object?>).single, <String, Object?>{
+        'name': '스쿼트',
+        'sets': 1,
+        'reps': '20분',
+        'weight': '-',
+      });
+      verifyNever(
+        () => dio.get<List<dynamic>>(
+          any(),
+          queryParameters: any(named: 'queryParameters'),
         ),
       );
-      final captured = verification.captured;
-      expect(captured[0], '$_schedulePath/early');
-      expect((captured[1] as Map<String, Object?>).keys, <String>['program']);
     },
   );
 
   test(
-    'registerProgram creates a real PT session when none is upcoming',
+    'registerProgram returns whether the server created a session',
     () async {
-      stubGet(<dynamic>[_session(id: 'done', time: '09:00', status: '완료')]);
+      const path = '/trainer/clients/m1/schedule-program';
       when(
-        () => dio.post<Map<String, dynamic>>(
-          _schedulePath,
-          data: any(named: 'data'),
-        ),
-      ).thenAnswer((_) async => _okMap(_schedulePath));
+        () => dio.put<Map<String, dynamic>>(path, data: any(named: 'data')),
+      ).thenAnswer(
+        (_) async =>
+            _okMap(path, <String, dynamic>{'attached_to_existing': false}),
+      );
 
       final attached = await repo.registerProgram(
         date: '2026-08-06',
@@ -290,26 +305,9 @@ void main() {
       );
 
       expect(attached, isFalse);
-      final body =
-          verify(
-                () => dio.post<Map<String, dynamic>>(
-                  _schedulePath,
-                  data: captureAny(named: 'data'),
-                ),
-              ).captured.single
-              as Map<String, Object?>;
-      expect(body['member_id'], 'm1');
-      expect(body['client_name'], '김민수');
-      expect(body['date'], '2026-08-06');
-      expect(body['time'], '16:00');
-      expect(body['type'], '1:1 PT');
-      expect(body['duration_minutes'], 60);
-      expect((body['program'] as List<Object?>).single, <String, Object?>{
-        'name': '플랭크',
-        'sets': 1,
-        'reps': '10분',
-        'weight': '-',
-      });
+      verify(
+        () => dio.put<Map<String, dynamic>>(path, data: any(named: 'data')),
+      ).called(1);
     },
   );
 

--- a/frontend/flutter_trainer/test/features/schedule/dio_schedule_repository_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/dio_schedule_repository_test.dart
@@ -38,12 +38,14 @@ Map<String, dynamic> _session({
   String date = '2026-08-06',
   String time = '10:00',
   String clientName = '김민수',
+  String? memberId = 'm1',
   String status = '예정',
   List<dynamic> program = const <dynamic>[],
 }) => <String, dynamic>{
   'id': id,
   'date': date,
   'time': time,
+  'member_id': memberId,
   'client_name': clientName,
   'type': '1:1 PT',
   'duration_minutes': 60,
@@ -223,6 +225,90 @@ void main() {
         'sets': 3,
         'reps': '12회',
         'weight': '60kg',
+      });
+    },
+  );
+
+  test(
+    'registerProgram updates the earliest upcoming session for the member',
+    () async {
+      stubGet(<dynamic>[
+        _session(id: 'done', time: '09:00', status: '완료'),
+        _session(id: 'late', time: '15:00'),
+        _session(id: 'early', time: '11:00'),
+      ]);
+      when(
+        () => dio.put<Map<String, dynamic>>(any(), data: any(named: 'data')),
+      ).thenAnswer((_) async => _okMap('$_schedulePath/early'));
+
+      final attached = await repo.registerProgram(
+        date: '2026-08-06',
+        clientId: 'm1',
+        clientName: '김민수',
+        time: '16:00',
+        program: const <ProgramItem>[
+          ProgramItem(name: '스쿼트', sets: 1, reps: '20분', weight: '-'),
+        ],
+      );
+
+      expect(attached, isTrue);
+      expect(capturedQuery(), <String, String>{
+        'date': '2026-08-06',
+        'member_id': 'm1',
+      });
+      final verification = verify(
+        () => dio.put<Map<String, dynamic>>(
+          captureAny(),
+          data: captureAny(named: 'data'),
+        ),
+      );
+      final captured = verification.captured;
+      expect(captured[0], '$_schedulePath/early');
+      expect((captured[1] as Map<String, Object?>).keys, <String>['program']);
+    },
+  );
+
+  test(
+    'registerProgram creates a real PT session when none is upcoming',
+    () async {
+      stubGet(<dynamic>[_session(id: 'done', time: '09:00', status: '완료')]);
+      when(
+        () => dio.post<Map<String, dynamic>>(
+          _schedulePath,
+          data: any(named: 'data'),
+        ),
+      ).thenAnswer((_) async => _okMap(_schedulePath));
+
+      final attached = await repo.registerProgram(
+        date: '2026-08-06',
+        clientId: 'm1',
+        clientName: '김민수',
+        time: '16:00',
+        program: const <ProgramItem>[
+          ProgramItem(name: '플랭크', sets: 1, reps: '10분', weight: '-'),
+        ],
+      );
+
+      expect(attached, isFalse);
+      final body =
+          verify(
+                () => dio.post<Map<String, dynamic>>(
+                  _schedulePath,
+                  data: captureAny(named: 'data'),
+                ),
+              ).captured.single
+              as Map<String, Object?>;
+      expect(body['member_id'], 'm1');
+      expect(body['client_name'], '김민수');
+      expect(body['date'], '2026-08-06');
+      expect(body['time'], '16:00');
+      expect(body['type'], '1:1 PT');
+      expect(body['duration_minutes'], 60);
+      expect((body['program'] as List<Object?>).single, <String, Object?>{
+        'name': '플랭크',
+        'sets': 1,
+        'reps': '10분',
+        'weight': '-',
       });
     },
   );


### PR DESCRIPTION
## Summary

* 실 API 모드에서 AI 코칭 화면이 로컬 Drift 추천 데이터를 노출하던 문제를 수정했습니다.
* AI 추천 루틴을 일정에 등록할 때 공통 `ScheduleRepository`를 사용하도록 변경하여 실제 백엔드 일정에 반영되게 했습니다.
* 예약으로 생성된 PT 일정에도 시간·회원·예약 정합성을 유지하면서 운동 프로그램과 메모를 저장할 수 있도록 보완했습니다.

---

## Changes

### ✨ Features

* `ScheduleRepository.registerProgram()` 공통 계약을 추가했습니다.
* 기존 일정이 있으면 해당 일정에 프로그램을 등록하고, 없으면 새로운 1:1 PT 일정을 생성하도록 구현했습니다.
* 실 API 저장소에서 회원 ID와 날짜를 기준으로 가장 가까운 예정 일정을 조회하여 프로그램을 등록하도록 구현했습니다.

### 🛠 Improvements

* AI 추천 저장소를 Mock API 설정에 따라 분리했습니다.
  * Mock 모드: `DriftAiRoutineRepository`
  * 실 API 모드: `EmptyAiRoutineRepository`
* 실 API 모드의 새로운 A/B 루틴 생성은 기존 FastAPI 루틴 생성 경로를 계속 사용합니다.
* 루틴 일정 등록 시 회원 이름뿐 아니라 실제 회원 ID를 전달하도록 개선했습니다.
* Drift 일정 등록도 동일한 저장소 계약을 사용하도록 정리했습니다.

### 🎨 UI/UX

* 화면 구조 변경은 없습니다.
* 실 API 모드에서 로컬 데모 추천이 실제 추천처럼 표시되거나 일정 등록 성공으로 잘못 안내되던 동작을 제거했습니다.

### 📚 Docs

* 별도 문서 변경은 없습니다.

### 🐛 Fixes

* 실 API 모드에서 번들된 로컬 AI 추천 데이터가 표시되는 문제를 수정했습니다.
* AI 루틴 일정 등록이 로컬 DB에만 저장되어 실제 트레이너 일정과 동기화되지 않던 문제를 수정했습니다.
* 예약 일정의 시간·회원·유형·수업 시간 변경 및 삭제는 계속 차단하되, 프로그램과 메모만 수정할 수 있도록 예약 정합성 보호 범위를 조정했습니다.
* 예약 일정에 프로그램을 등록해도 예약 슬롯의 잔여 인원과 일정 시간이 변경되지 않는 회귀 테스트를 추가했습니다.

---

## Commits

1. `7450496` fix(trainer): use real data paths for AI coaching (#532)

---

## Notes

* 최신 `main` 커밋 `f6c5812`를 기준으로 반영했으며 현재 머지 충돌은 없습니다.
* #543은 데모 채팅 시드와 채팅 UI를 다루므로 이 PR과 변경 파일 및 기능 범위가 겹치지 않습니다.
* 로컬 PostgreSQL 서버를 사용할 수 없어 PostgreSQL 예약 통합 테스트는 로컬에서 실행되지 않았습니다. Backend CI에서 최종 확인이 필요합니다.
* 기존 Flutter Web WASM 관련 경고는 발생했지만 Trainer Web 릴리스 빌드는 성공했습니다.

---

## Screenshots (Optional)

UI 배치 변경이 없는 데이터 경로 및 저장 동작 수정이므로 별도 스크린샷은 없습니다.

---

## Test Plan

* [x] Flutter 정적 분석 통과
* [x] AI 코칭·스케줄 관련 Flutter 테스트 통과
* [x] Trainer Web 릴리스 빌드 성공
* [x] Python 변경 파일 문법 검사 통과
* [ ] Backend PostgreSQL CI 통과 확인
* [ ] 실서버 연결 환경에서 루틴 생성 후 일정 등록 수동 확인

### Manual Test Steps

1. `USE_MOCK_API=false`로 트레이너 웹을 실행합니다.
2. 회원 상세 화면에서 AI 코칭으로 이동합니다.
3. A/B 추천 루틴을 생성하고 하나를 선택합니다.
4. 선택한 루틴을 일정에 등록합니다.
5. 스케줄 화면에서 해당 회원의 예정 일정에 운동 프로그램이 표시되는지 확인합니다.
6. 예정 일정이 없는 날짜에서는 새로운 1:1 PT 일정이 생성되는지 확인합니다.
7. 예약으로 생성된 일정에 프로그램을 등록해도 일정 시간과 슬롯 잔여 인원이 변경되지 않는지 확인합니다.

---

## Related Issues

Closes #532

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] Mock/실 API 데이터 경로 분리
* [x] 최신 `main` 반영 및 머지 충돌 없음
* [x] 데모 모드 동작 유지 확인
* [ ] Backend CI 최종 통과 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 코칭 추천 프로그램을 기존 예정 일정에 등록하거나, 일정이 없으면 새 개인 트레이닝 일정으로 저장합니다.
  * 예정된 일정은 예약 시간과 좌석 정보를 유지한 채 운동 프로그램만 수정할 수 있습니다.
  * 회원 식별 정보와 날짜를 기준으로 가장 이른 예정 일정을 자동으로 선택합니다.

* **버그 수정**
  * 예약 일정의 프로그램 수정 시 예약 정보와 잔여 좌석이 변경되지 않도록 개선했습니다.

* **테스트**
  * 일정 등록, 중복 등록, 회원 전환 및 예약 상태 보존 시나리오를 보강했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->