### PR TITLE
docs(dev): 회원 앱과 트레이너 웹을 하나의 로컬 백엔드로 띄우는 절차 문서화

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -44,13 +44,13 @@ alembic downgrade -1          # 한 단계 롤백
 검증: `python -m scripts.check_gemini` · `/v1/ai-coach/chat` 응답의 `sources` 가 채워지면 RAG 가 실제로 동작(규칙 폴백 아님).
 
 ## 프론트 연동 (실서버 전환)
-회원 앱·트레이너 앱 **양쪽 모두** 같은 방식으로 전환합니다.
+회원 앱(모바일)·트레이너 웹 **양쪽 모두** 같은 방식으로 전환합니다.
 ```bash
 flutter run --dart-define=USE_MOCK_API=false --dart-define=API_BASE_URL=http://localhost:8000/v1
 ```
 (LocalApiInterceptor 가 꺼지고 실제 /v1 서버로 요청)
 
-두 앱을 함께 띄워 회원↔트레이너 상호작용을 확인하는 절차·데모 계정·기동 실패 대처는
+둘을 함께 띄워 회원↔트레이너 상호작용을 확인하는 절차·데모 계정·기동 실패 대처는
 **[docs/local_fullstack.md](../docs/local_fullstack.md)** 에 정리했습니다.
 
 ## 준비물

--- a/backend/README.md
+++ b/backend/README.md
@@ -44,11 +44,14 @@ alembic downgrade -1          # 한 단계 롤백
 검증: `python -m scripts.check_gemini` · `/v1/ai-coach/chat` 응답의 `sources` 가 채워지면 RAG 가 실제로 동작(규칙 폴백 아님).
 
 ## 프론트 연동 (실서버 전환)
-프론트에서:
+회원 앱·트레이너 앱 **양쪽 모두** 같은 방식으로 전환합니다.
 ```bash
 flutter run --dart-define=USE_MOCK_API=false --dart-define=API_BASE_URL=http://localhost:8000/v1
 ```
 (LocalApiInterceptor 가 꺼지고 실제 /v1 서버로 요청)
+
+두 앱을 함께 띄워 회원↔트레이너 상호작용을 확인하는 절차·데모 계정·기동 실패 대처는
+**[docs/local_fullstack.md](../docs/local_fullstack.md)** 에 정리했습니다.
 
 ## 준비물
 - Docker Desktop (무료, 가입 없음)

--- a/docs/local_fullstack.md
+++ b/docs/local_fullstack.md
@@ -1,10 +1,10 @@
-# 로컬 풀스택 실행 (백엔드 + 회원 앱 + 트레이너 앱)
+# 로컬 풀스택 실행 (백엔드 + 회원 앱 + 트레이너 웹)
 
-두 앱을 **같은 백엔드·같은 DB** 로 띄우는 절차입니다. 회원↔트레이너 상호작용
+회원 앱(모바일)과 트레이너 웹을 **같은 백엔드·같은 DB** 로 띄우는 절차입니다. 회원↔트레이너 상호작용
 (회원이 올린 식단을 트레이너가 보는 것 등)은 이 구성에서만 확인할 수 있습니다.
 
-> 두 앱의 `useMockApi` 기본값은 `true` 입니다. dart-define 없이 실행하면 각 앱이
-> **자기 로컬 drift DB** 를 보기 때문에, 두 앱이 각각 잘 도는 것처럼 보여도 서로의
+> 둘 다 `useMockApi` 기본값이 `true` 입니다. dart-define 없이 실행하면 각각
+> **자기 로컬 drift DB** 를 보기 때문에, 둘 다 잘 도는 것처럼 보여도 서로의
 > 데이터는 절대 보이지 않습니다. 상호작용을 확인하려면 아래 3단계를 모두 거쳐야 합니다.
 
 ## 1. 백엔드
@@ -44,7 +44,10 @@ docker compose ps             # app, db 모두 Up
 docker compose logs app       # alembic upgrade 성공 후 uvicorn 기동
 ```
 
-## 2. 회원 앱
+## 2. 회원 앱 (모바일)
+
+로컬 검증은 Chrome 으로 띄우는 편이 빠릅니다. 실제 배포 타깃은 iOS/Android 입니다.
+
 
 ```bash
 cd frontend/flutter
@@ -53,7 +56,7 @@ flutter run -d chrome \
   --dart-define=API_BASE_URL=http://localhost:8000/v1
 ```
 
-## 3. 트레이너 앱
+## 3. 트레이너 웹
 
 ```bash
 cd frontend/flutter_trainer
