### PR TITLE
feat(backend): 채팅 발신·스케줄 생성에 멱등성 키 적용

### DIFF
--- a/backend/app/api/v1/member_coach.py
+++ b/backend/app/api/v1/member_coach.py
@@ -137,9 +137,18 @@ def send_to_coach(
     text = payload.text.strip()
     if not text:
         raise HTTPException(status_code=400, detail="빈 메시지는 보낼 수 없습니다.")
-    return trainer_service.send_message(
-        db, trainer_id, member.id, "member", text, viewer="member",
-    )
+    try:
+        return trainer_service.send_message(
+            db,
+            trainer_id,
+            member.id,
+            "member",
+            text,
+            viewer="member",
+            client_request_id=payload.client_request_id,
+        )
+    except trainer_service.IdempotencyConflict as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 
 @router.post("/me/coach/chat/read")

--- a/backend/app/api/v1/trainer.py
+++ b/backend/app/api/v1/trainer.py
@@ -326,10 +326,18 @@ def trainer_send_chat(
     text = payload.text.strip()
     if not text:
         raise HTTPException(status_code=400, detail="빈 메시지는 보낼 수 없습니다.")
-    return trainer_service.send_message(
-        db, trainer.id, member_id, "trainer", text,
-        notify=notification_service.TRAINER_MESSAGE,
-    )
+    try:
+        return trainer_service.send_message(
+            db,
+            trainer.id,
+            member_id,
+            "trainer",
+            text,
+            notify=notification_service.TRAINER_MESSAGE,
+            client_request_id=payload.client_request_id,
+        )
+    except trainer_service.IdempotencyConflict as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 
 @router.post("/trainer/clients/{member_id}/chat/read")
@@ -529,13 +537,22 @@ def trainer_create_session(
     """예약 추가(status 예정). member_id 를 주면 담당 고객이어야 한다(아니면 404)."""
     if payload.member_id:
         _require_client(db, trainer.id, payload.member_id)
-    return trainer_service.create_session(
-        db, trainer.id,
-        date=payload.date, time=payload.time, client_name=payload.client_name,
-        member_id=payload.member_id, type_=payload.type,
-        duration_minutes=payload.duration_minutes, note=payload.note,
-        program=payload.program,
-    )
+    try:
+        return trainer_service.create_session(
+            db,
+            trainer.id,
+            date=payload.date,
+            time=payload.time,
+            client_name=payload.client_name,
+            member_id=payload.member_id,
+            type_=payload.type,
+            duration_minutes=payload.duration_minutes,
+            note=payload.note,
+            program=payload.program,
+            client_request_id=payload.client_request_id,
+        )
+    except trainer_service.IdempotencyConflict as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 
 @router.put(

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -736,11 +736,25 @@ class ChatMessage(Base):
     )
     sender: Mapped[str] = mapped_column(String(20))  # trainer|member
     body: Mapped[str] = mapped_column(Text)
+    # 한 번의 발신 시도에 클라이언트가 붙이는 멱등키. NULL 은 기존 앱 요청이며
+    # 유니크 제약 밖에 남는다. sender 까지 scope 에 넣어 양방향이 같은 문자열 키를
+    # 우연히 만들어도 서로 충돌하지 않게 한다.
+    client_request_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
     read_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), index=True
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "trainer_id",
+            "member_id",
+            "sender",
+            "client_request_id",
+            name="uq_chat_messages_client_request",
+        ),
     )
 
 
@@ -771,8 +785,19 @@ class TrainerSchedule(Base):
     note: Mapped[str] = mapped_column(Text, default="")
     program_json: Mapped[str] = mapped_column(Text, default="[]")
     sort_order: Mapped[int] = mapped_column(Integer, default=0)
+    # 트레이너의 예약 생성 시도 단위 멱등키. 다른 create operation 과는 테이블이
+    # 달라 같은 문자열을 써도 충돌하지 않는다. NULL 은 구버전 요청 호환용이다.
+    client_request_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "trainer_id",
+            "client_request_id",
+            name="uq_trainer_schedule_client_request",
+        ),
     )
 
 

--- a/backend/app/schemas/trainer_api.py
+++ b/backend/app/schemas/trainer_api.py
@@ -120,6 +120,9 @@ class ChatMessageOut(BaseModel):
 class ChatSendRequest(BaseModel):
     # 상한만 둔다(빈/공백은 라우터에서 trim 후 400). 과도한 길이는 여기서 422.
     text: str = Field(max_length=2000)
+    # 발신 시도당 한 번 만들고 재시도에서 재사용한다. 선택값이라 구버전 앱도
+    # 기존처럼 전송할 수 있다.
+    client_request_id: str | None = Field(default=None, min_length=1, max_length=64)
 
 
 RoutineType = Literal["걷기", "유산소", "근력", "요가", "스트레칭", "기타"]
@@ -277,6 +280,7 @@ class ScheduleCreateRequest(BaseModel):
     duration_minutes: int = Field(default=0, ge=0, le=600)
     note: str = Field(default="", max_length=500)
     program: list[ProgramItem] = Field(default_factory=list, max_length=30)
+    client_request_id: str | None = Field(default=None, min_length=1, max_length=64)
 
     _v_date = field_validator("date")(_validate_ymd)
     _v_time = field_validator("time")(_validate_hhmm)

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -36,6 +36,10 @@ from app.services.coach import personal_ingest
 SODIUM_TARGET_MG = 2000
 
 
+class IdempotencyConflict(Exception):
+    """같은 멱등키가 이미 다른 payload 에 사용됐다."""
+
+
 def _today() -> date:
     return clock.today()
 
@@ -365,9 +369,47 @@ def build_chat_thread(
     ]
 
 
+def _chat_out(msg: ChatMessage, viewer: str) -> ChatMessageOut:
+    return ChatMessageOut(
+        id=msg.id,
+        sender=_sender_out(msg.sender, viewer),
+        body=msg.body,
+        time_label=_hhmm(msg.created_at),
+        created_at=_iso(msg.created_at),
+    )
+
+
+def find_message_by_client_request(
+    db: Session,
+    trainer_id: str,
+    member_id: str,
+    sender: str,
+    client_request_id: str,
+) -> ChatMessage | None:
+    return db.scalar(
+        select(ChatMessage).where(
+            ChatMessage.trainer_id == trainer_id,
+            ChatMessage.member_id == member_id,
+            ChatMessage.sender == sender,
+            ChatMessage.client_request_id == client_request_id,
+        )
+    )
+
+
+def _existing_message_out(
+    message: ChatMessage, *, text: str, viewer: str
+) -> ChatMessageOut:
+    if message.body != text:
+        raise IdempotencyConflict(
+            "같은 client_request_id에 다른 메시지를 보낼 수 없습니다."
+        )
+    return _chat_out(message, viewer)
+
+
 def send_message(
     db: Session, trainer_id: str, member_id: str, sender: str, text: str,
     viewer: str = "trainer", notify: str | None = None,
+    client_request_id: str | None = None,
 ) -> ChatMessageOut:
     """스레드에 메시지 추가(sender: 'trainer'|'member'). 로스터 last_message 는
     build_roster 가 최신 메시지를 읽어 자동 반영하므로 별도 비정규화가 없다.
@@ -379,15 +421,37 @@ def send_message(
     회원이 보낸 메시지에는 **트레이너 알림**을 남긴다(#503). 사이드바 미읽음 배지는
     지금 보고 있을 때만 눈에 들어오고, 지나가면 다시 볼 자리가 없었다.
     """
+    if client_request_id:
+        existing = find_message_by_client_request(
+            db, trainer_id, member_id, sender, client_request_id
+        )
+        if existing is not None:
+            return _existing_message_out(existing, text=text, viewer=viewer)
+
     msg = ChatMessage(
         id=f"chat-{uuid.uuid4().hex[:12]}",
         trainer_id=trainer_id,
         member_id=member_id,
         sender=sender,
         body=text,
+        client_request_id=client_request_id,
         created_at=datetime.now(timezone.utc),
     )
     db.add(msg)
