### PR TITLE
fix(trainer-clients): 트레이너 웹에서 당류 소수 정밀도 보존

### DIFF
--- a/frontend/flutter_trainer/lib/core/storage/app_database.dart
+++ b/frontend/flutter_trainer/lib/core/storage/app_database.dart
@@ -28,7 +28,7 @@ class TrainerClients extends Table {
   BoolColumn get active => boolean().withDefault(const Constant(true))();
   IntColumn get caloriesToday => integer()();
   IntColumn get sodiumMg => integer()();
-  IntColumn get sugarG => integer()();
+  RealColumn get sugarG => real()();
   RealColumn get carbsG => real().withDefault(const Constant(0))();
   RealColumn get proteinG => real().withDefault(const Constant(0))();
   RealColumn get fatG => real().withDefault(const Constant(0))();
@@ -174,7 +174,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.executor);
 
   @override
-  int get schemaVersion => 4;
+  int get schemaVersion => 5;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -204,6 +204,13 @@ class AppDatabase extends _$AppDatabase {
         await m.addColumn(clientDietEntries, clientDietEntries.carbsG);
         await m.addColumn(clientDietEntries, clientDietEntries.proteinG);
         await m.addColumn(clientDietEntries, clientDietEntries.fatG);
+      }
+      if (from < 5) {
+        // #565 sugar_g: INTEGER -> REAL. SQLite keeps non-integral values
+        // stored in an INTEGER-affinity column as REAL, so rebuilding this
+        // table would only add data-loss risk. Existing integers are read by
+        // drift as doubles (for example 17 -> 17.0), while the v5 declaration
+        // lets new values retain their fractional part.
       }
     },
   );

--- a/frontend/flutter_trainer/lib/core/storage/app_database.g.dart
+++ b/frontend/flutter_trainer/lib/core/storage/app_database.g.dart
@@ -312,11 +312,11 @@ class $TrainerClientsTable extends TrainerClients
   );
   static const VerificationMeta _sugarGMeta = const VerificationMeta('sugarG');
   @override
