### PR TITLE
fix(chat): 회원 앱·트레이너 웹 채팅 자동 갱신

### DIFF
--- a/frontend/flutter/lib/core/utils/active_polling_stream.dart
+++ b/frontend/flutter/lib/core/utils/active_polling_stream.dart
@@ -1,0 +1,90 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+
+/// Polls [load] while the stream has a listener and the application is in
+/// the foreground.
+///
+/// The first failure is surfaced so an initial loading error can be shown.
+/// Once a value has been emitted, transient failures are kept out of the
+/// stream: consumers continue showing the last good value while the next
+/// poll retries. Cancelling the subscription or backgrounding the app stops
+/// the timer immediately.
+Stream<T> activePollingStream<T>({
+  required Future<T> Function() load,
+  required Duration interval,
+}) {
+  late final StreamController<T> controller;
+  late final _LifecycleObserver lifecycleObserver;
+  Timer? timer;
+  bool cancelled = false;
+  bool loading = false;
+  bool hasValue = false;
+  bool foreground = _isForeground(WidgetsBinding.instance.lifecycleState);
+
+  late void Function() scheduleNext;
+
+  Future<void> poll() async {
+    if (cancelled || loading || !foreground) return;
+    loading = true;
+    try {
+      final T value = await load();
+      if (!cancelled && foreground) {
+        hasValue = true;
+        controller.add(value);
+      }
+    } catch (error, stackTrace) {
+      if (!cancelled && foreground && !hasValue) {
+        controller.addError(error, stackTrace);
+      }
+    } finally {
+      loading = false;
+      scheduleNext();
+    }
+  }
+
+  scheduleNext = () {
+    timer?.cancel();
+    timer = null;
+    if (cancelled || !foreground) return;
+    timer = Timer(interval, () => unawaited(poll()));
+  };
+
+  void handleLifecycle(AppLifecycleState state) {
+    final bool nextForeground = _isForeground(state);
+    if (foreground == nextForeground) return;
+    foreground = nextForeground;
+    timer?.cancel();
+    timer = null;
+    if (foreground) unawaited(poll());
+  }
+
+  lifecycleObserver = _LifecycleObserver(handleLifecycle);
+  controller = StreamController<T>(
+    onListen: () {
+      foreground = _isForeground(WidgetsBinding.instance.lifecycleState);
+      WidgetsBinding.instance.addObserver(lifecycleObserver);
+      if (foreground) unawaited(poll());
+    },
+    onCancel: () {
+      cancelled = true;
+      timer?.cancel();
+      timer = null;
+      WidgetsBinding.instance.removeObserver(lifecycleObserver);
+      unawaited(controller.close());
+    },
+  );
+  return controller.stream;
+}
+
+bool _isForeground(AppLifecycleState? state) =>
+    state == null || state == AppLifecycleState.resumed;
+
+class _LifecycleObserver with WidgetsBindingObserver {
+  _LifecycleObserver(this.onChanged);
+
+  final void Function(AppLifecycleState state) onChanged;
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) => onChanged(state);
+}

