### PR TITLE
feat(ai): 운동 기록을 개인 RAG에 적재

### DIFF
--- a/backend/app/api/v1/exercise.py
+++ b/backend/app/api/v1/exercise.py
@@ -20,11 +20,27 @@ from app.models.models import ExerciseSession
 from app.schemas.exercise_api import (
     ExerciseSessionCreate, ExerciseSessionOut, ExerciseWeekResponse,
 )
+from app.services.coach import personal_ingest
 from app.services.exercise_service import (
     WEEKDAY_LABELS, build_current_week, monday_of_str, monday_of_this_week_str,
 )
 
 router = APIRouter(tags=["exercise"])
+
+
+def _session_date(row: ExerciseSession) -> str:
+    """세션의 실제 날짜 YYYY-MM-DD. 저장은 (주 시작 + 요일 라벨)로 쪼개져 있다.
+
+    적재 문구에 날짜를 넣으려면 되돌려야 한다 — "월요일"만 적으면 몇 주 전 기록도
+    똑같이 보여 코치가 최근 것과 구분하지 못한다.
+    """
+    from datetime import date as _d, timedelta
+
+    try:
+        monday = _d.fromisoformat(row.week_start)
+        return (monday + timedelta(days=WEEKDAY_LABELS.index(row.day_label))).isoformat()
+    except (ValueError, IndexError):
+        return row.week_start
 
 _ALLOWED_TYPES = {"cardio", "strength", "yoga", "walking", "stretching", "other"}
 _ALLOWED_INTENSITIES = {"light", "moderate", "high"}