@@ -81,8 +84,8 @@ flutter run -d chrome \
 
 ## 상호작용이 실제로 연결됐는지 확인
 
-앱 없이 API 로만 30초 안에 확인할 수 있습니다. 회원이 올린 식단이 트레이너 쪽에
-나타나면 두 앱이 같은 DB 를 보고 있다는 뜻입니다.
+클라이언트 없이 API 로만 30초 안에 확인할 수 있습니다. 회원이 올린 식단이 트레이너 쪽에
+나타나면 둘이 같은 DB 를 보고 있다는 뜻입니다.
 
 ```bash
 M=$(curl -s -X POST http://localhost:8000/v1/auth/login \
@@ -111,5 +114,9 @@ curl -s -H "Authorization: Bearer $T" \
   Windows `curl.exe` 가 MSYS 경로를 못 읽습니다. `$(cygpath -w /tmp/x.jpg)` 로 변환하세요.
 - **셸에서 한글이 든 JSON 을 `-d` 로 보내면** 콘솔 인코딩(cp949) 때문에 깨져
   `400 There was an error parsing the body` 가 납니다. 파일(`-d @body.json`)로 보내거나
-  ASCII 로 확인하세요. 앱에서 보내는 요청은 정상입니다.
+  ASCII 로 확인하세요. 회원 앱·트레이너 웹이 보내는 요청은 정상입니다.
 - CORS 는 `.env` 기본값이 `CORS_ALLOW_ORIGINS=*` 라 로컬 웹에서 그대로 붙습니다.
+- **백엔드 테스트 스위트가 이 DB 를 그대로 씁니다**(`DATABASE_URL` 이 같은
+  `localhost:5432`). 손으로 API 를 찔러 데이터를 남기면 시드 개수를 단언하는 테스트가
+  깨집니다(예: `test_trainer_client_diet_maps_member_meals` 는 `len(meals) == 3`).
+  `pytest` 를 돌리기 전에 `docker compose down -v && docker compose up -d` 로 초기화하세요.

--- a/docs/local_fullstack.md
+++ b/docs/local_fullstack.md
@@ -1,0 +1,115 @@
+# 로컬 풀스택 실행 (백엔드 + 회원 앱 + 트레이너 앱)
+
+두 앱을 **같은 백엔드·같은 DB** 로 띄우는 절차입니다. 회원↔트레이너 상호작용
+(회원이 올린 식단을 트레이너가 보는 것 등)은 이 구성에서만 확인할 수 있습니다.
+
+> 두 앱의 `useMockApi` 기본값은 `true` 입니다. dart-define 없이 실행하면 각 앱이
+> **자기 로컬 drift DB** 를 보기 때문에, 두 앱이 각각 잘 도는 것처럼 보여도 서로의
+> 데이터는 절대 보이지 않습니다. 상호작용을 확인하려면 아래 3단계를 모두 거쳐야 합니다.
+
+## 1. 백엔드
+
+```bash
+cd backend
+cp .env.example .env          # JWT_SECRET 은 openssl rand -hex 32 로 교체 권장
+docker compose up -d --build
+```
+
+→ http://localhost:8000/docs (모든 경로는 `/v1/...`)
+
+AI 키는 없어도 됩니다. `GEMINI_API_KEY` 가 비어 있으면 식단 인식이 오프라인 스텁으로
+폴백해서 `/v1/diet/analyze` 가 그대로 동작합니다(CI 와 같은 경로).
+
+### 기동에 실패하면: 오래된 볼륨
+
+예전에 만들어 둔 `oncare_pgdata` 볼륨이 있으면 다음처럼 죽습니다.
+
+```
+alembic ... Running upgrade -> 0001_baseline
+psycopg.errors.DuplicateTable: relation "users" already exists
+```
+
+`create_all()` 로 만들어진 스키마가 남아 있는데 `alembic_version` 이 없어서, 마이그레이션이
+baseline 부터 다시 돌다 충돌하는 것입니다. 로컬 개발 DB 라 버리고 다시 만들면 됩니다.
+
+```bash
+docker compose down -v        # 볼륨 삭제 — 로컬 데이터가 사라집니다
+docker compose up -d
+```
+
+확인:
+
+```bash
+docker compose ps             # app, db 모두 Up
+docker compose logs app       # alembic upgrade 성공 후 uvicorn 기동
+```
+
+## 2. 회원 앱
+
+```bash
+cd frontend/flutter
+flutter run -d chrome \
+  --dart-define=USE_MOCK_API=false \
+  --dart-define=API_BASE_URL=http://localhost:8000/v1
+```
+
+## 3. 트레이너 앱
+
+```bash
+cd frontend/flutter_trainer
+bash tool/fetch_drift_wasm.sh   # 최초 1회
+flutter run -d chrome \
+  --dart-define=USE_MOCK_API=false \
+  --dart-define=API_BASE_URL=http://localhost:8000/v1
+```
+
+## 데모 계정
+
+`SEED_DEMO_DATA=true`(기본값)면 시드 계정이 생성됩니다. 비밀번호는 모두
+`.env` 의 `DEMO_LOGIN_PASSWORD`(기본 `oncare123`)입니다.
+
+| 역할 | 이메일 | 비고 |
+| --- | --- | --- |
+| 트레이너 | `trainer@oncare.com` | 담당 회원 3명 |
+| 회원 | `jisu@oncare.com` | 이지수 |
+| 회원 | `sungho@oncare.com` | 박성호 |
+| 회원 | `minsu@oncare.com` | 김민수 — **현재 로그인 불가**, 아래 참고 |
+
+> `minsu@oncare.com`(user-demo)은 `init_db` 가 빈 비밀번호 해시로 먼저 만들고
+> 트레이너 시드가 기존 사용자를 건너뛰기 때문에 로그인할 수 없습니다. 하필 트레이너의
+> 1번 고객이라 시연 계정으로 쓰기 쉬운데, 지금은 **`jisu@oncare.com` 을 쓰세요.**
+
+## 상호작용이 실제로 연결됐는지 확인
+
+앱 없이 API 로만 30초 안에 확인할 수 있습니다. 회원이 올린 식단이 트레이너 쪽에
+나타나면 두 앱이 같은 DB 를 보고 있다는 뜻입니다.
+
+```bash
+M=$(curl -s -X POST http://localhost:8000/v1/auth/login \
+      -d "username=jisu@oncare.com&password=oncare123" \
+    | python -c "import sys,json;print(json.load(sys.stdin)['access_token'])")
+T=$(curl -s -X POST http://localhost:8000/v1/auth/login \
+      -d "username=trainer@oncare.com&password=oncare123" \
+    | python -c "import sys,json;print(json.load(sys.stdin)['access_token'])")
+
+# 회원이 메시지를 보내면
+curl -s -X POST http://localhost:8000/v1/me/coach/chat \
+  -H "Authorization: Bearer $M" -H "Content-Type: application/json" \
+  -d '{"text":"hello from member"}'
+
+# 트레이너 스레드에 그대로 나타난다
+curl -s -H "Authorization: Bearer $T" \
+  http://localhost:8000/v1/trainer/clients/user-jisu/chat
+```
+
+로그인은 `OAuth2PasswordRequestForm` 이라 **JSON 이 아니라 폼 데이터**(`username=`)로
+보냅니다. 이메일을 `username` 필드에 넣습니다.
+
+## 알려진 함정
+
+- **Windows(Git Bash)에서 `curl -F "image=@/tmp/x.jpg"`** 는 `curl: (26)` 로 실패합니다.
+  Windows `curl.exe` 가 MSYS 경로를 못 읽습니다. `$(cygpath -w /tmp/x.jpg)` 로 변환하세요.
+- **셸에서 한글이 든 JSON 을 `-d` 로 보내면** 콘솔 인코딩(cp949) 때문에 깨져
+  `400 There was an error parsing the body` 가 납니다. 파일(`-d @body.json`)로 보내거나
+  ASCII 로 확인하세요. 앱에서 보내는 요청은 정상입니다.
+- CORS 는 `.env` 기본값이 `CORS_ALLOW_ORIGINS=*` 라 로컬 웹에서 그대로 붙습니다.

--- a/frontend/flutter_trainer/README.md
+++ b/frontend/flutter_trainer/README.md
@@ -113,7 +113,7 @@ dart run build_runner build --delete-conflicting-outputs
 
 ### 실 API 로 실행 (회원 앱과 데이터 공유)
 
-위 명령은 목업 모드입니다(`useMockApi` 기본값 `true`). 이 모드에서는 트레이너 앱이 자기
+위 명령은 목업 모드입니다(`useMockApi` 기본값 `true`). 이 모드에서는 트레이너 웹이 자기
 로컬 drift DB 를 보기 때문에 **회원 앱에서 만든 데이터가 보이지 않습니다.**
 
 ```bash

