### PR TITLE
fix(trainer): 루틴 배정 중복을 막는 멱등성 키 도입

### DIFF
--- a/backend/app/api/v1/trainer.py
+++ b/backend/app/api/v1/trainer.py
@@ -370,6 +370,7 @@ def trainer_assign_routine(
         db, trainer.id, member_id,
         name=payload.name.strip(), minutes=payload.minutes,
         type_=payload.type, reason=payload.reason, source=payload.source,
+        client_request_id=payload.client_request_id,
     )
 
 

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -662,8 +662,20 @@ class TrainerRoutine(Base):
     reason: Mapped[str] = mapped_column(String(200), default="")
     source: Mapped[str] = mapped_column(String(20), default="ai")  # ai|trainer
     sort_order: Mapped[int] = mapped_column(Integer, default=0)
+    # 재전송 중복 배정 방지용 멱등키(전송 시도당 1회 생성). NULL 허용 → 기존/무키
+    # 요청은 제약 밖. DietEntry.idempotency_key 와 같은 방식이다.
+    client_request_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "trainer_id",
+            "member_id",
+            "client_request_id",
+            name="uq_trainer_routines_client_request",
+        ),
     )
 
 

--- a/backend/app/schemas/trainer_api.py
+++ b/backend/app/schemas/trainer_api.py
@@ -146,6 +146,9 @@ class RoutineAssignRequest(BaseModel):
     type: RoutineType
     reason: str = Field(default="", max_length=200)
     source: RoutineSource = "trainer"
