### PR TITLE
fix(trainer): 주간 리포트 테스트의 DateTime.now() 의존 제거

### DIFF
--- a/frontend/flutter_trainer/test/features/reports/weekly_report_test.dart
+++ b/frontend/flutter_trainer/test/features/reports/weekly_report_test.dart
@@ -63,6 +63,11 @@ void main() {
           session(date: ymd(sunday.add(const Duration(days: 1)))),
         ],
         weekStart: wednesday,
+        // Every call here pins `today`. Left to DateTime.now() the report
+        // silently switches to "past week" mode once the clock leaves
+        // 8/3–8/9, which drops completionAvg/sodium and flips isGoodWeek.
+        // That is what broke the suite on 2026-08-10 (#551).
+        today: wednesday,
       );
 
       expect(report.sessionsBooked, 2);
@@ -75,6 +80,7 @@ void main() {
         client: makeClient(),
         sessions: <ScheduleSession>[session(date: ymd(monday), status: '공백')],
         weekStart: wednesday,
+        today: wednesday,
       );
 
       expect(report.sessionsBooked, 0);


### PR DESCRIPTION
## Summary

`weekly_report_test.dart` 의 `buildWeeklyReport()` 호출 중 2곳이 `today:` 를 넘기지 않아
`DateTime.now()` 로 폴백합니다. 리포트 대상 주는 **2026-08-03~08-09 고정**이라, 실제 시계가
그 주를 벗어나면 `isThisWeek` 가 false 로 뒤집혀 `completionAvg`·`sodium` 이 사라지고
`isGoodWeek` 가 무너집니다.

#546 이 이미 터진 1곳(line 194)을 고쳤지만, 나머지 2곳은 **같은 폭탄이 다음 경계를 기다리는
상태**로 남아 있었습니다. 이 PR 이 그 2곳을 정리합니다.

## Related Issues

Closes #551

## Changes

- `weekly_report_test.dart` line 56·74 의 `buildWeeklyReport()` 호출에 `today: wednesday` 추가
- 프로덕션 코드 무변경 (`buildWeeklyReport` 는 이미 `today` 주입 파라미터를 제공)

## Test Plan

- [x] `buildWeeklyReport` 호출 전수 검사 — `today:` 누락 **0건**
- [x] 같은 성격(고정 날짜 vs `DateTime.now()`)의 다른 후보 점검 — `dio_report_repository_test`,
      `consultations_page_test`, `date_format` 모두 안전함을 개별 확인
- [x] `flutter analyze` (flutter_trainer) — No issues found
- [x] `flutter test` (flutter_trainer) — **437개 통과**
- [x] `git merge-tree` 로 main 병합 충돌 **0건** 확인 (#546 과 겹치는 줄 없음)

## Notes

- main 에 빨간 표시가 없었던 이유: Trainer CI 에 `frontend/flutter_trainer/**` 경로 필터가 있어
  회원 앱만 바꾼 머지들에서는 아예 실행되지 않았습니다.
- 회원 앱에도 시계 주입 지점이 있으나 전부 "요일 인덱스 상대 계산"이라 이번과 성격이 다릅니다.
  이번 스코프에서 제외했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 주간 리포트 테스트가 현재 시스템 시간에 영향을 받지 않고 일관된 결과를 내도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->