### PR TITLE
chore(repo): 저장소 이름 변경(on-care)에 맞춰 링크·배포 파라미터 갱신

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -25,8 +25,8 @@ authors:
 # 본 파일도 함께 갱신할 것.
 date-released: "2026-05-20"
 version: "0.3.0+3"
-repository-code: "https://github.com/CSE-Sudo-26/sudo-capstone-project"
-url: "https://github.com/CSE-Sudo-26/sudo-capstone-project"
+repository-code: "https://github.com/CSE-Sudo-26/on-care"
+url: "https://github.com/CSE-Sudo-26/on-care"
 license: MIT
 keywords:
   - healthcare

--- a/docs/aws-frontend-deployment.md
+++ b/docs/aws-frontend-deployment.md
@@ -17,8 +17,8 @@ Flutter 회원 앱과 트레이너 웹을 하나의 private S3 버킷에 올리�
 AWS CloudShell에서 브랜치를 받은 뒤 템플릿을 먼저 검증합니다.
 
 ```bash
-git clone https://github.com/CSE-Sudo-26/sudo-capstone-project.git
-cd sudo-capstone-project
+git clone https://github.com/CSE-Sudo-26/on-care.git
+cd on-care
 git switch feat/aws-frontend-deployment
 
 aws cloudformation validate-template \
@@ -57,6 +57,17 @@ aws cloudformation deploy \
     ExistingGitHubOidcProviderArn=arn:aws:iam::<ACCOUNT_ID>:oidc-provider/token.actions.githubusercontent.com \
   --region ap-northeast-2
 ```
+
+> **이미 생성된 스택을 갱신하는 경우 주의합니다.** `aws cloudformation deploy`는 `--parameter-overrides`에 없는 파라미터를 이전 값 그대로 유지합니다. 저장소 이름이 `sudo-capstone-project`에서 `on-care`로 바뀌었으므로, 이름 변경 이전에 만들어진 스택은 템플릿의 `GitHubRepository` 기본값을 갱신해도 이전 값을 계속 씁니다. 이 경우 OIDC 신뢰 조건의 `sub`가 옛 저장소를 가리켜 배포 워크플로가 자격 증명을 받지 못하므로, 아래처럼 값을 명시해 한 번 갱신해야 합니다.
+>
+> ```bash
+> aws cloudformation deploy \
+>   --template-file infra/frontend-hosting.yml \
+>   --stack-name oncare-frontend \
+>   --capabilities CAPABILITY_IAM \
+>   --parameter-overrides GitHubRepository=on-care \
+>   --region ap-northeast-2
+> ```
 
 CloudFront 배포가 포함되어 있어 스택 생성에는 몇 분이 걸릴 수 있습니다. 완료되면 출력값을 확인합니다.
 

--- a/docs/frontend_deployment.md
+++ b/docs/frontend_deployment.md
@@ -34,7 +34,7 @@ Vercel 프로젝트가 이 Git 저장소와 연결되어 있으면 저장소 안
 이 배포는 GitHub Pages로 전달되는 중간 단계가 아니라 **Vercel이 같은 커밋을 독립적으로 배포하는 중복 경로**입니다. 공식 서비스에서 Vercel을 사용하지 않으므로 아래 순서로 연결을 정리합니다.
 
 1. 루트 [`vercel.json`](../vercel.json)의 `git.deploymentEnabled: false`를 반영해 모든 브랜치의 자동 배포를 차단합니다.
-2. Vercel Dashboard에서 `sudo-capstone-project`를 엽니다.
+2. Vercel Dashboard에서 이 저장소와 연결된 프로젝트를 엽니다. Vercel 프로젝트 이름은 GitHub 저장소 이름 변경을 따라가지 않으므로, 저장소가 `on-care`로 바뀐 뒤에도 목록에는 이전 이름인 `sudo-capstone-project`로 남아 있을 수 있습니다.
 3. `Settings` → `Git`에서 연결된 GitHub 저장소를 `Disconnect`합니다.
 4. GitHub 저장소의 Rulesets 또는 Branch protection에서 Vercel 관련 required check가 있으면 제거합니다.
 5. 새 PR을 갱신해 Vercel Preview와 Bot 댓글이 더 생성되지 않는지 확인합니다.

--- a/index.html
+++ b/index.html
@@ -296,7 +296,7 @@
         <a href="#team">팀</a>
       </div>
       <div class="nav-cta">
-        <a href="https://github.com/CSE-Sudo-26/sudo-capstone-project" target="_blank" rel="noopener" class="icon-link" aria-label="GitHub">
+        <a href="https://github.com/CSE-Sudo-26/on-care" target="_blank" rel="noopener" class="icon-link" aria-label="GitHub">
           <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 0 0 .5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.53-1.34-1.3-1.7-1.3-1.7-1.06-.72.08-.71.08-.71 1.17.08 1.79 1.2 1.79 1.2 1.04 1.79 2.73 1.27 3.4.97.1-.76.41-1.27.74-1.56-2.55-.29-5.23-1.28-5.23-5.7 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 5.8 0c2.2-1.5 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.4-5.25 5.69.42.36.8 1.08.8 2.18v3.23c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12 11.5 11.5 0 0 0 12 .5Z"/></svg>
         </a>
         <a href="https://ewhasudo.zapto.org/trainer/" target="_blank" rel="noopener" class="btn btn-outline">트레이너 웹</a>
