### PR TITLE
test(backend): 트레이너 세션 완료 테스트의 공유 DB 누적 의존 제거

### DIFF
--- a/backend/tests/test_trainer_schedule.py
+++ b/backend/tests/test_trainer_schedule.py
@@ -233,25 +233,17 @@ def test_schedule_update_member_id_empty_unassigns(client, db_session):
     "field",
     ["time", "client_name", "type", "duration_minutes", "note", "program"],
 )
-def test_schedule_update_rejects_null_for_non_nullable_fields(client, field):
+def test_schedule_update_rejects_null_for_non_nullable_fields(
+    client, field, make_pt_session
+):
     """명시적 null이 NOT NULL 컬럼까지 도달해 500을 만들지 않고 API 경계에서 422가 된다."""
     token = _tok(client)
-    c = client.post(
-        "/v1/trainer/schedule",
-        json={
-            "date": _today(),
-            "time": "16:50",
-            "client_name": "이지수",
-            "member_id": "user-jisu",
-            "type": "1:1 PT",
-            "duration_minutes": 40,
-        },
-        headers=_h(token),
-    )
-    assert c.status_code == 201, c.text
+    # 파라미터마다 세션이 하나씩 생긴다 — 지우지 않으면 실행 한 번에 여섯 건이
+    # 그대로 남아 이 파일에서 가장 크게 누적된다(#558).
+    sid = make_pt_session(token, time="16:50", duration_minutes=40)
 
     r = client.put(
-        f"/v1/trainer/schedule/{c.json()['id']}",
+        f"/v1/trainer/schedule/{sid}",
         json={field: None},
         headers=_h(token),
     )
@@ -294,27 +286,32 @@ def test_schedule_create_with_unlinked_member_404(client):
     assert r.status_code == 404
 
 
-def test_complete_session_logs_history_and_is_idempotent(client):
+def test_complete_session_logs_history_and_is_idempotent(
+    client, db_session, make_pt_session
+):
+    """완료 처리가 운동기록을 남기고, 재호출해도 중복되지 않는다.
+
+    목록 **개수**로 세지 않는다 — 이력 조회는 최신 60건 상한이라, 회원 이력이
+    상한에 닿으면 기록이 늘어도 개수가 그대로여서 단언이 엉뚱하게 깨진다(#558).
+    파생 기록의 id 는 `sched-hist-{sid}` 로 결정론적이니 그 행을 직접 본다.
+    """
+    from app.models import models
+
     token = _tok(client)
