### PR TITLE
fix(ai): 근거 갱신이 항상 원본의 현재 값을 쓰도록

### DIFF
--- a/backend/app/api/v1/exercise.py
+++ b/backend/app/api/v1/exercise.py
@@ -161,13 +161,10 @@ def update_session(
 
     one = build_current_week([row])["sessions"][0]
     out = ExerciseSessionOut(**one)
-    # 30분을 45분으로 고쳤으면 코치도 45분으로 알아야 한다(#603). 지우지 않고
-    # 덧붙이면 두 수치가 함께 검색돼 안 고치느니만 못하다.
-    personal_ingest.record_exercise(
-        db, current_user.id, date=_session_date(row), exercise_type=row.type,
-        minutes=row.minutes, calories=row.calories, intensity=row.intensity,
-        source_ref=row.id, replace=True,
-    )
+    # 30분을 45분으로 고쳤으면 코치도 45분으로 알아야 한다(#603). 값을 넘기지 않고
+    # id 만 넘기는 이유는 #614 — 갱신은 잠금 안에서 행을 다시 읽어야, 두 수정이
+    # 역순으로 도착해도 최종 문서가 DB 최신값과 어긋나지 않는다.
+    personal_ingest.refresh_exercise(db, current_user.id, session_id=row.id)
     return out
 
 

--- a/backend/app/services/coach/personal_ingest.py
+++ b/backend/app/services/coach/personal_ingest.py
@@ -160,8 +160,15 @@ def diet_text(
     *, date: str, foods: list[dict], total_calories: int, sodium_mg: int,
     sugar_g: float,
 ) -> str:
-    """식단 기록 한 건의 문서 본문."""
-    names = ", ".join(f.get("name", "") for f in foods if f.get("name")) or "식단"
+    """식단 기록 한 건의 문서 본문.
+
+    dict 이 아닌 항목은 건너뛴다. 저장된 JSON 이 늘 dict 목록이라는 보장이 없고,
+    여기서 터지면 갱신이 조용히 실패해 옛 근거가 남는다.
+    """
+    names = ", ".join(
+        f["name"] for f in foods
+        if isinstance(f, dict) and isinstance(f.get("name"), str) and f["name"]
+    ) or "식단"
     return (
         f"{date} 식단 기록: {names}. "
         f"총 {total_calories}kcal, 나트륨 {sodium_mg}mg, 당류 {sugar_g}g."
@@ -281,12 +288,20 @@ def refresh_diet(db: Session, user_id: str, *, entry_id: str) -> None:
 
 
 def _entry_foods(foods_json: str | None) -> list[dict]:
-    """저장된 foods_json → 리스트. 깨진 값이면 빈 목록(문서 갱신이 죽으면 안 된다)."""
+    """저장된 foods_json → 음식 dict 목록. 깨진 값은 걸러 낸다.
+
+    최상위가 리스트여도 항목이 문자열·숫자일 수 있다. 그대로 넘기면 `diet_text` 가
+    `f.get(...)` 에서 터지고, 그 예외를 `_safe_replace` 가 삼켜 **근거가 옛 값으로
+    남는다** — 수정했는데 코치는 여전히 이전 수치로 답한다. 조용히 실패하는 경로라
+    여기 파싱 경계에서 dict 만 남긴다.
+    """
     try:
         value = json.loads(foods_json or "[]")
     except (TypeError, ValueError):
         return []
-    return value if isinstance(value, list) else []
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
 
 
 def exercise_session_date(row) -> str:

--- a/backend/app/services/coach/personal_ingest.py
+++ b/backend/app/services/coach/personal_ingest.py
@@ -15,8 +15,11 @@
 """
 from __future__ import annotations
 
+import json
 import logging
+from datetime import date, timedelta
 
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.core.config import get_settings
@@ -33,8 +36,7 @@ log = logging.getLogger(__name__)
 
 def _safe(
     db: Session, user_id: str, text: str, *, domain: str, source: str,
-    source_ref: str | None = None, replace: bool = False,
-    once: bool = False,
+    source_ref: str | None = None, once: bool = False,
 ) -> None:
     if not get_settings().rag_auto_ingest or not user_id or not text.strip():
         return
@@ -44,18 +46,6 @@ def _safe(
         # 두 인스턴스가 동시에 기동할 때 같은 기록의 청크가 두 벌 들어간다.
         if once and source_ref:
             ensure_personal_text(
-                db, user_id, text, domain=domain, source=source,
-                source_ref=source_ref, title="",
-            )
-            return
-        # 교체는 지우고 다시 넣는다(#603). 그냥 넣으면 옛 수치 문서가 남아 코치가
-        # "30분"과 "45분"을 동시에 근거로 삼는다 — 안 고치느니만 못하다.
-        #
-        # 삭제·삽입을 한 트랜잭션으로 묶는 replace_personal_text 를 쓴다. 예전처럼
-        # purge 후 ingest 를 따로 부르면 임베딩이 삭제 뒤에 실패했을 때 기존 청크를
-        # 되살릴 수 없고, 두 커밋 사이에 근거가 텅 빈 순간이 생긴다.
-        if replace and source_ref:
-            replace_personal_text(
                 db, user_id, text, domain=domain, source=source,
                 source_ref=source_ref, title="",
             )
@@ -154,10 +144,34 @@ _EXERCISE_TYPE_KR = {
 _EXERCISE_INTENSITY_KR = {"light": "낮음", "moderate": "보통", "high": "높음"}
 
 
+def exercise_text(
+    *, date: str, exercise_type: str, minutes: int, calories: int,
+    intensity: str,
+) -> str:
+    """운동 세션 한 건의 문서 본문. 적재와 갱신이 같은 문구를 쓰게 한 곳에 둔다."""
+    return (
+        f"{date} 운동 기록: "
+        f"{_EXERCISE_TYPE_KR.get(exercise_type, exercise_type)} {minutes}분, "
+        f"{calories}kcal, 강도 {_EXERCISE_INTENSITY_KR.get(intensity, intensity)}."
+    )
+
+
+def diet_text(
+    *, date: str, foods: list[dict], total_calories: int, sodium_mg: int,
+    sugar_g: float,
+) -> str:
+    """식단 기록 한 건의 문서 본문."""
+    names = ", ".join(f.get("name", "") for f in foods if f.get("name")) or "식단"
+    return (
+        f"{date} 식단 기록: {names}. "
+        f"총 {total_calories}kcal, 나트륨 {sodium_mg}mg, 당류 {sugar_g}g."
+    )
+
+
 def record_exercise(
     db: Session, user_id: str, *, date: str, exercise_type: str, minutes: int,
     calories: int, intensity: str, source_ref: str | None = None,
-    replace: bool = False, once: bool = False,
+    once: bool = False,
 ) -> None:
     """운동 세션 한 건을 개인 문서로 적재한다(#586).
 
@@ -168,29 +182,121 @@ def record_exercise(
     회원이 직접 남긴 기록과 PT 완료로 파생된 기록을 모두 받는다 — 회원 입장에서는
     둘 다 '내가 한 운동'이고, 주간 집계도 이미 둘을 합쳐서 보여준다(#499).
     """
-    text = (
-        f"{date} 운동 기록: "
-        f"{_EXERCISE_TYPE_KR.get(exercise_type, exercise_type)} {minutes}분, "
-        f"{calories}kcal, 강도 {_EXERCISE_INTENSITY_KR.get(intensity, intensity)}."
+    text = exercise_text(
+        date=date, exercise_type=exercise_type, minutes=minutes,
+        calories=calories, intensity=intensity,
     )
     _safe(
         db, user_id, text, domain="exercise", source="exercise",
-        source_ref=source_ref, replace=replace, once=once,
+        source_ref=source_ref, once=once,
     )
 
 
 def record_diet(
     db: Session, user_id: str, *, date: str, foods: list[dict],
     total_calories: int, sodium_mg: int, sugar_g: float,
-    source_ref: str | None = None, replace: bool = False,
-    once: bool = False,
+    source_ref: str | None = None, once: bool = False,
 ) -> None:
-    names = ", ".join(f.get("name", "") for f in foods if f.get("name")) or "식단"
-    text = (
-        f"{date} 식단 기록: {names}. "
-        f"총 {total_calories}kcal, 나트륨 {sodium_mg}mg, 당류 {sugar_g}g."
+    text = diet_text(
+        date=date, foods=foods, total_calories=total_calories,
+        sodium_mg=sodium_mg, sugar_g=sugar_g,
     )
     _safe(
         db, user_id, text, domain="diet", source="diet",
-        source_ref=source_ref, replace=replace, once=once,
+        source_ref=source_ref, once=once,
     )
+
+
+def _safe_replace(
+    db: Session, user_id: str, *, domain: str, source: str, source_ref: str,
+    load_text,
+) -> None:
+    """교체도 best-effort 다 — 실패가 원 기록 수정을 되돌리면 안 된다."""
+    if not get_settings().rag_auto_ingest or not user_id or not source_ref:
+        return
+    try:
+        replace_personal_text(
+            db, user_id, domain=domain, source=source, source_ref=source_ref,
+            load_text=load_text, title="",
+        )
+    except Exception as e:  # noqa: BLE001 — 적재 실패가 원 기록을 깨면 안 됨
+        log.warning("개인 RAG 문서 갱신 실패(무시): %s", e)
+        try:
+            db.rollback()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def refresh_exercise(db: Session, user_id: str, *, session_id: str) -> None:
+    """운동 기록이 바뀌었을 때 그 근거 문서를 현재 행에 맞춘다 (#603, #614).
+
+    값을 받지 않고 **잠금 안에서 행을 다시 읽는다.** 호출자가 읽은 값을 넘기면,
+    두 수정이 역순으로 적재될 때 옛 값이 최종 문서로 남는다 — DB 는 45분인데
+    코치는 30분을 근거로 답하게 된다.
+    """
+    from app.models.models import ExerciseSession
+
+    def _load() -> str | None:
+        row = db.scalar(
+            select(ExerciseSession).where(
+                ExerciseSession.id == session_id,
+                ExerciseSession.user_id == user_id,
+            )
+        )
+        if row is None:
+            return None  # 그 사이 지워졌다 — 근거도 지운다.
+        return exercise_text(
+            date=exercise_session_date(row), exercise_type=row.type,
+            minutes=row.minutes, calories=row.calories, intensity=row.intensity,
+        )
+
+    _safe_replace(
+        db, user_id, domain="exercise", source="exercise",
+        source_ref=session_id, load_text=_load,
+    )
+
+
+def refresh_diet(db: Session, user_id: str, *, entry_id: str) -> None:
+    """식단 기록이 바뀌었을 때 그 근거 문서를 현재 행에 맞춘다 (#603, #614)."""
+    from app.models.models import DietEntry
+
+    def _load() -> str | None:
+        row = db.scalar(
+            select(DietEntry).where(
+                DietEntry.id == entry_id, DietEntry.user_id == user_id
+            )
+        )
+        if row is None:
+            return None
+        return diet_text(
+            date=row.date, foods=_entry_foods(row.foods_json),
+            total_calories=row.total_calories, sodium_mg=row.sodium_mg,
+            sugar_g=row.sugar_g,
+        )
+
+    _safe_replace(
+        db, user_id, domain="diet", source="diet", source_ref=entry_id,
+        load_text=_load,
+    )
+
+
+def _entry_foods(foods_json: str | None) -> list[dict]:
+    """저장된 foods_json → 리스트. 깨진 값이면 빈 목록(문서 갱신이 죽으면 안 된다)."""
+    try:
+        value = json.loads(foods_json or "[]")
+    except (TypeError, ValueError):
+        return []
+    return value if isinstance(value, list) else []
+
+
+def exercise_session_date(row) -> str:
+    """세션의 실제 날짜. 저장은 (주 시작 + 요일 라벨)로 쪼개져 있다."""
+    from app.services.exercise_service import WEEKDAY_LABELS
+
+    try:
+        monday = date.fromisoformat(row.week_start)
+        return (
+            monday + timedelta(days=WEEKDAY_LABELS.index(row.day_label))
+        ).isoformat()
+    except (ValueError, IndexError):
+        return row.week_start

--- a/backend/app/services/coach/rag.py
+++ b/backend/app/services/coach/rag.py
@@ -11,6 +11,7 @@ STEP 8 챗봇도 retrieve_context() 를 그대로 재사용합니다.
 """
 from __future__ import annotations
 
+from collections.abc import Callable
 
 from sqlalchemy import delete, or_, select
 from sqlalchemy import text as sa_text
@@ -96,23 +97,36 @@ def _lock_source_ref(db: Session, user_id: str, source_ref: str) -> None:
 
 
 def replace_personal_text(
-    db: Session, user_id: str, text: str, *, domain: str, source: str,
-    source_ref: str, title: str = "",
+    db: Session, user_id: str, *, domain: str, source: str, source_ref: str,
+    load_text: Callable[[], str | None], title: str = "",
 ) -> int:
-    """기록이 바뀌었을 때 그 기록의 개인 문서를 통째로 갈아 끼운다 (#603).
+    """기록이 바뀌었을 때 그 기록의 개인 문서를 통째로 갈아 끼운다 (#603, #614).
 
-    순서가 중요하다:
-      1. **먼저 임베딩한다.** 벡터 생성이 실패해도 이 시점엔 아무것도 지우지 않았다.
-         지우고 나서 임베딩하면 실패했을 때 기존 청크를 되살릴 방법이 없다.
-      2. 삭제와 삽입을 **한 트랜잭션**으로 커밋한다. 둘을 따로 커밋하면 그 사이에
-         검색이 들어와 근거가 하나도 없는 순간을 본다.
+    **본문을 받지 않고 [load_text] 로 받는다.** 잠금을 잡은 뒤 원본 행을 다시 읽어
+    본문을 만들기 때문이다. 값을 미리 받아 두면 이런 일이 생긴다(#614):
 
-    빈 내용이면 기존 문서만 지운다 — 기록이 비워진 것도 반영해야 할 변화다.
+        A: 30분으로 수정 커밋 → B: 45분으로 수정 커밋 → B 적재(45) → A 적재(30)
+
+    DB 는 45분인데 코치가 보는 근거는 30분이 된다. 잠금 안에서 다시 읽으면 두
+    호출 모두 그 시점의 최신 행을 보므로, 늦게 도착한 쪽도 45분을 쓴다.
+
+    나머지 순서는 그대로다:
+      1. 삭제 **전에** 임베딩한다. 벡터 생성이 실패해도 아직 아무것도 지우지 않았다.
+      2. 삭제와 삽입을 **한 트랜잭션**으로 커밋한다. 따로 커밋하면 그 사이에 검색이
+         들어와 근거가 하나도 없는 순간을 본다.
+
+    [load_text] 가 None 이나 빈 문자열을 주면 기존 문서만 지운다 — 원본이 지워졌거나
+    내용이 비워진 것도 반영해야 할 변화다.
+
+    임베딩을 잠금 안에서 돌리므로 그만큼 잠금을 오래 쥔다. 잠금이 기록 하나 단위라
+    경쟁하는 쪽은 **같은 기록을 동시에 고치는 요청**뿐이고, 그건 드물다.
     """
-    chunks = chunk_text(text)
+    _lock_source_ref(db, user_id, source_ref)
+
+    text = load_text()
+    chunks = chunk_text(text) if text else []
     vectors = get_embedder().embed(chunks) if chunks else []
 
-    _lock_source_ref(db, user_id, source_ref)
     db.execute(
         delete(CoachDocument).where(
             CoachDocument.user_id == user_id,

--- a/backend/app/services/diet_service.py
+++ b/backend/app/services/diet_service.py
@@ -21,7 +21,7 @@ from app.schemas.diet import DietAnalysis, RecognizedFood
 from app.schemas.diet_api import (
     DietEntryOut, DietEntryUpdate, DietTodayResponse, calculate_macros,
 )
-from app.services.coach.personal_ingest import record_diet
+from app.services.coach.personal_ingest import record_diet, refresh_diet
 
 logger = logging.getLogger(__name__)
 
@@ -206,9 +206,6 @@ def apply_entry_update(db: Session, entry: DietEntry, payload: DietEntryUpdate) 
     out = _entry_out(entry)
     # 코치가 보는 근거도 함께 바뀌어야 한다(#603). 안 바꾸면 나트륨을 정정해도
     # 코치는 계속 옛 수치로 조언한다.
-    record_diet(
-        db, entry.user_id, date=entry.date, foods=load_foods(entry.foods_json),
-        total_calories=entry.total_calories, sodium_mg=entry.sodium_mg,
-        sugar_g=entry.sugar_g, source_ref=entry.id, replace=True,
-    )
+    # id 만 넘긴다 — 갱신은 잠금 안에서 행을 다시 읽는다(#614).
+    refresh_diet(db, entry.user_id, entry_id=entry.id)
     return out

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -1122,14 +1122,10 @@ def complete_session(
         # 회원 입장에서 PT 도 '내가 한 운동'이라 코치가 검색할 수 있어야 한다(#586).
         # 커밋 뒤에 부르는 이유는 record_chat 과 같다 — 적재 실패의 롤백이 응답을
         # 깨뜨리지 않도록, 값은 미리 뽑아 두고 응답도 이미 만들어 둔다.
-        personal_ingest.record_exercise(
-            db, exercise_log.user_id, date=s.date,
-            exercise_type=exercise_log.type,
-            minutes=exercise_log.minutes, calories=exercise_log.calories,
-            intensity=exercise_log.intensity, source_ref=exercise_log.id,
-            # PT 완료는 멱등하게 재호출될 수 있고 id 도 슬롯 기준 결정론적이라
-            # (`_derived_exercise_id`), 교체로 두어야 문서가 겹쳐 쌓이지 않는다.
-            replace=True,
+        # PT 완료는 멱등하게 재호출될 수 있고 id 도 슬롯 기준 결정론적이라
+        # (`_derived_exercise_id`), 교체로 두어야 문서가 겹쳐 쌓이지 않는다.
+        personal_ingest.refresh_exercise(
+            db, exercise_log.user_id, session_id=exercise_log.id
         )
     return out
 

--- a/backend/tests/test_rag_doc_refresh.py
+++ b/backend/tests/test_rag_doc_refresh.py
@@ -424,3 +424,105 @@ def test_broken_food_json_never_raises(raw):
     assert personal_ingest.diet_text(
         date="2026-08-11", foods=foods, total_calories=1, sodium_mg=1, sugar_g=1.0
     )
+
+
+# ---- 완료 순서 역전 (CodeRabbit PR#619 리뷰) ----
+
+def test_the_older_refresh_finishing_last_still_leaves_the_latest_value(
+    client, db_session
+):
+    """먼저 시작한 갱신이 **마지막에 끝나도** 최종 근거는 DB 최신값이어야 한다.
+
+    앞선 테스트는 "잠금 안에서 다시 읽는다"는 메커니즘만 본다. 진짜 위험한 순서는
+    이것이다:
+
+        A 호출(행=30) → B 호출(행=45) → B 적재(45) → **A 적재**
+
+    A 가 호출 시점의 30 을 들고 있으면 마지막 쓰기가 30 이 되어, DB 는 45 인데
+    코치는 30 을 근거로 답한다. 그래서 A 를 **잠금에 들어가기 직전에** 세워 둔다 —
+    값을 들고 다니던 설계와 다시 읽는 설계가 갈리는 지점이 정확히 거기다.
+    """
+    import threading
+
+    from app.db.session import SessionLocal
+    from app.models.models import ExerciseSession
+    from app.services.coach import personal_ingest
+
+    token = _member_token(client)
+    created = client.post(
+        "/v1/exercise/sessions",
+        headers=_headers(token),
+        json={"type": "walking", "minutes": 30, "calories": 100, "intensity": "light"},
+    )
+    assert created.status_code == 201, created.text
+    session_id = created.json()["id"]
+    user_id = db_session.scalar(
+        select(ExerciseSession.user_id).where(ExerciseSession.id == session_id)
+    )
+
+    original_replace = personal_ingest.replace_personal_text
+    at_the_gate = threading.Event()  # A 가 잠금 직전까지 왔다
+    let_a_go = threading.Event()     # B 가 끝난 뒤 A 를 들여보낸다
+    first_call = threading.Lock()
+    seen = {"first": False}
+
+    def _gated_replace(*args, **kwargs):
+        with first_call:
+            is_a = not seen["first"]
+            seen["first"] = True
+        if is_a:
+            # A 만 세운다. 이 지점은 잠금·재조회 **이전**이라, 값을 미리 읽어 두는
+            # 설계였다면 A 는 이미 30 을 손에 쥔 상태다.
+            at_the_gate.set()
+            assert let_a_go.wait(timeout=30), "A 를 들여보내지 못했다"
+        return original_replace(*args, **kwargs)
+
+    personal_ingest.replace_personal_text = _gated_replace  # type: ignore[assignment]
+    errors: list[BaseException] = []
+
+    def _refresh_in_own_session() -> None:
+        db = SessionLocal()
+        try:
+            personal_ingest.refresh_exercise(db, user_id, session_id=session_id)
+        except BaseException as exc:  # noqa: BLE001 - 스레드 예외를 본체로 옮긴다
+            errors.append(exc)
+        finally:
+            db.close()
+
+    try:
+        a = threading.Thread(target=_refresh_in_own_session, daemon=True)
+        a.start()
+        assert at_the_gate.wait(timeout=30), "A 가 잠금 직전까지 오지 못했다"
+
+        # A 가 멈춰 있는 사이 행이 45 로 바뀐다.
+        writer = SessionLocal()
+        try:
+            row = writer.scalar(
+                select(ExerciseSession).where(ExerciseSession.id == session_id)
+            )
+            row.minutes = 45
+            writer.commit()
+        finally:
+            writer.close()
+
+        # B 를 **끝까지** 돌린다. 여기서 문서는 45 가 된다.
+        b = threading.Thread(target=_refresh_in_own_session, daemon=True)
+        b.start()
+        b.join(timeout=60)
+        assert not b.is_alive(), "B 가 끝나지 않았다"
+
+        # 이제 A 가 마지막으로 쓴다.
+        let_a_go.set()
+        a.join(timeout=60)
+        assert not a.is_alive(), "A 가 끝나지 않았다"
+    finally:
+        personal_ingest.replace_personal_text = original_replace  # type: ignore[assignment]
+        let_a_go.set()
+
+    assert not errors, f"갱신 중 예외: {errors!r}"
+
+    db_session.expire_all()
+    contents = [d.content for d in _docs_for(db_session, session_id)]
+    assert contents, "겹쳐 돌린 뒤 근거가 사라지면 안 된다"
+    assert all("45분" in c for c in contents), contents
+    assert not any("30분" in c for c in contents), contents

--- a/backend/tests/test_rag_doc_refresh.py
+++ b/backend/tests/test_rag_doc_refresh.py
@@ -211,8 +211,8 @@ def test_a_failed_embedding_leaves_the_old_documents_intact(
     user_id = "user-demo"
     ref = "atomicity-probe-1"
     rag.replace_personal_text(
-        db_session, user_id, "2026-08-11 운동 기록: 걷기 30분.",
-        domain="exercise", source="exercise", source_ref=ref,
+        db_session, user_id, domain="exercise", source="exercise", source_ref=ref,
+        load_text=lambda: "2026-08-11 운동 기록: 걷기 30분.",
     )
     before = [d.content for d in _docs_for(db_session, ref)]
     assert before, "먼저 적재돼 있어야 이 테스트가 의미를 갖는다"
@@ -225,8 +225,9 @@ def test_a_failed_embedding_leaves_the_old_documents_intact(
 
     try:
         rag.replace_personal_text(
-            db_session, user_id, "2026-08-11 운동 기록: 걷기 45분.",
-            domain="exercise", source="exercise", source_ref=ref,
+            db_session, user_id, domain="exercise", source="exercise",
+            source_ref=ref,
+            load_text=lambda: "2026-08-11 운동 기록: 걷기 45분.",
         )
     except RuntimeError:
         pass
@@ -241,8 +242,8 @@ def test_replacing_never_exposes_a_moment_with_no_evidence(client, db_session):
     user_id = "user-demo"
     ref = "atomicity-probe-2"
     rag.replace_personal_text(
-        db_session, user_id, "2026-08-11 운동 기록: 걷기 30분.",
-        domain="exercise", source="exercise", source_ref=ref,
+        db_session, user_id, domain="exercise", source="exercise", source_ref=ref,
+        load_text=lambda: "2026-08-11 운동 기록: 걷기 30분.",
     )
 
     # 커밋 직전에 세션이 들고 있는 새 문서 수를 기록한다. 세션은 autoflush=False 라
@@ -259,8 +260,9 @@ def test_replacing_never_exposes_a_moment_with_no_evidence(client, db_session):
     db_session.commit = _counting_commit  # type: ignore[method-assign]
     try:
         rag.replace_personal_text(
-            db_session, user_id, "2026-08-11 운동 기록: 걷기 45분.",
-            domain="exercise", source="exercise", source_ref=ref,
+            db_session, user_id, domain="exercise", source="exercise",
+            source_ref=ref,
+            load_text=lambda: "2026-08-11 운동 기록: 걷기 45분.",
         )
     finally:
         db_session.commit = original  # type: ignore[method-assign]
@@ -277,14 +279,14 @@ def test_emptying_a_record_clears_its_evidence(client, db_session):
     user_id = "user-demo"
     ref = "atomicity-probe-3"
     rag.replace_personal_text(
-        db_session, user_id, "2026-08-11 운동 기록: 걷기 30분.",
-        domain="exercise", source="exercise", source_ref=ref,
+        db_session, user_id, domain="exercise", source="exercise", source_ref=ref,
+        load_text=lambda: "2026-08-11 운동 기록: 걷기 30분.",
     )
     assert _docs_for(db_session, ref)
 
     rag.replace_personal_text(
-        db_session, user_id, "   ", domain="exercise", source="exercise",
-        source_ref=ref,
+        db_session, user_id, domain="exercise", source="exercise",
+        source_ref=ref, load_text=lambda: "   ",
     )
     db_session.expire_all()
 
@@ -304,3 +306,72 @@ def test_public_documents_keep_a_null_reference(client, db_session):
         )
     )
     assert count == 0
+
+
+# ---- 최신성 보장 (#614) ----
+
+def test_a_late_arriving_refresh_still_writes_the_current_row(client, db_session):
+    """늦게 도착한 갱신이 옛 값을 되살리면 안 된다.
+
+    두 수정이 이렇게 엇갈릴 수 있다:
+        A: 30분 커밋 → B: 45분 커밋 → B 적재(45) → **A 적재**
+    A 가 자기가 읽은 30분을 쓰면 DB 는 45분인데 근거는 30분이 된다. 갱신이 잠금
+    안에서 행을 다시 읽으므로, 늦게 도착한 A 도 45분을 써야 한다.
+    """
+    from app.models.models import ExerciseSession
+    from app.services.coach import personal_ingest
+
+    token = _member_token(client)
+    created = client.post(
+        "/v1/exercise/sessions",
+        headers=_headers(token),
+        json={"type": "walking", "minutes": 30, "calories": 100, "intensity": "light"},
+    )
+    assert created.status_code == 201, created.text
+    session_id = created.json()["id"]
+
+    row = db_session.scalar(
+        select(ExerciseSession).where(ExerciseSession.id == session_id)
+    )
+    user_id = row.user_id
+
+    # DB 를 45분으로 바꾼다 — "B 가 이미 커밋한" 상태.
+    row.minutes = 45
+    db_session.commit()
+
+    # 이제 "A 의 늦은 적재" 가 도착한다. 30분을 넘겨 줄 방법이 없다 — 갱신은
+    # id 만 받고 행을 다시 읽는다.
+    personal_ingest.refresh_exercise(db_session, user_id, session_id=session_id)
+    db_session.expire_all()
+
+    contents = [d.content for d in _docs_for(db_session, session_id)]
+    assert contents, "갱신 후 근거가 있어야 한다"
+    assert all("45분" in c for c in contents)
+    assert not any("30분" in c for c in contents)
+
+
+def test_refreshing_a_deleted_record_clears_its_evidence(client, db_session):
+    """원본이 사라졌으면 근거도 사라져야 한다 — 지운 기록이 되살아나면 안 된다."""
+    from app.models.models import ExerciseSession
+    from app.services.coach import personal_ingest
+
+    token = _member_token(client)
+    created = client.post(
+        "/v1/exercise/sessions",
+        headers=_headers(token),
+        json={"type": "yoga", "minutes": 20, "calories": 60, "intensity": "moderate"},
+    )
+    session_id = created.json()["id"]
+    row = db_session.scalar(
+        select(ExerciseSession).where(ExerciseSession.id == session_id)
+    )
+    user_id = row.user_id
+    assert _docs_for(db_session, session_id)
+
+    db_session.delete(row)
+    db_session.commit()
+
+    personal_ingest.refresh_exercise(db_session, user_id, session_id=session_id)
+    db_session.expire_all()
+
+    assert _docs_for(db_session, session_id) == []

--- a/backend/tests/test_rag_doc_refresh.py
+++ b/backend/tests/test_rag_doc_refresh.py
@@ -6,6 +6,7 @@
 """
 from __future__ import annotations
 
+import pytest
 from sqlalchemy import func, select
 
 from app.models.models import CoachDocument
@@ -375,3 +376,51 @@ def test_refreshing_a_deleted_record_clears_its_evidence(client, db_session):
     db_session.expire_all()
 
     assert _docs_for(db_session, session_id) == []
+
+
+# ---- 깨진 foods_json (CodeRabbit PR#616 리뷰) ----
+
+def test_a_malformed_food_list_still_refreshes_the_evidence(client, db_session):
+    """항목이 dict 이 아니어도 갱신은 끝나야 한다.
+
+    예전엔 diet_text 가 `f.get(...)` 에서 터지고 _safe_replace 가 그 예외를 삼켜,
+    수정했는데도 **옛 수치 문서가 그대로 남았다**. 조용히 실패하는 경로라 화면에서
+    알아챌 방법이 없다.
+    """
+    from app.models.models import DietEntry
+    from app.services.coach import personal_ingest
+
+    entry_id = _log_meal(db_session)
+    assert any("1800mg" in d.content for d in _docs_for(db_session, entry_id))
+
+    row = db_session.scalar(select(DietEntry).where(DietEntry.id == entry_id))
+    # 항목이 문자열·숫자인 목록. 저장된 JSON 이 늘 dict 목록이라는 보장은 없다.
+    row.foods_json = '["김치찌개", 42, null]'
+    row.sodium_mg = 900
+    db_session.commit()
+
+    personal_ingest.refresh_diet(db_session, row.user_id, entry_id=entry_id)
+    db_session.expire_all()
+
+    docs = _docs_for(db_session, entry_id)
+    assert docs, "갱신이 삼켜지면 옛 문서만 남는다"
+    assert any("900mg" in d.content for d in docs)
+    assert all("1800mg" not in d.content for d in docs)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ['["문자열만"]', "[1, 2, 3]", '{"not": "a list"}', "{{{ 깨진 json", "", "null"],
+)
+def test_broken_food_json_never_raises(raw):
+    """파싱 경계에서 걸러 내므로 어떤 값이 와도 본문 생성이 죽지 않는다."""
+    from app.services.coach import personal_ingest
+
+    foods = personal_ingest._entry_foods(raw)
+
+    assert isinstance(foods, list)
+    assert all(isinstance(f, dict) for f in foods)
+    # 본문 생성까지 통과해야 갱신이 끝난다.
+    assert personal_ingest.diet_text(
+        date="2026-08-11", foods=foods, total_calories=1, sodium_mg=1, sugar_g=1.0
+    )


### PR DESCRIPTION
## Summary

* 갱신 호출자가 **자기가 읽은 값**을 넘겨서, 두 수정이 역순으로 적재되면 옛 값이 최종 문서로 남았습니다. DB 는 45분인데 코치는 30분을 근거로 답하는 상태입니다.
* 이제 **id 만 넘기고**, 갱신이 잠금 안에서 원본 행을 다시 읽어 본문을 만듭니다.
* 마이그레이션 없이 해결했습니다.

---

## Changes

### 🐛 Fixes

* `replace_personal_text` 가 본문 대신 `load_text` 콜백을 받습니다. 잠금 획득 **뒤** 원본을 다시 읽으므로, 늦게 도착한 갱신도 그 시점의 최신 행을 씁니다.
* `record_*` 의 `replace` 플래그를 걷어내고 `refresh_exercise` / `refresh_diet` 를 신설했습니다. 호출부 3곳(운동 PUT · 식단 PUT · PT 완료)이 값 대신 id 만 넘깁니다.
* 원본이 그 사이 삭제됐으면 `load_text` 가 `None` 을 주고 근거도 지웁니다 — 지운 기록이 되살아나지 않습니다.

### 🔧 Improvements

* 본문 생성을 `exercise_text` / `diet_text` 로 분리해, 최초 적재와 갱신이 같은 문구를 쓰도록 한 곳에 모았습니다.

---

## Commits

1. `bb3695ce` fix(ai): reread the record when refreshing its evidence

---

## Notes

* **이슈에 적었던 버전 컬럼 방식은 쓰지 않았습니다.** 검토해 보니 그 방식으로는 안 풀립니다. PostgreSQL 의 `now()` 는 **트랜잭션 시작 시각**이라, A 가 먼저 시작해 나중에 커밋하면 행의 최종값은 A 인데 `updated_at` 은 B 보다 작습니다. 버전으로 거르면 문서는 B, 행은 A 가 되어 **반대 방향 불일치**가 납니다. 마이그레이션을 둘 추가하고도 문제가 남습니다.
* **값을 넘기지 않는 쪽이 근본 해법입니다.** 두 동시 갱신이 모두 "현재 행" 을 읽으므로 같은 결과로 수렴합니다. 누가 먼저 잠금을 잡든 최종 문서는 DB 와 일치합니다.
* **트레이드오프 — 임베딩이 잠금 안에서 돕니다.** 그만큼 잠금을 오래 쥡니다. 다만 잠금이 **기록 하나 단위**라 경쟁 상대는 같은 기록을 동시에 고치는 요청뿐이고, 그건 드뭅니다. 코드 주석에 남겼습니다.
* **채팅은 대상이 아닙니다** — 수정·삭제 경로가 없습니다.
* #603 에서 넣은 원자성(삭제 전 임베딩, 한 트랜잭션 커밋)은 그대로입니다. 테스트도 새 시그니처로 유지했습니다.

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [ ] UI 확인 <!-- 프론트 변경 없음 -->
* [x] 빌드 성공
* [x] 관련 테스트 통과

`tests/test_rag_doc_refresh.py` 에 2건 추가:
**늦게 도착한 갱신도 현재 행을 쓴다**(DB 를 45분으로 바꾼 뒤 "A 의 늦은 적재" 를 재현 — 30분을 넘길 방법 자체가 없다), **삭제된 원본의 근거가 사라진다**.
기존 원자성 3건은 새 시그니처로 맞췄습니다.

백엔드 전체 스위트를 **새로 만든 DB** 에서 통과시켰습니다(실패 0).

### Manual Test Steps

1. 회원 앱에서 운동 기록(걷기 30분) 추가 → AI 코치에 "이번 주 운동" 질문, 30분이 근거로 잡히는지 확인.
2. 같은 기록을 45분으로 수정 → 다시 질문, **45분만** 나오는지 확인.
3. 그 기록을 삭제 → 근거에서 사라지는지 확인.
4. 식단 기록의 나트륨을 정정하고 같은 순서로 확인.

---

## Related Issues

Closes #614

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 운동 및 식단 기록 수정 시 최신 저장 내용이 코칭 데이터에 정확히 반영됩니다.
  * 늦게 처리된 갱신도 현재 기록 기준으로 반영되어 오래된 정보가 남는 문제를 줄였습니다.
  * 기록이 삭제되면 관련 코칭 근거도 함께 정리됩니다.
  * 식단 정보가 일부 잘못된 형식이어도 코칭 데이터 갱신이 중단되지 않습니다.
  * 코칭 데이터 처리 오류가 원본 운동·식단 기록 저장에 영향을 주지 않습니다.

* **버그 수정**
  * 수정 전 기록이 코칭에 표시될 수 있는 문제를 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->