--- a/frontend/flutter_trainer/README.md
+++ b/frontend/flutter_trainer/README.md
@@ -111,6 +111,18 @@ dart run build_runner build --delete-conflicting-outputs
 로그인: 비어있지 않은 아무 이메일/비밀번호 → 시드 트레이너(김트레이너)로 로그인.
 "로그인 없이 데모 둘러보기"로 바로 진입할 수도 있습니다.
 
+### 실 API 로 실행 (회원 앱과 데이터 공유)
+
+위 명령은 목업 모드입니다(`useMockApi` 기본값 `true`). 이 모드에서는 트레이너 앱이 자기
+로컬 drift DB 를 보기 때문에 **회원 앱에서 만든 데이터가 보이지 않습니다.**
+
+```bash
+flutter run -d chrome   --dart-define=USE_MOCK_API=false   --dart-define=API_BASE_URL=http://localhost:8000/v1
+```
+
+백엔드 기동과 데모 계정, 상호작용 확인 방법은
+**[docs/local_fullstack.md](../../docs/local_fullstack.md)** 를 보세요.
+
 ## 구조
 
 [frontend/flutter/docs/STRUCTURE.md](../flutter/docs/STRUCTURE.md)의 레이어 규칙


### PR DESCRIPTION
## Summary

회원 앱과 트레이너 웹은 `useMockApi` 기본값이 `true` 라, dart-define 없이 실행하면 각각
**자기 로컬 drift DB** 를 봅니다. 둘 다 잘 도는 것처럼 보여도 서로의 데이터는 절대 보이지
않아서, 회원↔트레이너 상호작용은 확인 자체가 불가능한 상태였습니다.

