### PR TITLE
fix(backend): routine-options에 LLM 타임아웃·동시성 가드 적용

### DIFF
--- a/backend/app/services/trainer_routine_options_service.py
+++ b/backend/app/services/trainer_routine_options_service.py
@@ -304,7 +304,12 @@ def _call_llm(prompt: str):
     를 통해 올라와, 호출부의 `except (ValidationError, RoutineContractError)` 와
     타임아웃을 구분하는 자리가 흐려진다.
     """
-    if not _llm_slots.acquire(blocking=False):
+    # 자리를 딴 세마포어 **인스턴스**를 지역에 붙잡아 둔다. 워커가 전역을 다시 읽으면,
+    # 그 사이 전역이 교체됐을 때(테스트의 monkeypatch 가 그렇게 한다) 잡지도 않은
+    # 세마포어를 풀어 준다 — 원래 자리는 영영 안 돌아오고, 교체된 쪽은 초기값을 넘겨
+    # `BoundedSemaphore` 가 ValueError 를 던진다.
+    slots = _llm_slots
+    if not slots.acquire(blocking=False):
         raise LLMBusyError("LLM 동시 호출 한도 초과 — 규칙 폴백")
 
     def _call():
@@ -319,9 +324,17 @@ def _call_llm(prompt: str):
             )
         finally:
             # 타임아웃으로 호출부가 떠난 뒤라도 작업이 끝나면 자리를 반드시 돌려준다.
-            _llm_slots.release()
+            slots.release()
 
-    return _executor.submit(_call).result(timeout=LLM_TIMEOUT_SEC)
+    try:
+        future = _executor.submit(_call)
+    except RuntimeError:
+        # 스케줄링 자체가 실패하면 워커가 돌지 않아 위 `finally` 도 없다. 여기서
+        # 돌려주지 않으면 실패 한 번마다 동시 호출 한도가 영구히 1씩 줄어, 끝내
+        # 모든 요청이 포화로 떨어진다(인터프리터 종료 중 submit 이 이 경로다).
+        slots.release()
+        raise
+    return future.result(timeout=LLM_TIMEOUT_SEC)
 
 
 def _generate_with_llm(

--- a/backend/app/services/trainer_routine_options_service.py
+++ b/backend/app/services/trainer_routine_options_service.py
@@ -7,8 +7,10 @@ from __future__ import annotations
 
 import json
 import logging
+import threading
 import time
 # `time` 은 stdlib 모듈로 두고(경과 시간 측정), 자정 시각은 별칭으로 받는다.
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeout
 from datetime import date, datetime, timedelta
 from datetime import time as time_of_day
 
@@ -36,6 +38,56 @@ from app.services.coach import prompt_safety
 from app.services.coach.llm import DEFAULT_THINKING_BUDGET, get_coach_llm
 
 logger = logging.getLogger(__name__)
+
+
+class LLMBusyError(RuntimeError):
+    """LLM 동시 호출 한도가 차서 호출을 시도조차 하지 않았음을 알린다.
+
+    "실패"와 구분해야 로그에서 장애와 포화를 헷갈리지 않는다.
+    """
+
+
+#: LLM 응답을 기다리는 최대 시간(초).
+#:
+#: 생성 왕복이 실측 3~6초다(#579, 근거는 `config.py` 의 `routine_options_per_minute`
+#: 주석). 최악 실측의 두 배를 여유로 잡았다 — 6초에 바짝 붙이면 정상 호출이
+#: 산발적으로 잘려 트레이너가 이유 없이 규칙형을 받는다.
+#:
+#: 상한이 있다는 것 자체가 요점이다. 이 값이 없으면 끊어 주는 건 SDK 의 HTTP
+#: 타임아웃뿐인데 Gemini 30초, OpenAI/LiteLLM 60초라 워커 하나가 그만큼 묶인다.
+LLM_TIMEOUT_SEC = 12.0
+
+#: 사고 예산. 지연을 지배하는 값이라 호출부마다 따로 두지 않는다(#579).
+LLM_THINKING_BUDGET = DEFAULT_THINKING_BUDGET
+
+#: 동시에 진행할 LLM 호출 수.
+LLM_MAX_CONCURRENCY = 4
+
+#: 왜 식단 추천(`diet_recommendation_service`)과 같은 코드를 공통 헬퍼로 뽑지 않았나.
+#:
+#: 1. **풀을 공유하면 안 된다.** 헬퍼 하나에 executor·세마포어를 두면 홈 화면
+#:    추천이 몰릴 때 트레이너 루틴 생성이 같이 굶는다. 서로 무관한 기능이 서로의
+#:    포화에 끌려가는 건 중복을 없앤 대가로 치르기엔 비싸다.
+#: 2. 호출부마다 인스턴스를 만드는 헬퍼라면 1 은 피하지만, 그러려면 식단 쪽을 함께
+#:    고쳐야 한다. 그쪽 포화 테스트가 모듈 전역 `_llm_slots` 를 monkeypatch 하고
+#:    있어 테스트까지 따라 바뀐다 — 루틴 경로 버그를 고치는 이슈가 이미 검증된
+#:    코드를 건드리는 범위로 번진다.
+#: 3. 두 경로는 튜닝이 다르다(여긴 12초, 식단은 6초). 값이 갈리면 공통화의 이득도
+#:    그만큼 줄어든다.
+#:
+#: 세 번째 호출부가 생기면 그때 인스턴스형 헬퍼로 뽑는 편이 낫다.
+_executor = ThreadPoolExecutor(
+    max_workers=LLM_MAX_CONCURRENCY, thread_name_prefix="routine-options-llm"
+)
+
+#: 진행 중인 LLM 호출 수를 워커 수로 제한한다.
+#:
+#: `future.result(timeout=...)` 은 **기다리기를 포기할 뿐 작업을 취소하지 않는다.**
+#: 그래서 느린 호출이 몰리면 워커가 전부 묶이고 이후 submit 은 무한 큐에 쌓인다.
+#: 그 상태에서는 새 요청이 LLM 을 불러 보지도 못한 채 큐에서 타임아웃까지 기다렸다
+#: 폴백한다 — 규칙형만 나오면서 응답만 매번 느려진다.
+#: 빈 자리가 없으면 기다리지 않고 곧장 규칙 폴백으로 내려간다.
+_llm_slots = threading.BoundedSemaphore(LLM_MAX_CONCURRENCY)
 
 #: 프롬프트에 싣는 최근 대화 범위. 넓히면 오래된 통증 호소가 이미 나은 뒤에도
 #: 계속 루틴을 눌러 버리고, 좁히면 지난주 부상이 사라진다.
@@ -242,6 +294,36 @@ def _decode_json_object(text: str) -> dict:
     return parsed
 
 
+def _call_llm(prompt: str):
+    """LLM 호출 + 타임아웃. 실패는 호출부가 잡아 규칙 폴백으로 내린다.
+
+    빈 워커가 없으면 큐에서 기다리지 않고 즉시 실패시킨다(`_llm_slots` 주석 참고).
+    기다려 봐야 타임아웃이고, 그동안 요청 스레드만 붙잡아 두기 때문이다.
+
+    응답 파싱은 일부러 이 밖에 둔다 — 워커 안에서 파싱하면 계약 위반이 `Future`
+    를 통해 올라와, 호출부의 `except (ValidationError, RoutineContractError)` 와
+    타임아웃을 구분하는 자리가 흐려진다.
+    """
+    if not _llm_slots.acquire(blocking=False):
+        raise LLMBusyError("LLM 동시 호출 한도 초과 — 규칙 폴백")
+
+    def _call():
+        try:
+            # json_mode 와 사고 예산은 **반드시 함께** 넘긴다. 기본값(사고 켜짐)으로는
+            # 이 짧은 JSON 하나에도 10초 이상 걸려 클라이언트가 먼저 끊고 규칙형만
+            # 보게 된다. json_mode 만 켜면 오히려 더 느려진다(실측은 coach/llm.py).
+            return get_coach_llm().generate(
+                _SYSTEM_PROMPT, prompt,
+                json_mode=True,
+                thinking_budget=LLM_THINKING_BUDGET,
+            )
+        finally:
+            # 타임아웃으로 호출부가 떠난 뒤라도 작업이 끝나면 자리를 반드시 돌려준다.
+            _llm_slots.release()
+
+    return _executor.submit(_call).result(timeout=LLM_TIMEOUT_SEC)
+
+
 def _generate_with_llm(
     analysis: RoutineOptionAnalysisOut,
     request: RoutineOptionsRequest,
@@ -255,14 +337,7 @@ def _generate_with_llm(
         },
         ensure_ascii=False,
     )
-    # json_mode 와 사고 예산은 **반드시 함께** 넘긴다. 기본값(사고 켜짐)으로는 이
-    # 짧은 JSON 하나에도 10초 이상 걸려 클라이언트가 먼저 끊고 규칙형만 보게 된다.
-    # json_mode 만 켜면 오히려 더 느려진다(근거 실측은 coach/llm.py 주석).
-    result = get_coach_llm().generate(
-        _SYSTEM_PROMPT, prompt,
-        json_mode=True,
-        thinking_budget=DEFAULT_THINKING_BUDGET,
-    )
+    result = _call_llm(prompt)
     payload = _decode_json_object(result.text)
     payload["analysis"] = analysis.model_dump()
     payload["generated_by"] = "ai"
@@ -287,6 +362,26 @@ def generate_routine_options(
     had_chat = bool(analysis.recent_messages)
     try:
         options = _generate_with_llm(analysis, request)
+    except LLMBusyError:
+        # 포화 — 장애가 아니다. 부르지 않았으니 stack trace 도 남길 게 없다.
+        # 이 값이 자주 오르면 늘릴 것은 타임아웃이 아니라 동시성 한도다.
+        _record(started, reason="busy", had_chat_context=had_chat)
+        logger.info(
+            "맞춤 루틴 LLM 포화 — 규칙 기반 폴백 사용 (trainer_id=%s, member_id=%s)",
+            trainer_id, member_id,
+        )
+        return fallback
+    except FutureTimeout:
+        # 공급자가 살아는 있는데 제 시간에 못 준다. 계약 위반도 인프라 장애도
+        # 아니라서 따로 센다 — 셋을 섞으면 "프롬프트를 볼지, 한도를 올릴지,
+        # 공급자를 볼지"를 지표에서 가릴 수 없다.
+        _record(started, reason="timeout", had_chat_context=had_chat)
+        logger.warning(
+            "맞춤 루틴 LLM 타임아웃(%.1fs) — 규칙 기반 폴백 사용 "
+            "(trainer_id=%s, member_id=%s)",
+            LLM_TIMEOUT_SEC, trainer_id, member_id,
+        )
+        return fallback
     except (ValidationError, RoutineContractError) as exc:
         # 계약 위반 — 공급자는 살아 있는데 응답이 규격에 안 맞는다. 프롬프트나
         # 스키마를 손볼 신호라 인프라 장애와 섞으면 안 된다.

--- a/backend/tests/test_trainer_routine_options.py
+++ b/backend/tests/test_trainer_routine_options.py
@@ -1,6 +1,9 @@
 """Trainer routine-options endpoint and LLM fallback contract."""
 from __future__ import annotations
 
+import threading
+import time
+from concurrent.futures import TimeoutError as FutureTimeout
 from dataclasses import dataclass
 
 import pytest
@@ -11,6 +14,7 @@ from app.schemas.trainer_api import (
     RoutineOptionExerciseOut,
     RoutineOptionsRequest,
 )
+from app.core import metrics
 from app.services import trainer_routine_options_service
 from app.services.coach.llm import DEFAULT_THINKING_BUDGET
 
@@ -256,3 +260,189 @@ def test_routine_and_diet_paths_share_one_thinking_budget():
     from app.services import diet_recommendation_service
 
     assert diet_recommendation_service.LLM_THINKING_BUDGET == DEFAULT_THINKING_BUDGET
+    assert (
+        trainer_routine_options_service.LLM_THINKING_BUDGET
+        == DEFAULT_THINKING_BUDGET
+    )
+
+
+# ---- LLM 타임아웃·동시성 가드 (#584) ----
+#
+# 이 절의 테스트는 모두 `_call_llm` 을 직접 부른다. 엔드포인트를 거치면 느린
+# LLM 을 흉내내는 동안 DB 세션까지 물고 있어야 해서, 정작 검증하려는 성질
+# (요청 스레드가 언제 풀려나는가)이 다른 대기에 묻힌다.
+
+
+class _BlockingLlm:
+    """호출부가 풀어 줄 때까지 응답하지 않는 LLM — 죽지도 않고 답도 없는 상태."""
+
+    def __init__(self) -> None:
+        self.released = threading.Event()
+        self.entered = threading.Event()
+
+    def generate(self, system_prompt: str, user_prompt: str, **kwargs: object):
+        self.entered.set()
+        self.released.wait(timeout=30)
+        return _Result(_VALID_LLM_JSON)
+
+
+@pytest.fixture
+def blocking_llm(monkeypatch):
+    """응답하지 않는 LLM 을 물리고, 테스트가 끝나면 반드시 풀어 준다.
+
+    풀어 주지 않으면 워커가 남은 채 다음 테스트로 넘어가 뒤에서 엉뚱한 포화가 난다.
+    """
+    fake = _BlockingLlm()
+    monkeypatch.setattr(
+        trainer_routine_options_service, "get_coach_llm", lambda: fake
+    )
+    try:
+        yield fake
+    finally:
+        fake.released.set()
+
+
+def test_unresponsive_llm_gives_up_within_the_timeout(monkeypatch, blocking_llm):
+    """응답하지 않는 LLM 에서도 요청이 정해진 시간 안에 끝난다 (#584).
+
+    이 가드가 없으면 끊어 주는 건 SDK 의 HTTP 타임아웃뿐이라 Gemini 30초,
+    OpenAI/LiteLLM 60초 동안 워커 하나가 통째로 묶인다.
+    """
+    monkeypatch.setattr(trainer_routine_options_service, "LLM_TIMEOUT_SEC", 0.3)
+
+    started = time.monotonic()
+    with pytest.raises(FutureTimeout):
+        trainer_routine_options_service._call_llm("prompt")
+    elapsed = time.monotonic() - started
+
+    assert blocking_llm.entered.is_set(), "LLM 을 부르지도 않아 타임아웃이 검증되지 않았다"
+    # 상한을 넘기지 않는다는 것이 요점이다. 스케줄링 지연을 감안해 여유를 둔다.
+    assert elapsed < 5.0, f"타임아웃이 걸리지 않았다({elapsed:.1f}s)"
+
+
+def test_saturated_pool_falls_back_without_waiting(monkeypatch, blocking_llm):
+    """빈 자리가 없으면 큐에서 기다리지 않고 즉시 포화로 알린다 (#584).
+
+    기다려 봐야 타임아웃인데 그동안 요청 스레드만 붙잡힌다.
+    """
+    monkeypatch.setattr(
+        trainer_routine_options_service, "_llm_slots", threading.BoundedSemaphore(1)
+    )
+    trainer_routine_options_service._llm_slots.acquire()  # 유일한 자리를 미리 점유
+
+    started = time.monotonic()
+    with pytest.raises(trainer_routine_options_service.LLMBusyError):
+        trainer_routine_options_service._call_llm("prompt")
+    elapsed = time.monotonic() - started
+
+    assert elapsed < trainer_routine_options_service.LLM_TIMEOUT_SEC
+    assert not blocking_llm.entered.is_set(), "포화 상태인데 LLM 을 불렀다"
+
+
+def test_concurrent_requests_do_not_exhaust_the_worker_pool(monkeypatch, blocking_llm):
+    """동시 요청이 한도를 넘겨도 초과분은 큐에 쌓이지 않고 곧장 폴백으로 내려간다.
+
+    쌓이게 두면 워커가 전부 묶인 뒤 새 요청이 LLM 을 불러 보지도 못한 채 큐에서
+    타임아웃까지 기다린다 — 규칙형만 나오면서 응답만 느려지는 최악의 조합이다.
+    """
+    limit = 2
+    monkeypatch.setattr(
+        trainer_routine_options_service,
+        "_llm_slots",
+        threading.BoundedSemaphore(limit),
+    )
+    monkeypatch.setattr(trainer_routine_options_service, "LLM_TIMEOUT_SEC", 0.3)
+
+    outcomes: list[str] = []
+    lock = threading.Lock()
+
+    def _attempt() -> None:
+        try:
+            trainer_routine_options_service._call_llm("prompt")
+            result = "ok"
+        except trainer_routine_options_service.LLMBusyError:
+            result = "busy"
+        except FutureTimeout:
+            result = "timeout"
+        with lock:
+            outcomes.append(result)
+
+    threads = [threading.Thread(target=_attempt) for _ in range(6)]
+    started = time.monotonic()
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+    elapsed = time.monotonic() - started
+
+    assert not any(t.is_alive() for t in threads), "요청 스레드가 풀려나지 못했다"
+    assert len(outcomes) == 6
+    # 자리를 잡은 쪽은 타임아웃까지 가고, 초과분은 기다리지 않고 즉시 포화로 끝난다.
+    assert outcomes.count("busy") == 6 - limit
+    assert outcomes.count("timeout") == limit
+    # 초과분이 큐에서 순서를 기다렸다면 타임아웃이 직렬로 누적됐을 것이다.
+    assert elapsed < 5.0, f"초과 요청이 큐에서 기다렸다({elapsed:.1f}s)"
+
+
+def test_slots_are_returned_after_a_timeout(monkeypatch, blocking_llm):
+    """타임아웃으로 호출부가 떠난 뒤에도 작업이 끝나면 자리를 돌려준다.
+
+    `future.result(timeout=...)` 은 기다리기를 포기할 뿐 작업을 취소하지 않는다.
+    돌려주지 않으면 타임아웃 한 번마다 동시성 한도가 영구히 1씩 줄어, 결국 모든
+    요청이 포화로 떨어진다.
+    """
+    slots = threading.BoundedSemaphore(1)
+    monkeypatch.setattr(trainer_routine_options_service, "_llm_slots", slots)
+    monkeypatch.setattr(trainer_routine_options_service, "LLM_TIMEOUT_SEC", 0.3)
+
+    with pytest.raises(FutureTimeout):
+        trainer_routine_options_service._call_llm("prompt")
+
+    blocking_llm.released.set()  # 버려진 작업을 끝내 준다
+    assert slots.acquire(timeout=5), "타임아웃 뒤 자리가 반환되지 않았다"
+
+
+@pytest.mark.parametrize(
+    ("failure", "reason"),
+    [
+        (lambda: trainer_routine_options_service.LLMBusyError("포화"), "busy"),
+        (lambda: FutureTimeout(), "timeout"),
+    ],
+)
+def test_guard_failures_return_a_rule_fallback_and_are_counted_apart(
+    client, monkeypatch, failure, reason,
+):
+    """포화·타임아웃도 200 + 규칙 폴백으로 끝나고, 사유는 따로 센다 (#584).
+
+    사유를 나누는 이유는 대응이 다르기 때문이다 — `busy` 는 동시성 한도를,
+    `timeout` 은 공급자·모델 옵션을, `contract` 은 프롬프트를 보라는 신호다.
+    한 칸에 몰아 세면 이 셋이 지표에서 구분되지 않는다.
+    """
+    def _raise(*args, **kwargs):
+        raise failure()
+
+    monkeypatch.setattr(
+        trainer_routine_options_service, "_generate_with_llm", _raise
+    )
+    token = _trainer_token(client)
+    member_id = _first_client_id(client, token)
+    metrics.reset()
+
+    response = client.post(
+        f"/v1/trainer/clients/{member_id}/routine-options",
+        headers=_headers(token),
+        json={"available_minutes": 40, "intensity_preference": "high"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["generated_by"] == "rule"
+
+    counters = metrics.snapshot()["counters"]
+    assert counters[f"routine_options.fallback{{reason={reason}}}"] == 1
+    assert counters["routine_options.generated{by=rule}"] == 1
+    other_reasons = [
+        k for k in counters
+        if k.startswith("routine_options.fallback")
+        and k != f"routine_options.fallback{{reason={reason}}}"
+    ]
+    assert not other_reasons, f"사유가 섞였다: {other_reasons}"

--- a/backend/tests/test_trainer_routine_options.py
+++ b/backend/tests/test_trainer_routine_options.py
@@ -316,8 +316,11 @@ def test_unresponsive_llm_gives_up_within_the_timeout(monkeypatch, blocking_llm)
     elapsed = time.monotonic() - started
 
     assert blocking_llm.entered.is_set(), "LLM 을 부르지도 않아 타임아웃이 검증되지 않았다"
-    # 상한을 넘기지 않는다는 것이 요점이다. 스케줄링 지연을 감안해 여유를 둔다.
-    assert elapsed < 5.0, f"타임아웃이 걸리지 않았다({elapsed:.1f}s)"
+    # 상한을 **설정값 기준**으로 잡는다. 고정 상수로 두면 타임아웃이 그 아래
+    # 아무 값으로 회귀해도(예: 설정을 무시하고 4초) 테스트가 그대로 통과한다.
+    # 여유 2초는 CI 러너에서 스레드가 뜨는 시간 몫이다.
+    limit = trainer_routine_options_service.LLM_TIMEOUT_SEC + 2.0
+    assert elapsed < limit, f"타임아웃이 걸리지 않았다({elapsed:.1f}s > {limit:.1f}s)"
 
 
 def test_saturated_pool_falls_back_without_waiting(monkeypatch, blocking_llm):
@@ -446,3 +449,48 @@ def test_guard_failures_return_a_rule_fallback_and_are_counted_apart(
         and k != f"routine_options.fallback{{reason={reason}}}"
     ]
     assert not other_reasons, f"사유가 섞였다: {other_reasons}"
+
+
+def test_slot_is_returned_to_the_semaphore_it_was_taken_from(monkeypatch, blocking_llm):
+    """워커는 자리를 딴 그 인스턴스에 돌려준다 — 전역이 바뀌어도.
+
+    워커가 `_llm_slots` 전역을 다시 읽으면, 그 사이 전역이 교체됐을 때 잡지도 않은
+    세마포어를 풀어 준다. 원래 자리는 영영 안 돌아오고, 교체된 쪽은 초기값을 넘겨
+    `BoundedSemaphore` 가 ValueError 를 던진다.
+    """
+    original = threading.BoundedSemaphore(1)
+    replacement = threading.BoundedSemaphore(1)
+    monkeypatch.setattr(trainer_routine_options_service, "_llm_slots", original)
+    monkeypatch.setattr(trainer_routine_options_service, "LLM_TIMEOUT_SEC", 0.3)
+
+    with pytest.raises(FutureTimeout):
+        trainer_routine_options_service._call_llm("prompt")
+
+    # 호출부가 떠난 뒤 전역이 갈린다. 아직 워커는 블로킹 중이다.
+    monkeypatch.setattr(trainer_routine_options_service, "_llm_slots", replacement)
+    blocking_llm.released.set()
+
+    assert original.acquire(timeout=5), "자리를 딴 세마포어에 돌려주지 않았다"
+    # 교체본은 건드리지 않았어야 한다. 건드렸다면 초과 release 로 이미 깨졌다.
+    assert replacement.acquire(blocking=False), "엉뚱한 세마포어를 풀어 줬다"
+
+
+def test_slot_is_returned_when_scheduling_fails(monkeypatch):
+    """`submit()` 이 실패하면 워커가 돌지 않으므로 자리를 여기서 돌려줘야 한다.
+
+    돌려주지 않으면 실패 한 번마다 동시 호출 한도가 영구히 1씩 줄어, 끝내 모든
+    요청이 포화로 떨어진다.
+    """
+    slots = threading.BoundedSemaphore(1)
+    monkeypatch.setattr(trainer_routine_options_service, "_llm_slots", slots)
+
+    class _DeadExecutor:
+        def submit(self, fn):
+            raise RuntimeError("cannot schedule new futures after shutdown")
+
+    monkeypatch.setattr(trainer_routine_options_service, "_executor", _DeadExecutor())
+
+    with pytest.raises(RuntimeError):
+        trainer_routine_options_service._call_llm("prompt")
+
+    assert slots.acquire(blocking=False), "스케줄링 실패로 자리가 누수됐다"


### PR DESCRIPTION
Closes #584

## Summary

`generate_routine_options` 가 LLM 을 요청 스레드에서 상한 없이 부르고 있었습니다. 끊어 주는 건 SDK 의 HTTP 타임아웃뿐이라 Gemini 30초, OpenAI/LiteLLM 60초 동안 워커 하나가 통째로 묶입니다.

식단 추천(`diet_recommendation_service`)이 이미 해결해 둔 방식을 그대로 적용했습니다 — executor + `future.result(timeout=...)` + `BoundedSemaphore`. 빈 자리가 없으면 큐에서 기다리지 않고 곧장 규칙 폴백으로 내려갑니다. 기다려 봐야 타임아웃인데 그동안 요청 스레드만 붙잡히기 때문입니다.

## Changes

- **타임아웃 12초.** 생성 왕복 실측 3~6초(#579, 근거는 `config.py` 의 `routine_options_per_minute` 주석)의 두 배를 여유로 잡았습니다. 6초에 바짝 붙이면 정상 호출이 산발적으로 잘려 트레이너가 이유 없이 규칙형을 받습니다.
- **동시 호출 4개 제한.** 초과분은 대기하지 않고 즉시 포화로 폴백합니다.
- **폴백 사유에 `busy`·`timeout` 추가.** 기존 `contract`·`infra` 와 구분합니다 — 셋은 볼 곳이 서로 다릅니다(동시성 한도 / 공급자 / 프롬프트). 포화는 장애가 아니라 stack trace 를 남기지 않고 `info` 로만 찍습니다.
- 응답 파싱은 워커 밖에 두었습니다. 안에서 파싱하면 계약 위반이 `Future` 를 통해 올라와 타임아웃과 구분하는 자리가 흐려집니다.

이슈의 두 번째 항목(`except` 분리)은 #590 에서 이미 처리돼 이번 범위에서 빠졌습니다.

## Notes

**공통 헬퍼로 뽑지 않았습니다.** 이슈가 판단을 남겨 둔 부분이라 이유를 코드 주석에도 적었습니다.

1. 헬퍼 하나에 executor·세마포어를 두면 **풀이 공유돼** 홈 화면 추천이 몰릴 때 트레이너 루틴 생성이 같이 굶습니다. 서로 무관한 기능이 서로의 포화에 끌려가는 건 중복을 없앤 대가로 치르기엔 비쌉니다.
2. 호출부마다 인스턴스를 만드는 헬퍼라면 1 은 피하지만 식단 쪽을 함께 고쳐야 합니다. 그쪽 포화 테스트가 모듈 전역 `_llm_slots` 를 monkeypatch 하고 있어 테스트까지 따라 바뀝니다 — 루틴 경로 버그를 고치는 이슈가 이미 검증된 코드를 건드리는 범위로 번집니다.
3. 두 경로는 튜닝이 다릅니다(여긴 12초, 식단은 6초).

세 번째 호출부가 생기면 그때 인스턴스형 헬퍼로 뽑는 편이 낫다고 봅니다.

## Verification

- 새 테스트가 **가드를 걷어내면 실제로 실패하는지** 변이(mutation) 로 확인했습니다.
  - 타임아웃 제거 → 타임아웃 관련 3건 실패
  - 세마포어를 대기형으로 변경 → 6건 전부 `timeout` 으로 떨어지며 2건 실패 (이슈가 설명한 "큐에 쌓여 다 같이 느려지는" 상태가 그대로 재현)
- `pytest` 전체 통과. `test_trainer_schedule.py::test_schedule_seeded_timeline` 만 실패하는데, 이 브랜치와 무관한 기존 실패입니다(main 에서도 동일하게 로컬에서만 실패하고 CI 에서는 통과).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 루틴 생성 요청의 처리 안정성과 응답 속도를 개선했습니다.
  * 동시 요청이 많거나 처리 시간이 초과되면 지연 없이 규칙 기반 루틴을 제공합니다.
  * AI 생성 실패 시에도 기존 규칙 기반 결과로 자동 전환됩니다.
  * AI 요청의 처리 시간과 동시 실행 상태를 구분해 모니터링할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->