### PR TITLE
feat(backend): 데모 로스터를 15명으로 확장해 트레이너 웹의 화면 상태를 실 API 에서 재현

### DIFF
--- a/backend/app/db/init_db.py
+++ b/backend/app/db/init_db.py
@@ -56,6 +56,10 @@ def init_db() -> None:
         # 회원 계정 시드(seed_trainer_domain) 뒤에 호출.
         from app.db.seed_member_data import seed_member_health_data
         seed_member_health_data()
+        # 확장 회원(4~15)의 주간 지표. 상세 기록은 위 3명만 가지므로, 로스터·차트·
+        # 경고가 동작할 최소 기록만 따로 채운다(#572).
+        from app.db.seed_roster import seed_roster_metrics
+        seed_roster_metrics()
 
     _promote_admins()  # ADMIN_EMAILS 사용자를 관리자로 승격(멱등)
 

--- a/backend/app/db/seed_roster.py
+++ b/backend/app/db/seed_roster.py
@@ -1,0 +1,211 @@
+"""로스터 확장 회원(4~15번)의 주간 지표 시드.
+
+트레이너 웹의 목업 로스터(`frontend/flutter_trainer/lib/core/storage/seed_clients.dart`)
+는 고객 15명을 **화면 상태의 fixture** 로 설계했다 — 나트륨 초과, 이행률 저조, 휴면,
+답장 대기, 짧은 스파크라인 같은 상태를 클릭만으로 도달할 수 있게 하려고 고른 숫자다.
+실 API 시드는 3명뿐이라 실서버로 전환하면 그 상태 대부분이 재현되지 않았다(#572).
+
+여기서는 **지표를 만들 최소 기록만** 넣는다. 로스터의 주간 지표는 저장 필드가 아니라
+실데이터에서 계산되기 때문이다(`trainer_service._sodium_week` / `_week_completion`).
+따라서 "계정만 만들고 지표를 채운다"는 불가능하고, 하루치 식단·운동 기록이 곧 지표다.
+
+기존 3명(김민수·이지수·박성호)의 풍부한 상세 데이터(끼니별 음식·피드백·트레이너 메모·
+채팅·스케줄)는 `seed_member_data.py` 가 계속 담당한다. 여기 12명은 로스터·차트·경고가
+동작할 만큼만 채우고 상세는 비운다.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import timedelta
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core import clock
+from app.db.session import SessionLocal
+from app.models import models
+
+logger = logging.getLogger(__name__)
+
+#: 목업 로스터에서 옮긴 주간 지표.
+#:
+#: * ``sodium``  — 최근 7일 일별 나트륨(오래된→오늘). `_sodium_week` 가 날짜별 합으로 읽는다.
+#: * ``completion`` — 이번 주 월→일 일별 완료율. `_week_completion` 이 날짜별 최댓값으로 읽는다.
+#:   0 인 날은 "기록 없음" 이므로 행을 만들지 않는다(경고 규칙이 0 을 평균에서 제외한다).
+#: * ``awaiting`` — 회원이 마지막으로 말한 채로 남은 스레드(답장 대기 배지).
+#:
+#: 7개보다 짧은 나트륨 배열은 의도된 것이다 — 기록이 끊겼거나(문가영) 이제 막
+#: 시작한(노은채) 고객의 짧은 스파크라인을 그리기 위한 값이다. 끊긴 쪽은 과거에,
+#: 시작한 쪽은 오늘에 붙인다.
+_METRICS: dict[str, dict] = {
+    "user-hayun": {  # 정하윤 — V자: 무너졌다 회복, 나트륨 급락 후 반등
+        "sodium": [2900, 2600, 1500, 1250, 1400, 1900, 1650],
+        "completion": [100, 25, 0, 0, 50, 100, 100],
+        "awaiting": False,
+    },
+    "user-woojin": {  # 최우진 — 완벽한 주(경고 0). 정상 상태의 기준선
+        "sodium": [1300, 1250, 1100, 1200, 1150, 1090, 1180],
+        "completion": [100, 100, 100, 100, 100, 100, 100],
+        "awaiting": False,
+    },
+    "user-kangseoyeon": {  # 강서연 — 주중 완벽, 주말에 나트륨 폭발
+        "sodium": [1400, 1350, 1500, 1420, 1380, 3100, 2750],
+        "completion": [100, 100, 100, 100, 100, 0, 0],
+        "awaiting": False,
+    },
+    "user-dohyun": {  # 임도현 — 기록 전무(빈 상태 화면)
+        "sodium": [],
+        "completion": [0, 0, 0, 0, 0, 0, 0],
+        "awaiting": False,
+    },
+    "user-sera": {  # 오세라 — 우하향: 이행률 붕괴 + 나트륨 상승
+        "sodium": [1900, 2150, 2400, 2650, 2900, 3050, 3250],
+        "completion": [80, 60, 40, 33, 20, 0, 0],
+        "awaiting": True,
+    },
+    "user-junhyuk": {  # 배준혁 — 야근형: 이행률 저조 + 나트륨 들쭉날쭉
+        "sodium": [2100, 2600, 1800, 2900, 2200, 1600, 2280],
+        "completion": [50, 0, 33, 0, 25, 0, 0],
+        "awaiting": True,
+    },
+    "user-yuna": {  # 신유나 — 회복 중: 나트륨 우하향, 이행률 우상향
+        "sodium": [2800, 2500, 2200, 1950, 1800, 1750, 1720],
+        "completion": [0, 0, 33, 67, 100, 100, 100],
+        "awaiting": False,
+    },
+    "user-jiho": {  # 한지호 — 정체기: 목표선 위아래로 진동(경계값)
+        "sodium": [1990, 2010, 1995, 2005, 1998, 2015, 2010],
+        "completion": [67, 67, 67, 67, 67, 67, 67],
+        "awaiting": False,
+    },
+    "user-gayoung": {  # 문가영 — 휴면: 주 3일치만 기록되고 끊김
+        "sodium": [2100, 1950, 1030],
+        "completion": [33, 0, 0, 0, 0, 0, 0],
+        "awaiting": True,
+        "anchor": "past",
+    },
+    "user-taekyung": {  # 류태경 — 극단: 0↔100, 1200↔3200 지그재그
+        "sodium": [1200, 3100, 1350, 2950, 1100, 3200, 3100],
+        "completion": [100, 0, 100, 0, 100, 0, 0],
+        "awaiting": True,
+    },
+    "user-seojin": {  # 백서진 — 운동은 완벽한데 나트륨만 계속 초과
+        "sodium": [2400, 2550, 2700, 2600, 2800, 2650, 2680],
+        "completion": [100, 100, 100, 100, 100, 100, 100],
+        "awaiting": False,
+    },
+    "user-eunchae": {  # 노은채 — 단 하루만 기록(단일 포인트 스파크라인)
+        "sodium": [1450],
+        "completion": [100, 0, 0, 0, 0, 0, 0],
+        "awaiting": False,
+        "anchor": "today",
+    },
+}
+
+#: 상세 기록은 기존 3명만 둔다. 여기 12명의 식단은 지표를 만들기 위한 한 줄짜리다.
+_MEAL_NAME = "기록된 식사"
+_ROUTINE_LABEL = "AI 루틴 · 자율 운동"
+_AWAITING_TEXT = "트레이너님, 이번 주 루틴 관련해서 여쭤볼 게 있어요."
+
+
+def seed_roster_metrics() -> None:
+    """확장 회원의 주간 지표용 최소 기록을 시드(멱등)."""
+    db: Session = SessionLocal()
+    try:
+        for member_id, spec in _METRICS.items():
+            if db.get(models.User, member_id) is None:
+                continue  # 계정 시드가 건너뛴 회원(이메일 충돌 등)
+            _seed_sodium_days(db, member_id, spec)
+            _seed_completion_days(db, member_id, spec["completion"])
+            if spec.get("awaiting"):
+                _seed_awaiting_message(db, member_id)
+        db.commit()
+    finally:
+        db.close()
+
+
+def _sodium_offsets(values: list[int], anchor: str) -> list[tuple[int, int]]:
+    """(오늘로부터 며칠 전, 나트륨) 목록.
+
+    7개면 6일 전~오늘에 그대로 얹는다. 짧으면 [anchor] 를 따른다 — 기록이 끊긴
+    고객은 과거에, 이제 시작한 고객은 오늘에 붙어야 스파크라인이 이야기와 맞는다.
+    """
+    if not values:
+        return []
+    if len(values) >= 7:
+        return [(6 - i, v) for i, v in enumerate(values[-7:])]
+    if anchor == "today":
+        return [(len(values) - 1 - i, v) for i, v in enumerate(values)]
+    return [(6 - i, v) for i, v in enumerate(values)]
+
+
+def _seed_sodium_days(db: Session, member_id: str, spec: dict) -> None:
+    today = clock.today()
+    for offset, sodium in _sodium_offsets(spec["sodium"], spec.get("anchor", "recent")):
+        date = (today - timedelta(days=offset)).isoformat()
+        entry_id = f"seed-roster-diet-{member_id}-{date}"
+        if db.get(models.DietEntry, entry_id) is not None:
+            continue
+        # 하루 한 줄. 끼니별 상세는 기존 3명만 가진다.
+        calories = 500 + (sodium // 10)
+        db.add(models.DietEntry(
+            id=entry_id,
+            user_id=member_id,
+            date=date,
+            meal_type="lunch",
+            time_label="12:30",
+            foods_json=json.dumps(
+                [{"name": _MEAL_NAME, "calories": calories}], ensure_ascii=False
+            ),
+            total_calories=calories,
+            sodium_mg=sodium,
+            sugar_g=float(sodium) / 60.0,
+        ))
+
+
+def _seed_completion_days(db: Session, member_id: str, completion: list[int]) -> None:
+    monday = clock.today() - timedelta(days=clock.today().weekday())
+    for i, rate in enumerate(completion):
+        if rate <= 0:
+            continue  # 기록 없음 — 행을 만들면 '0% 수행'이라는 다른 뜻이 된다
+        date = (monday + timedelta(days=i)).isoformat()
+        hist_id = f"seed-roster-hist-{member_id}-{date}"
+        if db.get(models.RoutineHistory, hist_id) is not None:
+            continue
+        db.add(models.RoutineHistory(
+            id=hist_id,
+            member_id=member_id,
+            trainer_id=None,
+            date=date,
+            kind_label=_ROUTINE_LABEL,
+            completion_rate=rate,
+            exercises_json=json.dumps([], ensure_ascii=False),
+        ))
+
+
+def _seed_awaiting_message(db: Session, member_id: str) -> None:
+    """회원이 마지막으로 말한 채로 남은 스레드(답장 대기 배지)."""
+    from app.db.seed_trainer import TRAINER_ID
+
+    msg_id = f"seed-roster-chat-{member_id}"
+    if db.get(models.ChatMessage, msg_id) is not None:
+        return
+    exists = db.scalar(
+        select(models.ChatMessage.id)
+        .where(
+            models.ChatMessage.trainer_id == TRAINER_ID,
+            models.ChatMessage.member_id == member_id,
+        )
+        .limit(1)
+    )
+    if exists is not None:
+        return
+    db.add(models.ChatMessage(
+        id=msg_id,
+        trainer_id=TRAINER_ID,
+        member_id=member_id,
+        sender="member",
+        body=_AWAITING_TEXT,
+        created_at=clock.now(),
+    ))

--- a/backend/app/db/seed_trainer.py
+++ b/backend/app/db/seed_trainer.py
@@ -2,7 +2,9 @@
 트레이너 도메인 데모 시드.
 
 트레이너 앱의 데모/데이터 공유 데모를 위해 트레이너 계정 1명(김트레이너)과
-담당 회원 3명(김민수·이지수·박성호), 그리고 담당 링크를 시드한다.
+담당 회원 15명(#572), 그리고 담당 링크를 시드한다. 상세 기록(끼니별 음식·
+피드백·채팅·스케줄)은 앞의 3명만 가지고, 나머지는 로스터·차트가 동작할 만큼의
+주간 지표만 가진다(seed_roster).
 
 핵심(진짜 데이터 공유): 여기서 만드는 회원은 실제 회원 User 다. 이후 이슈에서
 이 회원들이 회원 앱으로 남긴 식단/운동/바이탈을 트레이너가 그대로 읽는다.
@@ -59,6 +61,21 @@ _MEMBERS: list[tuple[str, str, str, str, bool, int]] = [
     ("user-demo", "minsu@oncare.com", "김민수", "혈압 관리 · 체중 감량", True, 1),
     ("user-jisu", "jisu@oncare.com", "이지수", "체력 강화 · 다이어트", True, 2),
     ("user-sungho", "sungho@oncare.com", "박성호", "근력 향상", False, 3),
+    # 4~15: 트레이너 웹 목업 로스터와 같은 명단(#572). 주간 지표는 seed_roster 가
+    # 채운다 — 화면 상태(나트륨 초과·이행률 저조·휴면·답장 대기)를 실 API 에서도
+    # 재현하기 위한 fixture 다.
+    ("user-hayun", "hayun@oncare.demo", "정하윤", "산후 체력 회복", True, 4),
+    ("user-woojin", "woojin@oncare.demo", "최우진", "마라톤 완주 준비", True, 5),
+    ("user-kangseoyeon", "kangseoyeon@oncare.demo", "강서연", "체지방 감량", True, 6),
+    ("user-dohyun", "dohyun@oncare.demo", "임도현", "목표 설정 전", True, 7),
+    ("user-sera", "sera@oncare.demo", "오세라", "고혈압 관리", True, 8),
+    ("user-junhyuk", "junhyuk@oncare.demo", "배준혁", "수면 · 컨디션 개선", True, 9),
+    ("user-yuna", "yuna@oncare.demo", "신유나", "재활 후 복귀", True, 10),
+    ("user-jiho", "jiho@oncare.demo", "한지호", "현 체중 유지", True, 11),
+    ("user-gayoung", "gayoung@oncare.demo", "문가영", "체력 회복", False, 12),
+    ("user-taekyung", "taekyung@oncare.demo", "류태경", "벌크업", True, 13),
+    ("user-seojin", "seojin@oncare.demo", "백서진", "식습관 개선", True, 14),
+    ("user-eunchae", "eunchae@oncare.demo", "노은채", "운동 습관 만들기", True, 15),
 ]
 
 _CERTIFICATIONS = ["생활스포츠지도사 2급", "퍼스널트레이닝 CPT", "스포츠 영양사"]

--- a/backend/tests/test_roster_states.py
+++ b/backend/tests/test_roster_states.py
@@ -30,6 +30,16 @@ def _roster(client) -> list[dict]:
     return r.json()
 
 
+def _unread_counts(client) -> dict[str, int]:
+    token = _trainer_token(client)
+    r = client.get(
+        "/v1/trainer/chat/unread",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
 def test_roster_matches_the_seeded_member_list(client):
     from app.db.seed_trainer import _MEMBERS
 
@@ -38,7 +48,7 @@ def test_roster_matches_the_seeded_member_list(client):
 
 
 def test_every_alert_state_is_reachable_through_the_api(client):
-    """경고를 그릴 수 있는 고객이 상태별로 최소 1명씩 있다."""
+    """화면 상태를 그릴 수 있는 고객이 상태별로 최소 1명씩 있다."""
     rows = _roster(client)
 
     sodium_over = [
@@ -56,6 +66,10 @@ def test_every_alert_state_is_reachable_through_the_api(client):
 
     dormant = [r for r in rows if r.get("active") is False]
     assert dormant, "휴면 고객이 없다"
+
+    unread = _unread_counts(client)
+    awaiting_reply = [r for r in rows if unread.get(r["id"], 0) > 0]
+    assert awaiting_reply, "답장 대기 배지를 그릴 고객이 없다"
 
 
 def test_sparklines_cover_empty_short_and_full_weeks(client):

--- a/backend/tests/test_roster_states.py
+++ b/backend/tests/test_roster_states.py
@@ -1,0 +1,90 @@
+"""로스터가 트레이너 웹의 화면 상태를 실 API 에서도 재현하는지 (#572).
+
+목업 로스터(`seed_clients.dart`)의 15명은 **화면 상태의 fixture** 다 — 나트륨 초과,
+이행률 저조, 휴면, 답장 대기, 짧은 스파크라인을 클릭만으로 도달할 수 있게 고른 숫자다.
+실 API 시드가 3명뿐이던 동안에는 실서버로 전환하면 그 상태들이 대부분 도달 불가능했다.
+
+여기서 단언하는 것은 개별 숫자가 아니라 **상태가 하나라도 존재하는가** 다. 숫자를 그대로
+박으면 시드를 손볼 때마다 깨지고, 정작 지키려는 것(경고가 그려질 수 있는가)은 놓친다.
+임계값은 트레이너 웹 `client_alerts.dart` 와 맞춘다.
+"""
+from __future__ import annotations
+
+_SODIUM_OVER = 2000  # 하루 나트륨 초과 기준
+_COMPLETION_LOW = 60  # 기록된 날 평균 이행률이 이 아래면 '이행률 저조'
+
+
+def _trainer_token(client) -> str:
+    r = client.post(
+        "/v1/auth/login",
+        data={"username": "trainer@oncare.com", "password": "oncare123"},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["access_token"]
+
+
+def _roster(client) -> list[dict]:
+    token = _trainer_token(client)
+    r = client.get("/v1/trainer/clients", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def test_roster_matches_the_seeded_member_list(client):
+    from app.db.seed_trainer import _MEMBERS
+
+    rows = _roster(client)
+    assert len(rows) == len(_MEMBERS)
+
+
+def test_every_alert_state_is_reachable_through_the_api(client):
+    """경고를 그릴 수 있는 고객이 상태별로 최소 1명씩 있다."""
+    rows = _roster(client)
+
+    sodium_over = [
+        r for r in rows
+        if sum(1 for v in r.get("sodium_week") or [] if v > _SODIUM_OVER) >= 3
+    ]
+    assert sodium_over, "나트륨 초과 경고를 그릴 고객이 없다"
+
+    low_completion = []
+    for r in rows:
+        logged = [v for v in r.get("week_completion") or [] if v > 0]
+        if logged and sum(logged) / len(logged) < _COMPLETION_LOW:
+            low_completion.append(r)
+    assert low_completion, "이행률 저조 경고를 그릴 고객이 없다"
+
+    dormant = [r for r in rows if r.get("active") is False]
+    assert dormant, "휴면 고객이 없다"
+
+
+def test_sparklines_cover_empty_short_and_full_weeks(client):
+    """차트가 그려야 하는 기록 길이가 모두 존재한다.
+
+    전부 7일치면 '기록이 적을 때' 화면(빈 상태·단일 포인트)이 도달 불가능해진다.
+    """
+    lengths = {
+        len([v for v in (r.get("sodium_week") or []) if v > 0]) for r in _roster(client)
+    }
+    assert 0 in lengths, "기록이 전혀 없는 고객이 없다"
+    assert any(0 < n < 7 for n in lengths), "기록이 일부만 있는 고객이 없다"
+    assert 7 in lengths, "한 주를 꽉 채운 고객이 없다"
+
+
+def test_detailed_records_stay_with_the_original_three(client):
+    """상세 기록은 기존 3명만 가진다(#572 결정).
+
+    확장 회원은 로스터·차트가 동작할 최소 기록만 가진다. 12명 전원에게 끼니별 음식·
+    피드백·트레이너 메모까지 넣으면 시드 유지 비용이 커진다.
+    """
+    token = _trainer_token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    detailed = client.get("/v1/trainer/clients/user-jisu/diet", headers=headers)
+    assert detailed.status_code == 200
+    assert len(detailed.json()) >= 3, "기존 3명은 끼니별 상세를 유지해야 한다"
+
+    minimal = client.get("/v1/trainer/clients/user-seojin/diet", headers=headers)
+    assert minimal.status_code == 200
+    # 하루 한 줄짜리 — 있지만 상세하지는 않다.
+    assert minimal.json(), "확장 회원도 지표를 만들 기록은 있어야 한다"

--- a/backend/tests/test_trainer.py
+++ b/backend/tests/test_trainer.py
@@ -88,13 +88,14 @@ def test_unauthenticated_trainer_is_rejected(client):
 def test_demo_trainer_client_links_seeded(client, db_session):
     from sqlalchemy import select
 
-    from app.db.seed_trainer import TRAINER_ID
+    from app.db.seed_trainer import _MEMBERS, TRAINER_ID
     from app.models.models import TrainerClient
 
     links = db_session.scalars(
         select(TrainerClient).where(TrainerClient.trainer_id == TRAINER_ID)
     ).all()
-    assert len(links) == 3
+    # 명단 크기는 _MEMBERS 에서 읽는다 — 로스터가 늘 때마다 테스트를 고치지 않도록.
+    assert len(links) == len(_MEMBERS)
     member_ids = {l.member_id for l in links}
     assert {"user-demo", "user-jisu", "user-sungho"} <= member_ids
 
@@ -147,7 +148,7 @@ def test_member_api_still_works_without_token(client):
 def test_trainer_seed_is_idempotent(client, db_session):
     from sqlalchemy import func, select
 
-    from app.db.seed_trainer import TRAINER_ID, seed_trainer_domain
+    from app.db.seed_trainer import _MEMBERS, TRAINER_ID, seed_trainer_domain
     from app.models.models import TrainerClient, User
 
     # 여러 번 재실행해도 계정/링크 수가 늘지 않는다
@@ -157,7 +158,7 @@ def test_trainer_seed_is_idempotent(client, db_session):
         select(func.count()).select_from(TrainerClient)
         .where(TrainerClient.trainer_id == TRAINER_ID)
     )
-    assert links == 3
+    assert links == len(_MEMBERS)
     trainers = db_session.scalar(
         select(func.count()).select_from(User).where(User.role == "trainer")
     )


### PR DESCRIPTION
## Summary

트레이너 웹의 목업 로스터(`frontend/flutter_trainer/lib/core/storage/seed_clients.dart`)는 고객 15명을 **화면 상태를 재현하기 위한 fixture**로 설계했습니다. 파일 주석에도 해당 의도가 명시되어 있습니다.

> A demo roster is a fixture for the *charts*, not just the list. Three clients with mild, similar weeks left most of the console's states unreachable by clicking around.

하지만 실 API 시드는 **3명뿐**이었습니다.

따라서 `USE_MOCK_API=false`로 전환하면 나트륨 초과 배지, 이행률 저조 경고, 휴면 고객, 짧은 스파크라인 등의 상태가 **대부분 도달 불가능**해집니다.

즉, 목업에서만 보이는 UI 상태가 생기는 문제입니다.

#570 로컬 풀스택 검증 과정에서 해당 문제를 확인했습니다.

## Related Issues

Closes #572

## Changes

- `app/db/seed_trainer.py`
  - `_MEMBERS`를 3명 → **15명**으로 확장
  - 목업과 동일한 명단, 목표, 휴면 여부를 반영
- `app/db/seed_roster.py` (신규)
  - 확장 회원 12명의 주간 지표 생성을 위한 최소 기록 시드 추가
- `app/db/init_db.py`
  - 회원 상세 데이터 시드 이후 로스터 지표 시드 호출
- `tests/test_roster_states.py` (신규)
  - 화면 상태가 실제 API를 통해 도달 가능한지 검증
- `tests/test_trainer.py`
  - 하드코딩된 `== 3`을 `len(_MEMBERS)`로 변경

### "계정만 만들고 지표를 채운다"는 불가능했습니다

착수 전 계획은 다음과 같았습니다.

> 15명 전원 계정 + 지표, 상세 기록은 기존 3명만

하지만 구현 과정에서 이 전제가 맞지 않는 것을 확인했습니다.

주간 지표는 별도의 저장 필드가 아니라 **실제 기록 데이터에서 계산**됩니다.

```python
week_completion = _week_completion(
    hist_by_member.get(link.member_id, []),
    monday,
)  # RoutineHistory

sodium_week = _sodium_week(
    diet_rows,
    today,
)  # DietEntry
```

즉, 지표를 생성하려면 식단 및 루틴 기록 행이 필요하고, **그 기록 행 자체가 지표의 근거**가 됩니다.

따라서 다음과 같이 구현했습니다.

- 확장 회원 12명
  - 하루 한 줄짜리 식단 기록(끼니 상세 없음)
  - 완료율만 담은 루틴 이력
- 기존 3명
  - 끼니별 음식
  - 회원 피드백
  - 트레이너 메모
  - 채팅
  - 스케줄
  - 기존 `seed_member_data.py` 데이터 그대로 유지

또한 두 지표의 시간 창이 서로 다른 점도 반영했습니다.

- `sodium_week`: **오늘 기준 최근 7일**
- `week_completion`: **이번 주 월~일**

완료율이 0인 날에는 행을 생성하지 않습니다.

0%짜리 행을 추가하면 "기록은 했지만 0% 수행"이라는 다른 의미가 되며, 경고 규칙에서 평균 계산 시 0을 제외하는 기존 로직과도 맞지 않기 때문입니다.

## Test Plan

깨끗한 DB에서 Docker 이미지를 재빌드한 후 검증했습니다.

- [x] `flutter_trainer` 목업에서 15명의 지표를 **직접 파싱하여** 옮김
  - 손으로 값을 옮기지 않음
- [x] 실제 API `/v1/trainer/clients` 응답을 통해 각 상태가 재현되는 것을 확인

| 상태 | 결과 |
|---|---:|
| 고객 수 | 15명 |
| 나트륨 초과(3일 이상) | 8명 |
| 이행률 저조(기록일 평균 < 60) | 3명 |
| 휴면 | 2명 |
| 기록일수 분포 | `[0, 1, 3, 7]` |

기록일수 분포가 핵심입니다.

**빈 상태(0), 단일 포인트(1), 짧은 스파크라인(3), 꽉 찬 주(7)**가 모두 존재해야 차트가 표시할 수 있는 다양한 상태에 실제 API를 통해 접근할 수 있습니다.

- [x] `tests/test_roster_states.py` **4개 테스트 통과**
- [x] 백엔드 전체 테스트 통과
  - **595 passed, 4 skipped, 0 failed**
  - 깨끗한 DB + 전체 테스트 1회 실행
  - CI와 동일한 조건으로 검증

## Notes

- **테스트는 숫자가 아니라 상태를 검증합니다.**
  - 개별 값을 하드코딩하면 시드를 변경할 때마다 테스트를 수정해야 합니다.
  - 대신 실제로 보장하려는 것인 "각 경고 및 차트 상태에 도달할 수 있는가"를 검증합니다.
  - 임계값은 트레이너 웹의 `client_alerts.dart`와 동일하게 맞췄습니다.

- **기존 테스트의 하드코딩을 `len(_MEMBERS)`로 변경했습니다.**
  - 이후 로스터가 늘어나더라도 테스트 자체를 수정할 필요가 없습니다.

- **7개보다 짧은 나트륨 배열도 의도된 값입니다.**
  - 문가영: 3일
  - 노은채: 1일
  - 기록이 끊긴 경우는 과거 날짜에, 이제 막 시작한 경우는 오늘에 배치하여 스파크라인의 상태가 의도한 시나리오와 일치하도록 했습니다.

- 확장 회원 12명은 `@oncare.demo` 이메일을 사용합니다.
  - 기존 트레이너 데모 계정과 동일한 규칙
  - 비밀번호는 `DEMO_LOGIN_PASSWORD`로 동일

- 시드는 멱등성을 유지합니다.
  - 기존 행이 있으면 건너뜁니다.
  - 계정 시드가 스킵된 회원(이메일 충돌)도 FK 오류 없이 넘어갑니다.

---

## 참고: 검증 중 다시 확인된 함정

전체 테스트가 처음에 `assert 15 == 3`으로 실패했는데, **Docker 이미지가 다른 브랜치의 코드로 빌드된 상태로 남아 있던 것**이 원인이었습니다.

`docker compose up -d`는 기존 이미지를 재사용하므로, 브랜치를 변경한 뒤에는 다음과 같이 `--build`를 사용해야 합니다.

```bash
docker compose up -d --build
```

이번 세션에서 두 번째로 확인된 문제이므로, #570의 `docs/local_fullstack.md`에 이미 추가한 **로컬 DB 공유 관련 경고**와 함께 이 내용도 추가하는 것을 권장합니다.

## 현재 대기 브랜치

| 이슈 | 브랜치 | 커밋 |
|---|---|---|
| #570 | `chore/570-local-fullstack-dev` | `59a03a13` |
| #571 | `fix/571-demo-member-login` | `92ed8a0e` (리뷰 반영) |
| #572 | `feat/572-backend-seed-15-clients` | `a5b175f5` |
| #574 | `chore/574-trainer-web-only` | `be970d11` (리뷰 반영) |

현재 네 브랜치 모두 push 대기 중입니다.

### 권장 머지 순서

**#570 → #574 → #571 → #572**

#571과 #572가 모두 `seed_trainer.py`를 수정하지만, 변경 위치는 다릅니다.

- #571: `_seed_member_accounts` 함수 본문 수정
- #572: `_MEMBERS` 목록 수정

따라서 직접적인 충돌 가능성은 낮지만, 나중에 머지되는 PR에서 변경 사항이 정상적으로 반영되었는지 확인하는 것을 권장합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 트레이너 데모 로스터가 3명에서 15명으로 확대되었습니다.
  * 회원별 주간 나트륨 섭취량, 루틴 이행률, 답장 대기 상태가 초기화됩니다.
  * 로스터 및 차트에서 빈 기록, 부분 기록, 7일 전체 기록을 확인할 수 있습니다.
  * 확장 회원에게도 상태 확인에 필요한 최소 기록이 제공됩니다.
* **테스트**
  * 나트륨 초과, 낮은 이행률, 휴면 회원 등 다양한 상태가 올바르게 표시되는지 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->