원인은 단순했습니다 — **트레이너 웹 README 에 실 API 실행 방법이 아예 없었습니다.**
(백엔드 README 에는 있었습니다.) 그래서 둘을 같은 백엔드로 띄우는 경로가 사실상
문서화돼 있지 않았습니다.

## Related Issues

Closes #570

## Changes

- `docs/local_fullstack.md` (신규) — 3단계 기동, 데모 계정표, 30초 curl 검증,
  기동 실패 대처, Windows/셸 함정, **로컬 DB 를 테스트 스위트가 공유한다는 경고**
- `frontend/flutter_trainer/README.md` — 실 API 실행 명령 추가(누락돼 있었음)
- `backend/README.md` — 통합 문서 링크, 회원 앱·트레이너 웹 모두 해당함을 명시

코드 변경은 없습니다. 문서만 바뀝니다.

## Test Plan

최신 main 코드로 도커 이미지를 빌드해 **백엔드 경로를 실제로 실행**했습니다.

- [x] `docker compose up -d --build` 기동 (app, db 모두 Up)
- [x] AI 키 없이 `/v1/diet/analyze` 동작 — `engine: "stub"` 폴백
- [x] **회원 → 트레이너 식단 전달**: jisu 업로드 →
      `/v1/trainer/clients/user-jisu/diet` 가 4건 → 5건
- [x] **회원 → 트레이너 채팅**: jisu 발신(201) → 트레이너 스레드에 즉시 표시
- [x] 문서의 curl 스니펫을 그대로 복사 실행해 통과
- [ ] **회원 앱 / 트레이너 웹을 실 API 모드로 기동** — 미확인

> 마지막 항목은 아직 확인하지 못했습니다. 이 PR 이 검증한 것은 **백엔드 계약**까지이고,
> Flutter 클라이언트를 dart-define 으로 띄워보지는 않았습니다. 문서의 핵심 주장이므로
> 머지 전에 확인하는 것이 맞습니다.

## Notes — 실행 중 발견한 것

문서에 반영했고, 코드 수정이 필요한 것은 별도 이슈로 분리했습니다.

1. **오래된 볼륨이 있으면 기동 실패** — `create_all()` 로 만든 스키마가 남았는데
   `alembic_version` 이 없어 baseline 부터 다시 돌다
   `DuplicateTable: relation "users" already exists` 로 죽습니다.
   `docker compose down -v` 복구 절차를 문서에 넣었습니다.
   깨끗한 볼륨에서는 문서대로 정상 기동합니다.
2. **로컬 DB 를 테스트 스위트가 공유합니다** — `DATABASE_URL` 이 같은
   `localhost:5432` 를 보므로, 손으로 API 를 찔러 데이터를 남기면
   `test_trainer_client_diet_maps_member_meals` (`len(meals) == 3`) 같은 테스트가 깨집니다.
   실제로 겪어서 경고로 문서화했습니다.
3. **데모 회원 `minsu@oncare.com` 로그인 불가** → #571
4. **목업 고객 15명 vs 실 API 3명** → #572