@@ -97,7 +113,14 @@ def add_session(
 
     # 단건 응답도 프론트 표시 형식(date_label/time_label/items)을 채워 반환
     one = build_current_week([row])["sessions"][0]
-    return ExerciseSessionOut(**one)
+    out = ExerciseSessionOut(**one)
+    # 응답을 다 만든 뒤 적재한다(#586). 실패하면 personal_ingest 가 세션을 롤백하는데,
+    # 그때 row 가 만료되면 적재 실패가 기록 저장 실패로 번진다. 커밋은 이미 끝났다.
+    personal_ingest.record_exercise(
+        db, current_user.id, date=_session_date(row), type=row.type,
+        minutes=row.minutes, calories=row.calories, intensity=row.intensity,
+    )
+    return out
 
 
 @router.put("/exercise/sessions/{session_id}", response_model=ExerciseSessionOut)

--- a/backend/app/api/v1/exercise.py
+++ b/backend/app/api/v1/exercise.py
@@ -117,7 +117,7 @@ def add_session(
     # 응답을 다 만든 뒤 적재한다(#586). 실패하면 personal_ingest 가 세션을 롤백하는데,
     # 그때 row 가 만료되면 적재 실패가 기록 저장 실패로 번진다. 커밋은 이미 끝났다.
     personal_ingest.record_exercise(
-        db, current_user.id, date=_session_date(row), type=row.type,
+        db, current_user.id, date=_session_date(row), exercise_type=row.type,
         minutes=row.minutes, calories=row.calories, intensity=row.intensity,
     )
     return out

--- a/backend/app/services/coach/personal_ingest.py
+++ b/backend/app/services/coach/personal_ingest.py
@@ -103,7 +103,7 @@ _EXERCISE_INTENSITY_KR = {"light": "낮음", "moderate": "보통", "high": "높�
 
 
 def record_exercise(
-    db: Session, user_id: str, *, date: str, type: str, minutes: int,
+    db: Session, user_id: str, *, date: str, exercise_type: str, minutes: int,
     calories: int, intensity: str,
 ) -> None:
     """운동 세션 한 건을 개인 문서로 적재한다(#586).
@@ -116,7 +116,8 @@ def record_exercise(
     둘 다 '내가 한 운동'이고, 주간 집계도 이미 둘을 합쳐서 보여준다(#499).
     """
     text = (
-        f"{date} 운동 기록: {_EXERCISE_TYPE_KR.get(type, type)} {minutes}분, "
+        f"{date} 운동 기록: "
+        f"{_EXERCISE_TYPE_KR.get(exercise_type, exercise_type)} {minutes}분, "
         f"{calories}kcal, 강도 {_EXERCISE_INTENSITY_KR.get(intensity, intensity)}."
     )
     _safe(db, user_id, text, domain="exercise", source="exercise")

--- a/backend/app/services/coach/personal_ingest.py
+++ b/backend/app/services/coach/personal_ingest.py
@@ -1,6 +1,12 @@
 """회원의 기록을 개인 RAG 문서로 적재(best-effort).
 
-지금 적재하는 것: 식단 기록(`record_diet`), 트레이너↔회원 채팅(`record_chat`, #580).
+지금 적재하는 것: 식단 기록(`record_diet`), 트레이너↔회원 채팅(`record_chat`, #580),
+운동 세션(`record_exercise`, #586).
+
+혈압·혈당은 여기 없고 앞으로도 없다 — 입력이 번거로워 **제품에서 빼기로 한 항목**이다
+(그래서 `vitals` 테이블도 엔드포인트도 없다). 적재를 깜빡한 게 아니므로 나중에
+"운동은 있는데 혈압은 왜 없지" 로 다시 열지 말 것. 다만 코치 프롬프트는 아직
+혈압·혈당 조언을 지시하고 있어, 그쪽을 줄이는 건 별도 과제다.
 적재해 두면 회원 앱 AI 코치의 두 경로(홈 피드백 카드·챗봇)가 retrieve 를 통해
 자동으로 근거로 쓴다 — 코치 쪽 코드를 건드리지 않아도 된다.
 
@@ -81,6 +87,39 @@ def record_chat(
         db, member_id, f"{date} 대화 — {speaker}: {text.strip()}",
         domain="general", source="chat",
     )
+
+
+#: 운동 타입/강도의 한국어 라벨. 검색 질의도 답변도 한국어라 저장 코드값(cardio,
+#: light …)을 그대로 넣으면 임베딩이 질의와 겉돈다.
+_EXERCISE_TYPE_KR = {
+    "cardio": "유산소",
+    "walking": "걷기",
+    "strength": "근력",
+    "yoga": "요가",
+    "stretching": "스트레칭",
+    "other": "기타",
+}
+_EXERCISE_INTENSITY_KR = {"light": "낮음", "moderate": "보통", "high": "높음"}
+
+
+def record_exercise(
+    db: Session, user_id: str, *, date: str, type: str, minutes: int,
+    calories: int, intensity: str,
+) -> None:
+    """운동 세션 한 건을 개인 문서로 적재한다(#586).
+
+    운동 코치(`domain_coaches.exercise_coach`)는 `domain="exercise"` 로 검색하는데
+    지금까지 개인 문서가 하나도 없어, 프롬프트가 운동 조언을 지시해도 근거가 공공
+    가이드라인뿐이었다.
+
+    회원이 직접 남긴 기록과 PT 완료로 파생된 기록을 모두 받는다 — 회원 입장에서는
+    둘 다 '내가 한 운동'이고, 주간 집계도 이미 둘을 합쳐서 보여준다(#499).
+    """
+    text = (
+        f"{date} 운동 기록: {_EXERCISE_TYPE_KR.get(type, type)} {minutes}분, "
+        f"{calories}kcal, 강도 {_EXERCISE_INTENSITY_KR.get(intensity, intensity)}."
+    )
+    _safe(db, user_id, text, domain="exercise", source="exercise")
 
 
 def record_diet(

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -1075,7 +1075,8 @@ def complete_session(
         # 커밋 뒤에 부르는 이유는 record_chat 과 같다 — 적재 실패의 롤백이 응답을
         # 깨뜨리지 않도록, 값은 미리 뽑아 두고 응답도 이미 만들어 둔다.
         personal_ingest.record_exercise(
-            db, exercise_log.user_id, date=s.date, type=exercise_log.type,
+            db, exercise_log.user_id, date=s.date,
+            exercise_type=exercise_log.type,
             minutes=exercise_log.minutes, calories=exercise_log.calories,
             intensity=exercise_log.intensity,
         )

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -1049,6 +1049,7 @@ def complete_session(
         db.refresh(s)
         return _schedule_out(s)  # 동시 호출이 먼저 완료 처리함 — 기록 없이 현재 상태 반환
 
+    exercise_log: ExerciseSession | None = None
     if s.member_id:
         program = _program_items(s.program_json)
         exercises = [
@@ -1065,10 +1066,20 @@ def complete_session(
             exercises_json=json.dumps(exercises, ensure_ascii=False),
             trainer_note=note,
         ))
-        _add_member_exercise_log(db, s)
+        exercise_log = _add_member_exercise_log(db, s)
     db.commit()
     db.refresh(s)
-    return _schedule_out(s)
+    out = _schedule_out(s)
+    if exercise_log is not None:
+        # 회원 입장에서 PT 도 '내가 한 운동'이라 코치가 검색할 수 있어야 한다(#586).
+        # 커밋 뒤에 부르는 이유는 record_chat 과 같다 — 적재 실패의 롤백이 응답을
+        # 깨뜨리지 않도록, 값은 미리 뽑아 두고 응답도 이미 만들어 둔다.
+        personal_ingest.record_exercise(
+            db, exercise_log.user_id, date=s.date, type=exercise_log.type,
+            minutes=exercise_log.minutes, calories=exercise_log.calories,
+            intensity=exercise_log.intensity,
+        )
+    return out
 
 
 # ---- 회원측 미러 (내 담당 코치 / 받은 루틴 / 채팅 / 내 세션) ----

--- a/backend/tests/test_exercise_ingest.py
+++ b/backend/tests/test_exercise_ingest.py
@@ -1,0 +1,150 @@
+"""운동 세션의 개인 RAG 적재 (#586).
+
+운동 코치는 `domain="exercise"` 로 개인 문서를 검색하는데, 지금까지 그 도메인에
+개인 문서가 하나도 없어 프롬프트가 운동 조언을 지시해도 근거가 공공 가이드라인뿐이었다.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.coach import personal_ingest
+
+
+@pytest.fixture
+def _captured(monkeypatch):
+    """`_safe` 를 잡아 적재 인자를 그대로 본다(임베딩 호출 없이)."""
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        personal_ingest,
+        "_safe",
+        lambda db, user_id, text, *, domain, source: calls.append(
+            {"user_id": user_id, "text": text, "domain": domain, "source": source}
+        ),
+    )
+    return calls
+
+
+# ---- 문서 형태 (순수) ----
+
+def test_exercise_document_is_written_in_korean(_captured):
+    """저장 코드값(cardio/light)을 그대로 넣으면 한국어 질의와 임베딩이 겉돈다."""
+    personal_ingest.record_exercise(
+        None, "user-1", date="2026-08-11", type="cardio", minutes=30,
+        calories=250, intensity="light",
+    )
+
+    text = _captured[0]["text"]
+    assert "2026-08-11" in text
+    assert "유산소" in text and "cardio" not in text
+    assert "30분" in text
+    assert "250kcal" in text
+    assert "강도 낮음" in text and "light" not in text
+
+
+def test_exercise_is_ingested_into_the_exercise_domain(_captured):
+    personal_ingest.record_exercise(
+        None, "user-1", date="2026-08-11", type="strength", minutes=40,
+        calories=300, intensity="high",
+    )
+
+    assert _captured[0]["domain"] == "exercise"
+    assert _captured[0]["source"] == "exercise"
+
+
+@pytest.mark.parametrize(
+    ("type_", "expected"),
+    [
+        ("cardio", "유산소"),
+        ("walking", "걷기"),
+        ("strength", "근력"),
+        ("yoga", "요가"),
+        ("stretching", "스트레칭"),
+        ("other", "기타"),
+    ],
+)
+def test_every_allowed_exercise_type_has_a_label(_captured, type_, expected):
+    """라우터의 _ALLOWED_TYPES 전부를 덮는다 — 빠진 값은 코드가 그대로 노출된다."""
+    personal_ingest.record_exercise(
+        None, "u", date="2026-08-11", type=type_, minutes=10, calories=50,
+        intensity="moderate",
+    )
+    assert expected in _captured[-1]["text"]
+
+
+def test_an_unknown_code_degrades_to_itself_instead_of_crashing(_captured):
+    personal_ingest.record_exercise(
+        None, "u", date="2026-08-11", type="crossfit", minutes=10, calories=50,
+        intensity="extreme",
+    )
+
+    text = _captured[0]["text"]
+    assert "crossfit" in text and "extreme" in text
+
+
+# ---- 실제 경로 (DB) ----
+
+def _member_token(client) -> str:
+    r = client.post(
+        "/v1/auth/login",
+        data={"username": "minsu@oncare.com", "password": "oncare123"},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["access_token"]
+
+
+def test_logging_a_session_ingests_it(client, _captured):
+    token = _member_token(client)
+
+    r = client.post(
+        "/v1/exercise/sessions",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"type": "walking", "minutes": 25, "calories": 90, "intensity": "light"},
+    )
+
+    assert r.status_code == 201, r.text
+    assert len(_captured) == 1
+    assert _captured[0]["domain"] == "exercise"
+    assert "걷기" in _captured[0]["text"] and "25분" in _captured[0]["text"]
+
+
+def test_ingest_failure_never_breaks_the_session_save(client, monkeypatch):
+    """적재는 보조 인덱싱이다 — 실패해도 201 이어야 하고 기록도 남아야 한다."""
+    def _boom(*args, **kwargs):
+        raise RuntimeError("embedder down")
+
+    monkeypatch.setattr(personal_ingest, "ingest_personal_text", _boom)
+    token = _member_token(client)
+
+    r = client.post(
+        "/v1/exercise/sessions",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"type": "yoga", "minutes": 20, "calories": 60, "intensity": "moderate"},
+    )
+
+    assert r.status_code == 201, r.text
+    week = client.get(
+        "/v1/exercise/weeks/current",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert any(s["id"] == r.json()["id"] for s in week.json()["sessions"])
+
+
+def test_ingest_is_off_when_rag_auto_ingest_is_disabled(client, monkeypatch):
+    from app.core.config import get_settings
+
+    monkeypatch.setattr(get_settings(), "rag_auto_ingest", False)
+    calls: list[object] = []
+    monkeypatch.setattr(
+        personal_ingest, "ingest_personal_text",
+        lambda *a, **k: calls.append(a),
+    )
+    token = _member_token(client)
+
+    r = client.post(
+        "/v1/exercise/sessions",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"type": "cardio", "minutes": 15, "calories": 100, "intensity": "high"},
+    )
+
+    assert r.status_code == 201, r.text
+    assert calls == []

--- a/backend/tests/test_exercise_ingest.py
+++ b/backend/tests/test_exercise_ingest.py
@@ -29,7 +29,7 @@ def _captured(monkeypatch):
 def test_exercise_document_is_written_in_korean(_captured):
     """저장 코드값(cardio/light)을 그대로 넣으면 한국어 질의와 임베딩이 겉돈다."""
     personal_ingest.record_exercise(
-        None, "user-1", date="2026-08-11", type="cardio", minutes=30,
+        None, "user-1", date="2026-08-11", exercise_type="cardio", minutes=30,
         calories=250, intensity="light",
     )
 
@@ -43,7 +43,7 @@ def test_exercise_document_is_written_in_korean(_captured):
 
 def test_exercise_is_ingested_into_the_exercise_domain(_captured):
     personal_ingest.record_exercise(
-        None, "user-1", date="2026-08-11", type="strength", minutes=40,
+        None, "user-1", date="2026-08-11", exercise_type="strength", minutes=40,
         calories=300, intensity="high",
     )
 
@@ -65,7 +65,7 @@ def test_exercise_is_ingested_into_the_exercise_domain(_captured):
 def test_every_allowed_exercise_type_has_a_label(_captured, type_, expected):
     """라우터의 _ALLOWED_TYPES 전부를 덮는다 — 빠진 값은 코드가 그대로 노출된다."""
     personal_ingest.record_exercise(
-        None, "u", date="2026-08-11", type=type_, minutes=10, calories=50,
+        None, "u", date="2026-08-11", exercise_type=type_, minutes=10, calories=50,
         intensity="moderate",
     )
     assert expected in _captured[-1]["text"]
@@ -73,7 +73,8 @@ def test_every_allowed_exercise_type_has_a_label(_captured, type_, expected):
 
 def test_an_unknown_code_degrades_to_itself_instead_of_crashing(_captured):
     personal_ingest.record_exercise(
-        None, "u", date="2026-08-11", type="crossfit", minutes=10, calories=50,
+        None, "u", date="2026-08-11", exercise_type="crossfit", minutes=10,
+        calories=50,
         intensity="extreme",
     )
 


### PR DESCRIPTION
## Summary

* 운동 코치(`domain_coaches.exercise_coach`)가 `domain="exercise"` 로 개인 문서를 검색하는데 그 도메인에 문서가 **하나도 없어**, 프롬프트가 운동 조언을 지시해도 근거가 공공 가이드라인뿐이었습니다.
* 회원이 직접 남긴 운동 기록과 트레이너 PT 완료로 파생된 기록을 모두 개인 문서로 적재합니다.
* 저장 코드값(`cardio`, `light`)이 아니라 한국어 라벨(`유산소`, `낮음`)로 적재합니다 — 질의도 답변도 한국어라 코드값을 그대로 넣으면 임베딩이 겉돕니다.

---

## Changes

### ✨ Features

* `personal_ingest.record_exercise` 추가 (`domain="exercise"`, `source="exercise"`).
* `POST /exercise/sessions` — 커밋 뒤 적재. 응답을 먼저 만들고 부르므로 적재 실패의 롤백이 기록 저장을 깨지 않습니다.
* `trainer_service.complete_session` — PT 완료로 파생된 `ExerciseSession` 도 적재. 회원 입장에서는 둘 다 "내가 한 운동"이고 주간 집계도 이미 합산합니다(#499).

### 🔧 Improvements

* `_session_date` — 저장이 `week_start + day_label` 로 쪼개져 있어 실제 날짜로 되돌립니다. "월요일" 만 적으면 몇 주 전 기록과 최근 기록을 코치가 구분하지 못합니다.

### 📝 Docs

* `personal_ingest` 모듈 독스트링에 적재 대상(식단·채팅·운동)과 **혈압·혈당을 다루지 않는 이유**를 명시했습니다.

---

## Commits

1. `516a72cf` feat(ai): ingest exercise sessions into personal RAG

---

## Notes

* **이슈 범위를 줄였습니다.** 원래 제목은 "운동·혈압·혈당 기록도 개인 RAG에 적재" 였는데, 혈압·혈당은 **입력이 번거로워 제품에서 빼기로 한 항목**이라 저장 경로 자체가 없습니다(`vitals` 테이블·엔드포인트·입력 UI 모두 부재). 적재 대상이 아닙니다.
* **수정(PUT) 경로는 넣지 않았습니다.** `CoachDocument` 에 원본 레코드를 가리키는 키가 없어, 수정 시 재적재하면 옛 수치 문서가 남고 새 문서가 추가됩니다 — 코치가 "30분" 과 "45분" 을 동시에 근거로 삼게 되어 안 하느니만 못합니다. 제대로 하려면 문서에 외부 키를 달고 교체하는 스키마 변경이 필요합니다. `record_diet` 도 생성 시에만 적재하는 같은 한계라 동작은 일관됩니다. 필요하면 "기록 수정 시 개인 문서 갱신" 을 별도 이슈로 분리하는 게 맞습니다.
* **시드 운동 기록은 적재되지 않습니다.** 시드는 `ExerciseSession` 을 직접 insert 하고, 기존에도 개인 문서는 시드하지 않는 패턴을 따랐습니다(#580 과 동일). 데모 계정은 실시간으로 기록한 운동만 코치 근거에 잡힙니다.
* **부수 발견 — 프롬프트가 없는 데이터를 요구합니다.** `coach/chat.py:15` 와 `_EXERCISE_SYSTEM` 이 혈압·혈당 조언을 지시하는데 그 데이터는 앞으로도 없습니다. 프롬프트에서 덜어내는 게 최종 상태이며 별도 이슈로 분리하는 것을 제안합니다.
* **부수 발견 — README 가 사실과 다릅니다.** `backend/README.md:12` 가 STEP 5 를 ✅ 로 표시하며 존재하지 않는 `/vitals/{weight|blood-pressure|blood-sugar}` 엔드포인트를 문서화하고 있습니다. 이 PR 범위 밖이라 손대지 않았습니다.

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [ ] UI 확인 <!-- 프론트 변경 없음 -->
* [x] 빌드 성공
* [x] 관련 테스트 통과

`tests/test_exercise_ingest.py` 신설 (12건): 한국어 문서 형태, 도메인/소스, 허용 타입 6종 전수, 미지 코드 degrade, 실제 API 경로 적재, **적재 실패해도 201 + 기록 유지**, `RAG_AUTO_INGEST=false` 시 완전 차단.

백엔드 전체 스위트를 **새로 만든 DB** 에서 통과시켰습니다(실패 0).

### Manual Test Steps

1. 회원 앱에서 운동 기록 추가(예: 걷기 25분).
2. AI 코치에 "이번 주 운동 어땠어?" 질문 → 방금 기록이 근거로 반영되는지 확인.
3. 트레이너 웹에서 PT 세션 완료 처리 → 회원 코치가 그 PT 도 근거로 삼는지 확인.
4. `.env` 에 `RAG_AUTO_INGEST=false` 를 넣고 재기동 → 운동 기록 시 적재가 일어나지 않는지 확인.

---

## Related Issues

Closes #586

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 운동 세션이 개인 운동 기록으로 자동 저장됩니다.
  * 운동 날짜, 종류, 시간, 칼로리, 강도 정보가 기록됩니다.
  * 운동 종류와 강도가 한국어로 표시됩니다.

* **개선 사항**
  * 운동 기록 저장이 실패해도 세션 완료 처리는 정상적으로 진행됩니다.
  * 자동 적재 설정을 끄면 개인 기록 저장을 수행하지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->