--- a/frontend/flutter/lib/core/utils/active_polling_stream.dart
+++ b/frontend/flutter/lib/core/utils/active_polling_stream.dart
@@ -19,7 +19,9 @@ Stream<T> activePollingStream<T>({
   Timer? timer;
   bool cancelled = false;
   bool loading = false;
+  bool refreshPending = false;
   bool hasValue = false;
+  int lifecycleGeneration = 0;
   bool foreground = _isForeground(WidgetsBinding.instance.lifecycleState);
 
   late void Function() scheduleNext;
@@ -27,19 +29,30 @@ Stream<T> activePollingStream<T>({
   Future<void> poll() async {
     if (cancelled || loading || !foreground) return;
     loading = true;
+    final int requestGeneration = lifecycleGeneration;
     try {
       final T value = await load();
-      if (!cancelled && foreground) {
+      if (!cancelled &&
+          foreground &&
+          requestGeneration == lifecycleGeneration) {
         hasValue = true;
         controller.add(value);
       }
     } catch (error, stackTrace) {
-      if (!cancelled && foreground && !hasValue) {
+      if (!cancelled &&
+          foreground &&
+          requestGeneration == lifecycleGeneration &&
+          !hasValue) {
         controller.addError(error, stackTrace);
       }
     } finally {
       loading = false;
-      scheduleNext();
+      if (refreshPending && !cancelled && foreground) {
+        refreshPending = false;
+        unawaited(poll());
+      } else {
+        scheduleNext();
+      }
     }
   }
 
@@ -56,7 +69,14 @@ Stream<T> activePollingStream<T>({
     foreground = nextForeground;
     timer?.cancel();
     timer = null;
-    if (foreground) unawaited(poll());
+    if (!foreground) {
+      lifecycleGeneration += 1;
+      refreshPending = false;
+    } else if (loading) {
+      refreshPending = true;
+    } else {
+      unawaited(poll());
+    }
   }
 
   lifecycleObserver = _LifecycleObserver(handleLifecycle);

--- a/frontend/flutter/lib/features/member_coach/data/repositories/dio_member_coach_repository.dart
+++ b/frontend/flutter/lib/features/member_coach/data/repositories/dio_member_coach_repository.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 
 import 'package:oncare/core/errors/app_error.dart';
+import 'package:oncare/core/utils/active_polling_stream.dart';
 import 'package:oncare/features/member_coach/data/dtos/member_coach_dtos.dart';
 import 'package:oncare/features/member_coach/domain/entities/member_coach.dart';
 import 'package:oncare/features/member_coach/domain/repositories/member_coach_repository.dart';
@@ -9,9 +10,13 @@ import 'package:oncare/features/member_coach/domain/repositories/member_coach_re
 /// backend. The chat thread is the same one the trainer app writes to, so
 /// messages and routines flow both ways.
 class DioMemberCoachRepository implements MemberCoachRepository {
-  DioMemberCoachRepository(this._dio);
+  DioMemberCoachRepository(
+    this._dio, {
+    this.pollInterval = const Duration(seconds: 3),
+  });
 
   final Dio _dio;
+  final Duration pollInterval;
 
   @override
   Future<MemberCoach?> fetchCoach() async {
@@ -47,6 +52,13 @@ class DioMemberCoachRepository implements MemberCoachRepository {
     });
     return messages;
   }
+
+  @override
+  Stream<List<CoachMessage>> watchChat() =>
+      activePollingStream<List<CoachMessage>>(
+        load: fetchChat,
+        interval: pollInterval,
+      );
 
   @override
   Future<void> sendMessage(String text) async {

--- a/frontend/flutter/lib/features/member_coach/data/repositories/mock_member_coach_repository.dart
+++ b/frontend/flutter/lib/features/member_coach/data/repositories/mock_member_coach_repository.dart
@@ -195,6 +195,10 @@ class MockMemberCoachRepository implements MemberCoachRepository {
       List<CoachMessage>.unmodifiable(_chat);
 
   @override
+  Stream<List<CoachMessage>> watchChat() =>
+      Stream<List<CoachMessage>>.fromFuture(fetchChat());
+
+  @override
   Future<void> sendMessage(String text) async {
     final trimmed = text.trim();
     if (trimmed.isEmpty) return;

--- a/frontend/flutter/lib/features/member_coach/domain/repositories/member_coach_repository.dart
+++ b/frontend/flutter/lib/features/member_coach/domain/repositories/member_coach_repository.dart
@@ -21,6 +21,10 @@ abstract interface class MemberCoachRepository {
   /// The chat thread (oldest → newest).
   Future<List<CoachMessage>> fetchChat();
 
+  /// Watches the chat while its screen is active. Real API implementations
+  /// poll the shared thread; demo implementations emit their in-memory state.
+  Stream<List<CoachMessage>> watchChat();
+
   /// Sends a message to the coach. No-ops on blank text.
   Future<void> sendMessage(String text);
 

--- a/frontend/flutter/lib/features/member_coach/presentation/controllers/member_coach_providers.dart
+++ b/frontend/flutter/lib/features/member_coach/presentation/controllers/member_coach_providers.dart
@@ -33,9 +33,10 @@ final coachSessionsProvider = FutureProvider<List<CoachSession>>((ref) {
   return ref.watch(memberCoachRepositoryProvider).fetchSessions();
 }, name: 'coachSessions');
 
-/// The member↔coach chat thread (oldest → newest).
-final coachChatProvider = FutureProvider<List<CoachMessage>>((ref) {
-  return ref.watch(memberCoachRepositoryProvider).fetchChat();
+/// The member↔coach chat thread (oldest → newest). Auto-dispose ends
+/// real-API polling as soon as the full-screen chat route is closed.
+final coachChatProvider = StreamProvider.autoDispose<List<CoachMessage>>((ref) {
+  return ref.watch(memberCoachRepositoryProvider).watchChat();
 });
 
 /// Unread coach-sent message count for the entry badge.

--- a/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_chat_sheet.dart
+++ b/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_chat_sheet.dart
@@ -38,15 +38,6 @@ class _TrainerChatPageState extends ConsumerState<TrainerChatPage> {
   int _lastCount = -1;
   bool _sending = false;
 
-  @override
-  void initState() {
-    super.initState();
-    Future<void>.microtask(() async {
-      ref.invalidate(coachChatProvider);
-      await _markRead();
-    });
-  }
-
   /// 데모 안내 배너를 **하루 단위로** 끼워 넣은 목록을 만든다.
   ///
   /// 배너가 스레드 맨 앞·맨 뒤에 하나씩만 있으면, 사흘치 대화에서 "분석은 이
@@ -238,6 +229,9 @@ class _TrainerChatPageState extends ConsumerState<TrainerChatPage> {
                     if (messages.length != _lastCount) {
                       _lastCount = messages.length;
                       _scrollToBottom();
+                      // Mark newly polled trainer messages read while this
+                      // full-screen route is visible, then refresh its badge.
+                      Future<void>.microtask(_markRead);
                     }
                     return ListView(
                       controller: _scroll,

--- a/frontend/flutter/test/core/utils/active_polling_stream_test.dart
+++ b/frontend/flutter/test/core/utils/active_polling_stream_test.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/core/utils/active_polling_stream.dart';
+
+void main() {
+  final TestWidgetsFlutterBinding binding =
+      TestWidgetsFlutterBinding.ensureInitialized();
+
+  test(
+    'resume discards the in-flight response and immediately reloads',
+    () async {
+      final Completer<String> staleRequest = Completer<String>();
+      final Completer<String> freshRequest = Completer<String>();
+      final Completer<void> firstStarted = Completer<void>();
+      final Completer<void> secondStarted = Completer<void>();
+      final Completer<void> freshEmitted = Completer<void>();
+      final List<String> emitted = <String>[];
+      var calls = 0;
+
+      binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      final StreamSubscription<String> subscription =
+          activePollingStream<String>(
+            load: () {
+              calls += 1;
+              if (calls == 1) {
+                firstStarted.complete();
+                return staleRequest.future;
+              }
+              secondStarted.complete();
+              return freshRequest.future;
+            },
+            interval: const Duration(days: 1),
+          ).listen((String value) {
+            emitted.add(value);
+            if (value == 'fresh' && !freshEmitted.isCompleted) {
+              freshEmitted.complete();
+            }
+          });
+
+      try {
+        await firstStarted.future;
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+
+        expect(calls, 1);
+        staleRequest.complete('stale');
+        await secondStarted.future.timeout(const Duration(seconds: 1));
+
+        expect(calls, 2);
+        expect(emitted, isEmpty);
+
+        freshRequest.complete('fresh');
+        await freshEmitted.future.timeout(const Duration(seconds: 1));
+        expect(emitted, <String>['fresh']);
+      } finally {
+        if (!staleRequest.isCompleted) staleRequest.complete('cleanup');
+        if (!freshRequest.isCompleted) freshRequest.complete('cleanup');
+        await subscription.cancel();
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      }
+    },
+  );
+}

--- a/frontend/flutter/test/features/member_coach/dio_member_coach_repository_test.dart
+++ b/frontend/flutter/test/features/member_coach/dio_member_coach_repository_test.dart
@@ -23,6 +23,8 @@ DioException _httpError(int status, String path) => DioException(
 );
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   late _MockDio dio;
   late DioMemberCoachRepository repo;
 
@@ -100,6 +102,39 @@ void main() {
     ]);
     expect(chat.first.sender, CoachSender.trainer);
   });
+
+  test(
+    'watchChat polls and retries without replacing the last good data',
+    () async {
+      var calls = 0;
+      when(() => dio.get<List<dynamic>>('/me/coach/chat')).thenAnswer((
+        _,
+      ) async {
+        calls += 1;
+        if (calls == 2) throw _httpError(503, '/me/coach/chat');
+        return _ok<List<dynamic>>(<dynamic>[
+          <String, Object?>{
+            'id': calls == 1 ? 'before' : 'after',
+            'sender': 'trainer',
+            'body': 'message',
+            'time_label': '09:00',
+            'created_at': '2026-08-10T09:00:00Z',
+          },
+        ], '/me/coach/chat');
+      });
+
+      final emissions = await DioMemberCoachRepository(
+        dio,
+        pollInterval: const Duration(milliseconds: 5),
+      ).watchChat().take(2).toList().timeout(const Duration(seconds: 1));
+
+      expect(emissions.map((items) => items.single.id), <String>[
+        'before',
+        'after',
+      ]);
+      expect(calls, 3);
+    },
+  );
 
   test('fetchChat rejects a malformed list item', () async {
     when(() => dio.get<List<dynamic>>('/me/coach/chat')).thenAnswer(

--- a/frontend/flutter_trainer/lib/core/utils/active_polling_stream.dart
+++ b/frontend/flutter_trainer/lib/core/utils/active_polling_stream.dart
@@ -1,0 +1,90 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+
+/// Polls [load] while the stream has a listener and the application is in
+/// the foreground.
+///
+/// The first failure is surfaced so an initial loading error can be shown.
+/// Once a value has been emitted, transient failures are kept out of the
+/// stream: consumers continue showing the last good value while the next
+/// poll retries. Cancelling the subscription or backgrounding the app stops
+/// the timer immediately.
+Stream<T> activePollingStream<T>({
+  required Future<T> Function() load,
+  required Duration interval,
+}) {
+  late final StreamController<T> controller;
+  late final _LifecycleObserver lifecycleObserver;
+  Timer? timer;
+  bool cancelled = false;
+  bool loading = false;
+  bool hasValue = false;
+  bool foreground = _isForeground(WidgetsBinding.instance.lifecycleState);
+
+  late void Function() scheduleNext;
+
+  Future<void> poll() async {
+    if (cancelled || loading || !foreground) return;
+    loading = true;
+    try {
+      final T value = await load();
+      if (!cancelled && foreground) {
+        hasValue = true;
+        controller.add(value);
+      }
+    } catch (error, stackTrace) {
+      if (!cancelled && foreground && !hasValue) {
+        controller.addError(error, stackTrace);
+      }
+    } finally {
+      loading = false;
+      scheduleNext();
+    }
+  }
+
+  scheduleNext = () {
+    timer?.cancel();
+    timer = null;
+    if (cancelled || !foreground) return;
+    timer = Timer(interval, () => unawaited(poll()));
+  };
+
+  void handleLifecycle(AppLifecycleState state) {
+    final bool nextForeground = _isForeground(state);
+    if (foreground == nextForeground) return;
+    foreground = nextForeground;
+    timer?.cancel();
+    timer = null;
+    if (foreground) unawaited(poll());
+  }
+
+  lifecycleObserver = _LifecycleObserver(handleLifecycle);
+  controller = StreamController<T>(
+    onListen: () {
+      foreground = _isForeground(WidgetsBinding.instance.lifecycleState);
+      WidgetsBinding.instance.addObserver(lifecycleObserver);
+      if (foreground) unawaited(poll());
+    },
+    onCancel: () {
+      cancelled = true;
+      timer?.cancel();
+      timer = null;
+      WidgetsBinding.instance.removeObserver(lifecycleObserver);
+      unawaited(controller.close());
+    },
+  );
+  return controller.stream;
+}
+
+bool _isForeground(AppLifecycleState? state) =>
+    state == null || state == AppLifecycleState.resumed;
+
+class _LifecycleObserver with WidgetsBindingObserver {
+  _LifecycleObserver(this.onChanged);
+
+  final void Function(AppLifecycleState state) onChanged;
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) => onChanged(state);
+}

--- a/frontend/flutter_trainer/lib/core/utils/active_polling_stream.dart
+++ b/frontend/flutter_trainer/lib/core/utils/active_polling_stream.dart
@@ -19,7 +19,9 @@ Stream<T> activePollingStream<T>({
   Timer? timer;
   bool cancelled = false;
   bool loading = false;
+  bool refreshPending = false;
   bool hasValue = false;
+  int lifecycleGeneration = 0;
   bool foreground = _isForeground(WidgetsBinding.instance.lifecycleState);
 
   late void Function() scheduleNext;
@@ -27,19 +29,30 @@ Stream<T> activePollingStream<T>({
   Future<void> poll() async {
     if (cancelled || loading || !foreground) return;
     loading = true;
+    final int requestGeneration = lifecycleGeneration;
     try {
       final T value = await load();
-      if (!cancelled && foreground) {
+      if (!cancelled &&
+          foreground &&
+          requestGeneration == lifecycleGeneration) {
         hasValue = true;
         controller.add(value);
       }
     } catch (error, stackTrace) {
-      if (!cancelled && foreground && !hasValue) {
+      if (!cancelled &&
+          foreground &&
+          requestGeneration == lifecycleGeneration &&
+          !hasValue) {
         controller.addError(error, stackTrace);
       }
     } finally {
       loading = false;
-      scheduleNext();
+      if (refreshPending && !cancelled && foreground) {
+        refreshPending = false;
+        unawaited(poll());
+      } else {
+        scheduleNext();
+      }
     }
   }
 
@@ -56,7 +69,14 @@ Stream<T> activePollingStream<T>({
     foreground = nextForeground;
     timer?.cancel();
     timer = null;
-    if (foreground) unawaited(poll());
+    if (!foreground) {
+      lifecycleGeneration += 1;
+      refreshPending = false;
+    } else if (loading) {
+      refreshPending = true;
+    } else {
+      unawaited(poll());
+    }
   }
 
   lifecycleObserver = _LifecycleObserver(handleLifecycle);

--- a/frontend/flutter_trainer/lib/features/clients/data/repositories/dio_chat_repository.dart
+++ b/frontend/flutter_trainer/lib/features/clients/data/repositories/dio_chat_repository.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 
 import 'package:oncare_trainer/core/errors/app_error.dart';
+import 'package:oncare_trainer/core/utils/active_polling_stream.dart';
 import 'package:oncare_trainer/features/clients/data/dtos/chat_dtos.dart';
 import 'package:oncare_trainer/shared/models/client_chat_message.dart';
 import 'package:oncare_trainer/shared/services/chat_repository.dart';
@@ -9,18 +10,24 @@ import 'package:oncare_trainer/shared/services/chat_repository.dart';
 /// row set the member app reads via `/me/coach/chat`, so a trainer message
 /// is received in the member app and vice versa.
 ///
-/// Reads return single-emit streams (fetch → value); [ChatView] invalidates
-/// the thread/unread providers after a send or read so the next fetch shows
-/// the change. Selected when `USE_MOCK_API=false` (see
+/// The thread is polled only while its screen is subscribed and the app is in
+/// the foreground. Selected when `USE_MOCK_API=false` (see
 /// [chatRepositoryProvider]).
 class DioChatRepository implements ChatRepository {
-  DioChatRepository(this._dio);
+  DioChatRepository(
+    this._dio, {
+    this.pollInterval = const Duration(seconds: 3),
+  });
 
   final Dio _dio;
+  final Duration pollInterval;
 
   @override
   Stream<List<ClientChatMessage>> watchThread(String clientId) =>
-      Stream<List<ClientChatMessage>>.fromFuture(_fetchThread(clientId));
+      activePollingStream<List<ClientChatMessage>>(
+        load: () => _fetchThread(clientId),
+        interval: pollInterval,
+      );
 
   Future<List<ClientChatMessage>> _fetchThread(String clientId) async {
     final encodedId = Uri.encodeComponent(clientId);

--- a/frontend/flutter_trainer/test/core/utils/active_polling_stream_test.dart
+++ b/frontend/flutter_trainer/test/core/utils/active_polling_stream_test.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare_trainer/core/utils/active_polling_stream.dart';
+
+void main() {
+  final TestWidgetsFlutterBinding binding =
+      TestWidgetsFlutterBinding.ensureInitialized();
+
+  test(
+    'resume discards the in-flight response and immediately reloads',
+    () async {
+      final Completer<String> staleRequest = Completer<String>();
+      final Completer<String> freshRequest = Completer<String>();
+      final Completer<void> firstStarted = Completer<void>();
+      final Completer<void> secondStarted = Completer<void>();
+      final Completer<void> freshEmitted = Completer<void>();
+      final List<String> emitted = <String>[];
+      var calls = 0;
+
+      binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      final StreamSubscription<String> subscription =
+          activePollingStream<String>(
+            load: () {
+              calls += 1;
+              if (calls == 1) {
+                firstStarted.complete();
+                return staleRequest.future;
+              }
+              secondStarted.complete();
+              return freshRequest.future;
+            },
+            interval: const Duration(days: 1),
+          ).listen((String value) {
+            emitted.add(value);
+            if (value == 'fresh' && !freshEmitted.isCompleted) {
+              freshEmitted.complete();
+            }
+          });
+
+      try {
+        await firstStarted.future;
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+
+        expect(calls, 1);
+        staleRequest.complete('stale');
+        await secondStarted.future.timeout(const Duration(seconds: 1));
+
+        expect(calls, 2);
+        expect(emitted, isEmpty);
+
+        freshRequest.complete('fresh');
+        await freshEmitted.future.timeout(const Duration(seconds: 1));
+        expect(emitted, <String>['fresh']);
+      } finally {
+        if (!staleRequest.isCompleted) staleRequest.complete('cleanup');
+        if (!freshRequest.isCompleted) freshRequest.complete('cleanup');
+        await subscription.cancel();
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      }
+    },
+  );
+}

--- a/frontend/flutter_trainer/test/features/clients/dio_chat_repository_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/dio_chat_repository_test.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:dio/dio.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -24,6 +27,8 @@ DioException _httpError(int status, String path) => DioException(
 );
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   late _MockDio dio;
   late DioChatRepository repo;
 
@@ -56,6 +61,110 @@ void main() {
     expect(thread.map((m) => m.id).toList(), <String>['a', 'b']);
     expect(thread.last.sender, ChatSender.trainer);
   });
+
+  test('watchThread polls until its subscription is cancelled', () async {
+    var calls = 0;
+    when(() => dio.get<List<dynamic>>('/trainer/clients/m1/chat')).thenAnswer((
+      _,
+    ) async {
+      calls += 1;
+      return _ok<List<dynamic>>(<dynamic>[
+        <String, Object?>{
+          'id': 'm$calls',
+          'sender': 'client',
+          'body': 'message $calls',
+          'time_label': '09:00',
+          'created_at': '2026-08-10T09:00:00Z',
+        },
+      ], '/trainer/clients/m1/chat');
+    });
+
+    final emissions = await DioChatRepository(
+      dio,
+      pollInterval: const Duration(milliseconds: 5),
+    ).watchThread('m1').take(2).toList().timeout(const Duration(seconds: 1));
+
+    expect(emissions.map((items) => items.single.id), <String>['m1', 'm2']);
+    expect(calls, 2);
+  });
+
+  test(
+    'watchThread keeps the last value across a transient poll failure',
+    () async {
+      var calls = 0;
+      when(() => dio.get<List<dynamic>>('/trainer/clients/m1/chat')).thenAnswer(
+        (_) async {
+          calls += 1;
+          if (calls == 2) {
+            throw _httpError(503, '/trainer/clients/m1/chat');
+          }
+          return _ok<List<dynamic>>(<dynamic>[
+            <String, Object?>{
+              'id': calls == 1 ? 'before' : 'after',
+              'sender': 'client',
+              'body': 'message',
+              'time_label': '09:00',
+              'created_at': '2026-08-10T09:00:00Z',
+            },
+          ], '/trainer/clients/m1/chat');
+        },
+      );
+
+      final emissions = await DioChatRepository(
+        dio,
+        pollInterval: const Duration(milliseconds: 5),
+      ).watchThread('m1').take(2).toList().timeout(const Duration(seconds: 1));
+
+      expect(emissions.map((items) => items.single.id), <String>[
+        'before',
+        'after',
+      ]);
+      expect(calls, 3);
+    },
+  );
+
+  test(
+    'watchThread pauses in the background and resumes immediately',
+    () async {
+      var calls = 0;
+      when(() => dio.get<List<dynamic>>('/trainer/clients/m1/chat')).thenAnswer(
+        (_) async {
+          calls += 1;
+          return _ok<List<dynamic>>(
+            const <dynamic>[],
+            '/trainer/clients/m1/chat',
+          );
+        },
+      );
+      final repo = DioChatRepository(
+        dio,
+        pollInterval: const Duration(milliseconds: 20),
+      );
+      final first = Completer<void>();
+      final subscription = repo.watchThread('m1').listen((_) {
+        if (!first.isCompleted) first.complete();
+      });
+      final binding = TestWidgetsFlutterBinding.instance;
+      try {
+        await first.future.timeout(const Duration(seconds: 1));
+
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+        await Future<void>.delayed(const Duration(milliseconds: 60));
+        expect(calls, 1);
+
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+        await Future<void>.delayed(Duration.zero);
+        expect(calls, 2);
+
+        await subscription.cancel();
+        await Future<void>.delayed(const Duration(milliseconds: 60));
+        expect(calls, 2);
+      } finally {
+        binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+        await subscription.cancel();
+      }
+    },
+  );
 
   test('sendTrainerMessage POSTs the trimmed text', () async {
     when(


### PR DESCRIPTION
## Summary

- 회원 앱과 트레이너 웹에서 열려 있는 채팅을 자동으로 갱신합니다.
- 앱이 백그라운드로 이동하거나 채팅 화면이 닫히면 갱신을 중단합니다.
- 앱 복귀 시 즉시 최신 메시지와 읽음 상태를 다시 조회합니다.

## Changes

### Features

- 회원 앱과 트레이너 웹의 실 API 채팅에 3초 간격 갱신 적용
- 앱 포커스 복귀 시 즉시 채팅 재조회
- 채팅 화면 종료 시 폴링 자동 해제

### Improvements

- 회원 앱 채팅 Provider를 `autoDispose`로 변경
- 공통 생명주기 기반 갱신 스트림 추가
- 일시적인 네트워크 오류가 발생해도 마지막 정상 대화를 유지
- 데모 저장소의 기존 동작 유지

### UI Changes

- 없음

### Documentation

- 없음

### Fixes

- 상대 앱에서 보낸 메시지가 화면 재진입 전까지 표시되지 않던 문제 수정
- 읽음 처리 후 상대 앱의 미읽음 상태가 오래 남던 문제 수정

## Commits

1. `6db46af` — `fix(chat): sync active member and trainer threads`

## Notes

- WebSocket/SSE가 아닌 기존 REST API 기반 폴링 방식입니다.
- 채팅 화면이 활성화된 동안에만 3초 주기로 요청합니다.
- 이 PR은 #520의 채팅 동기화 범위만 다룹니다.
- 예약·고객 기록·루틴 및 완료 PT 동기화는 후속 PR로 분리합니다.

## Screenshots

- UI 변경 없음

## Test Plan

- [x] 회원 앱 채팅 관련 테스트 17개 통과
- [x] 트레이너 웹 채팅 관련 테스트 28개 통과
- [x] 회원 앱 `flutter analyze` 통과
- [x] 트레이너 웹 `flutter analyze` 통과

### Manual Test Steps

1. 실 API 환경에서 연결된 회원 계정과 트레이너 계정으로 로그인합니다.
2. 두 앱에서 동일한 채팅방을 엽니다.
3. 회원 앱에서 메시지를 전송하고 트레이너 웹에 3초 이내 표시되는지 확인합니다.
4. 트레이너 웹에서 답장을 보내고 회원 앱에 3초 이내 표시되는지 확인합니다.
5. 채팅을 읽은 뒤 상대 앱의 미읽음 표시가 갱신되는지 확인합니다.
6. 앱을 백그라운드로 전환한 뒤 요청이 중단되는지 확인합니다.
7. 앱으로 복귀했을 때 최신 대화가 즉시 조회되는지 확인합니다.

## Related Issues

Refs #520

## Checklist

- [x] 변경 범위가 채팅 동기화로 제한되어 있습니다.
- [x] 회원 앱과 트레이너 웹 양쪽을 테스트했습니다.
- [x] 기존 데모 모드 동작을 유지합니다.
- [x] 정적 분석을 통과했습니다.
- [x] 후속 작업은 별도 PR로 분리합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 회원 코치 채팅과 트레이너 고객 채팅이 주기적으로 자동 갱신됩니다.
  * 앱이 화면에 표시되는 동안 새 메시지를 확인하며, 백그라운드 복귀 시 즉시 최신 내용을 불러옵니다.
  * 새 메시지 수신 시 읽음 처리와 읽지 않은 메시지 배지가 자동으로 업데이트됩니다.

* **버그 수정**
  * 일시적인 네트워크 오류가 발생해도 마지막으로 확인한 채팅 내용을 유지합니다.
  * 채팅 화면을 닫으면 불필요한 자동 조회가 중지됩니다.

* **테스트**
  * 자동 갱신, 오류 복구, 백그라운드 전환 및 구독 취소 동작을 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->