### PR TITLE
fix(backend): 서버 타임존 미지정으로 도메인 날짜가 UTC 기준으로 밀리는 문제

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -37,6 +37,9 @@ KAKAO_TIMEOUT_SECONDS=3.0
 APPLE_CLIENT_IDS=
 
 # 기타
+# 로그 타임스탬프용. 도메인 날짜(오늘 식단·오늘/어제 라벨 등)는 이 값에 기대지 않고
+# app/core/clock.py 가 KST 로 직접 고정하므로, 비워 둬도 서비스 동작은 같다.
+TZ=Asia/Seoul
 CORS_ALLOW_ORIGINS=*
 # 운영은 false 권장. true로 켜면 DEMO_LOGIN_PASSWORD를 12자 이상으로 반드시 설정.
 SEED_DEMO_DATA=true

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,10 @@
 FROM python:3.12-slim
 WORKDIR /code
 
+# 로그 타임스탬프를 KST 로 맞춘다. 도메인 날짜 계산은 여기에 기대지 않는다 —
+# 기준 시각은 app/core/clock.py 가 ZoneInfo 로 직접 고정한다(#557).
+ENV TZ=Asia/Seoul
+
 # psycopg[binary] 휠이 libpq 를 번들하므로 apt 빌드 툴체인(build-essential/libpq-dev)이
 # 불필요하다 — 이미지에서 수백 MB 를 덜어낸다. (소스 빌드로 바꾸면 psycopg[c] + libpq-dev 필요)
 COPY requirements.txt .

--- a/backend/app/api/v1/dashboard.py
+++ b/backend/app/api/v1/dashboard.py
@@ -26,7 +26,6 @@ from app.schemas.dashboard_api import (
     DashboardSummary,
 )
 from app.schemas.diet_api import calculate_macros
-from app.services.exercise_service import monday_of_this_week_str
 
 router = APIRouter(tags=["dashboard"])
 
