### PR TITLE
fix(backend): routine-options에 rate limit 적용

### DIFF
--- a/backend/app/api/v1/trainer.py
+++ b/backend/app/api/v1/trainer.py
@@ -20,6 +20,8 @@ from sqlalchemy import func, select, update
 from sqlalchemy.orm import Session
 
 from app.api.deps import RequireTrainer
+from app.core.config import get_settings
+from app.core.rate_limit import rate_limit
 from app.core.security import hash_password, verify_password
 from app.db.session import get_db
 from app.models.models import Notification, TrainerClient, TrainerProfile
@@ -424,6 +426,14 @@ def trainer_delete_routine(
 @router.post(
     "/trainer/clients/{member_id}/routine-options",
     response_model=RoutineOptionsOut,
+    # LLM 을 부르는 엔드포인트라 /ai-coach/chat 과 같은 가드를 건다. 생성이
+    # 실패해 규칙형으로 폴백해도 공급자 호출 비용은 이미 나간 뒤이므로,
+    # 연타가 그대로 청구되지 않게 앞에서 막는다.
+    dependencies=[
+        Depends(
+            rate_limit("routine-options", get_settings().routine_options_per_minute)
+        )
+    ],
 )
 def trainer_routine_options(
     member_id: str,

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -128,6 +128,11 @@ class Settings(BaseSettings):
     # AI 코치 채팅 한도. 브루트포스 방어가 아니라 LLM 비용 가드라서 목적이 다르다.
     # 사람이 대화하는 속도로는 걸리지 않되, 폭주하는 클라이언트는 막는 값.
     coach_chat_per_minute: int = 20
+    # 트레이너 루틴 생성 한도. 채팅보다 낮게 잡는다 — 같은 LLM 비용에 회원 분석
+    # 쿼리가 더 얹히고, 슬라이더·강도·메모를 바꿔 가며 "생성"을 연타하기 쉬운
+    # UI 라 연타가 그대로 비용이 된다. 생성 왕복이 실측 3~6초라(#579) 사람이
+    # 결과를 보고 조정하는 속도로는 분당 10회에 닿지 않는다.
+    routine_options_per_minute: int = 10
 
     @property
     def admin_email_set(self) -> set[str]:

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -36,3 +36,52 @@ def test_register_is_rate_limited(client):
         )
     assert last.status_code == 429, last.text
     assert "Retry-After" in last.headers
+
+
+def test_routine_options_is_rate_limited(client, monkeypatch):
+    """LLM 을 부르는 루틴 생성도 한도를 넘기면 429 (#582).
+
+    한도가 없으면 슬라이더·강도·메모를 바꿔 가며 "생성"을 연타하는 UI 특성상
+    그대로 공급자 비용이 된다. 생성이 규칙형으로 폴백해도 호출 비용은 이미 나간
+    뒤라, 가드는 엔드포인트 앞단에 있어야 한다.
+    """
+    from app.core.config import get_settings
+    from app.services import trainer_routine_options_service
+
+    # 실제 LLM 을 부르지 않는다 — 여기서 보는 것은 한도이지 생성 품질이 아니다.
+    monkeypatch.setattr(
+        trainer_routine_options_service,
+        "get_coach_llm",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("provider off")),
+    )
+
+    token = client.post(
+        "/v1/auth/login",
+        data={"username": "trainer@oncare.com", "password": "oncare123"},
+    ).json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+    member_id = client.get("/v1/trainer/clients", headers=headers).json()[0]["id"]
+
+    limit = get_settings().routine_options_per_minute
+    last = None
+    for _ in range(limit + 1):
+        last = client.post(
+            f"/v1/trainer/clients/{member_id}/routine-options",
+            headers=headers,
+            json={"available_minutes": 30},
+        )
+
+    assert last.status_code == 429, last.text
+    assert "Retry-After" in last.headers
+
+
+def test_routine_options_limit_is_lower_than_coach_chat():
+    """루틴 생성 한도가 채팅보다 낮게 유지되는지 고정한다 (#582).
+
+    같은 LLM 비용에 회원 분석 쿼리가 더 얹히고 연타가 쉬운 UI 라, 채팅과 같거나
+    더 높은 값으로 되돌아가면 가드의 의미가 옅어진다.
+    """
+    from app.core.config import get_settings
+
+    settings = get_settings()
+    assert settings.routine_options_per_minute < settings.coach_chat_per_minute