+    #: 전송 시도당 클라이언트가 만드는 멱등키. 재시도 시 **같은 키를 다시 보내야**
+    #: 중복 배정이 막힌다. 없으면 기존처럼 매 요청이 새 배정이다(#581).
+    client_request_id: str | None = Field(default=None, max_length=64)
 
 
 class RoutineUpdateRequest(PartialUpdate):

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -14,6 +14,7 @@ from collections import defaultdict
 from datetime import date, datetime, timedelta, timezone
 
 from sqlalchemy import func, or_, select, tuple_, update
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.core import clock
@@ -600,11 +601,43 @@ def delete_routine(
     db.commit()
 
 
+def _routine_out(rt: TrainerRoutine) -> RoutineOut:
+    return RoutineOut(
+        id=rt.id, name=rt.name, minutes=rt.minutes, type=rt.type,
+        reason=rt.reason, source=rt.source,
+    )
+
+
+def find_routine_by_client_request(
+    db: Session, trainer_id: str, member_id: str, client_request_id: str
+) -> TrainerRoutine | None:
+    return db.scalar(
+        select(TrainerRoutine).where(
+            TrainerRoutine.trainer_id == trainer_id,
+            TrainerRoutine.member_id == member_id,
+            TrainerRoutine.client_request_id == client_request_id,
+        )
+    )
+
+
 def assign_routine(
     db: Session, trainer_id: str, member_id: str,
     name: str, minutes: int, type_: str, reason: str, source: str,
+    client_request_id: str | None = None,
 ) -> RoutineOut:
-    """회원에게 루틴 배정. 로스터 last_routine 은 build_roster 가 최신 루틴을 읽어 반영."""
+    """회원에게 루틴 배정. 로스터 last_routine 은 build_roster 가 최신 루틴을 읽어 반영.
+
+    [client_request_id] 가 오면 그 전송 시도에 대해 멱등하다. 같은 키로 다시
+    호출하면 새로 만들지 않고 먼저 저장된 배정을 그대로 돌려준다 — 전송 도중
+    끊겨 클라이언트가 재시도해도 회원에게 루틴이 두 번 배정되지 않는다(#581).
+    """
+    if client_request_id:
+        existing = find_routine_by_client_request(
+            db, trainer_id, member_id, client_request_id
+        )
+        if existing is not None:
+            return _routine_out(existing)
+
     # 이 회원 루틴들의 현재 최대 sort_order + 1 로 끝에 붙인다. timestamp 방식은 시드(0..n)와
     # 의미가 섞이고, 같은 초에 배정된 둘은 순서가 비결정적이었다(리뷰 #279).
     max_order = db.scalar(
@@ -621,9 +654,26 @@ def assign_routine(
         reason=reason,
         source=source,
         sort_order=(max_order or 0) + 1,
+        client_request_id=client_request_id,
         created_at=datetime.now(timezone.utc),
     )
     db.add(rt)
+    # 알림을 붙이기 **전에** 삽입을 flush 한다. 같은 키의 동시 요청 둘이 나란히 위
+    # 조회를 통과하면 유니크 제약이 한쪽을 막는데, 그 충돌을 여기서 잡아야 진 쪽이
+    # 알림까지 중복으로 쌓지 않는다(회원이 같은 배정 알림을 두 번 받지 않는다).
+    # queue() 는 내부 조회를 하므로 그때 autoflush 로 터지면 이 지점을 지나친다.
+    try:
+        db.flush()
+    except IntegrityError:
+        db.rollback()
+        if client_request_id:
+            existing = find_routine_by_client_request(
+                db, trainer_id, member_id, client_request_id
+            )
+            if existing is not None:
+                return _routine_out(existing)
+        raise
+
     # 배정은 회원이 앱을 열기 전에는 알 수 없는 변화다(#489).
     notification_service.queue(
         db,
@@ -634,10 +684,7 @@ def assign_routine(
     )
     db.commit()
     db.refresh(rt)
-    return RoutineOut(
-        id=rt.id, name=rt.name, minutes=rt.minutes, type=rt.type,
-        reason=rt.reason, source=rt.source,
-    )
+    return _routine_out(rt)
 
 
 # ---- 스케줄 (트레이너 타임라인 + 예약→수업→기록 완료 루프) ----

--- a/backend/migrations/versions/0028_routine_client_request_id.py
+++ b/backend/migrations/versions/0028_routine_client_request_id.py
@@ -1,0 +1,47 @@
+"""trainer_routines.client_request_id (재전송 중복 배정 방지)
+
+루틴 배정은 멱등하지 않아 매 요청이 새 행을 만든다. 전송 중 네트워크가 끊기면
+서버는 이미 커밋했는데 클라이언트는 실패로 처리하는 구간이 생기고, 트레이너가
+결과를 확인하지 않고 다시 보내면 회원에게 같은 루틴이 두 번 배정된다.
+
+전송 시도당 멱등키를 저장하고 (trainer_id, member_id, client_request_id) 유니크
+제약으로 재전송 중복을 차단한다. NULL 허용 → 기존/무키 요청은 제약 밖.
+기존 행 보존을 위한 추가형(additive) 마이그레이션이다.
+
+Postgres 는 NULL 을 서로 다른 값으로 보므로 키 없는 요청끼리는 충돌하지 않는다
+(0009_diet_idempotency_key 와 같은 성질).
+
+Revision ID: 0028_routine_client_req
+Revises: 0027_exercise_source
+Create Date: 2026-08-10
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "0028_routine_client_req"
+down_revision: str | Sequence[str] | None = "0027_exercise_source"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "trainer_routines",
+        sa.Column("client_request_id", sa.String(64), nullable=True),
+    )
+    op.create_unique_constraint(
+        "uq_trainer_routines_client_request",
+        "trainer_routines",
+        ["trainer_id", "member_id", "client_request_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "uq_trainer_routines_client_request", "trainer_routines", type_="unique"
+    )
+    op.drop_column("trainer_routines", "client_request_id")

--- a/backend/tests/test_trainer_routine_idempotency.py
+++ b/backend/tests/test_trainer_routine_idempotency.py
@@ -1,0 +1,201 @@
+"""루틴 배정 멱등성 (#581). DB 필요.
+
+배정은 멱등하지 않아 매 요청이 새 행을 만들었다. 전송 중 네트워크가 끊기면
+서버는 이미 커밋했는데 클라이언트는 실패로 처리하는 구간이 생기고, 트레이너가
+결과를 확인하지 않고 다시 보내면 회원에게 같은 루틴이 두 번 배정된다.
+
+전송 시도당 멱등키를 받아 같은 키의 재요청은 새로 만들지 않고 먼저 저장된
+배정을 그대로 돌려준다.
+"""
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+
+from app.models.models import TrainerRoutine
+
+MEMBER = "user-jisu"
+TRAINER = "trainer-demo"
+
+
+def _tok(client) -> str:
+    return client.post(
+        "/v1/auth/login",
+        data={"username": "trainer@oncare.com", "password": "oncare123"},
+    ).json()["access_token"]
+
+
+def _h(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _body(key: str | None, name: str = "저강도 걷기") -> dict:
+    body: dict = {"name": name, "minutes": 30, "type": "유산소", "reason": "혈압 관리"}
+    if key is not None:
+        body["client_request_id"] = key
+    return body
+
+
+@pytest.fixture()
+def cleanup_routines(client, db_session):
+    """테스트가 만든 루틴을 지운다.
+
+    지우지 않으면 이 회원의 루틴이 실행마다 쌓여 다른 테스트의 목록 단언을
+    흔든다(#558 과 같은 누적 취약성).
+    """
+    created: list[str] = []
+    yield created
+    token = _tok(client)
+    for routine_id in created:
+        client.delete(
+            f"/v1/trainer/clients/{MEMBER}/routines/{routine_id}", headers=_h(token)
+        )
+
+
+def _rows_for(db_session, key: str) -> list[TrainerRoutine]:
+    db_session.expire_all()
+    return list(
+        db_session.scalars(
+            select(TrainerRoutine).where(
+                TrainerRoutine.trainer_id == TRAINER,
+                TrainerRoutine.member_id == MEMBER,
+                TrainerRoutine.client_request_id == key,
+            )
+        ).all()
+    )
+
+
+def test_same_key_assigns_only_once(client, db_session, cleanup_routines):
+    """같은 키로 2회 호출 → 루틴은 1건, 두 응답은 같은 배정을 가리킨다."""
+    token = _tok(client)
+    key = f"req-{uuid4().hex[:12]}"
+
+    first = client.post(
+        f"/v1/trainer/clients/{MEMBER}/routines", json=_body(key), headers=_h(token)
+    )
+    assert first.status_code == 201, first.text
+    cleanup_routines.append(first.json()["id"])
+
+    second = client.post(
+        f"/v1/trainer/clients/{MEMBER}/routines", json=_body(key), headers=_h(token)
+    )
+    assert second.status_code == 201, second.text
+
+    # 같은 배정을 돌려준다 — 클라이언트는 재시도해도 같은 결과를 본다.
+    assert second.json()["id"] == first.json()["id"]
+    assert len(_rows_for(db_session, key)) == 1
+
+
+def test_retry_after_a_lost_response_does_not_duplicate(
+    client, db_session, cleanup_routines
+):
+    """응답을 못 받은 트레이너가 같은 키로 재전송해도 회원에게 1건만 배정된다.
+
+    이것이 이 이슈의 실제 시나리오다 — 서버는 커밋했는데 클라이언트는 실패로
+    본 상태에서의 재시도.
+    """
+    token = _tok(client)
+    key = f"req-{uuid4().hex[:12]}"
+
+    sent = client.post(
+        f"/v1/trainer/clients/{MEMBER}/routines", json=_body(key), headers=_h(token)
+    )
+    assert sent.status_code == 201
+    cleanup_routines.append(sent.json()["id"])
+
+    # 클라이언트가 응답을 잃고 같은 키로 두 번 더 재시도.
+    for _ in range(2):
+        again = client.post(
+            f"/v1/trainer/clients/{MEMBER}/routines", json=_body(key), headers=_h(token)
+        )
+        assert again.status_code == 201
+        assert again.json()["id"] == sent.json()["id"]
+
+    assert len(_rows_for(db_session, key)) == 1
+
+    # 회원 쪽 목록에도 하나만 보인다.
+    listed = client.get(
+        f"/v1/trainer/clients/{MEMBER}/routines", headers=_h(token)
+    ).json()
+    assert [r["id"] for r in listed].count(sent.json()["id"]) == 1
+
+
+def test_different_keys_create_separate_assignments(
+    client, db_session, cleanup_routines
+):
+    """키가 다르면 별개의 배정이다 — 멱등성이 정상 배정을 막지 않는다."""
+    token = _tok(client)
+    first_key = f"req-{uuid4().hex[:12]}"
+    second_key = f"req-{uuid4().hex[:12]}"
+
+    first = client.post(
+        f"/v1/trainer/clients/{MEMBER}/routines",
+        json=_body(first_key, name="아침 걷기"),
+        headers=_h(token),
+    )
+    second = client.post(
+        f"/v1/trainer/clients/{MEMBER}/routines",
+        json=_body(second_key, name="저녁 스트레칭"),
+        headers=_h(token),
+    )
+    assert first.status_code == 201 and second.status_code == 201
+    cleanup_routines.extend([first.json()["id"], second.json()["id"]])
+
+    assert first.json()["id"] != second.json()["id"]
+    assert len(_rows_for(db_session, first_key)) == 1
+    assert len(_rows_for(db_session, second_key)) == 1
+
+
+def test_requests_without_a_key_keep_the_previous_behaviour(
+    client, cleanup_routines
+):
+    """키가 없으면 기존대로 매 요청이 새 배정이다 — 구버전 앱이 깨지지 않는다."""
+    token = _tok(client)
+
+    ids = []
+    for _ in range(2):
+        response = client.post(
+            f"/v1/trainer/clients/{MEMBER}/routines",
+            json=_body(None),
+            headers=_h(token),
+        )
+        assert response.status_code == 201, response.text
+        ids.append(response.json()["id"])
+    cleanup_routines.extend(ids)
+
+    assert ids[0] != ids[1], "키 없는 요청까지 합쳐지면 정상 배정이 막힌다"
+
+
+def test_concurrent_same_key_requests_create_one_assignment(
+    client, db_session, cleanup_routines
+):
+    """같은 키의 동시 요청 둘이 나란히 들어와도 1건만 남는다.
+
+    조회-후-삽입 사이를 둘이 함께 지나가면 유니크 제약이 한쪽을 막는데, 그때
+    500 이 아니라 이긴 행을 돌려줘야 한다.
+    """
+    token = _tok(client)
+    key = f"req-{uuid4().hex[:12]}"
+    barrier = Barrier(2)
+
+    def send():
+        barrier.wait()
+        return client.post(
+            f"/v1/trainer/clients/{MEMBER}/routines",
+            json=_body(key),
+            headers=_h(token),
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        responses = [f.result(timeout=15) for f in [pool.submit(send) for _ in range(2)]]
+
+    assert [r.status_code for r in responses] == [201, 201], [r.text for r in responses]
+    ids = {r.json()["id"] for r in responses}
+    assert len(ids) == 1, "동시 요청이 서로 다른 배정을 만들었다"
+    cleanup_routines.extend(ids)
+
+    assert len(_rows_for(db_session, key)) == 1

--- a/frontend/flutter_trainer/lib/core/utils/request_id.dart
+++ b/frontend/flutter_trainer/lib/core/utils/request_id.dart
@@ -1,0 +1,20 @@
+import 'dart:math';
+
+/// Creates an idempotency key for one **send attempt**.
+///
+/// 서버는 `(trainer_id, member_id, client_request_id)` 로 중복 배정을 막는다
+/// (#581). 그래서 이 값의 수명이 핵심이다 — 재시도할 때는 **같은 키를 다시
+/// 보내야** 하고, 새 내용을 보낼 때만 새로 만든다. 요청마다 새로 만들면
+/// 멱등성이 아무것도 막지 못한다.
+///
+/// `uuid` 패키지를 들이지 않는다. 여기서 필요한 건 전역 유일성이 아니라 한
+/// 트레이너·회원 조합 안에서 겹치지 않을 정도의 무작위성이고, 그 정도는
+/// `Random.secure()` 로 충분하다.
+String newClientRequestId() {
+  final rng = Random.secure();
+  final buffer = StringBuffer('req-');
+  for (int i = 0; i < 16; i++) {
+    buffer.write(rng.nextInt(16).toRadixString(16));
+  }
+  return buffer.toString();
+}

--- a/frontend/flutter_trainer/lib/features/coaching/data/dtos/routine_dtos.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/data/dtos/routine_dtos.dart
@@ -41,13 +41,20 @@ AssignedRoutine assignedRoutineFromJson(Map<String, Object?> json) {
 
 /// [AssignedRoutine] → `RoutineAssignRequest` JSON. Clamps/normalises so the
 /// backend's validators (minutes 0–600, type literal, lengths) never 422.
-Map<String, Object?> assignRoutineToJson(AssignedRoutine r) {
+///
+/// [clientRequestId] 는 전송 시도의 멱등키다. 넣어 보내면 같은 키의 재요청이
+/// 새 배정을 만들지 않는다(#581). 생략하면 서버는 기존처럼 매번 새로 배정한다.
+Map<String, Object?> assignRoutineToJson(
+  AssignedRoutine r, {
+  String? clientRequestId,
+}) {
   return <String, Object?>{
     'name': r.name.trim().isEmpty ? 'AI 맞춤 루틴' : _truncate(r.name.trim(), 100),
     'minutes': r.minutes.clamp(0, 600),
     'type': kRoutineTypes.contains(r.type) ? r.type : '근력',
     'reason': _truncate(r.reason, 200),
     'source': r.source == 'trainer' ? 'trainer' : 'ai',
+    'client_request_id': ?clientRequestId,
   };
 }
 

--- a/frontend/flutter_trainer/lib/features/coaching/data/repositories/dio_trainer_routine_repository.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/data/repositories/dio_trainer_routine_repository.dart
@@ -15,21 +15,22 @@ class DioTrainerRoutineRepository implements TrainerRoutineRepository {
 
   /// Assigns [routine] to [memberId].
   ///
-  /// NOT idempotent: `POST /trainer/clients/{id}/routines` inserts a fresh
-  /// `rt-{uuid}` row on every call, with no client-request-id/dedup key
-  /// today. If this throws after a network timeout, the backend may have
-  /// already committed the assign before the client gave up waiting —
-  /// blindly retrying can leave the member with two copies of the same
-  /// routine. Callers that retry on failure should special-case a network/
-  /// timeout error (ambiguous outcome) rather than assume a clean retry is
-  /// always safe (review; a full fix needs a backend idempotency key).
+  /// [clientRequestId] 를 주면 그 전송 시도에 대해 멱등하다 — 서버가
+  /// `(trainer_id, member_id, client_request_id)` 로 중복을 막고, 같은 키의
+  /// 재요청에는 먼저 저장된 배정을 그대로 돌려준다(#581). 그래서 네트워크
+  /// 타임아웃처럼 결과를 알 수 없는 실패 뒤에도 **같은 키로** 안전하게 재시도할
+  /// 수 있다. 키를 생략하면 예전처럼 매 호출이 새 배정이 된다.
   @override
-  Future<void> assignRoutine(String memberId, AssignedRoutine routine) async {
+  Future<void> assignRoutine(
+    String memberId,
+    AssignedRoutine routine, {
+    String? clientRequestId,
+  }) async {
     final encodedId = Uri.encodeComponent(memberId);
     try {
       await _dio.post<Map<String, Object?>>(
         '/trainer/clients/$encodedId/routines',
-        data: assignRoutineToJson(routine),
+        data: assignRoutineToJson(routine, clientRequestId: clientRequestId),
       );
     } on DioException catch (e) {
       throw AppError.fromDio(e);

--- a/frontend/flutter_trainer/lib/features/coaching/data/repositories/trainer_routine_repository.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/data/repositories/trainer_routine_repository.dart
@@ -16,7 +16,15 @@ import 'package:oncare_trainer/features/coaching/domain/entities/assigned_routin
 ///  * [DioTrainerRoutineRepository] — the real FastAPI backend.
 abstract interface class TrainerRoutineRepository {
   /// Assigns [routine] to [memberId] (POST /trainer/clients/{id}/routines).
-  Future<void> assignRoutine(String memberId, AssignedRoutine routine);
+  ///
+  /// [clientRequestId] 는 **전송 시도**의 멱등키다. 재시도할 때 같은 값을 다시
+  /// 넘기면 회원에게 같은 루틴이 두 번 배정되지 않는다(#581). 새 내용을 보낼
+  /// 때만 새로 만든다 — 매 호출 새로 만들면 아무것도 막지 못한다.
+  Future<void> assignRoutine(
+    String memberId,
+    AssignedRoutine routine, {
+    String? clientRequestId,
+  });
 
   /// The member's currently assigned routines (newest first).
   Stream<List<AssignedRoutine>> watchAssignedRoutines(String memberId);
@@ -45,7 +53,11 @@ class MockTrainerRoutineRepository implements TrainerRoutineRepository {
   const MockTrainerRoutineRepository();
 
   @override
-  Future<void> assignRoutine(String memberId, AssignedRoutine routine) async {}
+  Future<void> assignRoutine(
+    String memberId,
+    AssignedRoutine routine, {
+    String? clientRequestId,
+  }) async {}
 
   @override
   Stream<List<AssignedRoutine>> watchAssignedRoutines(String memberId) =>

--- a/frontend/flutter_trainer/lib/features/coaching/presentation/pages/ai_routine_options_flow.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/pages/ai_routine_options_flow.dart
@@ -3,7 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:oncare_trainer/app/router/routes.dart';
-import 'package:oncare_trainer/core/errors/app_error.dart';
+import 'package:oncare_trainer/core/utils/request_id.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/design_system/tokens/elevation.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
@@ -58,6 +58,11 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
   bool _sending = false;
   bool _showAddExercise = false;
   bool _sent = false;
+
+  /// 진행 중인 전송 시도의 멱등키. 실패 후 재시도는 이 값을 그대로 다시 쓰고,
+  /// 전송이 성공하면 비운다 — 그래야 재시도가 중복 배정을 만들지 않으면서도
+  /// 다음 전송은 별개의 배정이 된다(#581).
+  String? _sendRequestId;
   RoutineOptions? _options;
   int _stage = 0;
   int _maxReachedStage = 0;
@@ -221,6 +226,11 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
     final messenger = ScaffoldMessenger.of(context);
     final routine = _composeRoutine(l);
 
+    // 이 전송 시도의 멱등키. 실패해서 트레이너가 다시 누르면 **같은 키**가 다시
+    // 나가므로, 앞 시도가 서버에 이미 커밋됐더라도 중복 배정되지 않는다(#581).
+    // 성공한 뒤에만 비워 다음 전송이 새 배정이 되게 한다.
+    _sendRequestId ??= newClientRequestId();
+
     setState(() => _sending = true);
     try {
       // Assigning the routine IS the delivery — the member receives it via
@@ -229,27 +239,18 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
       // the legacy single-shot editor's _send in ai_routine_page.dart).
       await ref
           .read(trainerRoutineRepositoryProvider)
-          .assignRoutine(widget.client.id, routine);
-    } catch (e) {
+          .assignRoutine(
+            widget.client.id,
+            routine,
+            clientRequestId: _sendRequestId,
+          );
+    } catch (_) {
       if (!mounted) return;
       setState(() => _sending = false);
-      // A network/timeout failure is AMBIGUOUS: the backend may already
-      // have committed the assign before the client gave up waiting for a
-      // response (POST /routines is not idempotent — every attempt inserts
-      // a new row). Blindly telling the trainer to "다시 시도" risks a
-      // duplicate routine landing on the member's app, so this case gets a
-      // different message asking them to verify first (review; a real
-      // fix needs a backend idempotency/dedup key — tracked separately).
-      final ambiguousOutcome = e is NetworkError;
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text(
-            ambiguousOutcome
-                ? l.coachSendNoResponse
-                : l.coachSendFailed,
-          ),
-        ),
-      );
+      // 네트워크 실패는 결과를 알 수 없다 — 서버가 이미 커밋한 뒤 응답만 유실됐을
+      // 수 있다. 다만 멱등키를 함께 보내므로 **같은 키로 재시도해도 중복 배정이
+      // 되지 않는다**(#581). 그래서 "먼저 확인하라" 대신 재시도를 안내한다.
+      messenger.showSnackBar(SnackBar(content: Text(l.coachSendFailed)));
       return;
     }
 
@@ -257,6 +258,7 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
     setState(() {
       _sending = false;
       _sent = true;
+      _sendRequestId = null; // 다음 전송은 새 배정이다.
     });
     messenger.showSnackBar(
       SnackBar(content: Text(l.aiRoutineSent(widget.client.name))),

--- a/frontend/flutter_trainer/lib/features/coaching/presentation/pages/coaching_page.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/pages/coaching_page.dart
@@ -3,8 +3,8 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'package:oncare_trainer/core/errors/app_error.dart';
 import 'package:oncare_trainer/core/utils/date_format.dart';
+import 'package:oncare_trainer/core/utils/request_id.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/design_system/tokens/elevation.dart';
 import 'package:oncare_trainer/design_system/tokens/layout.dart';
@@ -87,6 +87,11 @@ class _CoachingPageState extends ConsumerState<CoachingPage> {
   /// A homework send is in flight (blocks re-entry, disables the button).
   bool _sending = false;
 
+  /// 진행 중인 전송 시도의 멱등키와 그 대상 회원. 실패 후 재시도는 같은 키를
+  /// 다시 쓰고(중복 배정 방지), 성공하거나 대상이 바뀌면 새로 잡는다(#581).
+  String? _sendRequestId;
+  String? _sendRequestFor;
+
   /// A schedule registration just succeeded (drives the 3s flash).
   bool _registered = false;
   // Every client whose registration is in flight. Multiple clients may save
@@ -156,6 +161,13 @@ class _CoachingPageState extends ConsumerState<CoachingPage> {
     // the starting client, not whoever is on screen when it resolves
     // (review PR 239).
     final sentFor = client.id;
+    // 이 전송 시도의 멱등키. 실패 후 다시 누르면 같은 키가 나가므로 앞 시도가
+    // 이미 서버에 커밋됐어도 중복 배정되지 않는다(#581). 대상 회원이 바뀌면
+    // 다른 배정이므로 키도 새로 잡는다.
+    if (_sendRequestId == null || _sendRequestFor != sentFor) {
+      _sendRequestId = newClientRequestId();
+      _sendRequestFor = sentFor;
+    }
     setState(() => _sending = true);
     try {
       // Assigning the routine IS the delivery — the member receives it via
@@ -164,33 +176,27 @@ class _CoachingPageState extends ConsumerState<CoachingPage> {
       // shown in the member's routine feed, not as a chat bubble.
       await ref
           .read(trainerRoutineRepositoryProvider)
-          .assignRoutine(client.id, _summaryRoutine(items, total + custom));
-    } catch (e) {
+          .assignRoutine(
+            client.id,
+            _summaryRoutine(items, total + custom),
+            clientRequestId: _sendRequestId,
+          );
+    } catch (_) {
       if (!mounted || !_isStillSelected(sentFor)) return;
       setState(() => _sending = false);
-      // A network/timeout failure is AMBIGUOUS: the backend may already
-      // have committed the assign before the client gave up waiting for a
-      // response (POST /routines is not idempotent — every attempt inserts
-      // a new row). Blindly telling the trainer to "다시 시도" risks a
-      // duplicate routine landing on the member's app, so this case gets a
-      // different message asking them to verify first (review; a real
-      // fix needs a backend idempotency/dedup key — tracked separately).
-      final ambiguousOutcome = e is NetworkError;
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text(
-            ambiguousOutcome
-                ? l.coachSendNoResponse
-                : l.coachSendFailed,
-          ),
-        ),
-      );
+      // 네트워크 실패는 결과를 알 수 없지만, 멱등키를 함께 보내므로 **같은 키로
+      // 재시도해도 중복 배정이 되지 않는다**(#581). 그래서 "먼저 확인하라" 대신
+      // 재시도를 안내한다.
+      messenger.showSnackBar(SnackBar(content: Text(l.coachSendFailed)));
       return;
     }
     if (!mounted || !_isStillSelected(sentFor)) return;
     setState(() {
       _sending = false;
       _sent = true;
+      // 성공했으니 다음 전송은 새 배정이다.
+      _sendRequestId = null;
+      _sendRequestFor = null;
     });
     _sentTimer?.cancel();
     // Mock: after the confirmation, reset the edits for the next round.

--- a/frontend/flutter_trainer/test/features/clients/routine_crud_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/routine_crud_test.dart
@@ -66,7 +66,11 @@ class _FakeRoutineRepository implements TrainerRoutineRepository {
   };
 
   @override
-  Future<void> assignRoutine(String memberId, AssignedRoutine routine) async {}
+  Future<void> assignRoutine(
+    String memberId,
+    AssignedRoutine routine, {
+    String? clientRequestId,
+  }) async {}
 
   @override
   Stream<List<AssignedRoutine>> watchAssignedRoutines(String memberId) {

--- a/frontend/flutter_trainer/test/features/coaching/coaching_page_test.dart
+++ b/frontend/flutter_trainer/test/features/coaching/coaching_page_test.dart
@@ -182,8 +182,16 @@ class _SpyTrainerRoutineRepository implements TrainerRoutineRepository {
   final Object? throwOnAssign;
   AssignedRoutine? lastAssigned;
 
+  /// 전송 시도마다 넘어온 멱등키. 재시도가 같은 키를 쓰는지 본다(#581).
+  final List<String?> assignAttempts = <String?>[];
+
   @override
-  Future<void> assignRoutine(String memberId, AssignedRoutine routine) async {
+  Future<void> assignRoutine(
+    String memberId,
+    AssignedRoutine routine, {
+    String? clientRequestId,
+  }) async {
+    assignAttempts.add(clientRequestId);
     if (throwOnAssign != null) throw throwOnAssign!;
     lastAssigned = routine;
   }
@@ -1095,19 +1103,19 @@ void main() {
     );
 
     testWidgets(
-      'a network/timeout assign failure shows the ambiguous verify-first '
-      "message, not '다시 시도' (assign is not idempotent — retrying on an "
-      'ambiguous failure risks a duplicate routine)',
+      '네트워크 실패도 재시도를 안내한다 — 멱등키를 함께 보내므로 다시 눌러도 '
+      '회원에게 루틴이 두 번 배정되지 않는다 (#581)',
       (tester) async {
         await openRealApiTab(tester, assignError: const NetworkError());
 
         await tapSend(tester);
 
+        expect(find.text('전송에 실패했어요. 다시 시도해 주세요'), findsOneWidget);
         expect(
           find.text('응답을 받지 못했어요. 고객의 받은 루틴을 확인한 뒤 필요한 경우에만 다시 보내주세요'),
-          findsOneWidget,
+          findsNothing,
+          reason: '멱등해진 뒤에는 "먼저 확인하라"고 막을 이유가 없다',
         );
-        expect(find.text('전송에 실패했어요. 다시 시도해 주세요'), findsNothing);
       },
     );
 
@@ -1123,6 +1131,28 @@ void main() {
         findsNothing,
       );
     });
+
+    testWidgets(
+      '실패 후 재시도는 같은 멱등키를 다시 보낸다 (#581)',
+      (tester) async {
+        // 키가 매번 새로 생기면 서버의 유니크 제약이 아무것도 막지 못한다.
+        final routineRepo = await openRealApiTab(
+          tester,
+          assignError: const NetworkError(),
+        );
+
+        await tapSend(tester);
+        await tapSend(tester);
+
+        expect(routineRepo.assignAttempts, hasLength(2));
+        expect(routineRepo.assignAttempts.first, isNotNull);
+        expect(
+          routineRepo.assignAttempts.first,
+          routineRepo.assignAttempts.last,
+          reason: '재시도가 새 키를 만들면 중복 배정이 그대로 생긴다',
+        );
+      },
+    );
 
     testWidgets(
       'an all-custom send (every AI suggestion removed) assigns type/source '

--- a/frontend/flutter_trainer/test/features/coaching/routine_options_provider_and_flow_test.dart
+++ b/frontend/flutter_trainer/test/features/coaching/routine_options_provider_and_flow_test.dart
@@ -53,11 +53,17 @@ class _CapturingRoutineRepository implements TrainerRoutineRepository {
 
   AssignedRoutine? assigned;
   String? memberId;
+  String? lastClientRequestId;
 
   @override
-  Future<void> assignRoutine(String memberId, AssignedRoutine routine) async {
+  Future<void> assignRoutine(
+    String memberId,
+    AssignedRoutine routine, {
+    String? clientRequestId,
+  }) async {
     this.memberId = memberId;
     assigned = routine;
+    lastClientRequestId = clientRequestId;
   }
 
   @override
@@ -86,8 +92,16 @@ class _ThrowingRoutineRepository implements TrainerRoutineRepository {
 
   final Object error;
 
+  /// 시도마다 넘어온 멱등키 — 재시도가 같은 키인지 확인한다(#581).
+  final List<String?> attempts = <String?>[];
+
   @override
-  Future<void> assignRoutine(String memberId, AssignedRoutine routine) async {
+  Future<void> assignRoutine(
+    String memberId,
+    AssignedRoutine routine, {
+    String? clientRequestId,
+  }) async {
+    attempts.add(clientRequestId);
     throw error;
   }
 
@@ -357,22 +371,22 @@ void main() {
   });
 
   testWidgets(
-    'a network/timeout assign failure shows the ambiguous verify-first '
-    "message, not '다시 시도' (assign is not idempotent — retrying on an "
-    'ambiguous failure risks a duplicate routine)',
+    '네트워크 실패도 재시도를 안내하고, 재시도는 같은 멱등키를 다시 보낸다 (#581)',
     (tester) async {
+      // 서버가 (trainer_id, member_id, client_request_id) 로 중복 배정을 막으므로
+      // 애매한 실패(서버는 커밋했는데 응답만 유실) 뒤에도 안전하게 다시 보낼 수
+      // 있다. 예전에는 "먼저 확인하라"고 안내할 수밖에 없었다.
       tester.view.physicalSize = const Size(1000, 2400);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.resetPhysicalSize);
       addTearDown(tester.view.resetDevicePixelRatio);
 
+      final repository = _ThrowingRoutineRepository(const NetworkError());
       await tester.pumpWidget(
         ProviderScope(
           overrides: <Override>[
             appConfigProvider.overrideWithValue(_mockConfig),
-            trainerRoutineRepositoryProvider.overrideWithValue(
-              _ThrowingRoutineRepository(const NetworkError()),
-            ),
+            trainerRoutineRepositoryProvider.overrideWithValue(repository),
           ],
           child: MaterialApp(
           locale: const Locale('ko'),
@@ -390,16 +404,25 @@ void main() {
       );
 
       await _driveToSendReady(tester);
-      await tester.tap(
-        find.byKey(const ValueKey<String>('send-selected-routine')),
+      final sendButton = find.byKey(
+        const ValueKey<String>('send-selected-routine'),
       );
+      await tester.tap(sendButton);
       await tester.pumpAndSettle();
 
+      expect(find.text('전송에 실패했어요. 다시 시도해 주세요'), findsOneWidget);
+
+      // 트레이너가 다시 누른다 — 같은 키가 나가야 중복 배정이 안 생긴다.
+      await tester.tap(sendButton);
+      await tester.pumpAndSettle();
+
+      expect(repository.attempts, hasLength(2));
+      expect(repository.attempts.first, isNotNull);
       expect(
-        find.text('응답을 받지 못했어요. 고객의 받은 루틴을 확인한 뒤 필요한 경우에만 다시 보내주세요'),
-        findsOneWidget,
+        repository.attempts.first,
+        repository.attempts.last,
+        reason: '재시도가 새 키를 만들면 서버가 중복을 막을 수 없다',
       );
-      expect(find.text('전송에 실패했어요. 다시 시도해 주세요'), findsNothing);
     },
   );
 


### PR DESCRIPTION
## Summary

- 루틴 배정이 멱등하지 않아, 전송 중 끊기고 재시도하면 회원에게 같은 루틴이 두 번 배정되던 문제를 고칩니다.
- 전송 시도당 멱등키(`client_request_id`)를 받아 유니크 제약으로 막고, 같은 키의 재요청에는 먼저 저장된 배정을 그대로 돌려줍니다.
- 멱등해졌으므로 프론트가 쓰던 "먼저 확인해 주세요" 우회도 되돌립니다.

## Problem

`POST /trainer/clients/{member_id}/routines` 는 매 요청이 새 행을 만듭니다. 그래서 **전송 중 네트워크가 끊기면 서버는 이미 커밋했는데 클라이언트는 실패로 처리하는** 구간이 생깁니다.

프론트는 이 위험을 이미 인지하고 우회 중이었습니다 — 네트워크 오류일 때만 "다시 시도" 대신 "응답 없음, 먼저 확인해 주세요"를 띄웠습니다. 그 주석은 진짜 해결책이 백엔드 멱등키이며 "tracked separately" 라고 적어 두었지만, **실제로 그 추적 이슈가 없었습니다.**

지금 상태에서는 트레이너가 결과를 확인하러 들어가지 않으면 회원 앱에 같은 루틴이 두 번 배정됩니다.

## Approach

`DietEntry.idempotency_key` 라는 선례가 이미 있어 같은 방식을 따랐습니다.

- 전송 **시도**당 클라이언트가 키를 만들고, 재시도는 **같은 키**를 다시 보냅니다
- `(trainer_id, member_id, client_request_id)` 유니크 제약
- 같은 키의 재요청은 새로 만들지 않고 기존 배정을 반환(2xx 유지)
- NULL 허용 → 키 없는 기존 요청은 제약 밖이라 **구버전 앱도 그대로 동작**합니다

## Changes

### Fixes

- `TrainerRoutine.client_request_id` 추가 + 유니크 제약, 마이그레이션 `0028_routine_client_req`(추가형)
- `assign_routine` 이 같은 키의 재요청에 기존 배정을 반환
- 트레이너 앱이 전송 시도 단위로 키를 만들고 재시도 시 재사용 (성공하거나 대상 회원이 바뀔 때만 새로 발급)
- 네트워크 실패 안내를 "먼저 확인" → "다시 시도" 로 되돌림

### Improvements

- 알림 큐잉 **전에** flush 해 충돌을 먼저 잡습니다. `notification_service.queue()` 가 내부 조회를 하면서 autoflush 로 터지면 그 지점을 지나쳐, 경쟁에서 진 쪽이 알림까지 중복으로 쌓습니다 — 회원이 같은 배정 알림을 두 번 받게 됩니다.

### Features / UI Changes / Documentation

- 없음

## Commits

1. `2b453e5` — `fix(trainer): 루틴 배정에 멱등키를 도입해 재전송 중복을 막음`

## Notes

- **키의 수명이 이 수정의 핵심입니다.** 요청마다 새로 만들면 유니크 제약이 아무것도 막지 못합니다. 그래서 화면 상태로 들고 있다가 **성공한 뒤에만** 비웁니다. 프론트 테스트가 "재시도가 같은 키를 보내는지"를 직접 단언합니다.
- `uuid` 패키지를 새로 들이지 않았습니다. 필요한 건 전역 유일성이 아니라 한 트레이너·회원 조합 안에서 겹치지 않을 정도의 무작위성이라 `Random.secure()` 로 충분합니다.
- **동시 요청**도 다룹니다. 같은 키의 두 요청이 조회-후-삽입 사이를 함께 지나가면 유니크 제약이 한쪽을 막는데, 그때 500 이 아니라 이긴 행을 돌려줍니다.
- 이 브랜치와 무관한 **기존 실패 3건**이 있습니다 — `tests/test_trainer.py` 의 회원 탄단지 집계 테스트. **main 에서 동일하게 실패**하며 #565 담당 범위로 보입니다. 건드리지 않았습니다.
- 제외 범위(이슈 그대로): 다른 POST 엔드포인트의 멱등성, 오프라인 큐잉.

## Test Plan

- [x] `tests/test_trainer_routine_idempotency.py` 신규 5건
  - 같은 키 2회 → 루틴 1건, 두 응답이 같은 배정
  - 응답 유실 후 재전송 2회 → 회원 목록에도 1건
  - 키가 다르면 별개 배정 (멱등성이 정상 배정을 막지 않음)
  - 키 없는 요청은 기존 동작 유지 (구버전 앱 호환)
  - **동시 요청** 2건 → 1건만 생성, 둘 다 201
- [x] 백엔드 `pytest` — 위 기존 실패 3건 외 전부 통과
- [x] 마이그레이션 `alembic upgrade head` 적용 확인
- [x] 트레이너 앱 `flutter analyze` — No issues found
- [x] 트레이너 앱 `flutter test` — **451건 통과**
- [x] 프론트 회귀 방지 — 실패 후 재시도가 같은 키를 보내는지 두 화면(`coaching_page`, `ai_routine_options_flow`) 각각 단언

### Manual Test Steps

1. 트레이너 웹에서 루틴을 전송하고, 개발자도구로 네트워크를 끊어 실패를 만든다
2. 같은 화면에서 다시 전송한다
3. 회원 앱(또는 `GET /trainer/clients/{id}/routines`)에서 루틴이 **하나만** 보이는지 확인
4. 전송 성공 후 새 루틴을 만들어 보내면 별개 배정으로 추가되는지 확인

## Related Issues

Closes #581

## Checklist

- [x] 동일 키로 2회 호출 시 루틴이 1건만 생성됩니다.
- [x] 전송 도중 실패 후 재시도해도 회원 앱에 1건만 보입니다.
- [x] 재시도가 같은 키를 재사용하는지 테스트로 고정했습니다.
- [x] 키 없는 요청의 기존 동작이 유지됩니다(구버전 앱 호환).
- [x] 마이그레이션은 기존 행을 보존하는 추가형입니다.