@@ -188,7 +187,9 @@ def dashboard_summary(
     nutrition_week_prev = _nutrition_week(db, uid, this_monday - timedelta(days=7))
 
     # --- 이번 주 운동 집계 ---
-    week = monday_of_this_week_str()
+    # 위 식단·주간 추이와 같은 스냅샷에서 뽑는다 — 여기서 시계를 다시 읽으면
+    # KST 자정을 걸친 요청에서 한 응답 안의 기준 주가 갈린다.
+    week = this_monday.strftime("%Y-%m-%d")
     ex_rows = db.scalars(
         select(ExerciseSession).where(ExerciseSession.user_id == uid)
         .where(ExerciseSession.week_start == week)

--- a/backend/app/api/v1/dashboard.py
+++ b/backend/app/api/v1/dashboard.py
@@ -18,6 +18,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.api.deps import CurrentUser
+from app.core import clock
 from app.db.session import get_db
 from app.models.models import DietEntry, ExerciseSession, ScheduleEvent
 from app.schemas.dashboard_api import (
@@ -155,7 +156,7 @@ def dashboard_summary(
         if health_profile and health_profile.daily_sugar_g is not None
         else _MAX_SUGAR_G
     )
-    today_dt = datetime.now()
+    today_dt = clock.now()
     today = today_dt.strftime("%Y-%m-%d")
 
     # --- 오늘 식단 집계 ---

--- a/backend/app/api/v1/exercise.py
+++ b/backend/app/api/v1/exercise.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -15,6 +14,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.api.deps import CurrentUser
+from app.core import clock
 from app.db.session import get_db
 from app.models.models import ExerciseSession
 from app.schemas.exercise_api import (
@@ -74,7 +74,7 @@ def add_session(
         raise HTTPException(status_code=400, detail=f"허용되지 않는 운동 강도: {payload.intensity}")
     # minutes(>0)·calories(>=0) 는 ExerciseSessionCreate 의 Field 제약에서 422 로 검증됨
 
-    day_label = payload.day_label or WEEKDAY_LABELS[datetime.now().weekday()]
+    day_label = payload.day_label or WEEKDAY_LABELS[clock.today().weekday()]
     if day_label not in WEEKDAY_LABELS:
         raise HTTPException(status_code=400, detail=f"잘못된 요일 라벨: {day_label}")
 

--- a/backend/app/api/v1/exercise.py
+++ b/backend/app/api/v1/exercise.py
@@ -21,7 +21,7 @@ from app.schemas.exercise_api import (
     ExerciseSessionCreate, ExerciseSessionOut, ExerciseWeekResponse,
 )
 from app.services.exercise_service import (
-    WEEKDAY_LABELS, build_current_week, monday_of_this_week_str,
+    WEEKDAY_LABELS, build_current_week, monday_of_str, monday_of_this_week_str,
 )
 
 router = APIRouter(tags=["exercise"])
@@ -74,14 +74,17 @@ def add_session(
         raise HTTPException(status_code=400, detail=f"허용되지 않는 운동 강도: {payload.intensity}")
     # minutes(>0)·calories(>=0) 는 ExerciseSessionCreate 의 Field 제약에서 422 로 검증됨
 
-    day_label = payload.day_label or WEEKDAY_LABELS[clock.today().weekday()]
+    # 요일 라벨과 주차를 같은 스냅샷에서 뽑는다 — 따로 읽으면 KST 자정 사이에
+    # 저장된 한 세션의 요일과 주차가 서로 다른 날을 가리킬 수 있다.
+    today = clock.today()
+    day_label = payload.day_label or WEEKDAY_LABELS[today.weekday()]
     if day_label not in WEEKDAY_LABELS:
         raise HTTPException(status_code=400, detail=f"잘못된 요일 라벨: {day_label}")
 
     row = ExerciseSession(
         id=f"ex-{uuid.uuid4().hex[:12]}",
         user_id=current_user.id,
-        week_start=monday_of_this_week_str(),
+        week_start=monday_of_str(today.isoformat()),
         day_label=day_label,
         type=payload.type,
         minutes=payload.minutes,

--- a/backend/app/api/v1/schedule.py
+++ b/backend/app/api/v1/schedule.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import re
 import uuid
 from datetime import date as _date
-from datetime import datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -17,6 +16,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.api.deps import CurrentUser
+from app.core import clock
 from app.db.session import get_db
 from app.models.models import ScheduleEvent
 from app.schemas.misc_api import ScheduleEventCreate, ScheduleEventOut, ScheduleEventUpdate
@@ -74,7 +74,7 @@ def list_events(
             raise HTTPException(status_code=422, detail="month 는 YYYY-MM 형식이어야 합니다.")
         stmt = stmt.where(ScheduleEvent.date.like(f"{month}-%"))
     else:
-        target = date or datetime.now().strftime("%Y-%m-%d")
+        target = date or clock.today_iso()
         if not _is_ymd(target):
             raise HTTPException(status_code=422, detail="date 는 YYYY-MM-DD 형식이어야 합니다.")
         stmt = stmt.where(ScheduleEvent.date == target)

--- a/backend/app/core/clock.py
+++ b/backend/app/core/clock.py
@@ -1,0 +1,47 @@
+"""서비스 기준 시각 — 항상 KST(Asia/Seoul).
+
+`datetime.now()` 나 `date.today()`, 인자 없는 `astimezone()` 은 **서버 로컬
+타임존**을 따른다. 배포 이미지(`python:3.12-slim`)의 기본 타임존은 UTC 라,
+이 호출들을 그대로 쓰면 KST 00:00~09:00 사이에 서비스가 판단하는 "오늘"이
+하루 전이 된다 — 아침에 기록한 식사가 전날 식단으로 들어가고, '오늘/어제'
+라벨이 밀리고, 오늘 잡힌 세션이 '미래 세션'으로 거부된다(#557).
+
+컨테이너에 `TZ` 를 걸어 맞추는 방법도 있지만, 그러면 **정확성이 배포 설정에
+의존**한다. 설정을 빠뜨린 환경(로컬 도커 실행, 다른 호스팅)에서 조용히 어긋나므로
+코드에서 기준 시각을 고정한다.
+
+DB 의 `created_at` 은 UTC 로 저장된다. 저장값을 화면용 날짜/시각으로 바꿀 때는
+[to_seoul] 을 거친다.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from zoneinfo import ZoneInfo
+
+#: 서비스 기준 타임존. 단일 지역 서비스라 사용자별 타임존은 두지 않는다.
+SEOUL = ZoneInfo("Asia/Seoul")
+
+
+def now() -> datetime:
+    """KST 기준 현재 시각(tz-aware)."""
+    return datetime.now(SEOUL)
+
+
+def today() -> date:
+    """KST 기준 오늘 날짜."""
+    return now().date()
+
+
+def today_iso() -> str:
+    """KST 기준 오늘 날짜 `YYYY-MM-DD`. DB 의 `date` 컬럼과 같은 표기."""
+    return today().isoformat()
+
+
+def to_seoul(ts: datetime) -> datetime:
+    """저장된 시각을 KST 로 변환한다.
+
+    naive 는 UTC 로 간주한다 — `created_at` 이 UTC naive 로 들어오기 때문이다.
+    """
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    return ts.astimezone(SEOUL)

--- a/backend/app/db/seed_member_data.py
+++ b/backend/app/db/seed_member_data.py
@@ -21,12 +21,13 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import date, datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from app.core import clock
 from app.db.seed_trainer import TRAINER_ID, _MEMBERS
 from app.db.session import SessionLocal
 from app.models import models
@@ -304,7 +305,7 @@ def _seed_schedule(db: Session, valid: set[str]) -> None:
         )
     ) is None:
         return
-    today = date.today().isoformat()
+    today = clock.today_iso()
     # 오늘 스케줄이 이미 있으면 스킵(날짜 넘어가면 새로 시드)
     if db.scalar(
         select(models.TrainerSchedule.id)
@@ -424,7 +425,7 @@ def _seed_diet(db: Session, member_id: str) -> None:
     if not meals or not sodium_week:
         return
 
-    today = date.today()
+    today = clock.today()
     today_str = today.isoformat()
 
     # 오늘 3끼 (오늘 기록이 아직 없을 때만)
@@ -475,7 +476,7 @@ def _seed_history(db: Session, member_id: str) -> None:
     if not sessions:
         return
 
-    today = date.today()
+    today = clock.today()
     # 오늘 기록이 이미 있으면 스킵(멱등, 날짜 넘어가면 새로 시드)
     if db.scalar(
         select(models.RoutineHistory.id)
@@ -516,7 +517,7 @@ def _seed_exercise(db: Session, member_id: str) -> None:
     week = _EXERCISE_WEEK.get(member_id)
     if not week:
         return
-    today = date.today()
+    today = clock.today()
     week_start = (today - timedelta(days=today.weekday())).isoformat()  # 이번 주 월요일
     added = False
     for day_label, ex_type, minutes, calories in week:

--- a/backend/app/services/coach_service.py
+++ b/backend/app/services/coach_service.py
@@ -14,11 +14,10 @@ AI 코치 서비스.
 """
 from __future__ import annotations
 
-from datetime import datetime
-
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.core import clock
 from app.models.models import DietEntry, ExerciseSession
 from app.schemas.misc_api import AiCoachFeedback, CoachSuggestion
 from app.services.exercise_service import monday_of_this_week_str
@@ -26,7 +25,7 @@ from app.services.exercise_service import monday_of_this_week_str
 
 def _diet_suggestion(db: Session, user_id: str) -> CoachSuggestion:
     """식단 도메인 코치 (STEP 7에서 RAG+LLM 으로 교체)."""
-    today = datetime.now().strftime("%Y-%m-%d")
+    today = clock.today_iso()
     rows = db.scalars(
         select(DietEntry).where(DietEntry.user_id == user_id).where(DietEntry.date == today)
     ).all()
@@ -81,7 +80,7 @@ def _hydration_suggestion(db: Session, user_id: str) -> CoachSuggestion:
     RAG/LLM 전까지 규칙 기반으로 개인화한다: 나트륨이 높으면 배출을 위해 물을
     더 권하고, 그렇지 않으면 시간대에 맞춰 다르게 안내한다.
     """
-    today = datetime.now().strftime("%Y-%m-%d")
+    today = clock.today_iso()
     total_na = sum(
         r.sodium_mg for r in db.scalars(
             select(DietEntry).where(DietEntry.user_id == user_id)
@@ -96,7 +95,7 @@ def _hydration_suggestion(db: Session, user_id: str) -> CoachSuggestion:
                 "물을 충분히 마시면 나트륨 배출에 도움이 됩니다."
             ),
         )
-    hour = datetime.now().hour
+    hour = clock.now().hour
     if hour < 11:
         body = "아침 물 한 잔으로 하루를 시작해 보세요. 하루 6~8잔이 목표예요."
     elif hour < 18:
@@ -115,7 +114,7 @@ def build_feedback(db: Session, user_id: str, user_name: str) -> AiCoachFeedback
     STEP 7: 식단·운동 코치는 RAG 기반(domain_coaches)으로 동작.
     RAG 가 불가(키 미설정/자료 없음)하면 내부에서 STEP 6 규칙 기반으로 자동 폴백.
     """
-    hour = datetime.now().hour
+    hour = clock.now().hour
     if hour < 11:
         greeting = f"{user_name}님, 좋은 아침이에요! 오늘도 건강하게 시작해봐요."
     elif hour < 18:

--- a/backend/app/services/consultation_service.py
+++ b/backend/app/services/consultation_service.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import uuid
-from datetime import date, datetime, timezone
+from datetime import datetime, timezone
 
 from sqlalchemy import func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from app.core import clock
 from app.models.models import (
     ConsultationRequest,
     MemberGym,
@@ -103,7 +104,7 @@ def _validate_target(db: Session, payload: ConsultationCreate) -> None:
 def create_consultation(
     db: Session, member_id: str, payload: ConsultationCreate
 ) -> ConsultationOut:
-    if payload.preferred_date < date.today():
+    if payload.preferred_date < clock.today():
         raise InvalidConsultationRequest("상담 희망일은 오늘 이후여야 합니다.")
 
     _validate_target(db, payload)

--- a/backend/app/services/diet_recommendation_service.py
+++ b/backend/app/services/diet_recommendation_service.py
@@ -25,6 +25,7 @@ from datetime import date, timedelta
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.core import clock
 from app.data import meal_catalog
 from app.data.meal_catalog import CATALOG, DEFAULT_ORDER, RECOMMENDATION_COUNT, MealItem
 from app.models.models import DietEntry, HealthProfile
@@ -159,7 +160,7 @@ def build_context(db: Session, user_id: str, today: date | None = None) -> Nutri
     평균은 '기록이 있는 날' 기준이다. 기록이 없는 날을 0 으로 세면 하루만 기록한
     사용자의 평균이 실제보다 낮게 나와 과다 신호를 놓친다.
     """
-    today = today or date.today()
+    today = today or clock.today()
     start = (today - timedelta(days=LOOKBACK_DAYS - 1)).isoformat()
     end = today.isoformat()
 
@@ -397,7 +398,7 @@ def build_recommendations(
     # use_llm 을 키에 넣지 않으면 규칙 응답이 LLM 요청에 재사용된다(디버깅·비용 절감용
     # 호출 한 번이 그 사용자의 추천을 TTL 동안 규칙 결과로 고정해 버린다).
     cache_key = (
-        f"{user_id}:{(today or date.today()).isoformat()}:"
+        f"{user_id}:{(today or clock.today()).isoformat()}:"
         f"{ctx.fingerprint()}:llm={use_llm}"
     )
     hit = _cache.get(cache_key)

--- a/backend/app/services/diet_recommendation_service.py
+++ b/backend/app/services/diet_recommendation_service.py
@@ -388,7 +388,10 @@ def build_recommendations(
     today: date | None = None,
 ) -> DietRecommendationsResponse:
     """홈 추천 식단. 어떤 실패에도 카드 RECOMMENDATION_COUNT 장을 반환한다."""
-    ctx = build_context(db, user_id, today)
+    # 조회 구간과 캐시 키가 같은 날짜를 쓰도록 여기서 한 번만 확정한다 — 각자
+    # 시계를 읽으면 KST 자정 사이에 어제 데이터를 오늘 키로 캐싱할 수 있다.
+    effective_today = today or clock.today()
+    ctx = build_context(db, user_id, effective_today)
 
     # 근거가 없으면 LLM 을 부를 이유가 없다. 신규 가입자는 여기서 현재 홈 화면과
     # 동일한 기본 순서를 받는다.
@@ -398,7 +401,7 @@ def build_recommendations(
     # use_llm 을 키에 넣지 않으면 규칙 응답이 LLM 요청에 재사용된다(디버깅·비용 절감용
     # 호출 한 번이 그 사용자의 추천을 TTL 동안 규칙 결과로 고정해 버린다).
     cache_key = (
-        f"{user_id}:{(today or clock.today()).isoformat()}:"
+        f"{user_id}:{effective_today.isoformat()}:"
         f"{ctx.fingerprint()}:llm={use_llm}"
     )
     hit = _cache.get(cache_key)

--- a/backend/app/services/diet_service.py
+++ b/backend/app/services/diet_service.py
@@ -138,12 +138,15 @@ def save_analyzed_entry(
          "sodium_mg": f.sodium_mg, "sugar_g": f.sugar_g, "source": f.source}
         for f in analysis.foods
     ]
+    # 날짜와 시각은 같은 시계 스냅샷에서 뽑는다. 따로 읽으면 KST 자정 사이에
+    # date 는 어제, time_label 은 오늘이 되어 한 행 안에서 어긋난다.
+    recorded_at = clock.now()
     entry = DietEntry(
         id=f"diet-{uuid.uuid4().hex[:12]}",
         user_id=user_id,
-        date=today_str(),
+        date=recorded_at.date().isoformat(),
         meal_type=meal_type,
-        time_label=clock.now().strftime("%H:%M"),
+        time_label=recorded_at.strftime("%H:%M"),
         foods_json=json.dumps(foods_for_storage, ensure_ascii=False),
         total_calories=analysis.total_calories,
         carbs_g=analysis.total_carbs_g,

--- a/backend/app/services/diet_service.py
+++ b/backend/app/services/diet_service.py
@@ -10,12 +10,12 @@ from __future__ import annotations
 import json
 import logging
 import uuid
-from datetime import datetime
 
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from app.core import clock
 from app.models.models import DietEntry
 from app.schemas.diet import DietAnalysis, RecognizedFood
 from app.schemas.diet_api import (
@@ -32,7 +32,7 @@ DASH_SODIUM_LIMIT_MG = 2000
 
 
 def today_str() -> str:
-    return datetime.now().strftime("%Y-%m-%d")
+    return clock.today_iso()
 
 
 def load_foods(foods_json: str) -> list[dict]:
@@ -143,7 +143,7 @@ def save_analyzed_entry(
         user_id=user_id,
         date=today_str(),
         meal_type=meal_type,
-        time_label=datetime.now().strftime("%H:%M"),
+        time_label=clock.now().strftime("%H:%M"),
         foods_json=json.dumps(foods_for_storage, ensure_ascii=False),
         total_calories=analysis.total_calories,
         carbs_g=analysis.total_carbs_g,

--- a/backend/app/services/exercise_service.py
+++ b/backend/app/services/exercise_service.py
@@ -13,7 +13,9 @@
 """
 from __future__ import annotations
 
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
+
+from app.core import clock
 
 WEEKDAY_LABELS = ["월", "화", "수", "목", "금", "토", "일"]
 
@@ -35,9 +37,8 @@ _INTENSITY_FACTOR = {"light": 0.85, "moderate": 1.0, "high": 1.2}
 
 
 def monday_of_this_week_str() -> str:
-    now = datetime.now()
-    monday = now - timedelta(days=now.weekday())
-    return monday.strftime("%Y-%m-%d")
+    today = clock.today()
+    return (today - timedelta(days=today.weekday())).isoformat()
 
 
 def monday_of_str(day: str) -> str:
@@ -58,7 +59,7 @@ def weekday_label_of(day: str) -> str:
     try:
         d = date.fromisoformat(day)
     except (TypeError, ValueError):
-        return WEEKDAY_LABELS[datetime.now().weekday()]
+        return WEEKDAY_LABELS[clock.today().weekday()]
     return WEEKDAY_LABELS[d.weekday()]
 
 
@@ -70,8 +71,8 @@ def estimate_calories(type_: str, minutes: int, intensity: str) -> int:
 
 
 def _date_label_for_day(day_label: str) -> str:
-    now = datetime.now()
-    today_idx = now.weekday()  # 0=월
+    today = clock.today()
+    today_idx = today.weekday()  # 0=월
     if day_label not in WEEKDAY_LABELS:
         return day_label
     day_idx = WEEKDAY_LABELS.index(day_label)
@@ -81,7 +82,7 @@ def _date_label_for_day(day_label: str) -> str:
     if delta == 1:
         return "어제"
     if 1 < delta <= 6:
-        d = now - timedelta(days=delta)
+        d = today - timedelta(days=delta)
         return f"{d.month}월 {d.day}일"
     return f"{day_label}요일"
 

--- a/backend/app/services/reservation_service.py
+++ b/backend/app/services/reservation_service.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime, timezone
-from zoneinfo import ZoneInfo
 
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from app.core.clock import SEOUL
 from app.models.models import (
     TrainerClient,
     TrainerReservation,
@@ -21,8 +21,6 @@ from app.schemas.reservation_api import (
     TrainerSlotOut,
 )
 from app.services import notification_service
-
-SEOUL = ZoneInfo("Asia/Seoul")
 
 
 class SlotNotFound(Exception):

--- a/backend/app/services/trainer_routine_options_service.py
+++ b/backend/app/services/trainer_routine_options_service.py
@@ -75,7 +75,10 @@ def build_member_analysis(
     if link is None:
         raise ValueError("담당 고객을 찾을 수 없습니다.")
 
-    today = clock.today_iso()
+    # 오늘과 28일 창을 같은 스냅샷에서 뽑는다 — 따로 읽으면 KST 자정 사이에
+    # 한 응답의 '오늘 나트륨'과 '최근 4주 이행률'이 다른 날을 기준으로 잡힌다.
+    today_date = clock.today()
+    today = today_date.isoformat()
     sodium = int(
         db.scalar(
             select(func.coalesce(func.sum(DietEntry.sodium_mg), 0)).where(
@@ -86,7 +89,7 @@ def build_member_analysis(
         or 0
     )
 
-    since = (clock.today() - timedelta(days=27)).isoformat()
+    since = (today_date - timedelta(days=27)).isoformat()
     completion = db.scalar(
         select(func.avg(RoutineHistory.completion_rate)).where(
             RoutineHistory.member_id == member_id,

--- a/backend/app/services/trainer_routine_options_service.py
+++ b/backend/app/services/trainer_routine_options_service.py
@@ -7,11 +7,12 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import date, timedelta
+from datetime import timedelta
 
 from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
 
+from app.core import clock
 from app.models.models import DietEntry, RoutineHistory, TrainerClient, TrainerRoutine
 from app.schemas.trainer_api import (
     RoutineOptionAnalysisOut,
@@ -74,7 +75,7 @@ def build_member_analysis(
     if link is None:
         raise ValueError("담당 고객을 찾을 수 없습니다.")
 
-    today = date.today().isoformat()
+    today = clock.today_iso()
     sodium = int(
         db.scalar(
             select(func.coalesce(func.sum(DietEntry.sodium_mg), 0)).where(
@@ -85,7 +86,7 @@ def build_member_analysis(
         or 0
     )
 
-    since = (date.today() - timedelta(days=27)).isoformat()
+    since = (clock.today() - timedelta(days=27)).isoformat()
     completion = db.scalar(
         select(func.avg(RoutineHistory.completion_rate)).where(
             RoutineHistory.member_id == member_id,

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -16,6 +16,7 @@ from datetime import date, datetime, timedelta, timezone
 from sqlalchemy import func, or_, select, tuple_, update
 from sqlalchemy.orm import Session
 
+from app.core import clock
 from app.models.models import (
     ChatMessage, DietEntry, ExerciseSession, GymProfile, Place, RoutineHistory,
     TrainerClient, TrainerProfile, TrainerReservation, TrainerReservationSlot,
@@ -34,7 +35,7 @@ SODIUM_TARGET_MG = 2000
 
 
 def _today() -> date:
-    return datetime.now().date()
+    return clock.today()
 
 
 def today_iso() -> str:
@@ -93,13 +94,11 @@ def relative_time_label(ts: datetime) -> str:
 
 
 def _local_date_iso(ts: datetime) -> str:
-    """tz-aware(또는 naive=UTC 가정) 시각 → 로컬(서버 TZ) 날짜 YYYY-MM-DD.
+    """tz-aware(또는 naive=UTC 가정) 시각 → KST 날짜 YYYY-MM-DD.
 
-    created_at 은 UTC 로 저장되므로, 로컬 '오늘/어제' 판정과 맞추려면 로컬 날짜로 변환해야
+    created_at 은 UTC 로 저장되므로, '오늘/어제' 판정과 맞추려면 KST 날짜로 변환해야
     한다(안 그러면 KST 새벽엔 UTC 가 전날이라 '어제'로 어긋난다)."""
-    if ts.tzinfo is None:
-        ts = ts.replace(tzinfo=timezone.utc)
-    return ts.astimezone().date().isoformat()
+    return clock.to_seoul(ts).date().isoformat()
 
 
 def _today_totals(diet_rows: list[DietEntry], today_str: str) -> tuple[int, int, int]:
@@ -294,10 +293,8 @@ def build_client_history(
 # ---- 채팅 (트레이너↔회원, 양방향 공유 스레드) ----
 
 def _hhmm(ts: datetime) -> str:
-    """created_at → 로컬 HH:MM (KST 서버면 KST)."""
-    if ts.tzinfo is None:
-        ts = ts.replace(tzinfo=timezone.utc)
-    return ts.astimezone().strftime("%H:%M")
+    """created_at → KST HH:MM."""
+    return clock.to_seoul(ts).strftime("%H:%M")
 
 
 def _sender_out(sender: str, viewer: str = "trainer") -> str:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,7 @@ python-multipart>=0.0.9
 python-dotenv>=1.0
 google-genai>=1.0
 openai>=1.40
+# zoneinfo 의 타임존 DB. 슬림 컨테이너에는 시스템 tzdata 가 없을 수 있는데,
+# 기준 시각(app/core/clock.py)이 ZoneInfo("Asia/Seoul") 를 import 시점에 잡으므로
+# 없으면 앱이 아예 뜨지 않는다. 베이스 이미지와 무관하게 보장한다.
+tzdata>=2024.1

--- a/backend/tests/test_calendar_noti.py
+++ b/backend/tests/test_calendar_noti.py
@@ -4,11 +4,12 @@
 """
 from __future__ import annotations
 
-from datetime import date
+
+from app.core import clock
 
 
 def _today() -> str:
-    return date.today().isoformat()
+    return clock.today().isoformat()
 
 
 # ---- 캘린더 상세(일정 CRUD) ----

--- a/backend/tests/test_clock.py
+++ b/backend/tests/test_clock.py
@@ -1,0 +1,91 @@
+"""서비스 기준 시각이 서버 타임존과 무관하게 KST 인지 — DB 불필요 (#557).
+
+배포 이미지(`python:3.12-slim`)의 기본 타임존은 UTC 다. 서버 로컬 시간을 쓰면
+KST 00:00~09:00 사이에 서비스가 판단하는 '오늘'이 하루 전이 되어, 아침에 기록한
+식사가 전날 식단으로 들어가고 '오늘/어제' 라벨이 밀린다. 이 테스트는 프로세스
+타임존을 UTC 로 바꿔 놓고도 도메인 날짜가 KST 를 따르는지 고정한다.
+"""
+from __future__ import annotations
+
+import os
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.core import clock
+
+KST_OFFSET_SECONDS = 9 * 3600
+
+
+@pytest.fixture
+def utc_process_tz():
+    """프로세스 로컬 타임존을 UTC 로 바꾼다 — 배포 컨테이너와 같은 상태."""
+    if not hasattr(time, "tzset"):
+        pytest.skip("tzset 을 지원하지 않는 플랫폼")
+    original = os.environ.get("TZ")
+    os.environ["TZ"] = "UTC"
+    time.tzset()
+    try:
+        yield
+    finally:
+        if original is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = original
+        time.tzset()
+
+
+def _kst_today():
+    """테스트가 기대하는 KST 오늘 — clock 구현과 독립적으로 계산한다."""
+    return datetime.now(timezone.utc).astimezone(clock.SEOUL).date()
+
+
+def test_now_is_tz_aware_kst(utc_process_tz):
+    now = clock.now()
+    assert now.tzinfo is not None, "naive 시각은 서버 TZ 에 휘둘린다"
+    assert now.utcoffset().total_seconds() == KST_OFFSET_SECONDS
+
+
+def test_today_follows_kst_not_server_tz(utc_process_tz):
+    expected = _kst_today()
+    assert clock.today() == expected
+    assert clock.today_iso() == expected.isoformat()
+
+
+def test_kst_early_morning_is_not_previous_day():
+    """KST 새벽은 UTC 로는 전날 — 하루 밀리던 구간을 고정한다."""
+    # 2026-08-10 00:30 KST == 2026-08-09 15:30 UTC
+    instant = datetime(2026, 8, 9, 15, 30, tzinfo=timezone.utc)
+    assert instant.date().isoformat() == "2026-08-09"  # UTC 기준으로는 전날
+    assert clock.to_seoul(instant).date().isoformat() == "2026-08-10"
+
+
+def test_to_seoul_treats_naive_as_utc():
+    """created_at 은 UTC naive 로 저장되므로 UTC 로 간주해야 한다."""
+    naive = datetime(2026, 8, 9, 15, 30)
+    converted = clock.to_seoul(naive)
+    assert converted.date().isoformat() == "2026-08-10"
+    assert converted.strftime("%H:%M") == "00:30"
+
+
+def test_domain_today_helpers_use_kst(utc_process_tz):
+    """서비스 계층의 '오늘'이 전부 KST 를 따르는지 — 회귀 방지."""
+    from app.services import diet_service, exercise_service, trainer_service
+
+    expected = _kst_today()
+    assert diet_service.today_str() == expected.isoformat()
+    assert trainer_service.today_iso() == expected.isoformat()
+
+    monday = expected - timedelta(days=expected.weekday())
+    assert exercise_service.monday_of_this_week_str() == monday.isoformat()
+
+
+def test_trainer_labels_use_kst_dates():
+    """채팅 시각·이력 날짜 라벨이 UTC 가 아니라 KST 로 찍힌다."""
+    from app.services import trainer_service
+
+    # 2026-08-10 00:30 KST 에 저장된 메시지(UTC naive 로 보관된 형태)
+    created_at = datetime(2026, 8, 9, 15, 30)
+    assert trainer_service._hhmm(created_at) == "00:30"
+    assert trainer_service._local_date_iso(created_at) == "2026-08-10"

--- a/backend/tests/test_clock.py
+++ b/backend/tests/test_clock.py
@@ -81,6 +81,30 @@ def test_domain_today_helpers_use_kst(utc_process_tz):
     assert exercise_service.monday_of_this_week_str() == monday.isoformat()
 
 
+def test_domain_today_helpers_at_kst_early_morning(monkeypatch, utc_process_tz):
+    """KST 새벽 시각을 고정해 도메인 '오늘'을 검증한다.
+
+    실제 현재 시각에 기대면 KST 00:00~08:59 가 아닌 시간대에는 `date.today()`
+    같은 서버 로컬 날짜 회귀가 있어도 통과한다(UTC 와 KST 날짜가 같으므로).
+    문제 구간을 고정해야 회귀가 항상 잡힌다.
+    """
+    from app.services import diet_service, exercise_service, trainer_service
+
+    # 2026-03-02(월) 00:30 KST == 2026-03-01(일) 15:30 UTC.
+    # 일부러 **주가 갈리는** 시각을 골랐다 — UTC 로 밀리면 날짜뿐 아니라 주차까지
+    # 어긋나서, 어느 한쪽만 회귀해도 아래 단언이 잡는다.
+    frozen = datetime(2026, 3, 1, 15, 30, tzinfo=timezone.utc).astimezone(clock.SEOUL)
+    monkeypatch.setattr(clock, "now", lambda: frozen)
+
+    # 서버 로컬(UTC)로는 2026-03-01 이지만 서비스는 KST 날짜를 써야 한다.
+    assert clock.today().isoformat() == "2026-03-02"
+    assert clock.today_iso() == "2026-03-02"
+    assert diet_service.today_str() == "2026-03-02"
+    assert trainer_service.today_iso() == "2026-03-02"
+    # KST 로는 월요일 당일이 주 시작. UTC(일요일)로 읽으면 2026-02-23 이 된다.
+    assert exercise_service.monday_of_this_week_str() == "2026-03-02"
+
+
 def test_trainer_labels_use_kst_dates():
     """채팅 시각·이력 날짜 라벨이 UTC 가 아니라 KST 로 찍힌다."""
     from app.services import trainer_service

--- a/backend/tests/test_consultation_decision.py
+++ b/backend/tests/test_consultation_decision.py
@@ -9,13 +9,14 @@ DB 가 필요하므로 로컬에서는 skip 되고 CI(Postgres) 에서 실행된
 """
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import timedelta
 from uuid import uuid4
 
 import pytest
 
 from sqlalchemy.exc import IntegrityError
 
+from app.core import clock
 from app.core.security import hash_password
 from app.models.models import (
     ConsultationRequest,
@@ -159,7 +160,7 @@ def _request_consultation(
         "exercise_goal": "weight_loss",
         "health_purpose_type": "general",
         "health_purpose_detail": None,
-        "preferred_date": (date.today() + timedelta(days=1)).isoformat(),
+        "preferred_date": (clock.today() + timedelta(days=1)).isoformat(),
         "preferred_time_slot": "evening",
         "message": "상담 부탁드립니다.",
     }

--- a/backend/tests/test_consultations.py
+++ b/backend/tests/test_consultations.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from datetime import date, datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
 import pytest
 
+from app.core import clock
 from app.models.models import ConsultationRequest, Place, TrainerProfile, User
 from app.schemas.consultation_api import ConsultationOut
 
@@ -123,7 +124,7 @@ def _payload(
         "exercise_goal": "health",
         "health_purpose_type": "general",
         "health_purpose_detail": "  건강 습관 개선  ",
-        "preferred_date": (date.today() + timedelta(days=1)).isoformat(),
+        "preferred_date": (clock.today() + timedelta(days=1)).isoformat(),
         "preferred_time_slot": "afternoon",
         "message": "  상담을 받고 싶습니다.  ",
     }
@@ -133,7 +134,7 @@ def test_create_gym_consultation_sets_server_fields(client, db_session):
     member_id, token = _register_member(client)
     gym = _create_place(db_session)
     payload = _payload(gym_id=gym.id)
-    payload["preferred_date"] = date.today().isoformat()
+    payload["preferred_date"] = clock.today().isoformat()
 
     response = client.post(
         "/v1/consultations",
@@ -195,7 +196,7 @@ def test_consultation_out_validates_orm_instance():
         exercise_goal="health",
         health_purpose_type="general",
         health_purpose_detail=None,
-        preferred_date=date.today().isoformat(),
+        preferred_date=clock.today().isoformat(),
         preferred_time_slot="flexible",
         message=None,
         status="pending",
@@ -206,14 +207,14 @@ def test_consultation_out_validates_orm_instance():
     response = ConsultationOut.model_validate(consultation)
 
     assert response.id == consultation.id
-    assert response.preferred_date == date.today()
+    assert response.preferred_date == clock.today()
 
 
 def test_past_preferred_date_is_rejected(client, db_session):
     _, token = _register_member(client)
     gym = _create_place(db_session)
     payload = _payload(gym_id=gym.id)
-    payload["preferred_date"] = (date.today() - timedelta(days=1)).isoformat()
+    payload["preferred_date"] = (clock.today() - timedelta(days=1)).isoformat()
 
     response = client.post(
         "/v1/consultations", headers=_auth(token), json=payload
@@ -423,7 +424,7 @@ def test_partial_unique_index_allows_completed_but_rejects_second_pending(
         "trainer_id": trainer_id,
         "exercise_goal": "health",
         "health_purpose_type": "general",
-        "preferred_date": date.today().isoformat(),
+        "preferred_date": clock.today().isoformat(),
         "preferred_time_slot": "flexible",
     }
 

--- a/backend/tests/test_diet_recommendations.py
+++ b/backend/tests/test_diet_recommendations.py
@@ -13,11 +13,12 @@ from __future__ import annotations
 import threading
 import time
 import uuid
-from datetime import date, timedelta
+from datetime import timedelta
 
 import pytest
 from sqlalchemy import delete
 
+from app.core import clock
 from app.data.meal_catalog import CATALOG, DEFAULT_ORDER, RECOMMENDATION_COUNT
 from app.services import diet_recommendation_service as svc
 
@@ -52,7 +53,7 @@ def _make_high_sodium_member(db_session) -> tuple:
     db_session.add(user)
     db_session.commit()
 
-    today = date.today()
+    today = clock.today()
     for offset in range(svc.LOOKBACK_DAYS):
         day = (today - timedelta(days=offset)).isoformat()
         for meal, cal, sodium in (

--- a/backend/tests/test_member_seed.py
+++ b/backend/tests/test_member_seed.py
@@ -5,16 +5,18 @@ seed_member_health_data 를 먼저 돌린 상태를 검증한다.
 """
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import timedelta
 
 from sqlalchemy import func, select
+
+from app.core import clock
 
 
 _MEMBER_ID = "user-demo"
 
 
 def _this_monday_iso() -> str:
-    today = date.today()
+    today = clock.today()
     return (today - timedelta(days=today.weekday())).isoformat()
 
 
@@ -41,7 +43,7 @@ def test_exercise_seed_skips_future_weekdays(client, db_session):
     from app.db.seed_member_data import _WEEKDAY_INDEX
     from app.models.models import ExerciseSession
 
-    today_idx = date.today().weekday()
+    today_idx = clock.today().weekday()
     labels = db_session.scalars(
         select(ExerciseSession.day_label).where(
             ExerciseSession.user_id == _MEMBER_ID,

--- a/backend/tests/test_notification_hooks.py
+++ b/backend/tests/test_notification_hooks.py
@@ -11,13 +11,14 @@ DB 가 필요하므로 로컬에서는 skip 되고 CI(Postgres) 에서 실행된
 """
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import timedelta
 from uuid import uuid4
 
 import pytest
 
 from sqlalchemy import text
 
+from app.core import clock
 from app.core.security import hash_password
 from app.models.models import (
     ChatMessage,
@@ -191,7 +192,7 @@ def test_schedule_creates_a_notification(client, db_session):
         "/v1/trainer/schedule",
         headers=_auth(trainer_token),
         json={
-            "date": (date.today() + timedelta(days=1)).isoformat(),
+            "date": (clock.today() + timedelta(days=1)).isoformat(),
             "time": "10:00",
             "client_name": "알림 회원",
             "member_id": member_id,
@@ -251,7 +252,7 @@ def test_a_schedule_without_a_member_notifies_nobody(client, db_session):
         "/v1/trainer/schedule",
         headers=_auth(trainer_token),
         json={
-            "date": (date.today() + timedelta(days=1)).isoformat(),
+            "date": (clock.today() + timedelta(days=1)).isoformat(),
             "time": "14:00",
             "client_name": "신규 고객",
             "member_id": None,

--- a/backend/tests/test_signup_consultation_seam.py
+++ b/backend/tests/test_signup_consultation_seam.py
@@ -16,11 +16,12 @@ DB 가 필요하므로 로컬에서는 skip 되고 CI(Postgres) 에서 실행된
 """
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import timedelta
 from uuid import uuid4
 
 import pytest
 
+from app.core import clock
 from app.models.models import (
     ConsultationRequest,
     MemberGym,
@@ -152,7 +153,7 @@ def _request_consultation(client, token: str, gym_id: str) -> str:
             "exercise_goal": "strength",
             "health_purpose_type": "general",
             "health_purpose_detail": None,
-            "preferred_date": (date.today() + timedelta(days=1)).isoformat(),
+            "preferred_date": (clock.today() + timedelta(days=1)).isoformat(),
             "preferred_time_slot": "morning",
             "message": "상담 부탁드립니다.",
         },

--- a/backend/tests/test_trainer.py
+++ b/backend/tests/test_trainer.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from uuid import uuid4
 
+from app.core import clock
+
 
 def test_user_role_defaults_to_member():
     from app.models.models import User
@@ -244,7 +246,7 @@ def test_history_excludes_other_trainers_records(client, db_session):
     db_session.flush()  # RoutineHistory.trainer_id FK 성립을 위해 User 를 먼저 반영
     db_session.add(RoutineHistory(
         id="hist-other-secret", member_id="user-jisu", trainer_id="trainer-other",
-        date=date.today().isoformat(), kind_label="PT 세션 · 타트레이너",
+        date=clock.today().isoformat(), kind_label="PT 세션 · 타트레이너",
         completion_rate=100, exercises_json="[]",
         client_feedback="", trainer_note="비밀 메모",
     ))

--- a/backend/tests/test_trainer_schedule.py
+++ b/backend/tests/test_trainer_schedule.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 
 import time
 from concurrent.futures import ThreadPoolExecutor
-from datetime import date, timedelta
+from datetime import timedelta
 from threading import Barrier
 
 import pytest
 from sqlalchemy import select
 
+from app.core import clock
 from app.models.models import TrainerClient, TrainerSchedule
 
 
@@ -24,8 +25,8 @@ def _h(token: str) -> dict:
 
 
 def _today() -> str:
-    from datetime import date
-    return date.today().isoformat()
+    """서버가 쓰는 '오늘'과 같은 기준(KST). 러너 로컬 타임존이 UTC 여도 어긋나지 않는다."""
+    return clock.today().isoformat()
 
 
 def test_schedule_seeded_timeline(client):
@@ -68,7 +69,7 @@ def _delete_program_test_sessions(db_session, day: str) -> None:
 
 def test_schedule_program_command_reuses_the_created_session(client, db_session):
     token = _tok(client)
-    day = (date.today() + timedelta(days=61)).isoformat()
+    day = (clock.today() + timedelta(days=61)).isoformat()
     url = "/v1/trainer/clients/user-jisu/schedule-program"
     _delete_program_test_sessions(db_session, day)
 
@@ -109,7 +110,7 @@ def test_concurrent_schedule_program_commands_create_one_session(
     client, db_session
 ):
     token = _tok(client)
-    day = (date.today() + timedelta(days=62)).isoformat()
+    day = (clock.today() + timedelta(days=62)).isoformat()
     url = "/v1/trainer/clients/user-jisu/schedule-program"
     _delete_program_test_sessions(db_session, day)
 
@@ -337,10 +338,10 @@ def test_complete_session_logs_history_and_is_idempotent(client):
 
 
 def test_complete_future_session_rejected(client):
-    from datetime import date, timedelta
+    from datetime import timedelta
 
     token = _tok(client)
-    future = (date.today() + timedelta(days=3)).isoformat()
+    future = (clock.today() + timedelta(days=3)).isoformat()
     c = client.post(
         "/v1/trainer/schedule",
         json={"date": future, "time": "10:00", "member_id": "user-jisu", "type": "1:1 PT"},
@@ -691,7 +692,7 @@ def test_past_session_lands_in_its_own_week(client, db_session, make_pt_session)
     from app.models import models
 
     token = _tok(client)
-    past = date.today() - timedelta(days=9)
+    past = clock.today() - timedelta(days=9)
     sid = make_pt_session(token, date=past.isoformat(), time="20:20")
     client.post(f"/v1/trainer/schedule/{sid}/complete", json={}, headers=_h(token))
 


### PR DESCRIPTION
## Summary

- 백엔드 도메인 날짜가 서버 로컬 타임존을 따라가던 것을 KST 기준으로 고정합니다.
- 배포 이미지(`python:3.12-slim`)는 기본 타임존이 UTC 라, 지금 배포하면 KST 00:00~09:00 구간에서 "오늘"이 하루 전으로 계산됩니다.
- 기준 시각을 `app/core/clock.py` 한 곳에 모으고, 서버 로컬 시각을 읽던 호출을 전부 옮겼습니다.

## Problem

도메인 로직이 `datetime.now()`, `date.today()`, 인자 없는 `astimezone()` 으로 **서버 로컬 시간**을 읽고 있었습니다. `app/services/trainer_service.py` 의 `_local_date_iso()` 주석은 이 전제("KST 서버면 KST")를 명시적으로 적어 두었지만, 그 전제를 보장하는 설정이 어디에도 없었습니다. `.env.railway.example` 에만 `TZ=Asia/Seoul` 이 있고 `Dockerfile`·`.env.example`·배포 워크플로에는 없습니다.

KST 새벽 구간에서 나타나는 증상입니다.

- **식단** — 아침에 기록한 식사가 전날 식단으로 저장·조회됨
- **트레이너 화면** — "오늘 / 어제" 상대 날짜 라벨이 하루씩 밀림
- **세션 완료** — 미래 세션 방어 로직이 오늘 잡힌 세션을 미래로 판정해 완료 처리를 거부

개발·CI 환경이 전부 KST 로컬이라 지금까지 드러나지 않았습니다.

## Approach

컨테이너에 `TZ` 를 걸어 맞추는 방법도 있지만, 그러면 **정확성이 배포 설정에 의존**합니다. 설정을 빠뜨린 환경(로컬 도커 실행, 다른 호스팅)에서 조용히 어긋나므로 코드에서 기준 시각을 고정하는 쪽을 택했습니다.

`Dockerfile` 의 `TZ` 는 로그 타임스탬프를 KST 로 맞추는 용도로만 두고, 날짜 계산은 여기에 기대지 않습니다.

## Changes

### Features

- `app/core/clock.py` 신설 — 서비스 기준 시각을 KST 로 고정하는 단일 출처
  - `now()` / `today()` / `today_iso()` — KST 기준 현재 시각·오늘
  - `to_seoul()` — UTC 로 저장된 `created_at` 을 표시용 KST 로 변환 (naive 는 UTC 로 간주)

### Improvements

- 서버 로컬 시각을 읽던 호출을 전부 `clock` 으로 이관 — API 계층(dashboard·diet·exercise·schedule)과 서비스 계층(diet·exercise·coach·trainer·consultation·diet_recommendation·trainer_routine_options), 데모 시드
- `reservation_service` 가 따로 갖고 있던 `SEOUL` 상수를 `clock` 으로 합침
- `trainer_service` 의 `_local_date_iso()` / `_hhmm()` 이 서버 TZ 대신 KST 로 명시 변환
- 테스트가 `date.today()` 로 러너 로컬 날짜를 쓰던 곳을 서버와 같은 출처(`clock.today()`)로 통일 (아래 Follow-up 참고)
- `Dockerfile` 에 `TZ=Asia/Seoul` — 로그 타임스탬프용
- `requirements.txt` 에 `tzdata` — 슬림 이미지에 시스템 tzdata 가 없으면 `ZoneInfo("Asia/Seoul")` 이 import 시점에 실패해 앱이 아예 뜨지 않습니다. 베이스 이미지와 무관하게 보장합니다.
- `.env.example` 에 `TZ` 항목과 그 역할을 문서화

### UI Changes

- 없음 (백엔드 전용)

### Documentation

- 없음 (`.env.example` 주석 제외)

### Fixes

- KST 00:00~09:00 구간에 도메인 날짜가 하루 밀리던 문제

## Commits

1. `82c197b` — `fix(backend): 도메인 날짜를 서버 타임존과 무관하게 KST 로 고정`
2. `d09cfdc` — `fix(backend): 테스트의 '오늘'도 서버와 같은 KST 기준으로 맞춤`

## Notes

- API 응답 계약은 바뀌지 않습니다. 같은 시각에 대해 서버 TZ 가 KST 인 환경(현재 개발·CI)에서는 결과가 이전과 동일합니다.
- `datetime.now(timezone.utc)` 처럼 이미 tz-aware 로 명시된 호출(`relative_time_label`, `_iso`)은 그대로 두었습니다 — 서버 TZ 에 의존하지 않던 코드입니다.
- AWS 배포 파이프라인 설정은 #480 담당 범위와 겹치므로 건드리지 않았습니다. 이미지·앱 레벨에서 타임존이 확정되므로 배포 쪽에서 별도 설정 없이도 동작합니다.
- `tests/test_trainer_schedule.py::test_complete_session_logs_history_and_is_idempotent` 는 이 브랜치와 무관하게 로컬 공유 DB 누적 때문에 실패합니다 — #558 로 분리했습니다. CI 는 매번 새 Postgres 라 영향받지 않습니다.

## Follow-up found while testing

서버를 KST 로 고정하고 나니, 테스트가 `date.today()` 로 **러너 로컬 날짜**를 쓰는 곳들이 서버와 어긋나는 문제가 드러났습니다. CI 러너는 UTC 라, UTC 15:00~24:00(KST 00:00~09:00) 구간에 CI 가 돌면 테스트가 만든 날짜와 서버가 판단하는 오늘이 하루 달라집니다.

로컬 타임존을 UTC-10 으로 놓아 그 구간을 재현하니 두 건이 실제로 깨졌습니다.

- `test_create_gym_consultation_sets_server_fields` — 오늘로 보낸 상담 희망일이 서버 기준으로는 어제라 422
- `test_complete_session_adds_member_exercise_log` — 세션 날짜와 서버의 이번 주 월요일이 다른 주로 갈려 주간 집계에 안 잡힘

날짜를 서버와 같은 출처에서 가져오게 바꿔 러너 타임존과 무관하게 만들었습니다. 이대로 머지했다면 매일 UTC 15:00 이후에 CI 가 깨지는 시한폭탄이 됐을 겁니다 — #551 / #552 와 같은 계열입니다.

## Test Plan

- [x] `tests/test_clock.py` 신규 — 프로세스 타임존을 UTC 로 바꿔 놓고 검증
  - `clock.now()` 가 tz-aware 이고 UTC+9
  - `clock.today()` / `today_iso()` 가 서버 TZ 가 아니라 KST 를 따름
  - KST 새벽(UTC 로는 전날)이 전날로 밀리지 않음
  - naive `created_at` 을 UTC 로 간주해 KST 로 변환
  - 서비스 계층의 오늘(`diet_service`·`trainer_service`·`exercise_service`)이 전부 KST
  - 채팅 시각·이력 날짜 라벨이 KST
- [x] 백엔드 전체 테스트 통과 (#558 의 기존 실패 1건 제외 — 이 브랜치 이전부터 동일)
- [x] `TZ=UTC` 로도 전체 테스트 동일하게 통과
- [x] 러너 타임존을 바꿔 가며 전체 테스트 통과 확인 — UTC-10(`Pacific/Honolulu`), UTC+0, UTC+9. UTC-10 은 지금 시각 기준 로컬 날짜가 KST 와 다른 날이라, CI 가 UTC 15:00 이후에 도는 상황과 같은 조건입니다.
- [x] `TZ=UTC` 환경에서 앱 import 및 도메인 날짜 확인 — 프로세스 로컬은 06:02(UTC)인데 도메인 날짜·시각은 15:02 KST 로 정상

### Manual Test Steps

1. `cd backend && TZ=UTC pytest tests/test_clock.py` — 통과 확인
2. `TZ=UTC python -c "from app.core import clock; print(clock.now(), clock.today_iso())"` — KST 시각·날짜가 나오는지 확인
3. `TZ=Asia/Seoul` 로도 같은 결과인지 확인 (설정에 의존하지 않음)

## Related Issues

Closes #557

## Checklist

- [x] 변경 범위가 기준 시각 고정으로 제한되어 있습니다.
- [x] API 응답 계약과 DB 스키마는 바뀌지 않았습니다.
- [x] 서버 TZ 설정 없이도 동작합니다.
- [x] 회귀를 고정하는 테스트가 있습니다.
- [x] 배포 파이프라인(#480) 범위는 건드리지 않았습니다.