+    # 알림을 넣기 전에 DB 유니크 제약을 확인한다. 동시 재시도 중 진 요청이 여기서
+    # 막혀야 회원·트레이너 알림도 한 번만 생성된다.
+    try:
+        db.flush()
+    except IntegrityError:
+        db.rollback()
+        if client_request_id:
+            existing = find_message_by_client_request(
+                db, trainer_id, member_id, sender, client_request_id
+            )
+            if existing is not None:
+                return _existing_message_out(existing, text=text, viewer=viewer)
+        raise
+
     if sender == "member":
         member_name = db.scalar(select(User.name).where(User.id == member_id))
         notification_service.queue_for_trainer(
@@ -412,10 +476,7 @@ def send_message(
         )
     db.commit()
     db.refresh(msg)
-    out = ChatMessageOut(
-        id=msg.id, sender=_sender_out(msg.sender, viewer), body=msg.body,
-        time_label=_hhmm(msg.created_at), created_at=_iso(msg.created_at),
-    )
+    out = _chat_out(msg, viewer)
     # 적재는 응답을 다 만든 뒤에 한다(#580). 실패하면 personal_ingest 가 세션을
     # 롤백하는데, 그때 msg 가 만료돼 응답을 못 만들게 되면 적재 실패가 메시지
     # 발신 실패로 번진다. 커밋은 이미 끝났으니 롤백해도 메시지 자체는 남는다.
@@ -846,11 +907,61 @@ def _dump_program(
     return json.dumps(items, ensure_ascii=False)
 
 
+def _existing_schedule_out(
+    session: TrainerSchedule,
+    *,
+    date: str,
+    time: str,
+    client_name: str,
+    member_id: str | None,
+    type_: str,
+    duration_minutes: int,
+    note: str,
+    program_json: str,
+) -> ScheduleSessionOut:
+    same_payload = (
+        session.date == date
+        and session.time == time
+        and session.client_name == client_name
+        and session.member_id == member_id
+        and session.type == type_
+        and session.duration_minutes == duration_minutes
+        and session.note == note
+        and session.program_json == program_json
+    )
+    if not same_payload:
+        raise IdempotencyConflict(
+            "같은 client_request_id에 다른 스케줄을 생성할 수 없습니다."
+        )
+    return _schedule_out(session)
+
+
 def create_session(
     db: Session, trainer_id: str, *, date: str, time: str, client_name: str,
     member_id: str | None, type_: str, duration_minutes: int, note: str,
-    program: list[ProgramItem],
+    program: list[ProgramItem], client_request_id: str | None = None,
 ) -> ScheduleSessionOut:
+    program_json = _dump_program(program)
+    if client_request_id:
+        existing = db.scalar(
+            select(TrainerSchedule).where(
+                TrainerSchedule.trainer_id == trainer_id,
+                TrainerSchedule.client_request_id == client_request_id,
+            )
+        )
+        if existing is not None:
+            return _existing_schedule_out(
+                existing,
+                date=date,
+                time=time,
+                client_name=client_name,
+                member_id=member_id,
+                type_=type_,
+                duration_minutes=duration_minutes,
+                note=note,
+                program_json=program_json,
+            )
+
     s = TrainerSchedule(
         id=f"sched-{uuid.uuid4().hex[:12]}",
         trainer_id=trainer_id,
@@ -862,10 +973,38 @@ def create_session(
         duration_minutes=duration_minutes,
         status="예정",
         note=note,
-        program_json=_dump_program(program),
+        program_json=program_json,
         sort_order=0,
+        client_request_id=client_request_id,
     )
     db.add(s)
+    # 같은 키의 동시 요청은 유니크 제약으로 하나만 통과시킨 뒤, 패배한 요청은
+    # 승자의 행을 읽어 같은 결과를 반환한다. 알림은 flush 뒤라 중복되지 않는다.
+    try:
+        db.flush()
+    except IntegrityError:
+        db.rollback()
+        if client_request_id:
+            existing = db.scalar(
+                select(TrainerSchedule).where(
+                    TrainerSchedule.trainer_id == trainer_id,
+                    TrainerSchedule.client_request_id == client_request_id,
+                )
+            )
+            if existing is not None:
+                return _existing_schedule_out(
+                    existing,
+                    date=date,
+                    time=time,
+                    client_name=client_name,
+                    member_id=member_id,
+                    type_=type_,
+                    duration_minutes=duration_minutes,
+                    note=note,
+                    program_json=program_json,
+                )
+        raise
+
     # 회원 몫의 일정이 잡혔을 때만 알린다 — 가망 고객('신규 고객 · 상담')처럼
     # member_id 가 없는 슬롯은 알릴 대상 자체가 없다(#489).
     if member_id is not None:

--- a/backend/docs/TRAINER_DOMAIN.md
+++ b/backend/docs/TRAINER_DOMAIN.md
@@ -98,19 +98,25 @@
 | PUT | `/trainer/clients/{member_id}/routines/{routine_id}` | 루틴 부분 수정(이름·시간·종류·사유) |
 | DELETE | `/trainer/clients/{member_id}/routines/{routine_id}` | 루틴 철회 |
 | GET | `/trainer/clients/{member_id}/chat?before=&before_id=` | 채팅 스레드(커서 페이지네이션) |
-| POST | `/trainer/clients/{member_id}/chat` | 메시지 전송 |
+| POST | `/trainer/clients/{member_id}/chat` | 메시지 전송 (`client_request_id?`) |
 | POST | `/trainer/clients/{member_id}/chat/read` | 읽음 처리 |
 | GET | `/trainer/chat/unread` | 회원별 미확인 수 |
 | GET | `/trainer/schedule?date=` | 하루 타임라인 |
 | GET | `/trainer/schedule?from=&to=&member_id=` | 구간 조회 / 고객 필터 |
 | GET | `/trainer/schedule/booked-dates` | 예약 있는 날짜 |
-| POST | `/trainer/schedule` | 예약 생성(예정) |
+| POST | `/trainer/schedule` | 예약 생성(예정, `client_request_id?`) |
 | PUT | `/trainer/schedule/{id}` | 예약 수정 |
 | DELETE | `/trainer/schedule/{id}` | 예약 삭제 |
 | POST | `/trainer/schedule/{id}/complete` | 세션 완료(예정→완료) |
 | POST | `/trainer/clients/{member_id}/ai-coach` | 담당 고객 데이터 기반 AI 코칭 질의 |
 | GET | `/trainer/clients/{member_id}/report?week_start=` | 주간 리포트(어느 요일을 줘도 그 주 월요일로 정규화) |
 | POST | `/trainer/clients/{member_id}/report/send` | 리포트를 회원 채팅 스레드로 전송 |
+
+채팅 발신과 스케줄 생성의 `client_request_id`는 선택값이다. 클라이언트는 한
+사용자 행동에 한 번 생성하고 응답 유실 뒤 재시도에서 같은 값을 보낸다. 같은 사용자·
+동작·키·payload면 처음 생성된 결과를 다시 반환하고, 같은 키에 다른 payload면
+`409`다. 키가 없는 구버전 요청은 기존처럼 매번 새 행을 만든다. 채팅은 발신자까지
+scope에 포함해 회원과 트레이너가 우연히 같은 키를 만들어도 충돌하지 않는다.
 
 ### 스케줄 구간 조회 (`from`/`to`)
 
@@ -177,7 +183,7 @@ O2O 코칭의 재등록 고리. 세션 수·완료 수는 `trainer_schedule`, �
 | GET | `/me/coach/sessions` | 내 PT 세션(최근 100건) |
 | GET | `/me/coach/chat` | 채팅 스레드 |
 | GET | `/me/coach/chat/unread` | 미확인 수 |
-| POST | `/me/coach/chat` | 코치에게 메시지 전송 |
+| POST | `/me/coach/chat` | 코치에게 메시지 전송 (`client_request_id?`) |
 | POST | `/me/coach/chat/read` | 읽음 처리 |
 | DELETE | `/me/coach` | **헬스장 + 담당 트레이너** 해제(멱등, 204) |
 | DELETE | `/me/coach/trainer` | **담당 트레이너만** 해제 — 헬스장은 유지(멱등, 204) |

--- a/backend/migrations/versions/0031_create_action_request_ids.py
+++ b/backend/migrations/versions/0031_create_action_request_ids.py
@@ -1,0 +1,55 @@
+"""채팅 발신·스케줄 생성의 재시도 중복 방지
+
+Revision ID: 0031_create_action_ids
+Revises: 0030_doc_source_ref
+Create Date: 2026-08-11
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0031_create_action_ids"
+down_revision: str | Sequence[str] | None = "0030_doc_source_ref"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # nullable 이므로 기존 행은 그대로 유지되고 구버전 클라이언트도
+    # 유니크 제약 밖이다.
+    op.add_column(
+        "chat_messages",
+        sa.Column("client_request_id", sa.String(length=64), nullable=True),
+    )
+    op.create_unique_constraint(
+        "uq_chat_messages_client_request",
+        "chat_messages",
+        ["trainer_id", "member_id", "sender", "client_request_id"],
+    )
+    op.add_column(
+        "trainer_schedule",
+        sa.Column("client_request_id", sa.String(length=64), nullable=True),
+    )
+    op.create_unique_constraint(
+        "uq_trainer_schedule_client_request",
+        "trainer_schedule",
+        ["trainer_id", "client_request_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "uq_trainer_schedule_client_request",
+        "trainer_schedule",
+        type_="unique",
+    )
+    op.drop_column("trainer_schedule", "client_request_id")
+    op.drop_constraint(
+        "uq_chat_messages_client_request",
+        "chat_messages",
+        type_="unique",
+    )
+    op.drop_column("chat_messages", "client_request_id")

--- a/backend/tests/test_create_action_idempotency.py
+++ b/backend/tests/test_create_action_idempotency.py
@@ -1,0 +1,402 @@
+"""채팅 발신·스케줄 생성의 재시도 멱등성 (#605)."""
+from __future__ import annotations
+
+import importlib
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+from uuid import uuid4
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import inspect, or_, select
+
+from app.models.models import ChatMessage, Notification, TrainerSchedule
+
+TRAINER = "trainer-demo"
+MEMBER = "user-jisu"
+OTHER_MEMBER = "user-demo"
+KEY_PREFIX = "idem605-"
+
+
+def _trainer_token(client) -> str:
+    return client.post(
+        "/v1/auth/login",
+        data={"username": "trainer@oncare.com", "password": "oncare123"},
+    ).json()["access_token"]
+
+
+def _member_token(client, email: str = "jisu@oncare.com") -> str:
+    return client.post(
+        "/v1/auth/login",
+        data={"username": email, "password": "oncare123"},
+    ).json()["access_token"]
+
+
+def _headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _key() -> str:
+    return f"{KEY_PREFIX}{uuid4().hex[:12]}"
+
+
+def _schedule_body(key: str | None, *, note: str = "") -> dict:
+    body = {
+        "date": "2026-12-31",
+        "time": "16:00",
+        "client_name": "신규 상담",
+        "type": "상담",
+        "duration_minutes": 30,
+        "note": note,
+    }
+    if key is not None:
+        body["client_request_id"] = key
+    return body
+
+
+def _purge(db_session) -> None:
+    db_session.rollback()
+    db_session.query(Notification).filter(
+        Notification.body.like(f"{KEY_PREFIX}%")
+    ).delete(synchronize_session=False)
+    db_session.query(ChatMessage).filter(
+        or_(
+            ChatMessage.client_request_id.like(f"{KEY_PREFIX}%"),
+            ChatMessage.body.like(f"{KEY_PREFIX}%"),
+        )
+    ).delete(synchronize_session=False)
+    db_session.query(TrainerSchedule).filter(
+        or_(
+            TrainerSchedule.client_request_id.like(f"{KEY_PREFIX}%"),
+            TrainerSchedule.note.like(f"{KEY_PREFIX}%"),
+        )
+    ).delete(synchronize_session=False)
+    db_session.commit()
+
+
+@pytest.fixture(autouse=True)
+def _cleanup(db_session):
+    _purge(db_session)
+    yield
+    _purge(db_session)
+
+
+def _chat_rows(db_session, key: str) -> list[ChatMessage]:
+    db_session.expire_all()
+    return list(
+        db_session.scalars(
+            select(ChatMessage).where(ChatMessage.client_request_id == key)
+        ).all()
+    )
+
+
+def _schedule_rows(db_session, key: str) -> list[TrainerSchedule]:
+    db_session.expire_all()
+    return list(
+        db_session.scalars(
+            select(TrainerSchedule).where(
+                TrainerSchedule.client_request_id == key
+            )
+        ).all()
+    )
+
+
+def test_migration_preserves_existing_rows(db_session, monkeypatch):
+    migration = importlib.import_module(
+        "migrations.versions.0031_create_action_request_ids"
+    )
+    schema = f"idem605_{uuid4().hex[:12]}"
+    metadata = sa.MetaData(schema=schema)
+    chat = sa.Table(
+        "chat_messages",
+        metadata,
+        sa.Column("id", sa.String(64), primary_key=True),
+        sa.Column("trainer_id", sa.String(64), nullable=False),
+        sa.Column("member_id", sa.String(64), nullable=False),
+        sa.Column("sender", sa.String(20), nullable=False),
+    )
+    schedule = sa.Table(
+        "trainer_schedule",
+        metadata,
+        sa.Column("id", sa.String(64), primary_key=True),
+        sa.Column("trainer_id", sa.String(64), nullable=False),
+    )
+
+    engine = db_session.get_bind()
+    with engine.begin() as connection:
+        connection.execute(sa.schema.CreateSchema(schema))
+        try:
+            metadata.create_all(connection)
+            connection.execute(
+                chat.insert(),
+                [
+                    {
+                        "id": "old-chat-1",
+                        "trainer_id": "trainer-a",
+                        "member_id": "member-a",
+                        "sender": "trainer",
+                    },
+                    {
+                        "id": "old-chat-2",
+                        "trainer_id": "trainer-b",
+                        "member_id": "member-b",
+                        "sender": "member",
+                    },
+                ],
+            )
+            connection.execute(
+                schedule.insert(),
+                [
+                    {"id": "old-schedule-1", "trainer_id": "trainer-a"},
+                    {"id": "old-schedule-2", "trainer_id": "trainer-b"},
+                ],
+            )
+            connection.exec_driver_sql(f'SET LOCAL search_path TO "{schema}"')
+            operations = Operations(MigrationContext.configure(connection))
+            monkeypatch.setattr(migration, "op", operations)
+
+            migration.upgrade()
+
+            inspector = inspect(connection)
+            chat_columns = {
+                column["name"]: column
+                for column in inspector.get_columns("chat_messages", schema=schema)
+            }
+            schedule_columns = {
+                column["name"]: column
+                for column in inspector.get_columns(
+                    "trainer_schedule", schema=schema
+                )
+            }
+            assert chat_columns["client_request_id"]["nullable"] is True
+            assert schedule_columns["client_request_id"]["nullable"] is True
+            assert "uq_chat_messages_client_request" in {
+                constraint["name"]
+                for constraint in inspector.get_unique_constraints(
+                    "chat_messages", schema=schema
+                )
+            }
+            assert "uq_trainer_schedule_client_request" in {
+                constraint["name"]
+                for constraint in inspector.get_unique_constraints(
+                    "trainer_schedule", schema=schema
+                )
+            }
+            assert connection.scalars(
+                select(chat.c.id).order_by(chat.c.id)
+            ).all() == ["old-chat-1", "old-chat-2"]
+            assert connection.scalars(
+                select(schedule.c.id).order_by(schedule.c.id)
+            ).all() == ["old-schedule-1", "old-schedule-2"]
+
+            migration.downgrade()
+            inspector.clear_cache()
+            assert "client_request_id" not in {
+                column["name"]
+                for column in inspector.get_columns("chat_messages", schema=schema)
+            }
+            assert "client_request_id" not in {
+                column["name"]
+                for column in inspector.get_columns(
+                    "trainer_schedule", schema=schema
+                )
+            }
+        finally:
+            connection.execute(sa.schema.DropSchema(schema, cascade=True))
+
+
+def test_trainer_chat_retry_returns_the_same_message(client, db_session):
+    token = _trainer_token(client)
+    key = _key()
+    url = f"/v1/trainer/clients/{MEMBER}/chat"
+    body = {"text": f"{KEY_PREFIX}trainer-retry", "client_request_id": key}
+
+    first = client.post(url, json=body, headers=_headers(token))
+    second = client.post(url, json=body, headers=_headers(token))
+
+    assert first.status_code == second.status_code == 201
+    assert first.json()["id"] == second.json()["id"]
+    assert len(_chat_rows(db_session, key)) == 1
+    db_session.expire_all()
+    assert (
+        db_session.query(Notification)
+        .filter_by(body=f"{KEY_PREFIX}trainer-retry")
+        .count()
+        == 1
+    )
+
+
+def test_member_chat_retry_returns_the_same_message(client, db_session):
+    token = _member_token(client)
+    key = _key()
+    body = {"text": f"{KEY_PREFIX}member-retry", "client_request_id": key}
+
+    first = client.post("/v1/me/coach/chat", json=body, headers=_headers(token))
+    second = client.post("/v1/me/coach/chat", json=body, headers=_headers(token))
+
+    assert first.status_code == second.status_code == 201
+    assert first.json()["id"] == second.json()["id"]
+    assert len(_chat_rows(db_session, key)) == 1
+
+
+def test_schedule_retry_returns_the_same_session(client, db_session):
+    token = _trainer_token(client)
+    key = _key()
+    body = _schedule_body(key)
+
+    first = client.post("/v1/trainer/schedule", json=body, headers=_headers(token))
+    second = client.post("/v1/trainer/schedule", json=body, headers=_headers(token))
+
+    assert first.status_code == second.status_code == 201
+    assert first.json()["id"] == second.json()["id"]
+    assert len(_schedule_rows(db_session, key)) == 1
+
+
+@pytest.mark.parametrize(
+    ("path", "first", "second"),
+    [
+        (
+            f"/v1/trainer/clients/{MEMBER}/chat",
+            {"text": f"{KEY_PREFIX}first"},
+            {"text": f"{KEY_PREFIX}different"},
+        ),
+        (
+            "/v1/trainer/schedule",
+            _schedule_body(None),
+            _schedule_body(None, note="다른 payload"),
+        ),
+    ],
+)
+def test_same_key_with_different_payload_is_conflict(client, path, first, second):
+    token = _trainer_token(client)
+    key = _key()
+    first["client_request_id"] = key
+    second["client_request_id"] = key
+
+    created = client.post(path, json=first, headers=_headers(token))
+    conflict = client.post(path, json=second, headers=_headers(token))
+
+    assert created.status_code == 201
+    assert conflict.status_code == 409
+
+
+def test_different_keys_and_missing_keys_keep_creating(client, db_session):
+    token = _trainer_token(client)
+    first = client.post(
+        "/v1/trainer/schedule",
+        json=_schedule_body(_key()),
+        headers=_headers(token),
+    )
+    second = client.post(
+        "/v1/trainer/schedule",
+        json=_schedule_body(_key()),
+        headers=_headers(token),
+    )
+    no_key_body = _schedule_body(None, note=f"{KEY_PREFIX}no-key")
+    third = client.post(
+        "/v1/trainer/schedule", json=no_key_body, headers=_headers(token)
+    )
+    fourth = client.post(
+        "/v1/trainer/schedule", json=no_key_body, headers=_headers(token)
+    )
+
+    assert {
+        first.status_code,
+        second.status_code,
+        third.status_code,
+        fourth.status_code,
+    } == {201}
+    assert len({first.json()["id"], second.json()["id"]}) == 2
+    assert third.json()["id"] != fourth.json()["id"]
+
+    chat_url = f"/v1/trainer/clients/{MEMBER}/chat"
+    first_chat = client.post(
+        chat_url, json={"text": f"{KEY_PREFIX}no-key"}, headers=_headers(token)
+    )
+    second_chat = client.post(
+        chat_url, json={"text": f"{KEY_PREFIX}no-key"}, headers=_headers(token)
+    )
+    assert first_chat.status_code == second_chat.status_code == 201
+    assert first_chat.json()["id"] != second_chat.json()["id"]
+    db_session.expire_all()
+
+
+def test_same_key_is_isolated_by_user_sender_and_operation(client, db_session):
+    key = _key()
+    trainer = _trainer_token(client)
+    member = _member_token(client)
+    other_member = _member_token(client, "minsu@oncare.com")
+
+    trainer_chat = client.post(
+        f"/v1/trainer/clients/{MEMBER}/chat",
+        json={"text": f"{KEY_PREFIX}trainer", "client_request_id": key},
+        headers=_headers(trainer),
+    )
+    member_chat = client.post(
+        "/v1/me/coach/chat",
+        json={"text": f"{KEY_PREFIX}member", "client_request_id": key},
+        headers=_headers(member),
+    )
+    other_member_chat = client.post(
+        "/v1/me/coach/chat",
+        json={"text": f"{KEY_PREFIX}other-member", "client_request_id": key},
+        headers=_headers(other_member),
+    )
+    schedule = client.post(
+        "/v1/trainer/schedule",
+        json=_schedule_body(key, note="작업격리"),
+        headers=_headers(trainer),
+    )
+
+    assert {
+        trainer_chat.status_code,
+        member_chat.status_code,
+        other_member_chat.status_code,
+        schedule.status_code,
+    } == {201}
+    chat_rows = _chat_rows(db_session, key)
+    assert len(chat_rows) == 3
+    assert {(row.member_id, row.sender) for row in chat_rows} == {
+        (MEMBER, "trainer"),
+        (MEMBER, "member"),
+        (OTHER_MEMBER, "member"),
+    }
+    assert len(_schedule_rows(db_session, key)) == 1
+
+
+@pytest.mark.parametrize("operation", ["chat", "schedule"])
+def test_concurrent_same_key_creates_one_row(client, db_session, operation):
+    token = _trainer_token(client)
+    key = _key()
+    barrier = Barrier(2)
+
+    def send():
+        barrier.wait()
+        if operation == "chat":
+            return client.post(
+                f"/v1/trainer/clients/{MEMBER}/chat",
+                json={"text": f"{KEY_PREFIX}concurrent", "client_request_id": key},
+                headers=_headers(token),
+            )
+        return client.post(
+            "/v1/trainer/schedule",
+            json=_schedule_body(key),
+            headers=_headers(token),
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        responses = [
+            future.result(timeout=15)
+            for future in [pool.submit(send), pool.submit(send)]
+        ]
+
+    assert [response.status_code for response in responses] == [201, 201]
+    assert len({response.json()["id"] for response in responses}) == 1
+    rows = (
+        _chat_rows(db_session, key)
+        if operation == "chat"
+        else _schedule_rows(db_session, key)
+    )
+    assert len(rows) == 1

--- a/backend/tests/test_create_action_idempotency.py
+++ b/backend/tests/test_create_action_idempotency.py
@@ -59,7 +59,7 @@ def _schedule_body(key: str | None, *, note: str = "") -> dict:
 def _purge(db_session) -> None:
     db_session.rollback()
     db_session.query(Notification).filter(
-        Notification.body.like(f"{KEY_PREFIX}%")
+        Notification.body.like(f"%{KEY_PREFIX}%")
     ).delete(synchronize_session=False)
     db_session.query(ChatMessage).filter(
         or_(
@@ -368,21 +368,35 @@ def test_same_key_is_isolated_by_user_sender_and_operation(client, db_session):
 
 @pytest.mark.parametrize("operation", ["chat", "schedule"])
 def test_concurrent_same_key_creates_one_row(client, db_session, operation):
-    token = _trainer_token(client)
+    token = (
+        _member_token(client)
+        if operation == "chat"
+        else _trainer_token(client)
+    )
     key = _key()
     barrier = Barrier(2)
+    chat_body = f"{KEY_PREFIX}concurrent"
+    schedule_type = f"{KEY_PREFIX}schedule"
 
     def send():
         barrier.wait()
         if operation == "chat":
             return client.post(
-                f"/v1/trainer/clients/{MEMBER}/chat",
-                json={"text": f"{KEY_PREFIX}concurrent", "client_request_id": key},
+                "/v1/me/coach/chat",
+                json={"text": chat_body, "client_request_id": key},
                 headers=_headers(token),
             )
+        body = _schedule_body(key)
+        body.update(
+            {
+                "client_name": "이지수",
+                "member_id": MEMBER,
+                "type": schedule_type,
+            }
+        )
         return client.post(
             "/v1/trainer/schedule",
-            json=_schedule_body(key),
+            json=body,
             headers=_headers(token),
         )
 
@@ -400,3 +414,16 @@ def test_concurrent_same_key_creates_one_row(client, db_session, operation):
         else _schedule_rows(db_session, key)
     )
     assert len(rows) == 1
+    db_session.expire_all()
+    expected_body = (
+        chat_body
+        if operation == "chat"
+        else f"2026-12-31 16:00 · {schedule_type}"
+    )
+    expected_user = TRAINER if operation == "chat" else MEMBER
+    assert (
+        db_session.query(Notification)
+        .filter_by(user_id=expected_user, body=expected_body)
+        .count()
+        == 1
+    )

--- a/frontend/flutter/lib/core/utils/request_id.dart
+++ b/frontend/flutter/lib/core/utils/request_id.dart
@@ -1,0 +1,14 @@
+import 'dart:math';
+
+/// Creates a client idempotency key for one create attempt.
+///
+/// The caller must retain this value after a network failure and reuse it for
+/// the retry. A successful request or a different payload starts a new attempt.
+String newClientRequestId() {
+  final Random rng = Random.secure();
+  final StringBuffer buffer = StringBuffer('req-');
+  for (int i = 0; i < 16; i++) {
+    buffer.write(rng.nextInt(16).toRadixString(16));
+  }
+  return buffer.toString();
+}

--- a/frontend/flutter/lib/features/member_coach/data/repositories/dio_member_coach_repository.dart
+++ b/frontend/flutter/lib/features/member_coach/data/repositories/dio_member_coach_repository.dart
@@ -20,7 +20,7 @@ class DioMemberCoachRepository implements MemberCoachRepository {
   final Dio _dio;
   final Duration pollInterval;
   final String Function() _requestIdFactory;
-  ({String text, String id})? _pendingSend;
+  final Map<String, String> _pendingRequestIds = <String, String>{};
 
   @override
   Future<MemberCoach?> fetchCoach() async {
@@ -68,23 +68,24 @@ class DioMemberCoachRepository implements MemberCoachRepository {
   Future<void> sendMessage(String text) async {
     final trimmed = text.trim();
     if (trimmed.isEmpty) return;
-    final previous = _pendingSend;
-    final attempt = previous != null && previous.text == trimmed
-        ? previous
-        : (text: trimmed, id: _requestIdFactory());
-    _pendingSend = attempt;
+    final requestId = _pendingRequestIds.putIfAbsent(
+      trimmed,
+      _requestIdFactory,
+    );
     try {
       await _dio.post<Map<String, Object?>>(
         '/me/coach/chat',
         data: <String, Object?>{
           'text': trimmed,
-          'client_request_id': attempt.id,
+          'client_request_id': requestId,
         },
       );
     } on DioException catch (e) {
       throw AppError.fromDio(e);
     }
-    if (_pendingSend == attempt) _pendingSend = null;
+    if (_pendingRequestIds[trimmed] == requestId) {
+      _pendingRequestIds.remove(trimmed);
+    }
   }
 
   @override

--- a/frontend/flutter/lib/features/member_coach/data/repositories/dio_member_coach_repository.dart
+++ b/frontend/flutter/lib/features/member_coach/data/repositories/dio_member_coach_repository.dart
@@ -2,6 +2,7 @@ import 'package:dio/dio.dart';
 
 import 'package:oncare/core/errors/app_error.dart';
 import 'package:oncare/core/utils/active_polling_stream.dart';
+import 'package:oncare/core/utils/request_id.dart';
 import 'package:oncare/features/member_coach/data/dtos/member_coach_dtos.dart';
 import 'package:oncare/features/member_coach/domain/entities/member_coach.dart';
 import 'package:oncare/features/member_coach/domain/repositories/member_coach_repository.dart';
@@ -13,10 +14,13 @@ class DioMemberCoachRepository implements MemberCoachRepository {
   DioMemberCoachRepository(
     this._dio, {
     this.pollInterval = const Duration(seconds: 3),
-  });
+    String Function() requestIdFactory = newClientRequestId,
+  }) : _requestIdFactory = requestIdFactory;
 
   final Dio _dio;
   final Duration pollInterval;
+  final String Function() _requestIdFactory;
+  ({String text, String id})? _pendingSend;
 
   @override
   Future<MemberCoach?> fetchCoach() async {
@@ -64,14 +68,23 @@ class DioMemberCoachRepository implements MemberCoachRepository {
   Future<void> sendMessage(String text) async {
     final trimmed = text.trim();
     if (trimmed.isEmpty) return;
+    final previous = _pendingSend;
+    final attempt = previous != null && previous.text == trimmed
+        ? previous
+        : (text: trimmed, id: _requestIdFactory());
+    _pendingSend = attempt;
     try {
       await _dio.post<Map<String, Object?>>(
         '/me/coach/chat',
-        data: <String, Object?>{'text': trimmed},
+        data: <String, Object?>{
+          'text': trimmed,
+          'client_request_id': attempt.id,
+        },
       );
     } on DioException catch (e) {
       throw AppError.fromDio(e);
     }
+    if (_pendingSend == attempt) _pendingSend = null;
   }
 
   @override

--- a/frontend/flutter/test/features/member_coach/dio_member_coach_repository_test.dart
+++ b/frontend/flutter/test/features/member_coach/dio_member_coach_repository_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -206,6 +208,52 @@ void main() {
     expect(
       bodies[2]['client_request_id'],
       isNot(bodies[1]['client_request_id']),
+    );
+  });
+
+  test('another message does not replace a failed send request id', () async {
+    final firstResponse = Completer<Response<Map<String, Object?>>>();
+    var isFirstAttempt = true;
+    when(
+      () => dio.post<Map<String, Object?>>(
+        '/me/coach/chat',
+        data: any(named: 'data'),
+      ),
+    ).thenAnswer((invocation) {
+      final data = invocation.namedArguments[#data]! as Map<String, Object?>;
+      if (data['text'] == '첫 메시지' && isFirstAttempt) {
+        isFirstAttempt = false;
+        return firstResponse.future;
+      }
+      return Future<Response<Map<String, Object?>>>.value(
+        _ok<Map<String, Object?>>(<String, Object?>{
+          'id': 'x',
+        }, '/me/coach/chat'),
+      );
+    });
+
+    final firstSend = repo.sendMessage('첫 메시지');
+    final firstFailure = expectLater(firstSend, throwsA(isA<AppError>()));
+    await repo.sendMessage('두 번째 메시지');
+    firstResponse.completeError(_httpError(503, '/me/coach/chat'));
+    await firstFailure;
+    await repo.sendMessage('첫 메시지');
+
+    final bodies = verify(
+      () => dio.post<Map<String, Object?>>(
+        '/me/coach/chat',
+        data: captureAny(named: 'data'),
+      ),
+    ).captured.cast<Map<String, Object?>>();
+    expect(bodies.map((body) => body['text']), <String>[
+      '첫 메시지',
+      '두 번째 메시지',
+      '첫 메시지',
+    ]);
+    expect(bodies[0]['client_request_id'], bodies[2]['client_request_id']);
+    expect(
+      bodies[1]['client_request_id'],
+      isNot(bodies[0]['client_request_id']),
     );
   });
 

--- a/frontend/flutter/test/features/member_coach/dio_member_coach_repository_test.dart
+++ b/frontend/flutter/test/features/member_coach/dio_member_coach_repository_test.dart
@@ -2,6 +2,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
+import 'package:oncare/core/errors/app_error.dart';
 import 'package:oncare/features/member_coach/data/repositories/dio_member_coach_repository.dart';
 import 'package:oncare/features/member_coach/domain/entities/member_coach.dart';
 
@@ -30,7 +31,11 @@ void main() {
 
   setUp(() {
     dio = _MockDio();
-    repo = DioMemberCoachRepository(dio);
+    var requestId = 0;
+    repo = DioMemberCoachRepository(
+      dio,
+      requestIdFactory: () => 'req-${++requestId}',
+    );
   });
 
   test('fetchCoach returns the coach', () async {
@@ -164,12 +169,44 @@ void main() {
     verify(
       () => dio.post<Map<String, Object?>>(
         '/me/coach/chat',
-        data: <String, Object?>{'text': '좋아요'},
+        data: <String, Object?>{'text': '좋아요', 'client_request_id': 'req-1'},
       ),
     ).called(1);
 
     await repo.sendMessage('   ');
     verifyNoMoreInteractions(dio);
+  });
+
+  test('send retry keeps its request id and success rotates it', () async {
+    var calls = 0;
+    when(
+      () => dio.post<Map<String, Object?>>(
+        '/me/coach/chat',
+        data: any(named: 'data'),
+      ),
+    ).thenAnswer((_) async {
+      calls += 1;
+      if (calls == 1) throw _httpError(503, '/me/coach/chat');
+      return _ok<Map<String, Object?>>(<String, Object?>{
+        'id': 'x',
+      }, '/me/coach/chat');
+    });
+
+    await expectLater(repo.sendMessage('재시도'), throwsA(isA<AppError>()));
+    await repo.sendMessage('재시도');
+    await repo.sendMessage('재시도');
+
+    final bodies = verify(
+      () => dio.post<Map<String, Object?>>(
+        '/me/coach/chat',
+        data: captureAny(named: 'data'),
+      ),
+    ).captured.cast<Map<String, Object?>>();
+    expect(bodies[0]['client_request_id'], bodies[1]['client_request_id']);
+    expect(
+      bodies[2]['client_request_id'],
+      isNot(bodies[1]['client_request_id']),
+    );
   });
 
   test('unreadCount reads the unread field', () async {

--- a/frontend/flutter_trainer/lib/core/utils/request_id.dart
+++ b/frontend/flutter_trainer/lib/core/utils/request_id.dart
@@ -1,11 +1,11 @@
 import 'dart:math';
 
-/// Creates an idempotency key for one **send attempt**.
+/// Creates an idempotency key for one logical create attempt.
 ///
-/// 서버는 `(trainer_id, member_id, client_request_id)` 로 중복 배정을 막는다
-/// (#581). 그래서 이 값의 수명이 핵심이다 — 재시도할 때는 **같은 키를 다시
-/// 보내야** 하고, 새 내용을 보낼 때만 새로 만든다. 요청마다 새로 만들면
-/// 멱등성이 아무것도 막지 못한다.
+/// 서버는 operation마다 인증 주체와 `client_request_id`를 scope로
+/// 중복 생성을 막는다(#581, #605). 재시도할 때는 **같은 키를 다시
+/// 보내야** 하고, 새 사용자 행동에서만 새로 만든다. 요청마다 새로
+/// 만들면 멱등성이 아무것도 막지 못한다.
 ///
 /// `uuid` 패키지를 들이지 않는다. 여기서 필요한 건 전역 유일성이 아니라 한
 /// 트레이너·회원 조합 안에서 겹치지 않을 정도의 무작위성이고, 그 정도는

--- a/frontend/flutter_trainer/lib/features/clients/data/repositories/dio_chat_repository.dart
+++ b/frontend/flutter_trainer/lib/features/clients/data/repositories/dio_chat_repository.dart
@@ -24,8 +24,8 @@ class DioChatRepository implements ChatRepository {
   final Dio _dio;
   final Duration pollInterval;
   final String Function() requestIdFactory;
-  final Map<String, ({String text, String id})> _pendingSends =
-      <String, ({String text, String id})>{};
+  final Map<({String clientId, String text}), String> _pendingRequestIds =
+      <({String clientId, String text}), String>{};
 
   @override
   Stream<List<ClientChatMessage>> watchThread(String clientId) =>
@@ -64,24 +64,21 @@ class DioChatRepository implements ChatRepository {
     final trimmed = text.trim();
     if (trimmed.isEmpty) return;
     final encodedId = Uri.encodeComponent(clientId);
-    final previous = _pendingSends[clientId];
-    final attempt = previous != null && previous.text == trimmed
-        ? previous
-        : (text: trimmed, id: requestIdFactory());
-    _pendingSends[clientId] = attempt;
+    final payload = (clientId: clientId, text: trimmed);
+    final requestId = _pendingRequestIds.putIfAbsent(payload, requestIdFactory);
     try {
       await _dio.post<Map<String, Object?>>(
         '/trainer/clients/$encodedId/chat',
         data: <String, Object?>{
           'text': trimmed,
-          'client_request_id': attempt.id,
+          'client_request_id': requestId,
         },
       );
     } on DioException catch (e) {
       throw AppError.fromDio(e);
     }
-    if (_pendingSends[clientId] == attempt) {
-      _pendingSends.remove(clientId);
+    if (_pendingRequestIds[payload] == requestId) {
+      _pendingRequestIds.remove(payload);
     }
   }
 

--- a/frontend/flutter_trainer/lib/features/clients/data/repositories/dio_chat_repository.dart
+++ b/frontend/flutter_trainer/lib/features/clients/data/repositories/dio_chat_repository.dart
@@ -2,6 +2,7 @@ import 'package:dio/dio.dart';
 
 import 'package:oncare_trainer/core/errors/app_error.dart';
 import 'package:oncare_trainer/core/utils/active_polling_stream.dart';
+import 'package:oncare_trainer/core/utils/request_id.dart';
 import 'package:oncare_trainer/features/clients/data/dtos/chat_dtos.dart';
 import 'package:oncare_trainer/shared/models/client_chat_message.dart';
 import 'package:oncare_trainer/shared/services/chat_repository.dart';
@@ -17,10 +18,14 @@ class DioChatRepository implements ChatRepository {
   DioChatRepository(
     this._dio, {
     this.pollInterval = const Duration(seconds: 3),
+    this.requestIdFactory = newClientRequestId,
   });
 
   final Dio _dio;
   final Duration pollInterval;
+  final String Function() requestIdFactory;
+  final Map<String, ({String text, String id})> _pendingSends =
+      <String, ({String text, String id})>{};
 
   @override
   Stream<List<ClientChatMessage>> watchThread(String clientId) =>
@@ -59,13 +64,24 @@ class DioChatRepository implements ChatRepository {
     final trimmed = text.trim();
     if (trimmed.isEmpty) return;
     final encodedId = Uri.encodeComponent(clientId);
+    final previous = _pendingSends[clientId];
+    final attempt = previous != null && previous.text == trimmed
+        ? previous
+        : (text: trimmed, id: requestIdFactory());
+    _pendingSends[clientId] = attempt;
     try {
       await _dio.post<Map<String, Object?>>(
         '/trainer/clients/$encodedId/chat',
-        data: <String, Object?>{'text': trimmed},
+        data: <String, Object?>{
+          'text': trimmed,
+          'client_request_id': attempt.id,
+        },
       );
     } on DioException catch (e) {
       throw AppError.fromDio(e);
+    }
+    if (_pendingSends[clientId] == attempt) {
+      _pendingSends.remove(clientId);
     }
   }
 

--- a/frontend/flutter_trainer/lib/features/schedule/data/repositories/dio_schedule_repository.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/data/repositories/dio_schedule_repository.dart
@@ -10,6 +10,16 @@ import 'package:oncare_trainer/features/schedule/data/dtos/schedule_dtos.dart';
 import 'package:oncare_trainer/features/schedule/data/repositories/schedule_repository.dart';
 import 'package:oncare_trainer/features/schedule/domain/entities/schedule_session.dart';
 
+typedef _ScheduleCreatePayload = ({
+  String date,
+  String clientName,
+  String? clientId,
+  String time,
+  String type,
+  int durationMinutes,
+  String note,
+});
+
 /// The trainer's timeline against the FastAPI backend
 /// (`/v1/trainer/schedule*`). Selected when `USE_MOCK_API=false`.
 ///
@@ -30,17 +40,8 @@ class DioScheduleRepository implements ScheduleRepository {
   final Dio _dio;
   final Duration pollInterval;
   final String Function() requestIdFactory;
-  ({
-    String date,
-    String clientName,
-    String? clientId,
-    String time,
-    String type,
-    int durationMinutes,
-    String note,
-    String id,
-  })?
-  _pendingCreate;
+  final Map<_ScheduleCreatePayload, String> _pendingRequestIds =
+      <_ScheduleCreatePayload, String>{};
 
   final StreamController<void> _revisions = StreamController<void>.broadcast();
 
@@ -118,29 +119,16 @@ class DioScheduleRepository implements ScheduleRepository {
     required int durationMinutes,
     String note = '',
   }) async {
-    final previous = _pendingCreate;
-    final samePayload =
-        previous != null &&
-        previous.date == date &&
-        previous.clientName == clientName &&
-        previous.clientId == clientId &&
-        previous.time == time &&
-        previous.type == type &&
-        previous.durationMinutes == durationMinutes &&
-        previous.note == note;
-    final attempt = samePayload
-        ? previous
-        : (
-            date: date,
-            clientName: clientName,
-            clientId: clientId,
-            time: time,
-            type: type,
-            durationMinutes: durationMinutes,
-            note: note,
-            id: requestIdFactory(),
-          );
-    _pendingCreate = attempt;
+    final payload = (
+      date: date,
+      clientName: clientName,
+      clientId: clientId,
+      time: time,
+      type: type,
+      durationMinutes: durationMinutes,
+      note: note,
+    );
+    final requestId = _pendingRequestIds.putIfAbsent(payload, requestIdFactory);
     await _mutate(
       () => _dio.post<Map<String, dynamic>>(
         '/trainer/schedule',
@@ -152,11 +140,13 @@ class DioScheduleRepository implements ScheduleRepository {
           'type': type,
           'duration_minutes': durationMinutes,
           'note': note,
-          'client_request_id': attempt.id,
+          'client_request_id': requestId,
         },
       ),
     );
-    if (_pendingCreate == attempt) _pendingCreate = null;
+    if (_pendingRequestIds[payload] == requestId) {
+      _pendingRequestIds.remove(payload);
+    }
   }
 
   @override

--- a/frontend/flutter_trainer/lib/features/schedule/data/repositories/dio_schedule_repository.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/data/repositories/dio_schedule_repository.dart
@@ -5,6 +5,7 @@ import 'package:dio/dio.dart';
 import 'package:oncare_trainer/core/errors/app_error.dart';
 import 'package:oncare_trainer/core/utils/active_polling_stream.dart';
 import 'package:oncare_trainer/core/utils/date_format.dart';
+import 'package:oncare_trainer/core/utils/request_id.dart';
 import 'package:oncare_trainer/features/schedule/data/dtos/schedule_dtos.dart';
 import 'package:oncare_trainer/features/schedule/data/repositories/schedule_repository.dart';
 import 'package:oncare_trainer/features/schedule/domain/entities/schedule_session.dart';
@@ -23,10 +24,23 @@ class DioScheduleRepository implements ScheduleRepository {
   DioScheduleRepository(
     this._dio, {
     this.pollInterval = const Duration(seconds: 5),
+    this.requestIdFactory = newClientRequestId,
   });
 
   final Dio _dio;
   final Duration pollInterval;
+  final String Function() requestIdFactory;
+  ({
+    String date,
+    String clientName,
+    String? clientId,
+    String time,
+    String type,
+    int durationMinutes,
+    String note,
+    String id,
+  })?
+  _pendingCreate;
 
   final StreamController<void> _revisions = StreamController<void>.broadcast();
 
@@ -104,6 +118,29 @@ class DioScheduleRepository implements ScheduleRepository {
     required int durationMinutes,
     String note = '',
   }) async {
+    final previous = _pendingCreate;
+    final samePayload =
+        previous != null &&
+        previous.date == date &&
+        previous.clientName == clientName &&
+        previous.clientId == clientId &&
+        previous.time == time &&
+        previous.type == type &&
+        previous.durationMinutes == durationMinutes &&
+        previous.note == note;
+    final attempt = samePayload
+        ? previous
+        : (
+            date: date,
+            clientName: clientName,
+            clientId: clientId,
+            time: time,
+            type: type,
+            durationMinutes: durationMinutes,
+            note: note,
+            id: requestIdFactory(),
+          );
+    _pendingCreate = attempt;
     await _mutate(
       () => _dio.post<Map<String, dynamic>>(
         '/trainer/schedule',
@@ -115,9 +152,11 @@ class DioScheduleRepository implements ScheduleRepository {
           'type': type,
           'duration_minutes': durationMinutes,
           'note': note,
+          'client_request_id': attempt.id,
         },
       ),
     );
+    if (_pendingCreate == attempt) _pendingCreate = null;
   }
 
   @override

--- a/frontend/flutter_trainer/test/features/clients/dio_chat_repository_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/dio_chat_repository_test.dart
@@ -34,7 +34,8 @@ void main() {
 
   setUp(() {
     dio = _MockDio();
-    repo = DioChatRepository(dio);
+    var requestId = 0;
+    repo = DioChatRepository(dio, requestIdFactory: () => 'req-${++requestId}');
   });
 
   test('watchThread parses the message list (oldest→newest)', () async {
@@ -183,9 +184,44 @@ void main() {
     verify(
       () => dio.post<Map<String, Object?>>(
         '/trainer/clients/m1/chat',
-        data: <String, Object?>{'text': '안녕하세요'},
+        data: <String, Object?>{'text': '안녕하세요', 'client_request_id': 'req-1'},
       ),
     ).called(1);
+  });
+
+  test('a failed send reuses its key; a later send gets a new key', () async {
+    var calls = 0;
+    when(
+      () => dio.post<Map<String, Object?>>(
+        '/trainer/clients/m1/chat',
+        data: any(named: 'data'),
+      ),
+    ).thenAnswer((_) async {
+      calls += 1;
+      if (calls == 1) throw _httpError(503, '/trainer/clients/m1/chat');
+      return _ok<Map<String, Object?>>(<String, Object?>{
+        'id': 'x',
+      }, '/trainer/clients/m1/chat');
+    });
+
+    await expectLater(
+      repo.sendTrainerMessage(clientId: 'm1', text: '재시도'),
+      throwsA(isA<AppError>()),
+    );
+    await repo.sendTrainerMessage(clientId: 'm1', text: '재시도');
+    await repo.sendTrainerMessage(clientId: 'm1', text: '재시도');
+
+    final bodies = verify(
+      () => dio.post<Map<String, Object?>>(
+        '/trainer/clients/m1/chat',
+        data: captureAny(named: 'data'),
+      ),
+    ).captured.cast<Map<String, Object?>>();
+    expect(bodies[0]['client_request_id'], bodies[1]['client_request_id']);
+    expect(
+      bodies[2]['client_request_id'],
+      isNot(bodies[1]['client_request_id']),
+    );
   });
 
   test('sendTrainerMessage skips the network call for blank text', () async {
@@ -288,7 +324,7 @@ void main() {
     verify(
       () => dio.post<Map<String, Object?>>(
         '/trainer/clients/$encoded/chat',
-        data: <String, Object?>{'text': 'hi'},
+        data: <String, Object?>{'text': 'hi', 'client_request_id': 'req-1'},
       ),
     ).called(1);
     verify(

--- a/frontend/flutter_trainer/test/features/clients/dio_chat_repository_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/dio_chat_repository_test.dart
@@ -224,6 +224,52 @@ void main() {
     );
   });
 
+  test('another message does not replace a failed send request id', () async {
+    final firstResponse = Completer<Response<Map<String, Object?>>>();
+    var isFirstAttempt = true;
+    when(
+      () => dio.post<Map<String, Object?>>(
+        '/trainer/clients/m1/chat',
+        data: any(named: 'data'),
+      ),
+    ).thenAnswer((invocation) {
+      final data = invocation.namedArguments[#data]! as Map<String, Object?>;
+      if (data['text'] == '첫 메시지' && isFirstAttempt) {
+        isFirstAttempt = false;
+        return firstResponse.future;
+      }
+      return Future<Response<Map<String, Object?>>>.value(
+        _ok<Map<String, Object?>>(<String, Object?>{
+          'id': 'x',
+        }, '/trainer/clients/m1/chat'),
+      );
+    });
+
+    final firstSend = repo.sendTrainerMessage(clientId: 'm1', text: '첫 메시지');
+    final firstFailure = expectLater(firstSend, throwsA(isA<AppError>()));
+    await repo.sendTrainerMessage(clientId: 'm1', text: '두 번째 메시지');
+    firstResponse.completeError(_httpError(503, '/trainer/clients/m1/chat'));
+    await firstFailure;
+    await repo.sendTrainerMessage(clientId: 'm1', text: '첫 메시지');
+
+    final bodies = verify(
+      () => dio.post<Map<String, Object?>>(
+        '/trainer/clients/m1/chat',
+        data: captureAny(named: 'data'),
+      ),
+    ).captured.cast<Map<String, Object?>>();
+    expect(bodies.map((body) => body['text']), <String>[
+      '첫 메시지',
+      '두 번째 메시지',
+      '첫 메시지',
+    ]);
+    expect(bodies[0]['client_request_id'], bodies[2]['client_request_id']);
+    expect(
+      bodies[1]['client_request_id'],
+      isNot(bodies[0]['client_request_id']),
+    );
+  });
+
   test('sendTrainerMessage skips the network call for blank text', () async {
     await repo.sendTrainerMessage(clientId: 'm1', text: '   ');
     verifyNever(

--- a/frontend/flutter_trainer/test/features/schedule/dio_schedule_repository_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/dio_schedule_repository_test.dart
@@ -66,7 +66,11 @@ void main() {
 
   setUp(() {
     dio = _MockDio();
-    repo = DioScheduleRepository(dio);
+    var requestId = 0;
+    repo = DioScheduleRepository(
+      dio,
+      requestIdFactory: () => 'req-${++requestId}',
+    );
     addTearDown(repo.dispose);
   });
 
@@ -211,6 +215,44 @@ void main() {
     expect(emissions, hasLength(2));
     expect(emissions.last.map((s) => s.id), <String>['before', 'after']);
     await sub.cancel();
+  });
+
+  test('add retry reuses its request id; next create rotates it', () async {
+    var calls = 0;
+    when(
+      () => dio.post<Map<String, dynamic>>(
+        _schedulePath,
+        data: any(named: 'data'),
+      ),
+    ).thenAnswer((_) async {
+      calls += 1;
+      if (calls == 1) throw _httpError(503, _schedulePath);
+      return _okMap(_schedulePath);
+    });
+
+    Future<void> add() => repo.addSession(
+      date: '2026-08-06',
+      clientName: '김민수',
+      time: '15:00',
+      type: '1:1 PT',
+      durationMinutes: 60,
+    );
+
+    await expectLater(add(), throwsA(isA<AppError>()));
+    await add();
+    await add();
+
+    final bodies = verify(
+      () => dio.post<Map<String, dynamic>>(
+        _schedulePath,
+        data: captureAny(named: 'data'),
+      ),
+    ).captured.cast<Map<String, dynamic>>();
+    expect(bodies[0]['client_request_id'], bodies[1]['client_request_id']);
+    expect(
+      bodies[2]['client_request_id'],
+      isNot(bodies[1]['client_request_id']),
+    );
   });
 
   test('a FAILED mutation does not make readers re-fetch', () async {

--- a/frontend/flutter_trainer/test/features/schedule/dio_schedule_repository_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/dio_schedule_repository_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -252,6 +254,59 @@ void main() {
     expect(
       bodies[2]['client_request_id'],
       isNot(bodies[1]['client_request_id']),
+    );
+  });
+
+  test('another create does not replace a failed request id', () async {
+    final firstResponse = Completer<Response<Map<String, dynamic>>>();
+    var isFirstAttempt = true;
+    when(
+      () => dio.post<Map<String, dynamic>>(
+        _schedulePath,
+        data: any(named: 'data'),
+      ),
+    ).thenAnswer((invocation) {
+      final data = invocation.namedArguments[#data]! as Map<String, dynamic>;
+      if (data['note'] == '첫 일정' && isFirstAttempt) {
+        isFirstAttempt = false;
+        return firstResponse.future;
+      }
+      return Future<Response<Map<String, dynamic>>>.value(
+        _okMap(_schedulePath),
+      );
+    });
+
+    Future<void> add(String note) => repo.addSession(
+      date: '2026-08-06',
+      clientName: '김민수',
+      time: '15:00',
+      type: '1:1 PT',
+      durationMinutes: 60,
+      note: note,
+    );
+
+    final firstCreate = add('첫 일정');
+    final firstFailure = expectLater(firstCreate, throwsA(isA<AppError>()));
+    await add('두 번째 일정');
+    firstResponse.completeError(_httpError(503, _schedulePath));
+    await firstFailure;
+    await add('첫 일정');
+
+    final bodies = verify(
+      () => dio.post<Map<String, dynamic>>(
+        _schedulePath,
+        data: captureAny(named: 'data'),
+      ),
+    ).captured.cast<Map<String, dynamic>>();
+    expect(bodies.map((body) => body['note']), <String>[
+      '첫 일정',
+      '두 번째 일정',
+      '첫 일정',
+    ]);
+    expect(bodies[0]['client_request_id'], bodies[2]['client_request_id']);
+    expect(
+      bodies[1]['client_request_id'],
+      isNot(bodies[0]['client_request_id']),
     );
   });
 


### PR DESCRIPTION
## 문제

채팅 발신과 트레이너 스케줄 생성은 서버에서 저장에 성공한 뒤 응답이 유실되면, 클라이언트 재시도가 새 행을 만들어 같은 메시지·일정이 중복될 수 있었습니다.

실제 원인은 두 create 경로에 클라이언트 시도 식별자와 DB 수준 중복 방지 계약이 없었던 것입니다.

## 변경 사항

- 다음 request body에 선택적 `client_request_id`(1~64자)를 추가했습니다.
  - `POST /v1/trainer/clients/{member_id}/chat`
  - `POST /v1/me/coach/chat`
  - `POST /v1/trainer/schedule`
- 채팅은 `(trainer_id, member_id, sender, client_request_id)`, 스케줄은 `(trainer_id, client_request_id)` unique constraint로 격리했습니다.
- 같은 키와 같은 payload의 재시도는 최초 생성 결과를 201로 다시 반환합니다.
- 같은 키에 다른 payload가 오면 409 Conflict를 반환합니다.
- 키가 없는 기존 클라이언트는 기존처럼 매 요청을 새로 생성합니다.
- 삽입을 알림 생성 전에 flush하고, unique violation 시 rollback 후 승자 행을 다시 읽어 동시 요청에서도 메시지·일정·알림이 중복되지 않게 했습니다.
- 회원 앱과 Trainer Web Dio repository가 사용자 행동 단위 키를 만들고 실패한 동일 payload 재시도에서 같은 키를 유지하도록 했습니다.
- Mock repository와 기존 response 구조는 변경하지 않았습니다.

## DB migration

- `0031_create_action_ids`
- parent: `0030_doc_source_ref`
- 기존 행에는 nullable 컬럼이 추가되므로 데이터가 유지됩니다.
- upgrade/downgrade와 unique constraint를 모두 포함했습니다.
- 구형 형태의 임시 테이블에 여러 기존 행을 넣고 migration 전후 데이터 보존을 검증하는 테스트를 추가했습니다.

## 검증

- Backend 전체: 206 passed, 498 skipped
  - 로컬 PostgreSQL이 없어 DB 의존 테스트는 skip됐습니다.
- 관련 Backend suite: 3 passed, 43 skipped
- Alembic: `0031_create_action_ids (head)`
- Python compile: 통과
- 회원 앱 전체 `flutter test`: 483 passed
- Trainer Web 전체 `flutter test`: 468 passed
- Trainer Web 전체 `dart analyze`: 통과
- 회원 앱 변경 파일별 `dart analyze`: 통과
- `git diff --check`: 통과

회원 앱 전체 `flutter analyze`는 코드 진단 전에 Flutter 3.44 분석 서버가 한글 경로의 LSP 초기화 JSON을 절단하고 `custom_lint` AOT plugin을 시작하지 못해 완료되지 않았습니다. 변경 파일 분석은 모두 통과했습니다.

## 관련 작업 및 범위

- 작업 중 병합된 #607의 `0030_doc_source_ref` migration과 `record_chat(source_ref=msg.id)` 변경을 최신 main에서 보존하고 본 migration을 0031로 연결했습니다.
- 현재 열린 PR은 없습니다.
- 열린 #589, #604, #474는 각각 루틴 E2E, 시드 RAG, 푸시 알림 작업으로 이번 채팅·스케줄 create 멱등성 구현과 기능 범위가 중복되지 않습니다.
- Issue 본문의 후보였던 `POST /exercise/sessions`는 이번 제목과 확정 대상인 채팅·트레이너 스케줄 범위에서 제외했습니다. 운동 기록 멱등성은 별도 follow-up 대상입니다.
- 오프라인 큐, WebSocket, 공통 POST middleware, 알림 기능 변경은 포함하지 않았습니다.

Closes #605


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 채팅 메시지 전송과 일정 생성에 요청 식별자를 지원합니다.
  * 네트워크 실패 후 재시도 시 동일한 요청을 안전하게 재처리합니다.
  * 동일한 요청이 반복되면 기존 결과를 반환해 중복 생성과 중복 알림을 방지합니다.
* **버그 수정**
  * 동일한 식별자에 다른 내용이 사용되면 충돌 오류(HTTP 409)를 반환합니다.
  * 동시 요청에서도 메시지와 일정이 중복 생성되지 않습니다.
* **문서**
  * 관련 API의 요청 식별자 사용 규칙을 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->