### PR TITLE
docs(backend): AI 지표 표에 busy·timeout 폴백 사유 추가

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -59,6 +59,8 @@ curl -H "Authorization: Bearer $ADMIN_TOKEN" http://localhost:8000/v1/system/met
 | --- | --- |
 | `routine_options.generated{by=ai}` | LLM 이 만든 루틴. **0 이면 AI 경로가 죽은 것** |
 | `routine_options.generated{by=rule}` | 폴백으로 만든 루틴 |
+| `routine_options.fallback{reason=busy}` | 동시 호출 한도 초과 → `LLM_MAX_CONCURRENCY` 를 본다 |
+| `routine_options.fallback{reason=timeout}` | `LLM_TIMEOUT_SEC` 초과 → 아래 `llm_ms` 와 함께 본다 |
 | `routine_options.fallback{reason=contract}` | 응답 규격 위반 → 프롬프트·스키마를 본다 |
 | `routine_options.fallback{reason=infra}` | 키 미설정·설정 오타·네트워크·5xx |
 | `routine_options.with_chat_context` | 채팅 근거가 실린 채 AI 가 성공한 횟수(#580) |
@@ -67,8 +69,16 @@ curl -H "Authorization: Bearer $ADMIN_TOKEN" http://localhost:8000/v1/system/met
 | `diet_recommendations.generated{by=no_data}` | 근거가 없어 LLM 을 부르지 않음(신규 가입자) |
 | `diet_recommendations.fallback{reason=busy\|timeout\|error}` | 동시 호출 한도·타임아웃·그 외 실패 |
 
-`durations` 에는 `routine_options.llm_ms` 가 count/avg/max 로 들어온다 — #584 의
-타임아웃 값을 정할 근거다. 관리자는 `.env` 의 `ADMIN_EMAILS` 로 지정한다.
+사유가 넷인 이유는 볼 곳이 다르기 때문이다. `busy`·`timeout` 은 **공급자는 멀쩡한데
+우리 쪽 상한에 걸린 것**이라 동시성·타임아웃 설정을 조정할 신호이고, `contract` 는
+프롬프트나 스키마를, `infra` 는 키·네트워크를 본다. 한 칸에 뭉쳐 세면 이 구분이
+사라진다.
+
+`durations` 에는 `routine_options.llm_ms` 가 count/avg/max 로 들어온다. `timeout` 이
+쌓이는데 `avg_ms` 가 `LLM_TIMEOUT_SEC` 에 못 미치면 몇 건이 유난히 느린 것이므로
+`max_ms` 를 본다.
+
+관리자는 `.env` 의 `ADMIN_EMAILS` 로 지정한다.
 값은 프로세스 메모리에 있어 재시작하면 사라진다(단일 인스턴스 기준).
 
 ## 프론트 연동 (실서버 전환)

--- a/backend/tests/test_metrics_docs.py
+++ b/backend/tests/test_metrics_docs.py
@@ -1,0 +1,91 @@
+"""README 의 지표 표가 실제로 나오는 키와 일치하는가 (#615).
+
+표는 "`counters` 에 들어오는 키" 를 전부 적는다고 선언한다. 그런데 #584 가 사유
+둘(busy·timeout)을 추가하면서 표는 그대로였고, 지표를 보다 문서에 없는 값을 만나면
+"이상 동작" 으로 읽혀 원인 파악이 늦어졌다.
+
+사람이 매번 맞추는 대신 여기서 잡는다 — 사유가 늘면 이 테스트가 먼저 깨진다.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+_README = pathlib.Path(__file__).resolve().parents[1] / "README.md"
+_SOURCES = [
+    pathlib.Path(__file__).resolve().parents[1]
+    / "app" / "services" / "trainer_routine_options_service.py",
+    pathlib.Path(__file__).resolve().parents[1]
+    / "app" / "services" / "diet_recommendation_service.py",
+]
+
+#: `metrics.incr("name", label="value")` 와 `_record(..., reason="value")` 를 모두 잡는다.
+_INCR = re.compile(r'metrics\.incr\(\s*"([\w.]+)"(?:\s*,\s*(\w+)="([\w]+)")?')
+_RECORD_REASON = re.compile(r'_record\([^)]*reason="(\w+)"')
+
+
+def _emitted_keys() -> set[str]:
+    """코드가 실제로 올리는 카운터 키를 모은다."""
+    labelled: set[str] = set()
+    bare: set[str] = set()
+    reasons: set[str] = set()
+    for path in _SOURCES:
+        src = path.read_text(encoding="utf-8")
+        for name, label, value in _INCR.findall(src):
+            if label:
+                labelled.add(f"{name}{{{label}={value}}}")
+            else:
+                bare.add(name)
+        reasons.update(_RECORD_REASON.findall(src))
+
+    # `_record` 는 사유를 받아 routine_options.fallback 으로 올린다.
+    labelled.update(f"routine_options.fallback{{reason={r}}}" for r in reasons)
+
+    # 라벨 값이 변수인 호출(`reason=reason`)은 정규식이 이름만 잡는다. 같은 이름의
+    # 라벨 키가 이미 있으면 그 bare 항목은 파싱 부산물이므로 버린다.
+    named = {key.split("{", 1)[0] for key in labelled}
+    return labelled | {name for name in bare if name not in named}
+
+
+def _documented_keys() -> set[str]:
+    """README 표의 첫 칸에서 백틱으로 감싼 키를 뽑는다."""
+    documented: set[str] = set()
+    for line in _README.read_text(encoding="utf-8").splitlines():
+        if not line.startswith("| `"):
+            continue
+        # 셀 구분은 **이스케이프되지 않은** 파이프다. 표 안의 `reason=a\|b` 를
+        # 그냥 split 하면 키가 중간에서 잘린다.
+        key = re.split(r"(?<!\\)\|", line)[1].strip().strip("`")
+        # `reason=busy|timeout|error` 처럼 한 행이 여러 값을 묶은 경우를 펼친다.
+        match = re.match(r"^([\w.]+)\{(\w+)=([\w\\|]+)\}$", key)
+        if match:
+            name, label, values = match.groups()
+            for value in values.replace("\\", "").split("|"):
+                documented.add(f"{name}{{{label}={value}}}")
+        else:
+            documented.add(key)
+    return documented
+
+
+def test_every_emitted_counter_is_documented():
+    missing = _emitted_keys() - _documented_keys()
+
+    assert not missing, f"README 지표 표에 없는 카운터: {sorted(missing)}"
+
+
+def test_the_table_does_not_document_counters_that_no_longer_exist():
+    """지워진 지표가 표에 남으면 없는 값을 찾게 만든다."""
+    stale = {
+        key for key in _documented_keys() - _emitted_keys()
+        if key.startswith(("routine_options.", "diet_recommendations."))
+    }
+
+    assert not stale, f"코드에 없는데 표에 남은 카운터: {sorted(stale)}"
+
+
+@pytest.mark.parametrize("reason", ["busy", "timeout", "contract", "infra"])
+def test_the_routine_fallback_reasons_are_all_listed(reason):
+    """사유마다 볼 곳이 달라서, 하나라도 빠지면 그 경로만 진단이 막힌다."""
+    assert f"routine_options.fallback{{reason={reason}}}" in _documented_keys()


### PR DESCRIPTION
## Summary

* `backend/README.md` 의 지표 표는 `counters` 에 들어오는 키를 **전부** 적는다고 선언하는데, #584 가 추가한 `reason=busy` · `reason=timeout` 이 빠져 있었습니다.
* 지표를 보다 이 둘을 만나면 "문서에 없는 값" 으로 읽혀 원인 파악이 늦어집니다.
* 표만 고치면 다음에 또 밀리므로, **표와 코드를 대조하는 테스트**를 함께 넣었습니다.

---

## Changes

### 📝 Docs

* 빠졌던 두 행 추가. 각 사유가 가리키는 조치를 함께 적었습니다 — `busy` → `LLM_MAX_CONCURRENCY`, `timeout` → `LLM_TIMEOUT_SEC` 과 `llm_ms`.
* 사유가 넷인 **이유**를 한 문단으로 정리했습니다. `busy`·`timeout` 은 공급자가 아니라 우리 쪽 상한에 걸린 것이라 볼 곳이 다릅니다. 한 칸에 뭉치면 이 구분이 사라집니다.
* `durations` 설명 현행화 — 원문은 "#584 의 타임아웃 값을 정할 근거" 였는데 #584 는 이미 머지됐습니다. `timeout` 이 쌓이는데 `avg_ms` 가 낮으면 `max_ms` 를 보라는 사용법으로 바꿨습니다.

### 🔧 Improvements

* `tests/test_metrics_docs.py` — 서비스 소스에서 실제 방출 키를 뽑아 표와 **양방향** 비교합니다. 방출됐는데 문서에 없어도, 문서에만 있고 코드에 없어도 실패합니다.

---

## Commits

1. `2212e8c9` docs(backend): list every fallback reason the metrics emit

---

## Notes

* **테스트가 실제로 잡는지 확인했습니다.** `timeout` 행을 임시로 지우고 돌려 2건이 실패하는 것을 보고 되돌렸습니다. 통과만 확인하면 표를 안 읽는 테스트여도 초록불이 뜹니다.
* **만들다 파서 버그를 둘 잡았습니다.** 라벨 값이 변수인 호출(`metrics.incr("...", reason=reason)`)을 이름만으로 오인해 실재하지 않는 bare 키를 만들던 것과, 마크다운 표의 셀을 **이스케이프된** `\|` 에서도 잘라 키가 중간에서 끊기던 것입니다.
* 이 브랜치는 다른 작업 스택과 겹치지 않아 `main` 에 바로 올라갑니다.

---

## Test Plan

* [x] 기능 정상 동작 확인 <!-- 문서 + 테스트, 런타임 동작 변경 없음 -->
* [x] 예외 케이스 확인
* [ ] UI 확인
* [x] 빌드 성공
* [x] 관련 테스트 통과

백엔드 전체 스위트를 **새로 만든 DB** 에서 통과시켰습니다(실패 0).

### Manual Test Steps

1. 관리자 토큰으로 `GET /v1/system/metrics` 호출.
2. `counters` 에 나오는 키가 README 표에 전부 있는지 대조.
3. `.env` 의 `LLM_TIMEOUT_SEC` 을 1초로 낮추고 AI 루틴 생성 → `fallback{reason=timeout}` 이 오르고, 표에서 그 뜻을 찾을 수 있는지 확인.

---

## Related Issues

Closes #615

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인