@@ -331,7 +331,7 @@
           <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>
           데모 영상
         </a>
-        <a href="https://github.com/CSE-Sudo-26/sudo-capstone-project" target="_blank" rel="noopener" class="btn btn-ghost">GitHub</a>
+        <a href="https://github.com/CSE-Sudo-26/on-care" target="_blank" rel="noopener" class="btn btn-ghost">GitHub</a>
       </div>
       <div class="hero-meta">
         <div><b>사진 1장</b><small>간편 식단 기록</small></div>
@@ -722,7 +722,7 @@
         </div>
         <div class="foot-col">
           <h5>Project</h5>
-          <a href="https://github.com/CSE-Sudo-26/sudo-capstone-project" target="_blank" rel="noopener">GitHub 저장소</a>
+          <a href="https://github.com/CSE-Sudo-26/on-care" target="_blank" rel="noopener">GitHub 저장소</a>
           <a href="#compare">경쟁 분석</a>
           <a href="#business">비즈니스 모델</a>
           <a href="#team">팀 소개</a>

--- a/infra/frontend-hosting.yml
+++ b/infra/frontend-hosting.yml
@@ -7,7 +7,7 @@ Parameters:
     Default: CSE-Sudo-26
   GitHubRepository:
     Type: String
-    Default: sudo-capstone-project
+    Default: on-care
   GitHubBranch:
     Type: String
     Default: main


### PR DESCRIPTION
## Summary

저장소 이름이 `sudo-capstone-project`에서 `on-care`로 변경되었습니다. GitHub이 기존 URL을 리다이렉트해 주지만 저장소 안에 하드코딩된 슬러그와 배포 파라미터는 따라오지 않으므로 함께 갱신합니다.

Closes #591

## Changes

- **`index.html`** — 소개 페이지의 GitHub 링크 3곳(헤더 아이콘 · 상단 버튼 · 본문 링크)을 새 주소로 갱신했습니다.
- **`CITATION.cff`** — `repository-code`와 `url` 인용 메타데이터를 새 저장소로 맞췄습니다.
- **`infra/frontend-hosting.yml`** — `GitHubRepository` 파라미터 기본값을 `on-care`로 바꿨습니다.
- **`docs/aws-frontend-deployment.md`** — `git clone` URL과 이어지는 작업 디렉터리를 갱신하고, 기존 스택 갱신 시 주의사항을 덧붙였습니다.
- **`docs/frontend_deployment.md`** — 아래 Notes 참고.

## Notes

**Vercel 프로젝트 이름은 슬러그를 그대로 바꾸지 않았습니다.** Vercel 프로젝트 이름은 GitHub 저장소 이름 변경을 따라가지 않습니다. 문서를 `on-care`로 고치면 대시보드에 실제로 보이는 이름과 어긋나 오히려 찾기 어려워지므로, "이 저장소와 연결된 프로젝트를 연다"로 바꾸고 목록에는 이전 이름으로 남아 있을 수 있다는 점을 함께 적었습니다.

**AWS OIDC 신뢰 조건은 이 PR만으로 해소되지 않습니다.** `infra/frontend-hosting.yml`의 신뢰 조건은 `repo:CSE-Sudo-26/<저장소>:ref:refs/heads/main` 형태로 이미 배포된 CloudFormation 스택에 반영되어 있습니다. 게다가 `aws cloudformation deploy`는 `--parameter-overrides`에 없는 파라미터를 이전 값으로 유지하므로, 템플릿 기본값만 바꿔서는 기존 스택의 신뢰 조건이 옛 저장소를 계속 가리킵니다. 그대로 두면 AWS OIDC를 쓰는 배포 워크플로가 자격 증명을 받지 못합니다.

스택 업데이트는 AWS 배포 담당(#414) 영역이라 이 PR에서 실행하지 않았고, 대신 필요한 명령을 `docs/aws-frontend-deployment.md`에 인용 블록으로 남겼습니다.

## Out of scope (확인 후 변경하지 않음)

- **`README.md`** — 슬러그 참조가 없습니다. 배지는 정적 shields이고 링크는 커스텀 도메인·YouTube·팀원 프로필로 갑니다.
- **`.github/workflows/`** — 슬러그 하드코딩이 없습니다. `backend-deploy.yml`은 `github.repository`를 런타임 변수로 비교하고, Flutter `base-href`는 `/frontend/`·`/trainer/`라 저장소 이름과 무관합니다.
- **`CSE-Sudo-26` 조직명** — 조직은 그대로이므로 유지합니다.
- **`ECR_REPOSITORY: oncare-backend`** — 이미 제품명 기준입니다.
- **`CNAME`** — 커스텀 도메인은 변경되지 않았습니다.

## Verification

- `index.html`을 브라우저에서 열어 GitHub 링크 3개가 모두 `https://github.com/CSE-Sudo-26/on-care`로 연결되는지 DOM에서 확인했습니다.
- `CITATION.cff`와 `infra/frontend-hosting.yml`을 파싱해 문법이 유효한지, `GitHubRepository` 기본값이 `on-care`로 읽히는지 확인했습니다.
- 추적 대상 파일에 남은 옛 슬러그는 Vercel 안내 문구 한 곳뿐이며, 이는 위 Notes대로 의도한 것입니다.
