### PR TITLE
chore(ai): routine_ai의 죽은 LLM seam과 미사용 상수 정리

### DIFF
--- a/backend/app/services/routine_ai.py
+++ b/backend/app/services/routine_ai.py
@@ -1,13 +1,13 @@
-"""AI 루틴 A/B 생성 — 순수 로직(규칙형 폴백).
+"""AI 루틴 A/B 생성 — 순수 규칙형 로직.
 
 회원의 실데이터 요약(나트륨/완료율/목표)과 트레이너가 조종하는 입력(가능 시간/강도/
 메모)으로 두 계획을 만든다:
   * A안 — 짧고 지속하기 쉬운 회복 중심
   * B안 — 운동량/강도를 높인 루틴
 
-외부 LLM(Gemini 등)이 붙으면 `maybe_llm_plans` 가 계획을 반환하고, 실패/미설정이면
-여기 규칙형(`rule_based_plans`)으로 폴백한다. 규칙형은 결정적이라 테스트가 쉽고,
-의료 진단·치료 지시를 하지 않는다(운동 구성과 근거만 제시).
+LLM 생성과 이 규칙형 생성기로의 폴백은 `trainer_routine_options_service`가 담당한다.
+이 모듈은 결정적인 규칙형 계획만 만들며, 의료 진단·치료 지시를 하지 않는다
+(운동 구성과 근거만 제시).
 """
 from __future__ import annotations
 
@@ -21,7 +21,6 @@ _STRENGTH2 = ("플랭크", "근력")
 _STRETCH = ("코어 스트레칭", "스트레칭")
 _STRETCH2 = ("목·어깨 스트레칭", "스트레칭")
 
-_INTENSITY_KR = {"low": "낮음", "moderate": "보통", "high": "높음"}
 _B_LABEL = {"low": "낮음", "moderate": "보통", "high": "높음"}
 
 
@@ -108,13 +107,3 @@ def rule_based_plans(
         ),
     }
     return plan_a, plan_b
-
-
-def maybe_llm_plans(**kwargs) -> tuple[dict, dict] | None:
-    """LLM(Gemini 등) 연동 지점. 미설정/실패 시 None → 규칙형 폴백.
-
-    아직 외부 LLM 키를 두지 않았으므로 항상 None 을 반환한다. 연동 시 여기서
-    프롬프트를 구성해 A/B(JSON)를 받아 검증 후 반환하고, 예외/스키마 불일치는
-    삼켜 None 을 돌려 규칙형으로 안전하게 폴백한다.
-    """
-    return None

--- a/backend/app/services/trainer_routine_options_service.py
+++ b/backend/app/services/trainer_routine_options_service.py
@@ -114,7 +114,7 @@ def build_member_analysis(
     return RoutineOptionAnalysisOut(
         goal=link.goal,
         sodium_today_mg=sodium,
-        sodium_over_target=sodium > 2000,
+        sodium_over_target=sodium > routine_ai.SODIUM_TARGET_MG,
         avg_completion_rate=round(float(completion or 0)),
         latest_routine=latest.name if latest is not None else "-",
         note=request.trainer_note.strip(),

--- a/backend/tests/test_routine_options.py
+++ b/backend/tests/test_routine_options.py
@@ -107,16 +107,6 @@ def test_rule_based_rationale_cites_member_numbers_and_over_target():
     assert b["intensity"] == "낮음"
 
 
-def test_maybe_llm_plans_is_an_unused_seam_returning_none():
-    # 주의: 서비스는 이 함수를 쓰지 않는다(get_coach_llm 을 직접 호출).
-    # 남아 있는 이음새의 계약만 고정한다 — 폴백 경로는 아래 엔드포인트
-    # 테스트가 실제 호출 경로(get_coach_llm)를 막아서 검증한다.
-    assert routine_ai.maybe_llm_plans(
-        goal="", sodium_today_mg=0, avg_completion_rate=0,
-        available_minutes=30, intensity_preference="moderate", trainer_note="",
-    ) is None
-
-
 # ---- LLM 스텁 ----
 
 def _stub_llm(monkeypatch, behaviour):
@@ -124,8 +114,8 @@ def _stub_llm(monkeypatch, behaviour):
 
     서비스는 `from ... import get_coach_llm` 으로 이름을 바인딩하므로 원본
     모듈이 아니라 **서비스 모듈의 이름**을 갈아끼워야 한다. 예전 테스트는
-    `routine_ai.maybe_llm_plans` 를 patch 했는데 서비스가 그 함수를 쓰지
-    않아 무효였고, 키가 없는 CI 에서만 우연히 통과했다.
+    서비스가 사용하지 않는 규칙형 모듈의 seam을 patch해 무효였고, 키가 없는
+    CI에서만 우연히 통과했다.
 
     [behaviour] 가 Exception 이면 호출 시 그것을 던지고, 문자열이면 그
     문자열을 LLM 응답 본문으로 돌려준다.


### PR DESCRIPTION
## Summary

* 사용되지 않는 `maybe_llm_plans`와 관련 테스트를 제거했습니다.
* `routine_ai`가 규칙형 생성기 전용임을 명확히 설명하도록 문서를 현행화했습니다.
* 중복된 나트륨 기준값을 `SODIUM_TARGET_MG`로 일원화했습니다.

---

## Changes

### ✨ Features

* 없음

### 🔧 Improvements

* `trainer_routine_options_service`가 `routine_ai.SODIUM_TARGET_MG`를 사용하도록 변경
* 실제 LLM 연동과 규칙형 폴백의 책임 위치를 문서에 명확히 표시

### 🎨 UI/UX

* 없음

### 📝 Docs

* `routine_ai` 모듈 docstring을 현재 LLM 연동 구조에 맞게 수정
* 테스트의 오래된 LLM seam 설명을 현행화

### 🐛 Fixes

* 호출되지 않던 `maybe_llm_plans` 제거
* 미사용 상수 `_INTENSITY_KR` 제거
* 죽은 함수의 동작만 고정하던 테스트 제거

---

## Commits

1. `4b2eee03` chore(ai): remove dead routine LLM seam

---

## Notes

* API와 사용자 동작에는 변화가 없는 코드 정리 PR입니다.
* 실제 LLM 생성과 규칙형 폴백은 기존처럼 `trainer_routine_options_service`가 담당합니다.
* 규칙형 루틴 생성 로직 자체는 변경하지 않았습니다.

---

## Screenshots (Optional)

해당 없음 — 백엔드 코드 정리 작업입니다.

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인 — UI 변경 없음
* [ ] 빌드 성공 — 별도 빌드 미실행
* [x] 관련 테스트 통과

### Manual Test Steps

1. `cd backend`
2. `python -m pytest -q`
3. 전체 테스트 통과 및 기존 규칙형 폴백 동작 확인

테스트 결과: 전체 통과, 4개 skip, 실패 0

---

## Related Issues

Closes #587

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [ ] Merge 충돌 없음 — PR 생성 후 최종 확인
* [x] 데모 시나리오 영향 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 나트륨 섭취 초과 여부가 설정된 일일 기준값을 일관되게 사용하도록 개선했습니다.
  - 코칭 기능에서 AI 응답 오류나 비정상 결과가 발생해도 대체 처리 방식이 안정적으로 동작하도록 점검했습니다.

- **개선 사항**
  - 운동 루틴 생성 로직을 규칙 기반 동작에 맞게 정리해 결과의 일관성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->