--- a/frontend/flutter_trainer/lib/core/errors/app_error.dart
+++ b/frontend/flutter_trainer/lib/core/errors/app_error.dart
@@ -41,6 +41,11 @@ sealed class AppError implements Exception {
         if (code == 404) {
           return NotFoundError(message: e.message);
         }
+        if (code == 429) {
+          // 실패가 아니라 **잠시 뒤 되는** 상태다. 다른 오류와 뭉뚱그리면
+          // 트레이너가 고장으로 읽는다(#582).
+          return RateLimitedError(message: e.message);
+        }
         if (code == 400 || code == 422) {
           // The server rejected the INPUT, not the request. Callers show
           // this inline on the offending field rather than as a "다시
@@ -84,6 +89,12 @@ class NotFoundError extends AppError {
 /// server's own wording so the UI can show it verbatim.
 class ValidationError extends AppError {
   const ValidationError({super.message});
+}
+
+/// 429 — 한도 초과. 실패가 아니라 잠시 뒤 되는 상태라, 화면이 "실패했어요"
+/// 대신 기다렸다 다시 하라고 안내할 수 있게 따로 둔다(#582).
+class RateLimitedError extends AppError {
+  const RateLimitedError({super.message});
 }
 
 class ServerError extends AppError {

--- a/frontend/flutter_trainer/lib/features/coaching/presentation/pages/ai_routine_options_flow.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/pages/ai_routine_options_flow.dart
@@ -139,11 +139,19 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
         _stage = 1;
         _maxReachedStage = 1;
       });
-    } catch (_) {
+    } catch (e) {
       if (!mounted) return;
       final AppLocalizations l = AppLocalizations.of(context);
+      // 한도 초과는 고장이 아니라 잠시 뒤 되는 상태다. 다른 오류와 같은 문구를
+      // 쓰면 트레이너가 기능이 깨진 것으로 읽는다(#582).
       messenger.showSnackBar(
-        SnackBar(content: Text(l.aiGenerateFailed)),
+        SnackBar(
+          content: Text(
+            e is RateLimitedError
+                ? l.aiGenerateRateLimited
+                : l.aiGenerateFailed,
+          ),
+        ),
       );
     } finally {
       if (mounted) setState(() => _generating = false);

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
@@ -2750,6 +2750,12 @@ abstract class AppLocalizations {
   /// **'AI generation failed. Please try again in a moment'**
   String get aiGenerateFailed;
 
+  /// No description provided for @aiGenerateRateLimited.
+  ///
+  /// In en, this message translates to:
+  /// **'Too many generation requests. Please try again shortly'**
+  String get aiGenerateRateLimited;
+
   /// No description provided for @aiExerciseNameRequired.
   ///
   /// In en, this message translates to:

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
@@ -1503,6 +1503,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'AI generation failed. Please try again in a moment';
 
   @override
+  String get aiGenerateRateLimited =>
+      'Too many generation requests. Please try again shortly';
+
+  @override
   String get aiExerciseNameRequired => 'Enter an exercise name';
 
   @override

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
@@ -1465,6 +1465,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get aiGenerateFailed => 'AI 생성에 실패했어요. 잠시 후 다시 시도해 주세요';
 
   @override
+  String get aiGenerateRateLimited => 'AI 생성을 너무 자주 요청했어요. 잠시 후 다시 시도해 주세요';
+
+  @override
   String get aiExerciseNameRequired => '운동 이름을 입력해 주세요';
 
   @override

--- a/frontend/flutter_trainer/lib/l10n/app_en.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_en.arb
@@ -996,6 +996,7 @@
   "aiOptionPush": "Push",
   "aiOptionExisting": "Existing",
   "aiGenerateFailed": "AI generation failed. Please try again in a moment",
+  "aiGenerateRateLimited": "Too many generation requests. Please try again shortly",
   "aiExerciseNameRequired": "Enter an exercise name",
   "aiKeepOneExercise": "Keep at least one exercise",
   "aiRoutineSent": "Routine sent to {name}",

--- a/frontend/flutter_trainer/lib/l10n/app_ko.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_ko.arb
@@ -442,6 +442,10 @@
   "aiOptionPush": "강화안",
   "aiOptionExisting": "기존안",
   "aiGenerateFailed": "AI 생성에 실패했어요. 잠시 후 다시 시도해 주세요",
+  "aiGenerateRateLimited": "AI 생성을 너무 자주 요청했어요. 잠시 후 다시 시도해 주세요",
+  "@aiGenerateRateLimited": {
+    "description": "429 when the trainer taps 생성 repeatedly. Not a failure — it works again shortly (#582)."
+  },
   "aiExerciseNameRequired": "운동 이름을 입력해 주세요",
   "aiKeepOneExercise": "운동을 하나 이상 남겨 주세요",
   "aiRoutineSent": "{name}님에게 루틴을 전송했어요",

--- a/frontend/flutter_trainer/test/features/coaching/routine_options_provider_and_flow_test.dart
+++ b/frontend/flutter_trainer/test/features/coaching/routine_options_provider_and_flow_test.dart
@@ -127,6 +127,8 @@ Future<void> _driveToSendReady(WidgetTester tester) async {
 }
 
 void main() {
+  group('생성 실패 문구 분기', _rateLimitMessageTests);
+
   group('trainerRoutineOptionsRepositoryProvider', () {
     test('mock when USE_MOCK_API=true', () {
       final c = ProviderContainer(
@@ -444,5 +446,78 @@ void main() {
       find.text('응답을 받지 못했어요. 고객의 받은 루틴을 확인한 뒤 필요한 경우에만 다시 보내주세요'),
       findsNothing,
     );
+  });
+}
+
+/// Always throws [error] from `generate`, to exercise the generate button's
+/// failure-message branching (한도 초과 vs. 그 외).
+class _ThrowingOptionsRepository implements TrainerRoutineOptionsRepository {
+  _ThrowingOptionsRepository(this.error);
+
+  final Object error;
+
+  @override
+  Future<RoutineOptions> generate(
+    String memberId, {
+    required int availableMinutes,
+    required String intensityPreference,
+    required String trainerNote,
+  }) async {
+    throw error;
+  }
+}
+
+Future<void> _pumpFlowWithOptionsError(WidgetTester tester, Object error) async {
+  tester.view.physicalSize = const Size(1000, 2400);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: <Override>[
+        appConfigProvider.overrideWithValue(_mockConfig),
+        trainerRoutineOptionsRepositoryProvider.overrideWithValue(
+          _ThrowingOptionsRepository(error),
+        ),
+      ],
+      child: MaterialApp(
+        locale: const Locale('ko'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: AiRoutineOptionsFlow(
+          client: _client,
+          recommendedExercises: <RoutineExercise>[
+            RoutineExercise(name: '실내 자전거', minutes: 20, type: '유산소'),
+          ],
+          recommendedReason: '기존 고객 데이터 기반 추천',
+        ),
+      ),
+    ),
+  );
+
+  await tester.ensureVisible(
+    find.byKey(const ValueKey<String>('generate-routine-options')),
+  );
+  await tester.tap(
+    find.byKey(const ValueKey<String>('generate-routine-options')),
+  );
+  await tester.pumpAndSettle();
+}
+
+void _rateLimitMessageTests() {
+  testWidgets('한도 초과(429)는 고장이 아니라 기다리라고 안내한다 (#582)', (tester) async {
+    // 429 를 다른 오류와 뭉뚱그리면 트레이너가 기능이 깨진 것으로 읽는다.
+    await _pumpFlowWithOptionsError(tester, const RateLimitedError());
+
+    expect(find.text('AI 생성을 너무 자주 요청했어요. 잠시 후 다시 시도해 주세요'), findsOneWidget);
+    expect(find.text('AI 생성에 실패했어요. 잠시 후 다시 시도해 주세요'), findsNothing);
+  });
+
+  testWidgets('그 밖의 실패는 기존 문구를 그대로 쓴다 (#582)', (tester) async {
+    await _pumpFlowWithOptionsError(tester, const ServerError(statusCode: 500));
+
+    expect(find.text('AI 생성에 실패했어요. 잠시 후 다시 시도해 주세요'), findsOneWidget);
+    expect(find.text('AI 생성을 너무 자주 요청했어요. 잠시 후 다시 시도해 주세요'), findsNothing);
   });
 }


### PR DESCRIPTION
## Summary

- LLM 을 부르는 `routine-options` 에 rate limit 을 겁니다 — 같은 성격의 `/ai-coach/chat` 만 막혀 있던 상태였습니다.
- 한도는 채팅과 공유하지 않고 더 낮게 따로 뒀습니다.
- 앱이 429 를 다른 실패와 구분해 안내하도록 함께 고쳤습니다.

## Problem

`POST /trainer/clients/{member_id}/routine-options` 는 외부 LLM 을 호출하는데 **빈도 제한이 없었습니다.** 같은 성격의 `/ai-coach/chat` 은 `coach_chat_per_minute`(20) 으로 이미 막혀 있습니다.

루틴 생성 화면은 슬라이더·강도·메모를 바꿔 가며 "생성"을 반복하는 UI 라 연타가 자연스럽게 발생하고, 그게 그대로 공급자 비용이 됩니다. **생성이 규칙형으로 폴백해도 LLM 호출 비용은 이미 나간 뒤**라, 가드는 엔드포인트 앞단에 있어야 합니다.

## 한도를 따로 둔 이유

`coach_chat_per_minute` 재사용 대신 `routine_options_per_minute = 10` 을 새로 뒀습니다.

- 같은 LLM 비용에 **회원 분석 쿼리가 더 얹힙니다** (식단 합계·이행률·최근 루틴)
- 연타가 쉬운 UI 라 채팅보다 폭주 위험이 큽니다
- 생성 왕복이 실측 **3~6초**(#579)라, 사람이 결과를 보고 조정하는 속도로는 분당 10회에 닿지 않습니다

## Changes

### Fixes

- `trainer_routine_options` 라우터에 `rate_limit("routine-options", ...)` 의존성 추가
- `routine_options_per_minute` 설정 신설 (기본 10, 근거는 주석에)
- 앱: 429 를 `RateLimitedError` 로 매핑하고 생성 화면이 별도 문구로 안내

### Improvements

- `AppError.fromDio` 가 429 를 `ServerError` 로 흡수하던 것을 `RateLimitedError` 로 분리했습니다. 429 는 실패가 아니라 **잠시 뒤 되는** 상태라, 다른 오류와 뭉뚱그리면 트레이너가 고장으로 읽습니다.

### Features / UI Changes / Documentation

- 없음 (문구 추가만: `aiGenerateRateLimited`, ko/en)

## Commits

1. `698addc` — `fix(backend): routine-options에 rate limit 적용`

## Notes

- **앱 쪽 문제는 이슈가 지적한 그대로였습니다.** `_generate` 의 `catch (_)` 가 모든 오류를 `aiGenerateFailed` 하나로 뭉개고 있어, 429 가 와도 "AI 생성에 실패했어요"만 보였습니다. 재시도하면 되는 상황인데 실패로 읽힙니다.
- 키는 기존 헬퍼와 같이 **IP 기준**입니다(`/ai-coach/chat` 과 동일). 트레이너 단위로 바꾸는 것은 `rate_limit` 의존성 자체를 손대야 해서 이 이슈 범위 밖으로 뒀습니다.
- 이 브랜치와 무관한 **기존 실패 1건**이 있습니다 — `tests/test_trainer_schedule.py::test_schedule_seeded_timeline`(오늘 시드에 공백 슬롯이 없다고 실패). **main 을 체크아웃해 동일하게 실패하는 것을 확인**했습니다. 공유 로컬 DB 의 오늘자 시드 상태에 달린 문제로 보이며, CI 는 매번 새 DB 라 영향받지 않습니다.
- 제외 범위(이슈 그대로): 트레이너별 월간 쿼터·과금, 다른 엔드포인트 전반의 rate limit 재검토.

## Test Plan

- [x] `test_routine_options_is_rate_limited` — 한도+1 번째 요청이 429, `Retry-After` 헤더 확인
- [x] `test_routine_options_limit_is_lower_than_coach_chat` — 채팅보다 낮게 유지되는지 고정
- [x] 두 테스트가 **실제로 회귀를 잡는지 확인** — 라우터에서 `dependencies` 를 빼면 실패
- [x] 앱: 429 → 전용 문구 / 그 밖의 오류 → 기존 문구, 두 갈래 각각 단언. 분기를 되돌리면 실패하는 것도 확인
- [x] 백엔드 `pytest` — 위 기존 실패 1건 외 전부 통과
- [x] 트레이너 앱 `flutter analyze` — No issues found
- [x] 트레이너 앱 `flutter test` — **452건 통과**

### Manual Test Steps

1. 백엔드를 띄우고 트레이너 웹에서 "AI 루틴 생성"을 빠르게 11회 누른다
2. 11번째에 "AI 생성을 너무 자주 요청했어요. 잠시 후 다시 시도해 주세요" 가 보이는지 확인
3. 1분 뒤 다시 생성이 되는지 확인
4. `RATE_LIMIT_ENABLED=false` 로 두면 제한이 걸리지 않는지 확인

## Related Issues

Closes #582

## Checklist

- [x] 한도 초과 시 429 가 나가고, 앱이 이유를 구분해 안내합니다.
- [x] 한도 값을 따로 둔 근거를 코드 주석과 테스트로 남겼습니다.
- [x] 회귀를 고정하는 테스트가 있고, 되돌리면 실패하는 것을 확인했습니다.
- [x] 이 브랜치와 무관한 기존 실패를 숨기지 않고 적었습니다.