-    # 오늘 예정 세션 생성(user-jisu 매칭)
-    c = client.post(
-        "/v1/trainer/schedule",
-        json={
-            "date": _today(), "time": "18:30", "client_name": "이지수",
-            "member_id": "user-jisu", "type": "1:1 PT", "duration_minutes": 40,
-            "program": [
-                {"name": "레그프레스", "sets": 3, "reps": "12회", "weight": "80kg"},
-                {"name": "카프레이즈", "sets": 1, "reps": "20회", "weight": "-"},
-            ],
-        },
-        headers=_h(token),
+    # 오늘 예정 세션 생성(user-jisu 매칭). 픽스처가 테스트 끝에 지워 이력이 쌓이지 않는다.
+    sid = make_pt_session(
+        token,
+        time="18:30",
+        duration_minutes=40,
+        program=[
+            {"name": "레그프레스", "sets": 3, "reps": "12회", "weight": "80kg"},
+            {"name": "카프레이즈", "sets": 1, "reps": "20회", "weight": "-"},
+        ],
     )
-    sid = c.json()["id"]
+    hist_id = f"sched-hist-{sid}"
+    assert db_session.get(models.RoutineHistory, hist_id) is None
 
-    before = client.get("/v1/trainer/clients/user-jisu/history", headers=_h(token)).json()
-    n_before = len(before)
-
-    # 완료 처리 → 완료 상태 + 운동기록 1건 추가
+    # 완료 처리 → 완료 상태 + 이 세션의 운동기록 생성
     done = client.post(
         f"/v1/trainer/schedule/{sid}/complete",
         json={"note": "잘 마쳤어요"}, headers=_h(token),
@@ -322,32 +319,31 @@ def test_complete_session_logs_history_and_is_idempotent(client):
     assert done.status_code == 200, done.text
     assert done.json()["status"] == "완료"
 
+    db_session.expire_all()
+    logged = db_session.get(models.RoutineHistory, hist_id)
+    assert logged is not None, "완료 처리가 회원 운동기록을 남기지 않았다"
+    assert logged.trainer_note == "잘 마쳤어요"
+
     after = client.get("/v1/trainer/clients/user-jisu/history", headers=_h(token)).json()
-    assert len(after) == n_before + 1
     assert after[0]["label"] == "PT 세션 · 트레이너 지도"
     assert after[0]["trainer_note"] == "잘 마쳤어요"
     assert "레그프레스 3세트" in after[0]["exercises"]
 
-    # 재호출(멱등) → 상태 유지, 기록 중복 없음
+    # 재호출(멱등) → 상태 유지, 기록도 그 한 건 그대로(노트가 덮이지 않는다)
     again = client.post(
         f"/v1/trainer/schedule/{sid}/complete", json={"note": "x"}, headers=_h(token)
     )
     assert again.status_code == 200
-    after2 = client.get("/v1/trainer/clients/user-jisu/history", headers=_h(token)).json()
-    assert len(after2) == n_before + 1  # 중복 기록 없음
+    db_session.expire_all()
+    assert db_session.get(models.RoutineHistory, hist_id).trainer_note == "잘 마쳤어요"
 
 
-def test_complete_future_session_rejected(client):
+def test_complete_future_session_rejected(client, make_pt_session):
     from datetime import timedelta
 
     token = _tok(client)
     future = (clock.today() + timedelta(days=3)).isoformat()
-    c = client.post(
-        "/v1/trainer/schedule",
-        json={"date": future, "time": "10:00", "member_id": "user-jisu", "type": "1:1 PT"},
-        headers=_h(token),
-    )
-    sid = c.json()["id"]
+    sid = make_pt_session(token, date=future, time="10:00")
     r = client.post(f"/v1/trainer/schedule/{sid}/complete", json={}, headers=_h(token))
     assert r.status_code == 400  # 미래 일정 완료 불가
 
@@ -380,19 +376,16 @@ def test_booked_dates(client):
     assert _today() in dates  # 오늘 시드에 예약(공백 아님)이 있음
 
 
-def test_completed_session_cannot_be_edited(client):
+def test_completed_session_cannot_be_edited(client, make_pt_session):
     """완료된 세션 수정은 409 — 스케줄과 운동기록이 어긋나지 않게 한다(리뷰 재-#2)."""
     token = _tok(client)
-    c = client.post(
-        "/v1/trainer/schedule",
-        json={
-            "date": _today(), "time": "08:30", "client_name": "이지수",
-            "member_id": "user-jisu", "type": "1:1 PT",
-            "program": [{"name": "스쿼트", "sets": 3, "reps": "10회", "weight": "40kg"}],
-        },
-        headers=_h(token),
+    # 픽스처로 만들어 테스트 끝에 지운다 — 완료가 남기는 이력이 쌓이면 60건 상한에
+    # 닿아 다른 테스트가 깨진다(#558).
+    sid = make_pt_session(
+        token,
+        time="08:30",
+        program=[{"name": "스쿼트", "sets": 3, "reps": "10회", "weight": "40kg"}],
     )
-    sid = c.json()["id"]
     client.post(f"/v1/trainer/schedule/{sid}/complete", json={"note": "완료"}, headers=_h(token))
 
     # 완료 후 다른 회원으로 재배정 시도 → 409(데이터 분리 방지)
@@ -420,11 +413,14 @@ def test_schedule_invalid_date_time_422(client):
     # 잘못된/빈 시간
     assert client.post(url, json={**base, "time": "25:99"}, headers=_h(token)).status_code == 422
     assert client.post(url, json={**base, "time": ""}, headers=_h(token)).status_code == 422
-    # update 도 잘못된 시간 422
+    # update 도 잘못된 시간 422. 여기만 실제로 한 건이 만들어지므로 끝에 지운다(#558).
     sid = client.post(url, json=base, headers=_h(token)).json()["id"]
-    assert client.put(
-        f"{url}/{sid}", json={"time": "99:99"}, headers=_h(token)
-    ).status_code == 422
+    try:
+        assert client.put(
+            f"{url}/{sid}", json={"time": "99:99"}, headers=_h(token)
+        ).status_code == 422
+    finally:
+        client.delete(f"{url}/{sid}", headers=_h(token))
 
 
 # ---- 기간·고객 조회 (#378) ----
@@ -557,16 +553,22 @@ def test_schedule_member_only_returns_every_session_no_date_bound(client):
     assert created.status_code == 201, created.text
     old_id = created.json()["id"]
 
-    r = client.get(
-        "/v1/trainer/schedule",
-        params={"member_id": member_id},
-        headers=_sched_auth(token),
-    )
-    assert r.status_code == 200, r.text
-    ids = [s["id"] for s in r.json()]
-    assert old_id in ids
-    # 여전히 그 고객 것만.
-    assert all(s["status"] != "공백" for s in r.json())
+    # 지우지 않으면 이 고객의 세션이 실행마다 쌓인다. 회원별 조회는 최신 100건
+    # 상한이라, 상한에 닿는 순간 가장 오래된 이 2020 세션이 먼저 밀려나 여기서
+    # 깨진다 — 정확히 이 테스트가 증명하려는 것이 사라지는 셈이다(#558).
+    try:
+        r = client.get(
+            "/v1/trainer/schedule",
+            params={"member_id": member_id},
+            headers=_sched_auth(token),
+        )
+        assert r.status_code == 200, r.text
+        ids = [s["id"] for s in r.json()]
+        assert old_id in ids
+        # 여전히 그 고객 것만.
+        assert all(s["status"] != "공백" for s in r.json())
+    finally:
+        client.delete(f"/v1/trainer/schedule/{old_id}", headers=_sched_auth(token))
 
 
 def test_schedule_member_filter_rejects_someone_elses_client(client):


### PR DESCRIPTION
## Summary

- 트레이너 스케줄 테스트가 공유 DB 에 데이터를 남겨, 일정 횟수 이상 실행하면 영구히 깨지던 문제를 없앱니다.
- 목록 **개수**로 세던 단언을 기록 자체를 보는 방식으로 바꿔, 이력이 상한에 닿아도 흔들리지 않게 했습니다.
- 이 파일의 세션 생성이 실행 후 아무것도 남기지 않도록 정리했습니다.

## Problem

`tests/test_trainer_schedule.py::test_complete_session_logs_history_and_is_idempotent` 가 로컬에서 실패합니다.

```
assert 60 == (60 + 1)
```

두 가지가 겹친 결과입니다.

1. 고객 운동 이력 조회는 오래된 이력 무제한 로드를 막으려고 **최신 60건**으로 자릅니다. 의도된 동작입니다.
2. 이 테스트는 완료 처리 뒤 `len(after) == n_before + 1` 로 **목록 개수 증가**를 단언하는데, 자기가 만든 `RoutineHistory` 를 정리하지 않습니다.

`conftest.py` 의 `client` 픽스처는 공유 Postgres 에 붙어 시드된 상태를 그대로 씁니다. 실행할 때마다 `sched-hist-*` 행이 쌓이고, 누적이 상한에 도달하면 완료 처리를 해도 응답 개수가 더 늘지 않아 단언이 깨집니다.

CI 는 매 실행마다 새 Postgres 서비스를 띄우므로 누적이 없어 계속 green 이지만, **로컬에서 백엔드 테스트를 일정 횟수 이상 돌린 개발자는 그 시점부터 영구히 실패를 봅니다.** 코드가 아니라 테스트가 환경에 의존하는 문제입니다.

## Approach

이 파일에는 이미 정확히 이 문제를 막으려고 만든 `make_pt_session` 픽스처가 있고, 독스트링에 이렇게 적혀 있습니다 — *"정리하지 않으면 회원 이력이 테스트마다 쌓여, 최신 60건만 내려주는 `build_client_history` 의 상한에 닿는 순간 다른 테스트가 깨진다"*. 문제가 된 테스트들이 그 픽스처를 쓰지 않고 세션을 직접 만들고 있었습니다. 새 장치를 들이는 대신 기존 해법으로 모았습니다.

단언 방식도 함께 고쳤습니다. 완료 처리가 만드는 기록은 PK 가 `sched-hist-{sid}` 로 결정론적이고, 재호출은 조기 반환(멱등)합니다. 그래서 **개수 대신 그 행을 직접** 봅니다 — 상한과 무관해지고, 재호출이 노트를 덮지 않는지까지 확인하므로 원래 단언보다 멱등성을 정확히 검증합니다.

## Changes

### Fixes

- `test_complete_session_logs_history_and_is_idempotent` — 개수 단언을 `sched-hist-{sid}` 행 검증으로 교체하고 픽스처로 정리
- `test_completed_session_cannot_be_edited` — 완료가 남기는 이력이 쌓이지 않도록 픽스처 사용
- `test_schedule_update_rejects_null_for_non_nullable_fields` — 파라미터 6개라 실행마다 여섯 건이 남던 곳(이 파일 최대 누적원)
- `test_complete_future_session_rejected` — 픽스처 사용
- `test_schedule_invalid_date_time_422` — 유효 세션 한 건만 실제로 만들어지므로 그 건을 정리
- `test_schedule_member_only_returns_every_session_no_date_bound` — 회원별 조회 최신 100건 상한에 닿으면 이 테스트가 증명하려는 2020 세션이 먼저 밀려나므로 정리

### Features

- 없음

### Improvements

- 없음 (테스트 전용)

### UI Changes

- 없음

### Documentation

- 없음

## Commits

1. `05e79b6` — `test(backend): 트레이너 스케줄 테스트의 공유 DB 누적 제거`

## Notes

- **이 PR 은 #562 위에 쌓였습니다.** 두 PR 이 같은 파일(`tests/test_trainer_schedule.py`)을 고쳐서, 따로 두면 충돌합니다. **#562 를 먼저 병합한 뒤 이 PR 을 병합**해 주세요. base 는 #562 병합 시 자동으로 main 으로 바뀝니다.
- 프로덕션 코드는 건드리지 않았습니다. 60건·100건 상한은 의도된 동작이라 그대로 둡니다.
- 개수 단언을 없앴다고 검증이 약해지지 않습니다 — 오히려 "그 세션이 만든 기록"을 특정해서 보므로, 다른 테스트가 남긴 기록에 속지 않습니다.

## Test Plan

- [x] `tests/test_trainer_schedule.py` 34건 전부 통과 — **이미 오염된 로컬 DB**(`sched-hist` 131건 누적)에서도 통과
- [x] 백엔드 전체 594건 통과 (기존 실패 0)
- [x] 누적이 0 인지 실측 — 같은 DB 로 파일을 3회 연속 실행하며 행 수 측정

  | | `sched-hist` | `trainer_schedule` |
  |---|---|---|
  | 수정 전 | 실행마다 증가 | 실행마다 **+8** |
  | 수정 후 | 131 고정 | 709 고정 |

- [x] 전체 스위트를 같은 DB 로 반복 실행해도 통과·행 수 불변

### Manual Test Steps

1. `cd backend && pytest tests/test_trainer_schedule.py` 를 연속 3회 실행 — 매번 통과
2. 사이사이 `select count(*) from routine_history where id like 'sched-hist-%'` 로 행 수가 늘지 않는지 확인

## Related Issues

Closes #558

## Checklist

- [x] 변경 범위가 테스트 파일 하나로 제한되어 있습니다.
- [x] 프로덕션 코드·API 계약은 바뀌지 않았습니다.
- [x] 세션 완료가 기록을 남긴다는 원래 검증 의도가 유지됩니다.
- [x] 멱등성(재호출 시 기록 중복·덮어쓰기 없음) 검증이 유지·강화되었습니다.
- [x] 같은 DB 에 반복 실행해도 통과합니다.
