### PR TITLE
feat(obs): AI 생성·폴백 카운터 추가

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -49,9 +49,22 @@ alembic downgrade -1          # 한 단계 롤백
 ```bash
 curl -H "Authorization: Bearer $ADMIN_TOKEN" http://localhost:8000/v1/system/metrics
 ```
-`routine_options.generated{by=ai}` 가 0 이고 `fallback{reason=...}` 만 쌓이면 AI 경로가
-죽은 것이다. `reason=contract` 는 응답 규격 문제(프롬프트·스키마), `reason=infra` 는
-키 미설정·네트워크·5xx 다. 관리자는 `.env` 의 `ADMIN_EMAILS` 로 지정한다.
+응답의 `counters` 에 들어오는 키(전체 이름 그대로 조회):
+
+| 키 | 뜻 |
+| --- | --- |
+| `routine_options.generated{by=ai}` | LLM 이 만든 루틴. **0 이면 AI 경로가 죽은 것** |
+| `routine_options.generated{by=rule}` | 폴백으로 만든 루틴 |
+| `routine_options.fallback{reason=contract}` | 응답 규격 위반 → 프롬프트·스키마를 본다 |
+| `routine_options.fallback{reason=infra}` | 키 미설정·설정 오타·네트워크·5xx |
+| `routine_options.with_chat_context` | 채팅 근거가 실린 채 AI 가 성공한 횟수(#580) |
+| `diet_recommendations.generated{by=llm}` | LLM 이 만든 추천 |
+| `diet_recommendations.generated{by=rules}` | LLM 실패 후 규칙으로 만든 추천 |
+| `diet_recommendations.generated{by=no_data}` | 근거가 없어 LLM 을 부르지 않음(신규 가입자) |
+| `diet_recommendations.fallback{reason=busy\|timeout\|error}` | 동시 호출 한도·타임아웃·그 외 실패 |
+
+`durations` 에는 `routine_options.llm_ms` 가 count/avg/max 로 들어온다 — #584 의
+타임아웃 값을 정할 근거다. 관리자는 `.env` 의 `ADMIN_EMAILS` 로 지정한다.
 값은 프로세스 메모리에 있어 재시작하면 사라진다(단일 인스턴스 기준).
 
 ## 프론트 연동 (실서버 전환)

--- a/backend/README.md
+++ b/backend/README.md
@@ -43,6 +43,17 @@ alembic downgrade -1          # 한 단계 롤백
 임베딩 `gemini-embedding-001`(768) · 코치/인식 `gemini-flash-latest` · `.env`: `EMBEDDER=gemini`, `EMBED_DIM=768`.
 검증: `python -m scripts.check_gemini` · `/v1/ai-coach/chat` 응답의 `sources` 가 채워지면 RAG 가 실제로 동작(규칙 폴백 아님).
 
+## AI 폴백 지표
+루틴 생성·식단 추천은 실패해도 규칙 기반으로 조용히 폴백한다 — 사용자는 그럴듯한
+결과를 계속 받으므로 AI 가 죽어도 신고가 들어오지 않는다. 관리자 토큰으로 확인한다:
+```bash
+curl -H "Authorization: Bearer $ADMIN_TOKEN" http://localhost:8000/v1/system/metrics
+```
+`routine_options.generated{by=ai}` 가 0 이고 `fallback{reason=...}` 만 쌓이면 AI 경로가
+죽은 것이다. `reason=contract` 는 응답 규격 문제(프롬프트·스키마), `reason=infra` 는
+키 미설정·네트워크·5xx 다. 관리자는 `.env` 의 `ADMIN_EMAILS` 로 지정한다.
+값은 프로세스 메모리에 있어 재시작하면 사라진다(단일 인스턴스 기준).
+
 ## 프론트 연동 (실서버 전환)
 회원 앱(모바일)·트레이너 웹 **양쪽 모두** 같은 방식으로 전환합니다.
 ```bash

--- a/backend/app/api/v1/system.py
+++ b/backend/app/api/v1/system.py
@@ -15,6 +15,8 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
+from app.api.deps import RequireAdmin
+from app.core import metrics
 from app.core.config import get_settings
 from app.db.session import get_db
 
@@ -58,3 +60,16 @@ def readyz(db: Annotated[Session, Depends(get_db)]) -> dict[str, str]:
 @router.get("/version")
 def version() -> dict[str, str]:
     return {"api_version": "v1", "app_version": settings.app_version}
+
+
+@router.get("/system/metrics")
+def system_metrics(admin: RequireAdmin) -> dict[str, object]:
+    """AI 경로 성공/폴백 카운터(#583). 관리자 전용.
+
+    폴백은 조용하다 — 사용자는 그럴듯한 규칙형 결과를 계속 받으므로 아무도 신고하지
+    않는다. 여기서 `routine_options.generated{by=ai}` 가 0 이면 AI 가 죽은 것이다.
+
+    인증을 거는 이유: 어떤 공급자가 얼마나 실패하는지는 운영 정보다. 공개 헬스
+    체크(/healthz, /readyz)와 달리 LB 가 볼 필요도 없다.
+    """
+    return metrics.snapshot()

--- a/backend/app/core/metrics.py
+++ b/backend/app/core/metrics.py
@@ -1,0 +1,73 @@
+"""인프로세스 카운터 — AI 경로가 조용히 죽는 것을 보이게 한다(#583).
+
+배경: 루틴 생성도 식단 추천도 어떤 실패든 규칙 기반으로 조용히 폴백한다. 사용자는
+그럴듯한 결과를 계속 받으므로 아무도 신고하지 않고, 로그는 요청마다 한 줄씩 흘러가
+"요즘 AI 가 도는가?" 를 답해 주지 못한다. 실제로 그 때문에 루틴 생성이 상시 폴백인
+상태가 오래 방치됐다(#579).
+
+여기서 하는 일은 최소한이다 — 성공/폴백 횟수와 사유, LLM 소요 시간의 합·최댓값.
+`GET /system/metrics`(관리자 전용)로 읽는다.
+
+**단일 인스턴스/데모 기준이다.** 값은 프로세스 메모리에 있고 재시작하면 사라지며,
+여러 인스턴스로 늘리면 각자 자기 몫만 센다. 운영으로 갈 때는 Prometheus 나 StatsD
+로 교체한다(#480 배포와 함께 볼 문제).
+"""
+from __future__ import annotations
+
+import threading
+
+#: 라벨 조합당 한 칸. 카디널리티가 낮은 라벨(reason/by)만 쓴다 — user_id 같은 값을
+#: 라벨로 넣으면 이 딕셔너리가 사용자 수만큼 자란다.
+_counters: dict[str, int] = {}
+
+#: key -> (관측 횟수, 합계 ms, 최댓값 ms). 개별 값을 모아 두지 않는 이유는 같다 —
+#: 요청마다 리스트가 자라면 메모리가 단조 증가한다.
+_durations: dict[str, tuple[int, float, float]] = {}
+
+_lock = threading.Lock()
+
+
+def _key(name: str, labels: dict[str, str]) -> str:
+    if not labels:
+        return name
+    # 정렬해야 같은 라벨 조합이 순서와 무관하게 한 칸을 쓴다.
+    inner = ",".join(f"{k}={labels[k]}" for k in sorted(labels))
+    return f"{name}{{{inner}}}"
+
+
+def incr(name: str, /, **labels: str) -> None:
+    """카운터를 1 올린다. 계측 실패가 기능을 깨뜨리면 안 되므로 예외를 내지 않는다."""
+    key = _key(name, labels)
+    with _lock:
+        _counters[key] = _counters.get(key, 0) + 1
+
+
+def observe_ms(name: str, ms: float, /, **labels: str) -> None:
+    """소요 시간(ms)을 누적한다."""
+    key = _key(name, labels)
+    with _lock:
+        count, total, peak = _durations.get(key, (0, 0.0, 0.0))
+        _durations[key] = (count + 1, total + ms, max(peak, ms))
+
+
+def snapshot() -> dict[str, object]:
+    """현재 값을 읽는다. 평균은 여기서 계산해 읽는 쪽이 나눗셈을 안 하게 한다."""
+    with _lock:
+        counters = dict(_counters)
+        durations = {
+            key: {
+                "count": count,
+                "total_ms": round(total, 1),
+                "avg_ms": round(total / count, 1) if count else 0.0,
+                "max_ms": round(peak, 1),
+            }
+            for key, (count, total, peak) in _durations.items()
+        }
+    return {"counters": counters, "durations": durations}
+
+
+def reset() -> None:
+    """테스트 격리용. 운영 경로에서는 부르지 않는다."""
+    with _lock:
+        _counters.clear()
+        _durations.clear()

--- a/backend/app/services/diet_recommendation_service.py
+++ b/backend/app/services/diet_recommendation_service.py
@@ -25,7 +25,7 @@ from datetime import date, timedelta
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.core import clock
+from app.core import clock, metrics
 from app.data import meal_catalog
 from app.data.meal_catalog import CATALOG, DEFAULT_ORDER, RECOMMENDATION_COUNT, MealItem
 from app.models.models import DietEntry, HealthProfile
@@ -408,19 +408,26 @@ def build_recommendations(
     if hit and hit[0] > time.monotonic():
         return hit[1]
 
+    # 계측은 캐시 미스 이후에만 센다(#583) — 세는 대상은 '요청 수'가 아니라 '생성
+    # 시도'다. 캐시 적중까지 세면 TTL 길이가 폴백률을 흔든다.
     if use_llm:
         try:
             response = _response(ctx, _llm_items(ctx), personalized=True, source="llm")
+            metrics.incr("diet_recommendations.generated", by="llm")
             _cache_put(cache_key, response)
             return response
         except LLMBusyError:
+            metrics.incr("diet_recommendations.fallback", reason="busy")
             logger.info("diet recommendation LLM 포화 — 규칙 폴백")
         except FutureTimeout:
+            metrics.incr("diet_recommendations.fallback", reason="timeout")
             logger.warning("diet recommendation LLM timeout (%.1fs) — 규칙 폴백", LLM_TIMEOUT_SEC)
         except Exception:  # noqa: BLE001 - LLM 장애 종류와 무관하게 화면은 떠야 한다
+            metrics.incr("diet_recommendations.fallback", reason="error")
             logger.warning("diet recommendation LLM 실패 — 규칙 폴백", exc_info=True)
 
     # 규칙 폴백도 신호를 반영한 진짜 추천이다(예: 나트륨 과다 → 저나트륨 상위).
+    metrics.incr("diet_recommendations.generated", by="rules")
     response = _response(ctx, _fallback_items(ctx), personalized=True, source="rules")
     _cache_put(cache_key, response)
     return response

--- a/backend/app/services/diet_recommendation_service.py
+++ b/backend/app/services/diet_recommendation_service.py
@@ -396,6 +396,10 @@ def build_recommendations(
     # 근거가 없으면 LLM 을 부를 이유가 없다. 신규 가입자는 여기서 현재 홈 화면과
     # 동일한 기본 순서를 받는다.
     if not ctx.has_data or not ctx.signals:
+        # `rules` 가 아니라 별도 라벨을 쓴다 — 여기는 AI 가 실패한 게 아니라 부를
+        # 이유가 없었던 경우다. 같은 칸에 세면 신규 가입이 몰릴 때 폴백률이 치솟아
+        # AI 가 죽은 것처럼 보인다. `fallback` 카운터는 올리지 않는다(#583).
+        metrics.incr("diet_recommendations.generated", by="no_data")
         return _response(ctx, _fallback_items(ctx), personalized=False, source="fallback")
 
     # use_llm 을 키에 넣지 않으면 규칙 응답이 LLM 요청에 재사용된다(디버깅·비용 절감용

--- a/backend/app/services/trainer_routine_options_service.py
+++ b/backend/app/services/trainer_routine_options_service.py
@@ -7,12 +7,16 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import date, datetime, time, timedelta
+import time
+# `time` 은 stdlib 모듈로 두고(경과 시간 측정), 자정 시각은 별칭으로 받는다.
+from datetime import date, datetime, timedelta
+from datetime import time as time_of_day
 
+from pydantic import ValidationError
 from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
 
-from app.core import clock
+from app.core import clock, metrics
 from app.models.models import (
     ChatMessage,
     DietEntry,
@@ -166,7 +170,7 @@ def _recent_chat_lines(
     # 못 타고, 드라이버가 파라미터를 varchar 로 넘겨 타입 비교가 깨진다.
     since = datetime.combine(
         today_date - timedelta(days=CHAT_LOOKBACK_DAYS - 1),
-        time.min,
+        time_of_day.min,
         tzinfo=clock.SEOUL,
     )
     rows = db.execute(
@@ -259,14 +263,54 @@ def generate_routine_options(
 ) -> RoutineOptionsOut:
     analysis = build_member_analysis(db, trainer_id, member_id, request)
     fallback = build_rule_options(analysis, request)
+    started = time.monotonic()
+    had_chat = bool(analysis.recent_messages)
     try:
-        return _generate_with_llm(analysis, request)
-    except Exception:  # noqa: BLE001 — provider/network/JSON failures all fall back
+        options = _generate_with_llm(analysis, request)
+    except (ValidationError, ValueError) as exc:
+        # 계약 위반 — 공급자는 살아 있는데 응답이 규격에 안 맞는다. 프롬프트나
+        # 스키마를 손볼 신호라 인프라 장애와 섞으면 안 된다.
+        # (json.JSONDecodeError 는 ValueError 의 하위 타입이라 여기 걸린다.)
+        _record(started, reason="contract", had_chat_context=had_chat)
         logger.warning(
-            "맞춤 루틴 LLM 생성 실패 — 규칙 기반 폴백 사용 "
-            "(trainer_id=%s, member_id=%s)",
-            trainer_id,
-            member_id,
-            exc_info=True,
+            "맞춤 루틴 LLM 계약 위반 — 규칙 기반 폴백 사용 "
+            "(trainer_id=%s, member_id=%s): %s",
+            trainer_id, member_id, exc,
         )
         return fallback
+    except Exception:  # noqa: BLE001 — 키 미설정·네트워크·5xx, 그리고 우리 쪽 버그
+        # 이쪽은 stack trace 를 남긴다. 예전엔 한 덩어리로 삼켜서, 스키마 필드
+        # 이름을 잘못 쓴 버그도 조용히 규칙형으로 내려가 아무도 몰랐다.
+        _record(started, reason="infra", had_chat_context=had_chat)
+        logger.exception(
+            "맞춤 루틴 LLM 호출 실패 — 규칙 기반 폴백 사용 "
+            "(trainer_id=%s, member_id=%s)",
+            trainer_id, member_id,
+        )
+        return fallback
+
+    _record(started, reason=None, had_chat_context=had_chat)
+    return options
+
+
+def _record(
+    started: float, *, reason: str | None, had_chat_context: bool,
+) -> None:
+    """생성 결과를 계측한다(#583).
+
+    소요 시간은 성공·실패 모두 남긴다 — 타임아웃으로 폴백하는 경우 '얼마나 오래
+    기다렸는지'가 #584 의 타임아웃 값을 정하는 근거다.
+    """
+    metrics.observe_ms(
+        "routine_options.llm_ms", (time.monotonic() - started) * 1000
+    )
+    if reason:
+        metrics.incr("routine_options.generated", by="rule")
+        metrics.incr("routine_options.fallback", reason=reason)
+        return
+    metrics.incr("routine_options.generated", by="ai")
+    # 성공했을 때만 센다 — 규칙형은 채팅을 읽지 않으므로, 폴백까지 세면 이 지표가
+    # "채팅 근거가 AI 에 닿았다"는 질문에 거짓으로 답한다(#580 이 실환경에서
+    # 도는지 확인하려고 만든 카운터다).
+    if had_chat_context:
+        metrics.incr("routine_options.with_chat_context")

--- a/backend/app/services/trainer_routine_options_service.py
+++ b/backend/app/services/trainer_routine_options_service.py
@@ -217,15 +217,28 @@ def build_rule_options(
     )
 
 
+class RoutineContractError(ValueError):
+    """LLM 응답이 계약을 어겼다 — 공급자는 살아 있고, 볼 곳은 프롬프트·스키마다.
+
+    `ValueError` 를 통째로 계약 위반으로 잡으면 안 된다. `get_coach_llm()` 은
+    COACH_LLM 값이 오타면 `ValueError("알 수 없는 코치 LLM: ...")` 를 던지는데
+    (`coach/llm.py`), 그건 설정 문제라 프롬프트를 아무리 손봐도 안 고쳐진다.
+    계약 위반만 이 타입으로 좁혀 `reason=contract` 와 `reason=infra` 를 가른다.
+    """
+
+
 def _decode_json_object(text: str) -> dict:
     """LLM이 실수로 붙인 코드펜스·설명 앞뒤를 제거하고 첫 JSON 객체만 읽는다."""
     start = text.find("{")
     end = text.rfind("}")
     if start < 0 or end <= start:
-        raise ValueError("LLM 응답에 JSON 객체가 없습니다.")
-    parsed = json.loads(text[start : end + 1])
+        raise RoutineContractError("LLM 응답에 JSON 객체가 없습니다.")
+    try:
+        parsed = json.loads(text[start : end + 1])
+    except json.JSONDecodeError as exc:
+        raise RoutineContractError(f"LLM 응답 JSON 파싱 실패: {exc}") from exc
     if not isinstance(parsed, dict):
-        raise ValueError("LLM 응답은 JSON 객체여야 합니다.")
+        raise RoutineContractError("LLM 응답은 JSON 객체여야 합니다.")
     return parsed
 
 
@@ -251,7 +264,7 @@ def _generate_with_llm(
         options.plan_a.total_minutes > request.available_minutes
         or options.plan_b.total_minutes > request.available_minutes
     ):
-        raise ValueError("LLM 루틴 시간이 요청 가능한 시간을 초과했습니다.")
+        raise RoutineContractError("LLM 루틴 시간이 요청 가능한 시간을 초과했습니다.")
     return options
 
 
@@ -267,10 +280,11 @@ def generate_routine_options(
     had_chat = bool(analysis.recent_messages)
     try:
         options = _generate_with_llm(analysis, request)
-    except (ValidationError, ValueError) as exc:
+    except (ValidationError, RoutineContractError) as exc:
         # 계약 위반 — 공급자는 살아 있는데 응답이 규격에 안 맞는다. 프롬프트나
         # 스키마를 손볼 신호라 인프라 장애와 섞으면 안 된다.
-        # (json.JSONDecodeError 는 ValueError 의 하위 타입이라 여기 걸린다.)
+        # 넓은 ValueError 가 아니라 이 두 타입만 잡는다 — COACH_LLM 오타 같은
+        # 설정 오류도 ValueError 라, 그것까지 계약 위반으로 세면 지표가 엉킨다.
         _record(started, reason="contract", had_chat_context=had_chat)
         logger.warning(
             "맞춤 루틴 LLM 계약 위반 — 규칙 기반 폴백 사용 "
@@ -278,7 +292,7 @@ def generate_routine_options(
             trainer_id, member_id, exc,
         )
         return fallback
-    except Exception:  # noqa: BLE001 — 키 미설정·네트워크·5xx, 그리고 우리 쪽 버그
+    except Exception:  # noqa: BLE001 — 키 미설정·설정 오타·네트워크·5xx, 우리 쪽 버그
         # 이쪽은 stack trace 를 남긴다. 예전엔 한 덩어리로 삼켜서, 스키마 필드
         # 이름을 잘못 쓴 버그도 조용히 규칙형으로 내려가 아무도 몰랐다.
         _record(started, reason="infra", had_chat_context=had_chat)

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -187,6 +187,70 @@ def test_chat_grounded_generations_are_counted(client, monkeypatch):
     assert metrics.snapshot()["counters"]["routine_options.with_chat_context"] == 1
 
 
+def test_a_provider_config_typo_is_infra_not_contract(client, monkeypatch):
+    """COACH_LLM 오타는 ValueError 지만 설정 문제다 — 프롬프트를 봐도 안 고쳐진다.
+
+    `get_coach_llm()` 이 던지는 "알 수 없는 코치 LLM" 을 계약 위반으로 세면
+    지표를 보고 프롬프트·스키마만 뒤지게 된다(CodeRabbit PR#600 리뷰).
+    """
+    from app.services import trainer_routine_options_service as svc
+
+    token = _trainer_token(client)
+    member_id = _first_client_id(client, token)
+
+    def _unknown_provider(*_a, **_k):
+        raise ValueError("알 수 없는 코치 LLM: 'gemni'. 사용 가능: ['openai', 'gemini']")
+
+    monkeypatch.setattr(svc, "get_coach_llm", _unknown_provider)
+    metrics.reset()
+
+    assert _generate(client, token, member_id).json()["generated_by"] == "rule"
+
+    counters = metrics.snapshot()["counters"]
+    assert counters["routine_options.fallback{reason=infra}"] == 1
+    assert "routine_options.fallback{reason=contract}" not in counters
+
+
+def test_a_new_member_without_history_is_not_counted_as_a_fallback(
+    client, db_session
+):
+    """LLM 을 부를 이유가 없던 것과 LLM 이 실패한 것은 다르다.
+
+    같은 칸에 세면 신규 가입이 몰릴 때 폴백률이 치솟아 AI 가 죽은 것처럼 보인다
+    (CodeRabbit PR#600 리뷰).
+    """
+    import uuid
+
+    from sqlalchemy import delete
+
+    from app.core.security import hash_password
+    from app.models.models import User
+
+    email = f"metrics-newbie-{uuid.uuid4().hex[:8]}@example.com"
+    user = User(
+        id=f"user-{uuid.uuid4().hex[:12]}", email=email, name="신규",
+        hashed_password=hash_password("pw!"), role="member",
+    )
+    db_session.add(user)
+    db_session.commit()
+    try:
+        token = client.post(
+            "/v1/auth/login", data={"username": email, "password": "pw!"}
+        ).json()["access_token"]
+        metrics.reset()
+
+        client.get("/v1/diet/recommendations", headers=_headers(token))
+
+        counters = metrics.snapshot()["counters"]
+        assert counters["diet_recommendations.generated{by=no_data}"] == 1
+        assert not any(
+            k.startswith("diet_recommendations.fallback") for k in counters
+        )
+    finally:
+        db_session.execute(delete(User).where(User.id == user.id))
+        db_session.commit()
+
+
 # ---- 노출 엔드포인트 ----
 
 def test_metrics_endpoint_requires_authentication(client):

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -1,0 +1,207 @@
+"""AI 폴백 계측 (#583).
+
+핵심 성질: AI 가 조용히 죽어도 사용자는 그럴듯한 규칙형 결과를 받으므로 아무도
+신고하지 않는다. 그 상태를 지표로 볼 수 있어야 한다.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.core import metrics
+
+
+@pytest.fixture(autouse=True)
+def _clean_metrics():
+    metrics.reset()
+    yield
+    metrics.reset()
+
+
+# ---- 레지스트리 (순수) ----
+
+def test_labels_collapse_to_one_slot_regardless_of_order():
+    metrics.incr("thing", a="1", b="2")
+    metrics.incr("thing", b="2", a="1")
+
+    assert metrics.snapshot()["counters"] == {"thing{a=1,b=2}": 2}
+
+
+def test_distinct_label_values_are_counted_separately():
+    metrics.incr("routine_options.fallback", reason="contract")
+    metrics.incr("routine_options.fallback", reason="infra")
+    metrics.incr("routine_options.fallback", reason="infra")
+
+    counters = metrics.snapshot()["counters"]
+    assert counters["routine_options.fallback{reason=contract}"] == 1
+    assert counters["routine_options.fallback{reason=infra}"] == 2
+
+
+def test_durations_keep_a_summary_not_every_sample():
+    for ms in (100.0, 300.0, 200.0):
+        metrics.observe_ms("llm_ms", ms)
+
+    d = metrics.snapshot()["durations"]["llm_ms"]
+    assert d["count"] == 3
+    assert d["total_ms"] == 600.0
+    assert d["avg_ms"] == 200.0
+    assert d["max_ms"] == 300.0
+
+
+def test_snapshot_is_a_copy_so_readers_cannot_mutate_state():
+    metrics.incr("thing")
+    snap = metrics.snapshot()
+    snap["counters"]["thing"] = 999
+
+    assert metrics.snapshot()["counters"]["thing"] == 1
+
+
+# ---- 루틴 생성 경로 (DB) ----
+
+def _trainer_token(client) -> str:
+    r = client.post(
+        "/v1/auth/login",
+        data={"username": "trainer@oncare.com", "password": "oncare123"},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["access_token"]
+
+
+def _headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _generate(client, token: str, member_id: str):
+    return client.post(
+        f"/v1/trainer/clients/{member_id}/routine-options",
+        headers=_headers(token),
+        json={"available_minutes": 40},
+    )
+
+
+def _first_client_id(client, token: str) -> str:
+    r = client.get("/v1/trainer/clients", headers=_headers(token))
+    assert r.status_code == 200, r.text
+    return r.json()[0]["id"]
+
+
+_VALID_PLANS = {
+    "plan_a": {
+        "key": "A", "label": "회복 루틴", "intensity": "낮음",
+        "total_minutes": 20, "reason": "회복 위주",
+        "rationale": "부담을 줄인 회복 루틴입니다.",
+        "exercises": [{"name": "가벼운 걷기", "minutes": 20, "type": "걷기"}],
+    },
+    "plan_b": {
+        "key": "B", "label": "표준 루틴", "intensity": "보통",
+        "total_minutes": 30, "reason": "표준 강도",
+        "rationale": "평소 강도를 유지하는 루틴입니다.",
+        "exercises": [{"name": "인터벌 러닝", "minutes": 30, "type": "유산소"}],
+    },
+}
+
+
+def _stub_llm(monkeypatch, behaviour):
+    from app.services import trainer_routine_options_service as svc
+    from app.services.coach.llm_base import LLMResult
+
+    class _StubLLM:
+        def generate(self, system_prompt: str, user_prompt: str) -> LLMResult:
+            if isinstance(behaviour, Exception):
+                raise behaviour
+            return LLMResult(text=behaviour, model="stub")
+
+    monkeypatch.setattr(svc, "get_coach_llm", lambda *a, **k: _StubLLM())
+
+
+def test_successful_generation_is_counted_as_ai(client, monkeypatch):
+    token = _trainer_token(client)
+    member_id = _first_client_id(client, token)
+    _stub_llm(monkeypatch, json.dumps(_VALID_PLANS, ensure_ascii=False))
+    metrics.reset()
+
+    assert _generate(client, token, member_id).json()["generated_by"] == "ai"
+
+    counters = metrics.snapshot()["counters"]
+    assert counters["routine_options.generated{by=ai}"] == 1
+    assert not any(k.startswith("routine_options.fallback") for k in counters)
+
+
+def test_a_malformed_response_is_counted_as_a_contract_fallback(
+    client, monkeypatch
+):
+    """공급자는 살아 있는데 규격이 틀렸다 — 프롬프트/스키마를 볼 신호."""
+    token = _trainer_token(client)
+    member_id = _first_client_id(client, token)
+    _stub_llm(monkeypatch, '{"plan_a": {"key": "A"}}')
+    metrics.reset()
+
+    assert _generate(client, token, member_id).json()["generated_by"] == "rule"
+
+    counters = metrics.snapshot()["counters"]
+    assert counters["routine_options.fallback{reason=contract}"] == 1
+    assert counters["routine_options.generated{by=rule}"] == 1
+
+
+def test_a_provider_failure_is_counted_as_an_infra_fallback(client, monkeypatch):
+    """키 미설정·네트워크·5xx — 계약 위반과 섞이면 원인을 못 가른다."""
+    token = _trainer_token(client)
+    member_id = _first_client_id(client, token)
+    _stub_llm(monkeypatch, RuntimeError("GEMINI_API_KEY 가 설정되지 않았습니다."))
+    metrics.reset()
+
+    assert _generate(client, token, member_id).json()["generated_by"] == "rule"
+
+    counters = metrics.snapshot()["counters"]
+    assert counters["routine_options.fallback{reason=infra}"] == 1
+    assert "routine_options.fallback{reason=contract}" not in counters
+
+
+def test_llm_duration_is_recorded_even_when_the_call_fails(client, monkeypatch):
+    """#584 의 타임아웃 값은 '실패까지 얼마나 기다렸나'에서 나온다."""
+    token = _trainer_token(client)
+    member_id = _first_client_id(client, token)
+    _stub_llm(monkeypatch, RuntimeError("provider down"))
+    metrics.reset()
+
+    _generate(client, token, member_id)
+
+    assert metrics.snapshot()["durations"]["routine_options.llm_ms"]["count"] == 1
+
+
+def test_chat_grounded_generations_are_counted(client, monkeypatch):
+    """#580 이 실환경에서도 도는지 — 근거가 실린 생성만 따로 센다."""
+    token = _trainer_token(client)
+    member_id = _first_client_id(client, token)
+    client.post(
+        f"/v1/trainer/clients/{member_id}/chat",
+        headers=_headers(token),
+        json={"text": "계측 확인용 메시지입니다 무릎이 불편해요"},
+    )
+    _stub_llm(monkeypatch, json.dumps(_VALID_PLANS, ensure_ascii=False))
+    metrics.reset()
+
+    _generate(client, token, member_id)
+
+    assert metrics.snapshot()["counters"]["routine_options.with_chat_context"] == 1
+
+
+# ---- 노출 엔드포인트 ----
+
+def test_metrics_endpoint_requires_authentication(client):
+    assert client.get("/v1/system/metrics").status_code == 401
+
+
+def test_metrics_endpoint_forbidden_for_a_normal_user(client):
+    """어떤 공급자가 얼마나 실패하는지는 운영 정보다."""
+    email = "metrics-viewer@example.com"
+    client.post(
+        "/v1/auth/register",
+        json={"email": email, "password": "pw!", "name": "u"},
+    )
+    token = client.post(
+        "/v1/auth/login", data={"username": email, "password": "pw!"}
+    ).json()["access_token"]
+
+    assert client.get("/v1/system/metrics", headers=_headers(token)).status_code == 403


### PR DESCRIPTION
## Summary

* 루틴 생성과 식단 추천이 **조용히** 규칙 폴백하기 때문에, AI 가 완전히 죽어도 지표상 정상과 구분되지 않았습니다.
* 두 경로에 생성 성공/폴백 카운터를 붙이고, 폴백 사유를 `contract`(응답 규격 위반) 와 `infra`(키·네트워크·5xx) 로 나눴습니다.
* `GET /v1/system/metrics`(관리자 전용)로 읽습니다.

---

## Changes

### ✨ Features

* `app/core/metrics.py` 신설 — 스레드 안전 인프로세스 카운터 + 소요 시간 요약(count/total/avg/max).
* `GET /v1/system/metrics` — `RequireAdmin` 게이트. 어떤 공급자가 얼마나 실패하는지는 운영 정보라 공개 헬스체크와 분리했습니다.
* `routine_options.generated{by=ai|rule}` · `routine_options.fallback{reason=contract|infra}` · `routine_options.llm_ms` · `routine_options.with_chat_context`.
* `diet_recommendations.generated{by=llm|rules}` · `diet_recommendations.fallback{reason=busy|timeout|error}`.

### 🔧 Improvements

* `generate_routine_options` 의 `except Exception` 한 덩어리를 둘로 나눴습니다. 계약 위반은 `logger.warning`(예상되는 일), 그 외는 `logger.exception`(스택 트레이스). 예전에는 스키마 필드명을 잘못 쓴 버그도 조용히 규칙형으로 내려가 아무도 몰랐습니다.

### 📝 Docs

* `backend/README.md` 에 "AI 폴백 지표" 절 — curl 예시와 해석법(`by=ai` 가 0 이면 AI 경로가 죽은 것).

---

## Commits

1. `9fed37f2` feat(obs): count AI generations and fallbacks

---

## Notes

* **`except` 분리는 #584 의 작업 항목과 겹칩니다.** #583 의 완료 조건이 "폴백 사유를 contract/infra 로 구분해 기록" 이라 분류가 선행돼야 했습니다. #584 에 남은 범위는 executor + 세마포어 + 타임아웃입니다.
* **`llm_ms` 는 실패 시에도 기록합니다.** #584 의 타임아웃 값은 "실패까지 얼마나 기다렸나" 에서 나오므로, 이 지표가 그 근거가 됩니다.
* **`with_chat_context` 는 AI 성공 시에만 셉니다.** 규칙형은 채팅을 읽지 않아서, 폴백까지 세면 "채팅 근거가 AI 에 닿았다" 는 질문에 거짓으로 답하게 됩니다. #580 이 실환경에서도 도는지 확인하려고 만든 카운터입니다.
* **식단 경로는 캐시 미스 이후에만 셉니다.** 세는 대상이 '요청 수' 가 아니라 '생성 시도' 라서, 캐시 적중까지 세면 TTL 길이가 폴백률을 흔듭니다.
* **단일 인스턴스/데모 기준입니다.** 값은 프로세스 메모리에 있고 재시작하면 사라집니다. 여러 인스턴스로 늘리면 각자 자기 몫만 셉니다 — 운영 전환은 #480 배포와 함께 볼 문제라 Prometheus/StatsD 교체 지점을 모듈 독스트링에 남겼습니다.
* **이슈 본문 정정:** #583 에 "`observability.py` 에 폴백 카운터 추가(현재 존재하나 이 경로에 미연결)" 라고 적었는데, 확인해 보니 그 파일에는 카운터 인프라가 **아예 없습니다**(request-id · 액세스 로그 · 전역 예외 처리뿐). 그래서 `metrics.py` 를 새로 만들었습니다.
* 라벨은 카디널리티가 낮은 값(`reason`/`by`)만 씁니다. `user_id` 같은 값을 라벨로 넣으면 레지스트리가 사용자 수만큼 자랍니다 — 모듈 주석에 명시했습니다.

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [ ] UI 확인 <!-- 프론트 변경 없음 -->
* [x] 빌드 성공
* [x] 관련 테스트 통과

`tests/test_metrics.py` 신설 (10건): 라벨 순서 무관 집계, 라벨값별 분리, 소요 시간 요약, snapshot 불변성, 성공→`by=ai`, 잘못된 JSON→`reason=contract`, 공급자 실패→`reason=infra`, 실패 시에도 소요 시간 기록, 채팅 근거 카운트, 엔드포인트 401/403.

백엔드 전체 스위트를 **새로 만든 DB** 에서 통과시켰습니다.

### Manual Test Steps

1. `.env` 의 `ADMIN_EMAILS` 에 본인 계정을 넣고 백엔드 기동, 해당 계정으로 로그인.
2. LLM 키 없이 트레이너 웹에서 AI 루틴 생성 → `/v1/system/metrics` 에 `fallback{reason=infra}` 가 오르는지 확인.
3. 키를 넣고 다시 생성 → `generated{by=ai}` 가 오르고 `llm_ms.avg_ms` 가 찍히는지 확인.
4. 일반 회원 계정으로 `/v1/system/metrics` 호출 → 403 확인.

---

## Related Issues

Closes #583

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 관리자가 AI 기반 루틴 생성 및 식단 추천의 성공·폴백 지표를 조회할 수 있습니다.
  - 폴백 발생 원인을 계약 오류, 시간 초과, 인프라 오류 등으로 구분해 확인할 수 있습니다.
  - AI 처리 시간과 평균·최대 소요 시간 등의 성능 지표를 제공합니다.

- **버그 수정**
  - 자정 전후 대화 문맥 조회 기준을 개선했습니다.
  - AI 생성 실패 시에도 기존 규칙 기반 추천 및 루틴 생성이 안정적으로 유지됩니다.

- **문서**
  - 관리자 지표 조회 방법과 메트릭 보존 범위를 안내하는 문서를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->