-  late final GeneratedColumn<int> sugarG = GeneratedColumn<int>(
+  late final GeneratedColumn<double> sugarG = GeneratedColumn<double>(
     'sugar_g',
     aliasedName,
     false,
-    type: DriftSqlType.int,
+    type: DriftSqlType.double,
     requiredDuringInsert: true,
   );
   static const VerificationMeta _carbsGMeta = const VerificationMeta('carbsG');
@@ -611,7 +611,7 @@ class $TrainerClientsTable extends TrainerClients
         data['${effectivePrefix}sodium_mg'],
       )!,
       sugarG: attachedDatabase.typeMapping.read(
-        DriftSqlType.int,
+        DriftSqlType.double,
         data['${effectivePrefix}sugar_g'],
       )!,
       carbsG: attachedDatabase.typeMapping.read(
@@ -662,7 +662,7 @@ class TrainerClientRow extends DataClass
   final bool active;
   final int caloriesToday;
   final int sodiumMg;
-  final int sugarG;
+  final double sugarG;
   final double carbsG;
   final double proteinG;
   final double fatG;
@@ -701,7 +701,7 @@ class TrainerClientRow extends DataClass
     map['active'] = Variable<bool>(active);
     map['calories_today'] = Variable<int>(caloriesToday);
     map['sodium_mg'] = Variable<int>(sodiumMg);
-    map['sugar_g'] = Variable<int>(sugarG);
+    map['sugar_g'] = Variable<double>(sugarG);
     map['carbs_g'] = Variable<double>(carbsG);
     map['protein_g'] = Variable<double>(proteinG);
     map['fat_g'] = Variable<double>(fatG);
@@ -749,7 +749,7 @@ class TrainerClientRow extends DataClass
       active: serializer.fromJson<bool>(json['active']),
       caloriesToday: serializer.fromJson<int>(json['caloriesToday']),
       sodiumMg: serializer.fromJson<int>(json['sodiumMg']),
-      sugarG: serializer.fromJson<int>(json['sugarG']),
+      sugarG: serializer.fromJson<double>(json['sugarG']),
       carbsG: serializer.fromJson<double>(json['carbsG']),
       proteinG: serializer.fromJson<double>(json['proteinG']),
       fatG: serializer.fromJson<double>(json['fatG']),
@@ -774,7 +774,7 @@ class TrainerClientRow extends DataClass
       'active': serializer.toJson<bool>(active),
       'caloriesToday': serializer.toJson<int>(caloriesToday),
       'sodiumMg': serializer.toJson<int>(sodiumMg),
-      'sugarG': serializer.toJson<int>(sugarG),
+      'sugarG': serializer.toJson<double>(sugarG),
       'carbsG': serializer.toJson<double>(carbsG),
       'proteinG': serializer.toJson<double>(proteinG),
       'fatG': serializer.toJson<double>(fatG),
@@ -795,7 +795,7 @@ class TrainerClientRow extends DataClass
     bool? active,
     int? caloriesToday,
     int? sodiumMg,
-    int? sugarG,
+    double? sugarG,
     double? carbsG,
     double? proteinG,
     double? fatG,
@@ -931,7 +931,7 @@ class TrainerClientsCompanion extends UpdateCompanion<TrainerClientRow> {
   final Value<bool> active;
   final Value<int> caloriesToday;
   final Value<int> sodiumMg;
-  final Value<int> sugarG;
+  final Value<double> sugarG;
   final Value<double> carbsG;
   final Value<double> proteinG;
   final Value<double> fatG;
@@ -970,7 +970,7 @@ class TrainerClientsCompanion extends UpdateCompanion<TrainerClientRow> {
     this.active = const Value.absent(),
     required int caloriesToday,
     required int sodiumMg,
-    required int sugarG,
+    required double sugarG,
     this.carbsG = const Value.absent(),
     this.proteinG = const Value.absent(),
     this.fatG = const Value.absent(),
@@ -1000,7 +1000,7 @@ class TrainerClientsCompanion extends UpdateCompanion<TrainerClientRow> {
     Expression<bool>? active,
     Expression<int>? caloriesToday,
     Expression<int>? sodiumMg,
-    Expression<int>? sugarG,
+    Expression<double>? sugarG,
     Expression<double>? carbsG,
     Expression<double>? proteinG,
     Expression<double>? fatG,
@@ -1043,7 +1043,7 @@ class TrainerClientsCompanion extends UpdateCompanion<TrainerClientRow> {
     Value<bool>? active,
     Value<int>? caloriesToday,
     Value<int>? sodiumMg,
-    Value<int>? sugarG,
+    Value<double>? sugarG,
     Value<double>? carbsG,
     Value<double>? proteinG,
     Value<double>? fatG,
@@ -1106,7 +1106,7 @@ class TrainerClientsCompanion extends UpdateCompanion<TrainerClientRow> {
       map['sodium_mg'] = Variable<int>(sodiumMg.value);
     }
     if (sugarG.present) {
-      map['sugar_g'] = Variable<int>(sugarG.value);
+      map['sugar_g'] = Variable<double>(sugarG.value);
     }
     if (carbsG.present) {
       map['carbs_g'] = Variable<double>(carbsG.value);
@@ -4029,7 +4029,7 @@ typedef $$TrainerClientsTableCreateCompanionBuilder =
       Value<bool> active,
       required int caloriesToday,
       required int sodiumMg,
-      required int sugarG,
+      required double sugarG,
       Value<double> carbsG,
       Value<double> proteinG,
       Value<double> fatG,
@@ -4050,7 +4050,7 @@ typedef $$TrainerClientsTableUpdateCompanionBuilder =
       Value<bool> active,
       Value<int> caloriesToday,
       Value<int> sodiumMg,
-      Value<int> sugarG,
+      Value<double> sugarG,
       Value<double> carbsG,
       Value<double> proteinG,
       Value<double> fatG,
@@ -4115,7 +4115,7 @@ class $$TrainerClientsTableFilterComposer
     builder: (column) => ColumnFilters(column),
   );
 
-  ColumnFilters<int> get sugarG => $composableBuilder(
+  ColumnFilters<double> get sugarG => $composableBuilder(
     column: $table.sugarG,
     builder: (column) => ColumnFilters(column),
   );
@@ -4210,7 +4210,7 @@ class $$TrainerClientsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
-  ColumnOrderings<int> get sugarG => $composableBuilder(
+  ColumnOrderings<double> get sugarG => $composableBuilder(
     column: $table.sugarG,
     builder: (column) => ColumnOrderings(column),
   );
@@ -4291,7 +4291,7 @@ class $$TrainerClientsTableAnnotationComposer
   GeneratedColumn<int> get sodiumMg =>
       $composableBuilder(column: $table.sodiumMg, builder: (column) => column);
 
-  GeneratedColumn<int> get sugarG =>
+  GeneratedColumn<double> get sugarG =>
       $composableBuilder(column: $table.sugarG, builder: (column) => column);
 
   GeneratedColumn<double> get carbsG =>
@@ -4368,7 +4368,7 @@ class $$TrainerClientsTableTableManager
                 Value<bool> active = const Value.absent(),
                 Value<int> caloriesToday = const Value.absent(),
                 Value<int> sodiumMg = const Value.absent(),
-                Value<int> sugarG = const Value.absent(),
+                Value<double> sugarG = const Value.absent(),
                 Value<double> carbsG = const Value.absent(),
                 Value<double> proteinG = const Value.absent(),
                 Value<double> fatG = const Value.absent(),
@@ -4408,7 +4408,7 @@ class $$TrainerClientsTableTableManager
                 Value<bool> active = const Value.absent(),
                 required int caloriesToday,
                 required int sodiumMg,
-                required int sugarG,
+                required double sugarG,
                 Value<double> carbsG = const Value.absent(),
                 Value<double> proteinG = const Value.absent(),
                 Value<double> fatG = const Value.absent(),

--- a/frontend/flutter_trainer/lib/core/storage/seed_clients.dart
+++ b/frontend/flutter_trainer/lib/core/storage/seed_clients.dart
@@ -51,9 +51,8 @@ const List<_Client> _clients = <_Client>[
     active: true,
     calories: 1067,
     sodiumMg: 3428,
-    // TrainerClient's existing sugar contract is int; the real DTO also
-    // normalises 17.8 to 17, so the mock follows that same display value.
-    sugarG: 17,
+    // Keep this aligned with the member app's current mock daily total.
+    sugarG: 17.8,
     lastRoutine: '오늘',
     weekCompletion: <int>[100, 67, 100, 0, 100, 67, 100],
     sodiumWeek: <int>[2400, 2200, 1900, 2050, 2300, 1850, 3428],

--- a/frontend/flutter_trainer/lib/core/storage/seed_data.dart
+++ b/frontend/flutter_trainer/lib/core/storage/seed_data.dart
@@ -13,7 +13,7 @@ part 'seed_clients.dart';
 
 /// Idempotent seeder for the trainer app's local DB. Runs at bootstrap.
 ///
-/// **Flag.** `AppKeyValues['trainer_seeded_v7']` stores the date string
+/// **Flag.** `AppKeyValues['trainer_seeded_v8']` stores the date string
 /// (`YYYY-MM-DD`) the seed last ran with. Bump the version suffix
 /// whenever the seeded *content* changes — otherwise a browser that
 /// already seeded today keeps the old data until the date rolls over.
@@ -26,8 +26,9 @@ part 'seed_clients.dart';
 ///   `seed-`-prefixed row and re-insert, sliding the trainer's schedule
 ///   onto today so the 스케줄 탭 is never empty on a later calendar day.
 ///
-/// The flag is `_v7` (was `_v6`): 김민수's diet now matches the member
-/// app mock for #527. `_v6` added client diet macros. `_v5` had grown
+/// The flag is `_v8` (was `_v7`): 김민수's sugar now preserves the member
+/// app mock's 17.8g for #565. `_v7` aligned his diet for #527, `_v6` added
+/// client diet macros, and `_v5` had grown
 /// 김민수's thread from five messages
 /// to fifteen so the member and trainer demos tell the same story (#543).
 /// `_v4` had bumped `_v3` when the roster grew from three clients to
@@ -48,7 +49,7 @@ part 'seed_clients.dart';
 Future<void> seedIfEmpty(AppDatabase db) async {
   final today = ymd(DateTime.now());
 
-  if (await db.readValue('trainer_seeded_v7') == today) return;
+  if (await db.readValue('trainer_seeded_v8') == today) return;
 
   // A fixed, ancient anchor for seed chat timestamps. Using a constant
   // (not DateTime.now()) keeps seed messages ordered before ANY reply
@@ -219,7 +220,7 @@ Future<void> seedIfEmpty(AppDatabase db) async {
     });
 
     // ---- Mark seeded (inside the txn so it commits atomically) ----
-    await db.putValue('trainer_seeded_v7', today);
+    await db.putValue('trainer_seeded_v8', today);
   });
 }
 
@@ -316,7 +317,7 @@ class _Client {
   final bool active;
   final int calories;
   final int sodiumMg;
-  final int sugarG;
+  final double sugarG;
   final String lastRoutine;
   final List<int> weekCompletion;
   final List<int> sodiumWeek;

--- a/frontend/flutter_trainer/lib/features/clients/data/dtos/client_dtos.dart
+++ b/frontend/flutter_trainer/lib/features/clients/data/dtos/client_dtos.dart
@@ -19,7 +19,7 @@ TrainerClient trainerClientFromJson(Map<String, Object?> json) {
     active: json['active'] == true,
     calories: _int(json['calories']),
     sodiumMg: _int(json['sodium_mg']),
-    sugarG: _int(json['sugar_g']),
+    sugarG: _double(json['sugar_g']),
     carbsG: _double(json['carbs_g']),
     proteinG: _double(json['protein_g']),
     fatG: _double(json['fat_g']),

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/diet_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/diet_view.dart
@@ -121,7 +121,7 @@ class _NutritionSummary extends StatelessWidget {
                 unit: 'g',
                 // Navy base like the other tiles — orange only when over.
                 color: AppColors.accentDark,
-                warn: client.sugarG > sugarTargetG,
+                warn: client.sugarOverBudget,
               ),
             ],
           ),

--- a/frontend/flutter_trainer/lib/features/coaching/presentation/pages/coaching_page.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/pages/coaching_page.dart
@@ -868,7 +868,7 @@ class _DietSummaryCard extends StatelessWidget {
                 value: client.sugarG,
                 unit: 'g',
                 color: AppColors.accentDark,
-                warn: client.sugarG > sugarTargetG,
+                warn: client.sugarOverBudget,
               ),
             ],
           ),

--- a/frontend/flutter_trainer/lib/shared/models/trainer_client.dart
+++ b/frontend/flutter_trainer/lib/shared/models/trainer_client.dart
@@ -57,7 +57,7 @@ class TrainerClient {
   final int sodiumMg;
 
   /// Today's sugar (g).
-  final int sugarG;
+  final double sugarG;
 
   /// Today's carbohydrate intake (g).
   final double carbsG;
@@ -82,6 +82,9 @@ class TrainerClient {
   /// Sodium exceeds the [sodiumTargetMg] daily target — surfaced as a
   /// warning on the list card and counted by the AI summary.
   bool get sodiumOverBudget => sodiumMg > sodiumTargetMg;
+
+  /// Sugar exceeds the [sugarTargetG] daily target.
+  bool get sugarOverBudget => sugarG > sugarTargetG;
 
   /// Days in [sodiumWeek] that were over the daily target.
   int get sodiumOverDays =>

--- a/frontend/flutter_trainer/test/core/storage/app_database_migration_test.dart
+++ b/frontend/flutter_trainer/test/core/storage/app_database_migration_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:oncare_trainer/core/storage/app_database.dart';
 
 void main() {
-  test('v3 to v4 adds macro columns and preserves existing rows', () async {
+  test('v3 to v5 adds macro columns and preserves existing rows', () async {
     final executor = NativeDatabase.memory(
       setup: (database) {
         database.execute('''
@@ -63,9 +63,10 @@ void main() {
     final meal = await db.select(db.clientDietEntries).getSingle();
     final version = await db.customSelect('PRAGMA user_version').getSingle();
 
-    expect(version.read<int>('user_version'), 4);
+    expect(version.read<int>('user_version'), 5);
     expect(client.id, 'existing-client');
     expect(client.caloriesToday, 500);
+    expect(client.sugarG, 12.0);
     expect(client.carbsG, 0);
     expect(client.proteinG, 0);
     expect(client.fatG, 0);
@@ -74,5 +75,61 @@ void main() {
     expect(meal.carbsG, 0);
     expect(meal.proteinG, 0);
     expect(meal.fatG, 0);
+  });
+
+  test('v4 to v5 preserves integer sugar and all client rows', () async {
+    final executor = NativeDatabase.memory(
+      setup: (database) {
+        database.execute('''
+          CREATE TABLE trainer_clients (
+            id TEXT NOT NULL PRIMARY KEY,
+            name TEXT NOT NULL,
+            avatar TEXT NOT NULL,
+            goal TEXT NOT NULL,
+            last_message TEXT NOT NULL,
+            last_time TEXT NOT NULL,
+            active INTEGER NOT NULL DEFAULT 1 CHECK (active IN (0, 1)),
+            calories_today INTEGER NOT NULL,
+            sodium_mg INTEGER NOT NULL,
+            sugar_g INTEGER NOT NULL,
+            carbs_g REAL NOT NULL DEFAULT 0,
+            protein_g REAL NOT NULL DEFAULT 0,
+            fat_g REAL NOT NULL DEFAULT 0,
+            last_routine TEXT NOT NULL,
+            week_completion_json TEXT NOT NULL,
+            sodium_week_json TEXT NOT NULL DEFAULT '[]',
+            sort_order INTEGER NOT NULL DEFAULT 0
+          )
+        ''');
+        database.execute('''
+          INSERT INTO trainer_clients (
+            id, name, avatar, goal, last_message, last_time, active,
+            calories_today, sodium_mg, sugar_g, carbs_g, protein_g, fat_g,
+            last_routine, week_completion_json, sodium_week_json, sort_order
+          ) VALUES
+            ('client-a', '기존 회원 A', 'A', '혈압 관리', '보존 메시지', '방금', 1,
+             500, 700, 12, 40.5, 20, 10, '어제', '[100]', '[700]', 1),
+            ('client-b', '기존 회원 B', 'B', '체중 감량', '다른 메시지', '1시간 전', 0,
+             900, 1200, 61, 80, 35.5, 22, '3일 전', '[50]', '[1200]', 2)
+        ''');
+        database.execute('PRAGMA user_version = 4');
+      },
+    );
+    final db = AppDatabase.forTesting(executor);
+    addTearDown(db.close);
+
+    final clients = await db.select(db.trainerClients).get()
+      ..sort((a, b) => a.sortOrder.compareTo(b.sortOrder));
+    final version = await db.customSelect('PRAGMA user_version').getSingle();
+
+    expect(version.read<int>('user_version'), 5);
+    expect(clients, hasLength(2));
+    expect(clients[0].name, '기존 회원 A');
+    expect(clients[0].sugarG, 12.0);
+    expect(clients[0].carbsG, 40.5);
+    expect(clients[1].name, '기존 회원 B');
+    expect(clients[1].active, isFalse);
+    expect(clients[1].sugarG, 61.0);
+    expect(clients[1].proteinG, 35.5);
   });
 }

--- a/frontend/flutter_trainer/test/core/storage/seed_data_test.dart
+++ b/frontend/flutter_trainer/test/core/storage/seed_data_test.dart
@@ -52,8 +52,21 @@ void main() {
       }
 
       expect(await db.select(db.clientChatMessages).get(), isNotEmpty);
-      expect(await db.readValue('trainer_seeded_v7'), _todayString());
+      expect(await db.readValue('trainer_seeded_v8'), _todayString());
     });
+
+    test(
+      '김민수 sugar matches the member mock and survives drift roundtrip',
+      () async {
+        await seedIfEmpty(db);
+
+        final minsu = await (db.select(
+          db.trainerClients,
+        )..where((c) => c.id.equals('seed-client-1'))).getSingle();
+        // frontend/flutter's current MockDietRepository daily total is 17.8g.
+        expect(minsu.sugarG, 17.8);
+      },
+    );
 
     // The roster is a fixture for the *charts*, not just the list — its
     // whole point is that every state the console can render is reachable
@@ -157,13 +170,13 @@ void main() {
 
     test('stale flag (different date) re-seeds schedule onto today', () async {
       await seedIfEmpty(db);
-      await db.putValue('trainer_seeded_v7', '2020-01-01');
+      await db.putValue('trainer_seeded_v8', '2020-01-01');
 
       await seedIfEmpty(db);
 
       final schedule = await db.select(db.trainerScheduleEntries).get();
       expect(schedule.every((s) => s.date == _todayString()), isTrue);
-      expect(await db.readValue('trainer_seeded_v7'), _todayString());
+      expect(await db.readValue('trainer_seeded_v8'), _todayString());
     });
 
     test(
@@ -252,7 +265,7 @@ void main() {
 
         // Simulate an older build: already seeded TODAY under a previous
         // flag, plus a runtime (non-seed) client that must survive.
-        await db.putValue('trainer_seeded_v1', today);
+        await db.putValue('trainer_seeded_v7', today);
         await db
             .into(db.trainerClients)
             .insert(
@@ -286,7 +299,7 @@ void main() {
         expect(week.length, 7);
         expect(week.any((v) => (v as num) > 0), isTrue);
 
-        expect(await db.readValue('trainer_seeded_v7'), today);
+        expect(await db.readValue('trainer_seeded_v8'), today);
       },
     );
 
@@ -308,7 +321,7 @@ void main() {
           );
 
       // Force a re-seed.
-      await db.putValue('trainer_seeded_v7', '2020-01-01');
+      await db.putValue('trainer_seeded_v8', '2020-01-01');
       await seedIfEmpty(db);
 
       final chat = await db.select(db.clientChatMessages).get();

--- a/frontend/flutter_trainer/test/features/clients/client_detail_diet_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_diet_test.dart
@@ -62,6 +62,7 @@ void main() {
           .firstWhere((client) => client.id == 'seed-client-1');
       expect(minsu.calories, 1067);
       expect(minsu.sodiumMg, 3428);
+      expect(minsu.sugarG, 17.8);
       expect(minsu.carbsG, 120);
       expect(minsu.proteinG, 45);
       expect(minsu.fatG, 45);
@@ -155,6 +156,17 @@ void main() {
         find.descendant(of: sodiumTile, matching: find.text('mg 초과')),
         findsOneWidget,
       );
+      final sugarTile = find.byWidgetPredicate(
+        (widget) => widget is MetricTile && widget.label == _ko.metricSugar,
+      );
+      expect(
+        find.descendant(of: sugarTile, matching: find.text('17.8')),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(of: sugarTile, matching: find.text('g')),
+        findsOneWidget,
+      );
       // The detail header plus the 7-day trend card push every meal card
       // down, so reach them by scrolling.
       await tester.scrollUntilVisible(find.text('아침'), 150);
@@ -175,6 +187,21 @@ void main() {
         150,
       );
       expect(find.textContaining('나트륨이 목표치를 1428mg 초과했어요'), findsOneWidget);
+    });
+
+    testWidgets('integer-valued sugar keeps the existing compact format', (
+      tester,
+    ) async {
+      await openDiet(tester, '이지수');
+
+      final sugarTile = find.byWidgetPredicate(
+        (widget) => widget is MetricTile && widget.label == _ko.metricSugar,
+      );
+      expect(
+        find.descendant(of: sugarTile, matching: find.text('38')),
+        findsOneWidget,
+      );
+      expect(find.text('38.0'), findsNothing);
     });
 
     testWidgets('a recorded 0g meal remains a meal instead of empty state', (

--- a/frontend/flutter_trainer/test/features/clients/client_dtos_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_dtos_test.dart
@@ -3,21 +3,22 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:oncare_trainer/features/clients/data/dtos/client_dtos.dart';
 import 'package:oncare_trainer/shared/models/trainer_client.dart';
 
-TrainerClient _client(String id, {required int sodiumMg}) => TrainerClient(
-  id: id,
-  name: id,
-  avatar: id.substring(0, 1),
-  goal: '',
-  lastMessage: '',
-  lastTime: '',
-  active: true,
-  calories: 0,
-  sodiumMg: sodiumMg,
-  sugarG: 0,
-  lastRoutine: '',
-  weekCompletion: const <int>[],
-  sodiumWeek: const <int>[],
-);
+TrainerClient _client(String id, {required int sodiumMg, double sugarG = 0}) =>
+    TrainerClient(
+      id: id,
+      name: id,
+      avatar: id.substring(0, 1),
+      goal: '',
+      lastMessage: '',
+      lastTime: '',
+      active: true,
+      calories: 0,
+      sodiumMg: sodiumMg,
+      sugarG: sugarG,
+      lastRoutine: '',
+      weekCompletion: const <int>[],
+      sodiumWeek: const <int>[],
+    );
 
 void main() {
   group('trainerClientFromJson', () {
@@ -32,7 +33,7 @@ void main() {
         'active': true,
         'calories': 1800,
         'sodium_mg': 2100,
-        'sugar_g': 40,
+        'sugar_g': 17.8,
         'carbs_g': 150.5,
         'protein_g': 90,
         'fat_g': 48.25,
@@ -44,12 +45,19 @@ void main() {
       expect(c.id, 'm1');
       expect(c.name, '김민수');
       expect(c.sodiumMg, 2100);
+      expect(c.sugarG, 17.8);
       expect(c.carbsG, 150.5);
       expect(c.proteinG, 90);
       expect(c.fatG, 48.25);
       expect(c.sodiumOverBudget, isTrue); // 2100 > 2000 target
       expect(c.weekCompletion, <int>[100, 80, 0, 60, 90, 0, 0]);
       expect(c.sodiumWeek, <int>[1900, 2200, 2100]);
+    });
+
+    test('normalizes an integer sugar value to double', () {
+      final c = trainerClientFromJson(<String, Object?>{'sugar_g': 17});
+
+      expect(c.sugarG, 17.0);
     });
 
     test('tolerates double-encoded numbers and missing lists (web JSON)', () {
@@ -162,6 +170,23 @@ void main() {
       ]);
 
       expect(ordered.map((c) => c.sodiumMg).toList(), <int>[2500, 2600, 500]);
+    });
+  });
+
+  group('sugar warning threshold', () {
+    test('keeps the existing strict greater-than rule for decimal values', () {
+      expect(
+        _client('under', sodiumMg: 0, sugarG: 49.9).sugarOverBudget,
+        isFalse,
+      );
+      expect(
+        _client('equal', sodiumMg: 0, sugarG: 50).sugarOverBudget,
+        isFalse,
+      );
+      expect(
+        _client('over', sodiumMg: 0, sugarG: 50.1).sugarOverBudget,
+        isTrue,
+      );
     });
   });
 }

--- a/frontend/flutter_trainer/test/features/coaching/coaching_page_test.dart
+++ b/frontend/flutter_trainer/test/features/coaching/coaching_page_test.dart
@@ -401,6 +401,7 @@ void main() {
       expect(find.text('AI 코칭'), findsWidgets);
       // 김민수 (3428mg, over) → cardio-boost verdict.
       expect(find.text('AI 판단: 나트륨 초과 → 유산소 강화 권장'), findsOneWidget);
+      expect(find.text('17.8'), findsOneWidget);
       expect(find.text('저강도 유산소 (걷기)'), findsOneWidget);
       expect(find.text('혈압 안정에 효과적'), findsOneWidget);
     });

--- a/frontend/flutter_trainer/test/helpers/client_factory.dart
+++ b/frontend/flutter_trainer/test/helpers/client_factory.dart
@@ -12,7 +12,7 @@ TrainerClient makeClient({
   bool active = true,
   int calories = 1800,
   int sodiumMg = 1500,
-  int sugarG = 30,
+  double sugarG = 30,
   String lastMessage = '안녕하세요',
   String lastTime = '방금',
   String lastRoutine = '오늘',


### PR DESCRIPTION
## Summary

* Trainer Web의 실제 API DTO에서 `sugar_g`를 정수로 변환하던 절삭 경로를 제거했습니다.
* Domain model, Drift, Mock/Seed까지 당류 계약을 `double`로 통일해 `17.8 → 17.8g` 정밀도를 보존합니다.
* 기존 설치의 정수형 당류와 다른 고객 행을 보존하는 v4 → v5 migration 및 회귀 테스트를 추가했습니다.

---

## Changes

### 🔧 Improvements

* `TrainerClient.sugarG`를 `double`로 변경했습니다.
* 실제 API DTO가 프로젝트의 기존 `_double()` 파서를 재사용하도록 변경했습니다.
* 당류 경고 판정을 `sugarOverBudget`으로 모아 기존의 엄격한 `> 50` 기준을 유지했습니다.

### 🎨 UI/UX

* 기존 `MetricTile` formatter를 그대로 사용해 소수 당류는 `17.8g`, 정수 당류는 `17g`으로 표시합니다.
* 고객 상세 식단과 AI 코칭 식단 요약 양쪽 표시 경로를 검증했습니다.

### 🐛 Fixes

* 실제 절삭 지점은 DTO의 `_int(json['sugar_g'])`, `TrainerClient.sugarG: int`, Drift `IntColumn`, Trainer Mock의 정수 시드였습니다.
* Drift schema를 v5로 올리고 `sugarG`를 `RealColumn`으로 선언했습니다.
* SQLite가 INTEGER affinity 컬럼에서도 비정수 값을 REAL로 보존하는 기존 프로젝트 migration 방식을 사용해 테이블 재생성 없이 기존 `17 → 17.0`과 다른 고객 데이터를 유지합니다.
* 김민수의 Trainer Mock 당류를 회원 앱의 현재 Mock 합계와 동일한 `17.8g`으로 맞추고 seed flag를 v8로 갱신했습니다.
* Backend와 회원 앱의 타입/구조는 변경하지 않았습니다.

---

## Commits

1. `85fe32bc` fix(trainer-clients): 트레이너 웹에서 당류 소수 정밀도 보존

---

## Notes

* 열린 PR #606, #607과 DTO·모델·Drift·시드·당류 표시 기능 범위가 겹치지 않음을 확인했습니다.
* 관련 선행 작업은 #527 / PR #564이며, 이 PR은 그 과정에서 발견된 당류 정밀도 손실만 해결합니다.
* 최근 PR #590, #593, #595가 일부 Trainer 코칭 파일을 변경했지만 AI 루틴/멱등성/rate-limit 범위로 기능 중복은 없으며, 모두 반영된 최신 `main` 위에서 검증했습니다.
* UI 재설계나 다른 영양소 타입 전환은 포함하지 않았습니다.

---

## Screenshots (Optional)

표시 형식은 기존 공용 `MetricTile`을 유지하며 테스트로 `17.8g` 렌더링을 검증했습니다.

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 실제 API roster 응답의 `sugar_g: 17.8`이 domain에서 `17.8`로 유지되는지 확인합니다.
2. Mock 모드에서 김민수의 오늘 영양 요약과 AI 코칭 식단 요약이 `17.8g`으로 표시되는지 확인합니다.
3. v4 정수 당류 DB를 v5로 열어 기존 당류와 다른 고객 데이터가 보존되는지 확인합니다.

### Automated Checks

* `flutter test --reporter compact` — 462 tests passed
* `dart analyze` — No issues found
* `flutter build web --release --no-wasm-dry-run` — passed
* `git diff --check` — passed
* Drift generated code regenerated with `dart run build_runner build --delete-conflicting-outputs`

---

## Related Issues

Closes #565

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 당류 섭취량을 소수점 단위로 표시하고 저장할 수 있습니다.
  * 기존 정수형 당류 데이터도 정상적으로 유지·변환됩니다.
  * 당류 목표 초과 경고가 일관된 기준으로 표시됩니다.
  * 시드 데이터의 당류 값이 실제 앱 표시 기준에 맞게 업데이트되었습니다.
* **버그 수정**
  * 정수 당류 값이 불필요하게 소수점으로 표시되지 않도록 개선했습니다.
  * 소수 당류 값의 초과 경고 기준을 정확히 적용했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->