### PR TITLE
fix(diet): 식단 저장소 통일과 REAL_API 경로 입도 재설계

### DIFF
--- a/frontend/flutter/docs/API_CATALOG.md
+++ b/frontend/flutter/docs/API_CATALOG.md
@@ -91,7 +91,7 @@
 
 | Method | Path | Body / Query | 응답 | Flutter 사용처 |
 | --- | --- | --- | --- | --- |
-| GET | `/diet/days/today` | — | `DietDay` | `MockDietRepository.fetchToday` |
+| GET | `/diet/days/today` | — | `DietDay` | `DioDietRepository.fetchToday` (데모는 `LocalApiInterceptor` 가 응답) |
 | GET | `/diet/days/{date}` | `date=YYYY-MM-DD` | `DietDay` | (캘린더 진입 시) |
 | POST | `/diet/entries` | `DietEntry` (without id) | 생성된 `DietEntry` | FAB "식단 추가" |
 | PATCH | `/diet/entries/{id}` | partial `DietEntry` | 갱신된 entry | 식사 수정 |

--- a/frontend/flutter/docs/API_CATALOG.md
+++ b/frontend/flutter/docs/API_CATALOG.md
@@ -91,12 +91,19 @@
 
 | Method | Path | Body / Query | 응답 | Flutter 사용처 |
 | --- | --- | --- | --- | --- |
-| GET | `/diet/days/today` | — | `DietDay` | `DioDietRepository.fetchToday` (데모는 `LocalApiInterceptor` 가 응답) |
-| GET | `/diet/days/{date}` | `date=YYYY-MM-DD` | `DietDay` | (캘린더 진입 시) |
-| POST | `/diet/entries` | `DietEntry` (without id) | 생성된 `DietEntry` | FAB "식단 추가" |
-| PATCH | `/diet/entries/{id}` | partial `DietEntry` | 갱신된 entry | 식사 수정 |
-| DELETE | `/diet/entries/{id}` | — | `204` | 식사 삭제 |
-| POST | `/diet/photo-scan` | `multipart/form-data: file` | `{candidates: FoodItem[]}` | (Stage 4 후속 — 카메라) |
+| GET | `/diet/days/today` | — | `DietDay` | `DioDietRepository.fetchToday` |
+| GET | `/diet/days/{date}` | `date=YYYY-MM-DD` | `DietDay` | `fetchByDate` — 날짜 이동 |
+| GET | `/diet/recommendations` | — | `MealRecommendations` | 홈 "AI 추천 식단" |
+| POST | `/diet/analyze` | `multipart/form-data: image, meal_type, idempotency_key?` | `{entry_id, analysis}` | 사진으로 식단 추가 |
+| PUT | `/diet/entries/{id}` | partial `DietEntry` | 갱신된 `DietEntry` | 식사 수정 |
+| DELETE | `/diet/entries/{id}` | — | `{status: "deleted"}` | 식사 삭제 |
+
+끼니를 만드는 경로는 **사진 분석 하나뿐이다.** 별도의 생성 엔드포인트는 없다 — 인식
+결과가 곧 기록이고, 사용자가 고칠 것은 수정으로 처리한다. `idempotency_key` 는 응답을
+잃은 재시도가 같은 끼니를 두 번 남기지 않게 한다(요청당 1회 생성해 재시도에 재사용).
+
+데모 빌드에서는 이 표의 모든 경로를 `LocalApiInterceptor` 가 drift 로 답한다. `REAL_API`
+로 분석만 실 백엔드에 맡길 수 있고, 그때도 조회·수정·삭제는 로컬이 답한다.
 
 `DietEntry`:
 ```json
@@ -107,7 +114,9 @@
   "foods": [{ "name": "오트밀", "calories": 220 }],
   "total_calories": 315,
   "sodium_mg": 380,
-  "sugar_g": 18
+  "sugar_g": 18,
+  "ai_comment": "오트밀로 식이섬유를 챙겼어요.",
+  "photo_asset": "assets/images/diet-oatmeal-banana.jpeg"
 }
 ```
 

--- a/frontend/flutter/lib/core/config/app_config.dart
+++ b/frontend/flutter/lib/core/config/app_config.dart
@@ -2,24 +2,57 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 enum Environment { dev, staging, prod }
 
-/// `REAL_API` 로 켤 수 있는 기능 키 → 실 백엔드로 보낼 경로 접두사.
+/// 실 백엔드로 넘길 엔드포인트 하나 — **메서드까지 함께** 본다.
 ///
-/// 목업 인터셉터가 가로채는 경로 중 **어디까지를 실 서버로 넘길지**를 여기 한 곳에서
+/// 경로 접두사만으로 판정하면 같은 접두사의 읽기까지 함께 열린다. 그것이 실제로
+/// 문제를 만들었기 때문에 메서드를 계약에 넣는다([kRealApiFeatures] 참고).
+class RealApiRoute {
+  /// 이 메서드 + 경로 접두사에 해당하는 요청을 실 백엔드로 보낸다.
+  const RealApiRoute(this.method, this.pathPrefix);
+
+  /// HTTP 메서드. 대문자로 적는다.
+  final String method;
+
+  /// 경로 접두사. `/` 로 시작한다.
+  final String pathPrefix;
+
+  /// [method]/[path] 요청이 이 경로에 해당하는가.
+  bool matches(String method, String path) =>
+      method.toUpperCase() == this.method && path.startsWith(pathPrefix);
+}
+
+/// `REAL_API` 로 켤 수 있는 기능 키 → 실 백엔드로 보낼 엔드포인트.
+///
+/// 목업 인터셉터가 가로채는 요청 중 **어디까지를 실 서버로 넘길지**를 여기 한 곳에서
 /// 정한다. 기능별로 임시 플래그(`REAL_AI_COACH`, `REAL_AUTH` …)를 각각 만들면
 /// `AppConfig` 와 인터셉터라는 같은 파일이 이슈마다 고쳐져 충돌하므로, 키 목록을 받는
 /// 스위치 하나로 통일한다.
 ///
-/// 새 기능을 켤 수 있게 하려면 여기에 키와 경로만 추가하면 된다 — 인터셉터는 손대지
-/// 않는다.
-const Map<String, List<String>> kRealApiFeatures = <String, List<String>>{
-  // AI 코치(온이) 대화·피드백. 리포지토리를 교체하지 않고 인터셉터만 가로채는
-  // 구조라, 경로만 흘려보내면 곧바로 실 Gemini 응답이 된다.
-  'ai-coach': <String>['/ai-coach'],
-  // 소셜 로그인 포함 인증. 실 OAuth 토큰을 서버가 검증하게 하려면 필요하다.
-  'auth': <String>['/auth'],
-  // 식단 기록·분석·추천.
-  'diet': <String>['/diet'],
-};
+/// ## 기준선: 쓰기만 실 서버, 읽기는 로컬 (#616)
+///
+/// 예전에는 키가 경로 접두사였다(`'ai-coach' → '/ai-coach'`). 그러면 켜는 순간 대화
+/// 전송뿐 아니라 **이력 조회까지** 실 서버로 갔고, 두 가지가 깨졌다.
+///
+///  * 코치 화면을 열 때 읽는 초기 이력이 데모 것에서 서버 것으로 바뀐다 — 데모 화면은
+///    스위치와 무관하게 지금 그대로여야 한다.
+///  * 배포 데모는 토큰이 없어 방문자 전원이 데모 계정 하나를 공유한다. 이력을 서버에서
+///    읽으면 다음 방문자가 앞 방문자의 질문을 그대로 보게 된다.
+///
+/// 그래서 여는 것은 **AI 가 실제로 일하는 호출(쓰기)** 뿐이다. 조회는 로컬 인터셉터가
+/// 계속 담당하므로 화면의 초기 상태가 움직이지 않는다.
+///
+/// 새 기능을 켤 수 있게 하려면 여기에 키와 엔드포인트만 추가한다 — 인터셉터는 손대지
+/// 않는다. 추가할 때도 같은 기준을 지킨다: 조회를 여는 것은 그럴 이유를 따로 적을 때뿐이다.
+const Map<String, List<RealApiRoute>> kRealApiFeatures =
+    <String, List<RealApiRoute>>{
+      // AI 코치(온이). 대화 전송만 실 서버로 — 이력·피드백 조회는 로컬이 준다.
+      'ai-coach': <RealApiRoute>[RealApiRoute('POST', '/ai-coach/chat')],
+      // 소셜 로그인 포함 인증. `/auth/*` 는 전부 쓰기(로그인·가입·소셜 교환)라
+      // 접두사 하나로 충분하다.
+      'auth': <RealApiRoute>[RealApiRoute('POST', '/auth')],
+      // 식단 사진 분석만 실 서버로 — 날짜별 조회·추천·수정·삭제는 로컬이 준다.
+      'diet': <RealApiRoute>[RealApiRoute('POST', '/diet/analyze')],
+    };
 
 class AppConfig {
   const AppConfig({
@@ -48,17 +81,21 @@ class AppConfig {
   ///
   /// 비어 있으면(기본값) 지금까지의 데모 동작과 **완전히 동일**하다.
   ///
-  /// 키 → 경로 대응은 [kRealApiFeatures] 참고.
+  /// 키 → 엔드포인트 대응은 [kRealApiFeatures] 참고.
   /// 예: `--dart-define=REAL_API=ai-coach,auth`
   final Set<String> realApiFeatures;
 
-  /// 이 경로를 목업이 아니라 실 백엔드로 보내야 하는가.
-  bool isRealApiPath(String path) {
+  /// 이 요청을 목업이 아니라 실 백엔드로 보내야 하는가.
+  ///
+  /// 경로만이 아니라 [method] 도 함께 받는다 — 같은 접두사의 조회까지 딸려 열리면
+  /// 데모 화면이 바뀌기 때문이다([kRealApiFeatures] 참고).
+  bool isRealApi(String method, String path) {
     if (realApiFeatures.isEmpty) return false;
     for (final String feature in realApiFeatures) {
-      final List<String> prefixes = kRealApiFeatures[feature] ?? const <String>[];
-      for (final String prefix in prefixes) {
-        if (path.startsWith(prefix)) return true;
+      final List<RealApiRoute> routes =
+          kRealApiFeatures[feature] ?? const <RealApiRoute>[];
+      for (final RealApiRoute route in routes) {
+        if (route.matches(method, path)) return true;
       }
     }
     return false;

--- a/frontend/flutter/lib/core/network/dio_client.dart
+++ b/frontend/flutter/lib/core/network/dio_client.dart
@@ -42,10 +42,10 @@ final dioProvider = Provider<Dio>((ref) {
         LocalApiInterceptor(
           ref.watch(appDatabaseProvider),
           logger,
-          isRealApiPath: config.isRealApiPath,
+          isRealApi: config.isRealApi,
         ),
       )
-      ..add(MockApiInterceptor(logger, isRealApiPath: config.isRealApiPath));
+      ..add(MockApiInterceptor(logger, isRealApi: config.isRealApi));
   }
   dio.interceptors.add(AuthInterceptor(ref));
   if (!config.isProd) {

--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -38,16 +38,18 @@ const Map<String, String> _seedDietPhotoAssets = <String, String>{
 /// `core/network/case_mapper.dart` so the contract matches the real
 /// server's Pydantic models.
 class LocalApiInterceptor extends Interceptor {
-  LocalApiInterceptor(this._db, this._logger, {this.isRealApiPath});
+  LocalApiInterceptor(this._db, this._logger, {this.isRealApi});
 
   final AppDatabase _db;
   final Logger _logger;
 
-  /// 이 경로를 목업이 아니라 실 백엔드로 보내야 하는지 판정한다(`AppConfig.isRealApiPath`).
+  /// 이 요청을 목업이 아니라 실 백엔드로 보내야 하는지 판정한다(`AppConfig.isRealApi`).
   ///
   /// 주입받는 이유는 이 인터셉터가 설정에 직접 의존하지 않게 하기 위해서다 —
   /// 테스트에서 설정 전체를 세우지 않고 이 함수만 넘기면 된다.
-  final bool Function(String path)? isRealApiPath;
+  ///
+  /// 메서드를 함께 받는 이유는 조회가 딸려 열리지 않게 하기 위해서다(#616).
+  final bool Function(String method, String path)? isRealApi;
 
   // Path-pattern → handler map. Static paths get O(1) dispatch;
   // path-with-id endpoints (`/diet/entries/{id}`) fall to the regex
@@ -100,7 +102,7 @@ class LocalApiInterceptor extends Interceptor {
 
     // REAL_API 로 켠 기능은 목업이 가로채지 않고 실 백엔드로 흘려보낸다.
     // (null 을 돌려주면 다음 인터셉터를 거쳐 실 네트워크로 나간다.)
-    if (isRealApiPath != null && isRealApiPath!(path)) {
+    if (isRealApi != null && isRealApi!(method, path)) {
       _logger.d('[local-api] $key → 실 백엔드(REAL_API)');
       return null;
     }

--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -8,23 +8,8 @@ import 'package:logger/logger.dart';
 
 import 'package:oncare/core/demo/demo_ai_advice.dart';
 import 'package:oncare/core/storage/app_database.dart';
-
-const Map<String, String> _seedDietPhotoAssets = <String, String>{
-  'seed-diet-breakfast':
-      'assets/images/breakfast-scrambled-egg-strawberry.jpg',
-  'seed-diet-lunch': 'assets/images/lunch-jjamppong.jpg',
-  'seed-diet-snack': 'assets/images/snack-coffee-nuts.jpg',
-  'seed-diet-yesterday-breakfast':
-      'assets/images/diet-oatmeal-banana.jpeg',
-  'seed-diet-yesterday-lunch': 'assets/images/diet-chicken-salad.jpg',
-  'seed-diet-yesterday-dinner': 'assets/images/diet-doenjang-rice.jpeg',
-  'seed-diet-two-days-ago-breakfast':
-      'assets/images/diet-greek-yogurt-nuts.jpeg',
-  'seed-diet-two-days-ago-lunch':
-      'assets/images/diet-vegetable-bibimbap.jpg',
-  'seed-diet-two-days-ago-dinner':
-      'assets/images/diet-salmon-brown-rice.jpeg',
-};
+import 'package:oncare/core/storage/seed_data.dart' show kDietDayMessagesKey;
+import 'package:oncare/features/diet/domain/entities/meal_recommendation.dart';
 
 /// A drift-backed dummy backend. Intercepts dio requests and serves
 /// them out of the local SQLite database so the app can run as a
@@ -60,6 +45,7 @@ class LocalApiInterceptor extends Interceptor {
     'GET /version': _version,
     'GET /dashboard/summary': _dashboardSummary,
     'GET /diet/days/today': _dietToday,
+    'GET /diet/recommendations': _dietRecommendations,
     'POST /diet/analyze': _dietAnalyze,
     'GET /exercise/weeks/current': _exerciseCurrentWeek,
     'POST /exercise/sessions': _exerciseAddSession,
@@ -93,6 +79,74 @@ class LocalApiInterceptor extends Interceptor {
       return;
     }
     handler.next(options);
+  }
+
+  /// 실 백엔드가 처리한 응답 중, 로컬 데모 데이터에 비춰야 하는 것을 반영한다.
+  ///
+  /// 지금은 식단 분석 하나다. `REAL_API` 로 분석만 실 서버에 맡기면 인식은 진짜가
+  /// 되지만 목록은 여전히 로컬에서 읽으므로, 반영하지 않으면 **방금 찍은 끼니가
+  /// 목록에 나타나지 않는다.**
+  ///
+  /// 인터셉터가 스스로 만든 응답은 여기로 오지 않는다 — `handler.resolve` 는 뒤따르는
+  /// 응답 인터셉터를 부르지 않는 것이 기본값이라, 로컬 경로에서 두 번 저장될 일이 없다.
+  @override
+  Future<void> onResponse(
+    Response<Object?> response,
+    ResponseInterceptorHandler handler,
+  ) async {
+    try {
+      await _mirrorRealAnalyze(response);
+    } catch (e, st) {
+      // 반영에 실패해도 인식 결과 자체는 사용자에게 보여 준다. 화면이 비는 것보다
+      // 목록 반영이 한 번 빠지는 편이 낫다.
+      _logger.e('[local-api] 실 분석 결과 로컬 반영 실패', error: e, stackTrace: st);
+    }
+    handler.next(response);
+  }
+
+  /// 실 백엔드가 준 분석 결과를 로컬 오늘 식단에 넣는다.
+  Future<void> _mirrorRealAnalyze(Response<Object?> response) async {
+    final RequestOptions options = response.requestOptions;
+    final String method = options.method.toUpperCase();
+    if (method != 'POST' || !options.path.startsWith('/diet/analyze')) return;
+    if (isRealApi == null || !isRealApi!(method, options.path)) return;
+
+    final Object? body = response.data;
+    if (body is! Map) return;
+    final Object? analysis = body['analysis'];
+    if (analysis is! Map) return;
+
+    final String id = (body['entry_id'] as String?) ?? '';
+    if (id.isEmpty) return;
+
+    final List<Object?> foods =
+        (analysis['foods'] as List<Object?>?) ?? const <Object?>[];
+    final (String mealType, String? idempotencyKey) = _analyzeRequestFields(
+      options,
+    );
+    final DateTime now = DateTime.now();
+
+    // 서버가 준 id 를 그대로 쓴다 — 이어지는 수정·삭제가 같은 행을 가리킨다.
+    // 같은 응답이 두 번 들어와도(재시도) 덮어쓰기라 중복 행이 생기지 않는다.
+    await _db
+        .into(_db.dietEntries)
+        .insertOnConflictUpdate(
+          DietEntriesCompanion.insert(
+            id: id,
+            date: _todayDateString(),
+            mealType: mealType,
+            timeLabel:
+                '${now.hour.toString().padLeft(2, '0')}:${now.minute.toString().padLeft(2, '0')}',
+            foodsJson: jsonEncode(foods),
+            totalCalories: (analysis['total_calories'] as num?)?.toInt() ?? 0,
+            sodiumMg: Value((analysis['total_sodium_mg'] as num?)?.toInt() ?? 0),
+            sugarG: Value(
+              (analysis['total_sugar_g'] as num?)?.toDouble() ?? 0.0,
+            ),
+            aiComment: Value((analysis['coach_comment'] as String?) ?? ''),
+            idempotencyKey: Value(idempotencyKey),
+          ),
+        );
   }
 
   Future<Response<Object?>?> _safeHandle(RequestOptions options) async {
@@ -268,6 +322,10 @@ class LocalApiInterceptor extends Interceptor {
       'fat_g': macros.fatG,
       'sodium_mg': row.sodiumMg,
       'sugar_g': row.sugarG,
+      // 수정은 끼니 내용만 바꾼다 — 코멘트와 사진은 그 행의 것을 그대로 돌려준다.
+      // 빼먹으면 수정 직후 목록에서 사진과 코멘트가 사라진다.
+      'ai_comment': row.aiComment,
+      'photo_asset': row.photoAsset.isEmpty ? null : row.photoAsset,
     });
   }
 
@@ -536,7 +594,8 @@ class LocalApiInterceptor extends Interceptor {
         'fat_g': macros.fatG,
         'sodium_mg': r.sodiumMg,
         'sugar_g': r.sugarG,
-        'photo_asset': _seedDietPhotoAssets[r.id],
+        'ai_comment': r.aiComment,
+        'photo_asset': r.photoAsset.isEmpty ? null : r.photoAsset,
       });
     }
     return _ok(options, <String, Object?>{
@@ -545,12 +604,60 @@ class LocalApiInterceptor extends Interceptor {
       'total_sodium_mg': totalSodium,
       'total_sugar_g': totalSugar,
       'macros': _macroPayload(totalCarbs, totalProtein, totalFat),
-      'ai_coach_message': totalSodium > 2000
-          ? '오늘 나트륨 섭취가 많았어요. 저녁은 담백한 구이/샐러드로 균형을 맞춰봐요!'
-          : rows.isEmpty
-          ? '아직 오늘 식단 기록이 없어요. 첫 끼니를 기록해 볼까요?'
-          : '균형 잡힌 하루였어요. 내일도 이대로 가요!',
+      'ai_coach_message':
+          await _dietDayMessage(date) ??
+          _derivedDietDayMessage(totalSodium: totalSodium, empty: rows.isEmpty),
     });
+  }
+
+  /// GET /diet/recommendations — 홈 "AI 추천 식단".
+  ///
+  /// 데모에는 개인화 근거가 없다(로그인하지 않은 둘러보기). 그래서 서버가 고르는
+  /// 대신 앱과 서버가 공유하는 기본 순서를 그대로 돌려주고, `reason_text` 는 비워
+  /// 둔다 — 카드 문구는 앱의 l10n 기본값이 쓰여 로케일을 따라간다.
+  ///
+  /// `personalized` 를 false 로 주는 것이 핵심이다. 화면이 그 값으로 근거 줄을
+  /// 감추므로, 근거가 없는데 있는 척하지 않게 된다.
+  Future<Response<Object?>> _dietRecommendations(RequestOptions options) async {
+    return _ok(options, <String, Object?>{
+      'items': <Map<String, Object?>>[
+        for (final MealRecommendation item in MealRecommendations.fallback.items)
+          <String, Object?>{'key': item.key, 'reason_key': item.reasonKey},
+      ],
+      'personalized': false,
+      'days_with_data': 0,
+      'avg_sodium_mg': 0,
+      'sodium_limit_mg': 0,
+    });
+  }
+
+  /// 시드가 정해 둔 그 날짜의 코치 문구. 없으면 null.
+  ///
+  /// 시연에 쓰는 사흘은 문장이 정해져 있다(`kDietDayMessagesKey`). 그 날짜에
+  /// 수치 기반 문구를 대신 쓰면 데모 화면의 문장이 바뀌므로 저장된 것을 먼저 본다.
+  Future<String?> _dietDayMessage(String date) async {
+    final String? raw = await _db.readValue(kDietDayMessagesKey);
+    if (raw == null || raw.isEmpty) return null;
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map<String, Object?>) return null;
+      final Object? message = decoded[date];
+      return message is String && message.isNotEmpty ? message : null;
+    } on FormatException {
+      return null;
+    }
+  }
+
+  /// 시드에 문장이 없는 날짜용 — 그날의 수치를 보고 만든 문구.
+  String _derivedDietDayMessage({
+    required int totalSodium,
+    required bool empty,
+  }) {
+    if (empty) return '아직 오늘 식단 기록이 없어요. 첫 끼니를 기록해 볼까요?';
+    if (totalSodium > 2000) {
+      return '오늘 나트륨 섭취가 많았어요. 저녁은 담백한 구이/샐러드로 균형을 맞춰봐요!';
+    }
+    return '균형 잡힌 하루였어요. 내일도 이대로 가요!';
   }
 
   /// POST /diet/analyze — the mock can't see the uploaded image, so it
@@ -559,27 +666,15 @@ class LocalApiInterceptor extends Interceptor {
   /// drift so it shows up in GET /diet/days/today. `diet-` id (not
   /// `seed-`) means seedIfEmpty never wipes it.
   Future<Response<Object?>> _dietAnalyze(RequestOptions options) async {
-    // meal_type·idempotency_key 는 multipart FormData 또는 Map 에서 추출.
-    String mealType = 'lunch';
-    String? idempotencyKey;
-    final data = options.data;
-    if (data is FormData) {
-      for (final MapEntry<String, String> f in data.fields) {
-        if (f.key == 'meal_type' && f.value.isNotEmpty) mealType = f.value;
-        if (f.key == 'idempotency_key' && f.value.isNotEmpty) {
-          idempotencyKey = f.value;
-        }
-      }
-    } else if (data is Map) {
-      mealType = (data['meal_type'] as String?) ?? 'lunch';
-      idempotencyKey = data['idempotency_key'] as String?;
-    }
+    final (String mealType, String? idempotencyKey) = _analyzeRequestFields(
+      options,
+    );
 
     // 같은 멱등키가 이미 저장돼 있으면 새로 저장하지 않고 기존 entry 를 반환(재시도 중복 방지).
     if (idempotencyKey != null) {
       final existing =
           await (_db.select(_db.dietEntries)
-                ..where((t) => t.idempotencyKey.equals(idempotencyKey!)))
+                ..where((t) => t.idempotencyKey.equals(idempotencyKey)))
               .getSingleOrNull();
       if (existing != null) {
         final storedFoods = (jsonDecode(existing.foodsJson) as List<Object?>)
@@ -592,7 +687,9 @@ class LocalApiInterceptor extends Interceptor {
             'total_calories': existing.totalCalories,
             'total_sodium_mg': existing.sodiumMg,
             'total_sugar_g': existing.sugarG,
-            'coach_comment': '',
+            // 저장해 둔 코멘트를 그대로 돌려준다. 빈 문자열을 주면 재시도한
+            // 사용자만 코멘트 없는 결과를 보게 된다.
+            'coach_comment': existing.aiComment,
           },
         });
       }
@@ -623,7 +720,9 @@ class LocalApiInterceptor extends Interceptor {
     const int totalCal = 615;
     const int totalNa = 1200;
     const double totalSugar = 9;
-    const String coach = '비빔밥은 채소가 풍부해 좋아요. 나트륨이 다소 높으니 고추장·간장을 조금 줄여보세요.';
+    // 데모가 보여 주던 문장 그대로. 식단이 인메모리 목업 저장소에서 이 경로로
+    // 옮겨 오면서 문구가 달라지면 시연 화면이 바뀐다.
+    const String coach = '비빔밥은 채소가 풍부해 좋아요. 나트륨이 다소 높으니 장을 줄여보세요.';
 
     final now = DateTime.now();
     final id = 'diet-${now.microsecondsSinceEpoch}';
@@ -640,6 +739,10 @@ class LocalApiInterceptor extends Interceptor {
             totalCalories: totalCal,
             sodiumMg: const Value(totalNa),
             sugarG: const Value(totalSugar),
+            // 인식 결과의 코멘트를 행에 남긴다 — 목록으로 돌아갔을 때도 끼니
+            // 카드에 그대로 보인다. 사진은 붙이지 않는다(업로드한 사진을 데모가
+            // 보관하지 않으므로, 남의 사진을 대신 보여 주게 된다).
+            aiComment: const Value(coach),
             idempotencyKey: Value(idempotencyKey),
           ),
         );
@@ -655,6 +758,28 @@ class LocalApiInterceptor extends Interceptor {
         'coach_comment': coach,
       },
     });
+  }
+
+  /// 분석 요청에서 끼니 구분과 멱등키를 꺼낸다.
+  ///
+  /// 요청 본문은 실기기에서 multipart([FormData]), 테스트에서 Map 으로 온다.
+  /// 로컬 응답과 실 백엔드 응답의 로컬 반영이 같은 값을 봐야 하므로 한곳에 둔다.
+  (String, String?) _analyzeRequestFields(RequestOptions options) {
+    String mealType = 'lunch';
+    String? idempotencyKey;
+    final data = options.data;
+    if (data is FormData) {
+      for (final MapEntry<String, String> f in data.fields) {
+        if (f.key == 'meal_type' && f.value.isNotEmpty) mealType = f.value;
+        if (f.key == 'idempotency_key' && f.value.isNotEmpty) {
+          idempotencyKey = f.value;
+        }
+      }
+    } else if (data is Map) {
+      mealType = (data['meal_type'] as String?) ?? 'lunch';
+      idempotencyKey = data['idempotency_key'] as String?;
+    }
+    return (mealType, idempotencyKey);
   }
 
   String _todayDateString() {

--- a/frontend/flutter/lib/core/network/interceptors/mock_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/mock_api_interceptor.dart
@@ -5,12 +5,14 @@ import 'package:logger/logger.dart';
 /// before the real REST backend exists. Toggle via
 /// `--dart-define=USE_MOCK_API=false`.
 class MockApiInterceptor extends Interceptor {
-  MockApiInterceptor(this._logger, {this.isRealApiPath});
+  MockApiInterceptor(this._logger, {this.isRealApi});
   final Logger _logger;
 
-  /// 이 경로를 목업이 아니라 실 백엔드로 보내야 하는지 판정한다
-  /// (`AppConfig.isRealApiPath`). LocalApiInterceptor 와 같은 규칙을 쓴다.
-  final bool Function(String path)? isRealApiPath;
+  /// 이 요청을 목업이 아니라 실 백엔드로 보내야 하는지 판정한다
+  /// (`AppConfig.isRealApi`). LocalApiInterceptor 와 같은 규칙을 쓴다.
+  ///
+  /// 메서드를 함께 받는 이유는 조회가 딸려 열리지 않게 하기 위해서다(#616).
+  final bool Function(String method, String path)? isRealApi;
 
   // Path → JSON map. Add new mock endpoints here as features need them.
   static const Map<String, Map<String, Object?>> _routes =
@@ -26,7 +28,7 @@ class MockApiInterceptor extends Interceptor {
   @override
   void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
     // REAL_API 로 켠 기능은 목업이 가로채지 않고 실 백엔드로 흘려보낸다.
-    if (isRealApiPath != null && isRealApiPath!(options.path)) {
+    if (isRealApi != null && isRealApi!(options.method, options.path)) {
       handler.next(options);
       return;
     }

--- a/frontend/flutter/lib/core/storage/app_database.dart
+++ b/frontend/flutter/lib/core/storage/app_database.dart
@@ -27,6 +27,13 @@ class DietEntries extends Table {
   // 당류만 실수. 서버 계약(diet_entries.sugar_g)이 float 이고 도메인 엔티티도
   // double 이라, 로컬 캐시만 정수면 데모 모드에서 8.5 가 8 로 잘린다.
   RealColumn get sugarG => real().withDefault(const Constant(0.0))();
+  // 끼니별 AI 코멘트. 식단 상세가 이 값을 그대로 그린다. 데모 시드가 채워 두고,
+  // 새로 분석된 항목은 인식 응답이 준 코멘트를 받는다. 값이 없으면 화면이 칸을
+  // 통째로 감추므로 빈 문자열이 안전한 기본값이다.
+  TextColumn get aiComment => text().withDefault(const Constant(''))();
+  // 끼니 사진 에셋 경로. 예전에는 인터셉터가 시드 id → 에셋 맵을 들고 있어서
+  // 새로 추가된 항목에는 사진이 붙지 않았다. 행이 자기 사진을 갖게 한다.
+  TextColumn get photoAsset => text().withDefault(const Constant(''))();
   // 재시도 중복 저장 방지 멱등키(요청당 1회). 무키 요청은 null.
   TextColumn get idempotencyKey => text().nullable()();
   DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
@@ -109,7 +116,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.executor);
 
   @override
-  int get schemaVersion => 6;
+  int get schemaVersion => 7;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -143,6 +150,14 @@ class AppDatabase extends _$AppDatabase {
         // 그대로 REAL 로 저장되고, 읽을 때는 drift 가 선언 타입(double)으로
         // 매핑한다. 기존 정수 값도 8 → 8.0 으로 읽혀 손실이 없다.
         // 스키마 버전만 올려 이 결정을 기록해 둔다.
+      }
+      if (from < 7) {
+        // 끼니별 AI 코멘트·사진 컬럼 추가 — 기존 행은 빈 문자열.
+        //
+        // 식단이 인메모리 목업 저장소에서 로컬 인터셉터 경로로 옮겨 오면서
+        // 필요해졌다. 그 두 값은 목업 쪽에만 있었고 테이블에는 자리가 없었다.
+        await m.addColumn(dietEntries, dietEntries.aiComment);
+        await m.addColumn(dietEntries, dietEntries.photoAsset);
       }
     },
   );

--- a/frontend/flutter/lib/core/storage/app_database.g.dart
+++ b/frontend/flutter/lib/core/storage/app_database.g.dart
@@ -301,6 +301,30 @@ class $DietEntriesTable extends DietEntries
     requiredDuringInsert: false,
     defaultValue: const Constant(0.0),
   );
+  static const VerificationMeta _aiCommentMeta = const VerificationMeta(
+    'aiComment',
+  );
+  @override
+  late final GeneratedColumn<String> aiComment = GeneratedColumn<String>(
+    'ai_comment',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(''),
+  );
+  static const VerificationMeta _photoAssetMeta = const VerificationMeta(
+    'photoAsset',
+  );
+  @override
+  late final GeneratedColumn<String> photoAsset = GeneratedColumn<String>(
+    'photo_asset',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(''),
+  );
   static const VerificationMeta _idempotencyKeyMeta = const VerificationMeta(
     'idempotencyKey',
   );
@@ -334,6 +358,8 @@ class $DietEntriesTable extends DietEntries
     totalCalories,
     sodiumMg,
     sugarG,
+    aiComment,
+    photoAsset,
     idempotencyKey,
     createdAt,
   ];
@@ -409,6 +435,18 @@ class $DietEntriesTable extends DietEntries
         sugarG.isAcceptableOrUnknown(data['sugar_g']!, _sugarGMeta),
       );
     }
+    if (data.containsKey('ai_comment')) {
+      context.handle(
+        _aiCommentMeta,
+        aiComment.isAcceptableOrUnknown(data['ai_comment']!, _aiCommentMeta),
+      );
+    }
+    if (data.containsKey('photo_asset')) {
+      context.handle(
+        _photoAssetMeta,
+        photoAsset.isAcceptableOrUnknown(data['photo_asset']!, _photoAssetMeta),
+      );
+    }
     if (data.containsKey('idempotency_key')) {
       context.handle(
         _idempotencyKeyMeta,
@@ -465,6 +503,14 @@ class $DietEntriesTable extends DietEntries
         DriftSqlType.double,
         data['${effectivePrefix}sugar_g'],
       )!,
+      aiComment: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}ai_comment'],
+      )!,
+      photoAsset: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}photo_asset'],
+      )!,
       idempotencyKey: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}idempotency_key'],
@@ -491,6 +537,8 @@ class DietEntryRow extends DataClass implements Insertable<DietEntryRow> {
   final int totalCalories;
   final int sodiumMg;
   final double sugarG;
+  final String aiComment;
+  final String photoAsset;
   final String? idempotencyKey;
   final DateTime createdAt;
   const DietEntryRow({
@@ -502,6 +550,8 @@ class DietEntryRow extends DataClass implements Insertable<DietEntryRow> {
     required this.totalCalories,
     required this.sodiumMg,
     required this.sugarG,
+    required this.aiComment,
+    required this.photoAsset,
     this.idempotencyKey,
     required this.createdAt,
   });
@@ -516,6 +566,8 @@ class DietEntryRow extends DataClass implements Insertable<DietEntryRow> {
     map['total_calories'] = Variable<int>(totalCalories);
     map['sodium_mg'] = Variable<int>(sodiumMg);
     map['sugar_g'] = Variable<double>(sugarG);
+    map['ai_comment'] = Variable<String>(aiComment);
+    map['photo_asset'] = Variable<String>(photoAsset);
     if (!nullToAbsent || idempotencyKey != null) {
       map['idempotency_key'] = Variable<String>(idempotencyKey);
     }
@@ -533,6 +585,8 @@ class DietEntryRow extends DataClass implements Insertable<DietEntryRow> {
       totalCalories: Value(totalCalories),
       sodiumMg: Value(sodiumMg),
       sugarG: Value(sugarG),
+      aiComment: Value(aiComment),
+      photoAsset: Value(photoAsset),
       idempotencyKey: idempotencyKey == null && nullToAbsent
           ? const Value.absent()
           : Value(idempotencyKey),
@@ -554,6 +608,8 @@ class DietEntryRow extends DataClass implements Insertable<DietEntryRow> {
       totalCalories: serializer.fromJson<int>(json['totalCalories']),
       sodiumMg: serializer.fromJson<int>(json['sodiumMg']),
       sugarG: serializer.fromJson<double>(json['sugarG']),
+      aiComment: serializer.fromJson<String>(json['aiComment']),
+      photoAsset: serializer.fromJson<String>(json['photoAsset']),
       idempotencyKey: serializer.fromJson<String?>(json['idempotencyKey']),
       createdAt: serializer.fromJson<DateTime>(json['createdAt']),
     );
@@ -570,6 +626,8 @@ class DietEntryRow extends DataClass implements Insertable<DietEntryRow> {
       'totalCalories': serializer.toJson<int>(totalCalories),
       'sodiumMg': serializer.toJson<int>(sodiumMg),
       'sugarG': serializer.toJson<double>(sugarG),
+      'aiComment': serializer.toJson<String>(aiComment),
+      'photoAsset': serializer.toJson<String>(photoAsset),
       'idempotencyKey': serializer.toJson<String?>(idempotencyKey),
       'createdAt': serializer.toJson<DateTime>(createdAt),
     };
@@ -584,6 +642,8 @@ class DietEntryRow extends DataClass implements Insertable<DietEntryRow> {
     int? totalCalories,
     int? sodiumMg,
     double? sugarG,
+    String? aiComment,
+    String? photoAsset,
     Value<String?> idempotencyKey = const Value.absent(),
     DateTime? createdAt,
   }) => DietEntryRow(
@@ -595,6 +655,8 @@ class DietEntryRow extends DataClass implements Insertable<DietEntryRow> {
     totalCalories: totalCalories ?? this.totalCalories,
     sodiumMg: sodiumMg ?? this.sodiumMg,
     sugarG: sugarG ?? this.sugarG,
+    aiComment: aiComment ?? this.aiComment,
+    photoAsset: photoAsset ?? this.photoAsset,
     idempotencyKey: idempotencyKey.present
         ? idempotencyKey.value
         : this.idempotencyKey,
@@ -612,6 +674,10 @@ class DietEntryRow extends DataClass implements Insertable<DietEntryRow> {
           : this.totalCalories,
       sodiumMg: data.sodiumMg.present ? data.sodiumMg.value : this.sodiumMg,
       sugarG: data.sugarG.present ? data.sugarG.value : this.sugarG,
+      aiComment: data.aiComment.present ? data.aiComment.value : this.aiComment,
+      photoAsset: data.photoAsset.present
+          ? data.photoAsset.value
+          : this.photoAsset,
       idempotencyKey: data.idempotencyKey.present
           ? data.idempotencyKey.value
           : this.idempotencyKey,
@@ -630,6 +696,8 @@ class DietEntryRow extends DataClass implements Insertable<DietEntryRow> {
           ..write('totalCalories: $totalCalories, ')
           ..write('sodiumMg: $sodiumMg, ')
           ..write('sugarG: $sugarG, ')
+          ..write('aiComment: $aiComment, ')
+          ..write('photoAsset: $photoAsset, ')
           ..write('idempotencyKey: $idempotencyKey, ')
           ..write('createdAt: $createdAt')
           ..write(')'))
@@ -646,6 +714,8 @@ class DietEntryRow extends DataClass implements Insertable<DietEntryRow> {
     totalCalories,
     sodiumMg,
     sugarG,
+    aiComment,
+    photoAsset,
     idempotencyKey,
     createdAt,
   );
@@ -661,6 +731,8 @@ class DietEntryRow extends DataClass implements Insertable<DietEntryRow> {
           other.totalCalories == this.totalCalories &&
           other.sodiumMg == this.sodiumMg &&
           other.sugarG == this.sugarG &&
+          other.aiComment == this.aiComment &&
+          other.photoAsset == this.photoAsset &&
           other.idempotencyKey == this.idempotencyKey &&
           other.createdAt == this.createdAt);
 }
@@ -674,6 +746,8 @@ class DietEntriesCompanion extends UpdateCompanion<DietEntryRow> {
   final Value<int> totalCalories;
   final Value<int> sodiumMg;
   final Value<double> sugarG;
+  final Value<String> aiComment;
+  final Value<String> photoAsset;
   final Value<String?> idempotencyKey;
   final Value<DateTime> createdAt;
   final Value<int> rowid;
@@ -686,6 +760,8 @@ class DietEntriesCompanion extends UpdateCompanion<DietEntryRow> {
     this.totalCalories = const Value.absent(),
     this.sodiumMg = const Value.absent(),
     this.sugarG = const Value.absent(),
+    this.aiComment = const Value.absent(),
+    this.photoAsset = const Value.absent(),
     this.idempotencyKey = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.rowid = const Value.absent(),
@@ -699,6 +775,8 @@ class DietEntriesCompanion extends UpdateCompanion<DietEntryRow> {
     required int totalCalories,
     this.sodiumMg = const Value.absent(),
     this.sugarG = const Value.absent(),
+    this.aiComment = const Value.absent(),
+    this.photoAsset = const Value.absent(),
     this.idempotencyKey = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.rowid = const Value.absent(),
@@ -717,6 +795,8 @@ class DietEntriesCompanion extends UpdateCompanion<DietEntryRow> {
     Expression<int>? totalCalories,
     Expression<int>? sodiumMg,
     Expression<double>? sugarG,
+    Expression<String>? aiComment,
+    Expression<String>? photoAsset,
     Expression<String>? idempotencyKey,
     Expression<DateTime>? createdAt,
     Expression<int>? rowid,
@@ -730,6 +810,8 @@ class DietEntriesCompanion extends UpdateCompanion<DietEntryRow> {
       if (totalCalories != null) 'total_calories': totalCalories,
       if (sodiumMg != null) 'sodium_mg': sodiumMg,
       if (sugarG != null) 'sugar_g': sugarG,
+      if (aiComment != null) 'ai_comment': aiComment,
+      if (photoAsset != null) 'photo_asset': photoAsset,
       if (idempotencyKey != null) 'idempotency_key': idempotencyKey,
       if (createdAt != null) 'created_at': createdAt,
       if (rowid != null) 'rowid': rowid,
@@ -745,6 +827,8 @@ class DietEntriesCompanion extends UpdateCompanion<DietEntryRow> {
     Value<int>? totalCalories,
     Value<int>? sodiumMg,
     Value<double>? sugarG,
+    Value<String>? aiComment,
+    Value<String>? photoAsset,
     Value<String?>? idempotencyKey,
     Value<DateTime>? createdAt,
     Value<int>? rowid,
@@ -758,6 +842,8 @@ class DietEntriesCompanion extends UpdateCompanion<DietEntryRow> {
       totalCalories: totalCalories ?? this.totalCalories,
       sodiumMg: sodiumMg ?? this.sodiumMg,
       sugarG: sugarG ?? this.sugarG,
+      aiComment: aiComment ?? this.aiComment,
+      photoAsset: photoAsset ?? this.photoAsset,
       idempotencyKey: idempotencyKey ?? this.idempotencyKey,
       createdAt: createdAt ?? this.createdAt,
       rowid: rowid ?? this.rowid,
@@ -791,6 +877,12 @@ class DietEntriesCompanion extends UpdateCompanion<DietEntryRow> {
     if (sugarG.present) {
       map['sugar_g'] = Variable<double>(sugarG.value);
     }
+    if (aiComment.present) {
+      map['ai_comment'] = Variable<String>(aiComment.value);
+    }
+    if (photoAsset.present) {
+      map['photo_asset'] = Variable<String>(photoAsset.value);
+    }
     if (idempotencyKey.present) {
       map['idempotency_key'] = Variable<String>(idempotencyKey.value);
     }
@@ -814,6 +906,8 @@ class DietEntriesCompanion extends UpdateCompanion<DietEntryRow> {
           ..write('totalCalories: $totalCalories, ')
           ..write('sodiumMg: $sodiumMg, ')
           ..write('sugarG: $sugarG, ')
+          ..write('aiComment: $aiComment, ')
+          ..write('photoAsset: $photoAsset, ')
           ..write('idempotencyKey: $idempotencyKey, ')
           ..write('createdAt: $createdAt, ')
           ..write('rowid: $rowid')
@@ -2352,6 +2446,8 @@ typedef $$DietEntriesTableCreateCompanionBuilder =
       required int totalCalories,
       Value<int> sodiumMg,
       Value<double> sugarG,
+      Value<String> aiComment,
+      Value<String> photoAsset,
       Value<String?> idempotencyKey,
       Value<DateTime> createdAt,
       Value<int> rowid,
@@ -2366,6 +2462,8 @@ typedef $$DietEntriesTableUpdateCompanionBuilder =
       Value<int> totalCalories,
       Value<int> sodiumMg,
       Value<double> sugarG,
+      Value<String> aiComment,
+      Value<String> photoAsset,
       Value<String?> idempotencyKey,
       Value<DateTime> createdAt,
       Value<int> rowid,
@@ -2417,6 +2515,16 @@ class $$DietEntriesTableFilterComposer
 
   ColumnFilters<double> get sugarG => $composableBuilder(
     column: $table.sugarG,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get aiComment => $composableBuilder(
+    column: $table.aiComment,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get photoAsset => $composableBuilder(
+    column: $table.photoAsset,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -2480,6 +2588,16 @@ class $$DietEntriesTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get aiComment => $composableBuilder(
+    column: $table.aiComment,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get photoAsset => $composableBuilder(
+    column: $table.photoAsset,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<String> get idempotencyKey => $composableBuilder(
     column: $table.idempotencyKey,
     builder: (column) => ColumnOrderings(column),
@@ -2525,6 +2643,14 @@ class $$DietEntriesTableAnnotationComposer
 
   GeneratedColumn<double> get sugarG =>
       $composableBuilder(column: $table.sugarG, builder: (column) => column);
+
+  GeneratedColumn<String> get aiComment =>
+      $composableBuilder(column: $table.aiComment, builder: (column) => column);
+
+  GeneratedColumn<String> get photoAsset => $composableBuilder(
+    column: $table.photoAsset,
+    builder: (column) => column,
+  );
 
   GeneratedColumn<String> get idempotencyKey => $composableBuilder(
     column: $table.idempotencyKey,
@@ -2574,6 +2700,8 @@ class $$DietEntriesTableTableManager
                 Value<int> totalCalories = const Value.absent(),
                 Value<int> sodiumMg = const Value.absent(),
                 Value<double> sugarG = const Value.absent(),
+                Value<String> aiComment = const Value.absent(),
+                Value<String> photoAsset = const Value.absent(),
                 Value<String?> idempotencyKey = const Value.absent(),
                 Value<DateTime> createdAt = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
@@ -2586,6 +2714,8 @@ class $$DietEntriesTableTableManager
                 totalCalories: totalCalories,
                 sodiumMg: sodiumMg,
                 sugarG: sugarG,
+                aiComment: aiComment,
+                photoAsset: photoAsset,
                 idempotencyKey: idempotencyKey,
                 createdAt: createdAt,
                 rowid: rowid,
@@ -2600,6 +2730,8 @@ class $$DietEntriesTableTableManager
                 required int totalCalories,
                 Value<int> sodiumMg = const Value.absent(),
                 Value<double> sugarG = const Value.absent(),
+                Value<String> aiComment = const Value.absent(),
+                Value<String> photoAsset = const Value.absent(),
                 Value<String?> idempotencyKey = const Value.absent(),
                 Value<DateTime> createdAt = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
@@ -2612,6 +2744,8 @@ class $$DietEntriesTableTableManager
                 totalCalories: totalCalories,
                 sodiumMg: sodiumMg,
                 sugarG: sugarG,
+                aiComment: aiComment,
+                photoAsset: photoAsset,
                 idempotencyKey: idempotencyKey,
                 createdAt: createdAt,
                 rowid: rowid,

--- a/frontend/flutter/lib/core/storage/seed_data.dart
+++ b/frontend/flutter/lib/core/storage/seed_data.dart
@@ -5,9 +5,18 @@ import 'package:drift/drift.dart';
 import 'package:oncare/core/demo/demo_ai_advice.dart';
 import 'package:oncare/core/storage/app_database.dart';
 
+/// 하루 단위 코치 문구(날짜 → 문장)를 담는 키-값 키.
+///
+/// 끼니가 아니라 **하루**에 붙는 문장이라 `dietEntries` 행에 둘 자리가 없고, 시연용
+/// 날짜 셋뿐이라 테이블을 새로 만들 이유도 없다. 시드가 쓰고 로컬 인터셉터가 읽는다.
+///
+/// 날짜별로 키를 나누지 않고 한 키에 묶는 이유: 시드는 날이 바뀌면 앞으로 미끄러지는데,
+/// 키를 날짜마다 만들면 지난 날짜 키가 계속 쌓인다. 한 키를 통째로 덮어쓰면 그 문제가 없다.
+const String kDietDayMessagesKey = 'diet_day_messages';
+
 /// Date-aware idempotent seeder. Runs at bootstrap.
 ///
-/// **Flag format (v4+).** `AppKeyValues['seeded_v13']` stores the
+/// **Flag format (v4+).** `AppKeyValues['seeded_v14']` stores the
 /// *date string* the seed last ran with (`YYYY-MM-DD`). Behaviour:
 ///
 /// - `null` (first ever boot, or upgrading from v1/v2) — wipe any
@@ -38,7 +47,7 @@ Future<void> seedIfEmpty(AppDatabase db) async {
   final twoDaysAgo = _fmtDate(now.subtract(const Duration(days: 2)));
   final weekStart = _fmtDate(_mondayOfThisWeek(now));
 
-  final seedDate = await db.readValue('seeded_v13');
+  final seedDate = await db.readValue('seeded_v14');
   if (seedDate == today) {
     // Already seeded for today — leave both seed rows and user rows
     // untouched.
@@ -74,6 +83,9 @@ Future<void> seedIfEmpty(AppDatabase db) async {
   await db.deleteValue('seeded_v10');
   await db.deleteValue('seeded_v11');
   await db.deleteValue('seeded_v12');
+  // v14: 끼니별 AI 코멘트·사진이 행으로 내려오고 하루 코치 문구가 추가됐다.
+  // 플래그를 올리지 않으면 오늘 이미 시드된 설치가 빈 코멘트를 그대로 들고 있게 된다.
+  await db.deleteValue('seeded_v13');
   // Also clear the curated KV advice so re-seed state is fully reset: this
   // version re-writes it below, but if a later seed drops or renames the key
   // an existing install would otherwise keep the stale text forever.
@@ -111,6 +123,8 @@ Future<void> seedIfEmpty(AppDatabase db) async {
           totalCalories: 217,
           sodiumMg: const Value(221),
           sugarG: const Value(6.3),
+          aiComment: const Value('단백질과 식이섬유의 깔끔한 조합으로, 소금 간과 기름만 조절하면 혈당과 혈압 모두 잡는 우수한 식단입니다.'),
+          photoAsset: const Value('assets/images/breakfast-scrambled-egg-strawberry.jpg'),
         ),
         DietEntriesCompanion.insert(
           id: 'seed-diet-lunch',
@@ -132,6 +146,8 @@ Future<void> seedIfEmpty(AppDatabase db) async {
           totalCalories: 750,
           sodiumMg: const Value(3200),
           sugarG: const Value(8.5),
+          aiComment: const Value('정제 면과 높은 나트륨으로 혈압·혈당 부담이 매우 크니, 국물은 남기고 야채 위주로 드시는 것이 좋습니다.'),
+          photoAsset: const Value('assets/images/lunch-jjamppong.jpg'),
         ),
         DietEntriesCompanion.insert(
           id: 'seed-diet-snack',
@@ -161,6 +177,8 @@ Future<void> seedIfEmpty(AppDatabase db) async {
           totalCalories: 100,
           sodiumMg: const Value(7),
           sugarG: const Value(3.0),
+          aiComment: const Value('당류와 칼로리가 낮고 견과류의 건강한 지방이 채워져 완벽한 간식입니다.'),
+          photoAsset: const Value('assets/images/snack-coffee-nuts.jpg'),
         ),
         DietEntriesCompanion.insert(
           id: 'seed-diet-yesterday-breakfast',
@@ -190,6 +208,8 @@ Future<void> seedIfEmpty(AppDatabase db) async {
           totalCalories: 355,
           sodiumMg: const Value(101),
           sugarG: const Value(20.0),
+          aiComment: const Value('오트밀로 식이섬유를 챙겼어요. 바나나가 들어가 당류는 다소 높은 편이에요.'),
+          photoAsset: const Value('assets/images/diet-oatmeal-banana.jpeg'),
         ),
         DietEntriesCompanion.insert(
           id: 'seed-diet-yesterday-lunch',
@@ -210,6 +230,8 @@ Future<void> seedIfEmpty(AppDatabase db) async {
           totalCalories: 315,
           sodiumMg: const Value(395),
           sugarG: const Value(10.0),
+          aiComment: const Value('닭가슴살과 채소로 단백질과 식이섬유를 고르게 섭취했어요.'),
+          photoAsset: const Value('assets/images/diet-chicken-salad.jpg'),
         ),
         DietEntriesCompanion.insert(
           id: 'seed-diet-yesterday-dinner',
@@ -239,6 +261,8 @@ Future<void> seedIfEmpty(AppDatabase db) async {
           totalCalories: 610,
           sodiumMg: const Value(1305),
           sugarG: const Value(5.7),
+          aiComment: const Value('밥과 찌개를 함께 섭취해 포만감은 좋지만 국물은 조금 남기면 좋아요.'),
+          photoAsset: const Value('assets/images/diet-doenjang-rice.jpeg'),
         ),
         DietEntriesCompanion.insert(
           id: 'seed-diet-two-days-ago-breakfast',
@@ -268,6 +292,8 @@ Future<void> seedIfEmpty(AppDatabase db) async {
           totalCalories: 320,
           sodiumMg: const Value(80),
           sugarG: const Value(9.0),
+          aiComment: const Value('그릭 요거트의 단백질과 견과류의 불포화지방을 고르게 섭취했어요.'),
+          photoAsset: const Value('assets/images/diet-greek-yogurt-nuts.jpeg'),
         ),
         DietEntriesCompanion.insert(
           id: 'seed-diet-two-days-ago-lunch',
@@ -288,6 +314,8 @@ Future<void> seedIfEmpty(AppDatabase db) async {
           totalCalories: 610,
           sodiumMg: const Value(900),
           sugarG: const Value(12.0),
+          aiComment: const Value('야채가 풍부한 비빔밥이에요. 고추장을 줄이면 나트륨을 더 조절할 수 있어요.'),
+          photoAsset: const Value('assets/images/diet-vegetable-bibimbap.jpg'),
         ),
         DietEntriesCompanion.insert(
           id: 'seed-diet-two-days-ago-dinner',
@@ -317,6 +345,8 @@ Future<void> seedIfEmpty(AppDatabase db) async {
           totalCalories: 675,
           sodiumMg: const Value(510),
           sugarG: const Value(9.0),
+          aiComment: const Value('연어의 지방과 현미밥의 복합 탄수화물 조합이 좋아요.'),
+          photoAsset: const Value('assets/images/diet-salmon-brown-rice.jpeg'),
         ),
       ]);
     });
@@ -558,7 +588,18 @@ Future<void> seedIfEmpty(AppDatabase db) async {
   // 노출한다.
   await db.putValue('dashboard_ai_advice', kDailyCombinedAdviceKey);
 
-  await db.putValue('seeded_v13', today);
+  // 식단 탭의 하루 코치 문구. 시연에 쓰는 세 날짜만 문장을 정해 두고, 그 밖의
+  // 날짜는 인터셉터가 수치를 보고 만든 문구로 대신한다([kDietDayMessagesKey]).
+  await db.putValue(
+    kDietDayMessagesKey,
+    jsonEncode(<String, String>{
+      today: '점심 짬뽕으로 오늘 나트륨 섭취가 많았어요. 저녁은 양념을 줄인 채소와 단백질 위주로 구성해 보세요.',
+      yesterday: '나트륨을 잘 조절했고 단백질도 고르게 섭취한 하루였어요.',
+      twoDaysAgo: '연어와 현미밥으로 탄단지 균형을 잘 맞췄어요.',
+    }),
+  );
+
+  await db.putValue('seeded_v14', today);
 }
 
 String _fmtDate(DateTime d) =>

--- a/frontend/flutter/lib/features/diet/presentation/controllers/diet_controller.dart
+++ b/frontend/flutter/lib/features/diet/presentation/controllers/diet_controller.dart
@@ -1,24 +1,23 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'package:oncare/core/config/app_config.dart';
 import 'package:oncare/core/network/dio_client.dart';
 import 'package:oncare/features/diet/data/repositories/dio_diet_repository.dart';
-import 'package:oncare/features/diet/data/repositories/mock_diet_repository.dart';
 import 'package:oncare/features/diet/data/sources/image_picker_meal_photo_picker.dart';
 import 'package:oncare/features/diet/domain/entities/diet_day.dart';
 import 'package:oncare/features/diet/domain/entities/meal_recommendation.dart';
 import 'package:oncare/features/diet/domain/repositories/diet_repository.dart';
 import 'package:oncare/features/diet/domain/repositories/meal_photo_picker.dart';
 
+/// 식단 저장소 — 빌드와 무관하게 **항상** 네트워크 구현이다.
+///
+/// 데모 응답은 `LocalApiInterceptor` 가 drift 에서 만들어 준다. AI 코치가 이미 쓰는
+/// 구조이고, 식단만 저장소 단에서 갈라져 있던 것이 `REAL_API=diet` 를 죽은 스위치로
+/// 만들었다 — 인메모리 구현은 Dio 를 타지 않으니 인터셉터의 통과 규칙에 닿을 일이
+/// 없었다(#616).
+///
+/// 이제 분석 요청만 실 백엔드로 흘려보낼 수 있고, 나머지 조회·수정·삭제는 그대로
+/// 로컬이 답하므로 데모 화면이 움직이지 않는다.
 final dietRepositoryProvider = Provider<DietRepository>((ref) {
-  // In local/demo mode serve the fully-populated mock day (food photos,
-  // per-food nutrition, per-meal AI feedback) so the diet tab renders
-  // real-looking data with no backend. The real REST repo is used otherwise.
-  if (ref.watch(appConfigProvider).useMockApi) {
-    // One instance per provider lifetime so in-memory CRUD (analyze/edit/
-    // delete) persists across `dietTodayProvider` invalidations for the session.
-    return MockDietRepository();
-  }
   return DioDietRepository(ref.watch(dioProvider));
 }, name: 'dietRepository');
 

--- a/frontend/flutter/test/core/network/local_api_interceptor_diet_demo_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_diet_demo_test.dart
@@ -1,0 +1,268 @@
+/// 식단이 인메모리 목업 저장소에서 로컬 인터셉터 경로로 옮겨 오면서, 데모 화면이
+/// 그대로인지를 고정하는 회귀 테스트 — #616.
+///
+/// 옮기기 전 화면은 저장소가 들고 있던 값으로 그려졌다. 그 값 중 셋은 인터셉터
+/// 경로에 자리가 없어서 새로 만들어야 했고, 하나라도 빠지면 시연 화면이 조용히
+/// 달라진다.
+///
+///  * 끼니별 AI 코멘트 — 테이블에 컬럼이 없었다.
+///  * 끼니 사진 — 인터셉터가 시드 id → 에셋 맵을 들고 있어 새 항목엔 붙지 않았다.
+///  * 하루 코치 문구 — 저장소는 정해진 문장, 인터셉터는 나트륨 임계값 분기였다.
+library;
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
+
+import 'package:oncare/core/network/interceptors/local_api_interceptor.dart';
+import 'package:oncare/core/storage/app_database.dart';
+import 'package:oncare/core/storage/seed_data.dart';
+
+String _dateString(DateTime d) =>
+    '${d.year.toString().padLeft(4, '0')}-'
+    '${d.month.toString().padLeft(2, '0')}-'
+    '${d.day.toString().padLeft(2, '0')}';
+
+void main() {
+  late AppDatabase db;
+  late Dio dio;
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    dio = Dio(BaseOptions(baseUrl: 'https://example.test'));
+    dio.interceptors.add(LocalApiInterceptor(db, Logger(level: Level.off)));
+  });
+
+  tearDown(() => db.close());
+
+  group('시드가 채운 데모 식단', () {
+    setUp(() => seedIfEmpty(db));
+
+    test('끼니마다 AI 코멘트와 사진이 함께 내려온다', () async {
+      final res = await dio.get<Map<String, Object?>>('/diet/days/today');
+      final entries = (res.data!['entries']! as List<Object?>)
+          .cast<Map<String, Object?>>();
+
+      expect(entries, isNotEmpty);
+      for (final entry in entries) {
+        expect(
+          entry['ai_comment'],
+          isA<String>().having((String s) => s.isNotEmpty, '비어 있지 않다', isTrue),
+          reason: '${entry['meal_type']} 끼니에 코멘트가 없다',
+        );
+        expect(
+          entry['photo_asset'],
+          isA<String>().having(
+            (String s) => s.startsWith('assets/images/'),
+            '에셋 경로다',
+            isTrue,
+          ),
+          reason: '${entry['meal_type']} 끼니에 사진이 없다',
+        );
+      }
+    });
+
+    test('하루 코치 문구는 수치가 아니라 시드가 정한 문장이다', () async {
+      final res = await dio.get<Map<String, Object?>>('/diet/days/today');
+
+      // 시드 하루 나트륨은 권장치를 넘는다. 수치 기반 분기를 그대로 쓰면 여기서
+      // 일반 경고 문구가 나오고, 데모가 보여 주던 문장이 사라진다.
+      expect(res.data!['total_sodium_mg'], greaterThan(2000));
+      expect(res.data!['ai_coach_message'], contains('짬뽕'));
+    });
+
+    test('지난 날짜도 그 날짜의 문장을 쓴다', () async {
+      final yesterday = _dateString(
+        DateTime.now().subtract(const Duration(days: 1)),
+      );
+      final res = await dio.get<Map<String, Object?>>(
+        '/diet/days/$yesterday',
+      );
+
+      expect(res.data!['ai_coach_message'], '나트륨을 잘 조절했고 단백질도 고르게 섭취한 하루였어요.');
+    });
+
+    test('끼니를 수정해도 코멘트와 사진이 남는다', () async {
+      final today = await dio.get<Map<String, Object?>>('/diet/days/today');
+      final first = (today.data!['entries']! as List<Object?>)
+          .cast<Map<String, Object?>>()
+          .first;
+
+      final res = await dio.put<Map<String, Object?>>(
+        '/diet/entries/${first['id']}',
+        data: <String, Object?>{'time_label': '09:00'},
+      );
+
+      expect(res.data!['time_label'], '09:00');
+      expect(res.data!['ai_comment'], first['ai_comment']);
+      expect(res.data!['photo_asset'], first['photo_asset']);
+    });
+  });
+
+  group('시드가 없는 날짜', () {
+    test('저장된 문장이 없으면 수치를 보고 만든 문구로 답한다', () async {
+      // 시드를 돌리지 않았으므로 그 날짜에는 정해진 문장이 없다.
+      final res = await dio.get<Map<String, Object?>>('/diet/days/2020-01-01');
+
+      expect(res.data!['entries'], isEmpty);
+      expect(res.data!['ai_coach_message'], contains('아직'));
+    });
+  });
+
+  group('추천', () {
+    test('개인화 근거가 없다고 밝히고 기본 순서를 돌려준다', () async {
+      final res = await dio.get<Map<String, Object?>>('/diet/recommendations');
+
+      final items = (res.data!['items']! as List<Object?>)
+          .cast<Map<String, Object?>>();
+      expect(items.map((Map<String, Object?> e) => e['key']).toList(), <String>[
+        'chicken_salad',
+        'brown_rice_box',
+        'salmon',
+        'tofu',
+        'namul_bibimbap',
+      ]);
+      // 근거가 없는데 있는 척하면 화면이 빈 근거 줄을 그린다.
+      expect(res.data!['personalized'], isFalse);
+      // reason_text 를 비워 둬야 카드 문구가 앱의 로케일 기본값을 쓴다.
+      for (final item in items) {
+        expect(item.containsKey('reason_text'), isFalse);
+        expect(item['reason_key'], isA<String>());
+      }
+    });
+  });
+
+  group('분석 결과 저장', () {
+    test('로컬이 만든 결과에도 코멘트가 함께 남는다', () async {
+      await dio.post<Map<String, Object?>>(
+        '/diet/analyze',
+        data: <String, Object?>{'meal_type': 'dinner'},
+      );
+
+      final res = await dio.get<Map<String, Object?>>('/diet/days/today');
+      final dinner = (res.data!['entries']! as List<Object?>)
+          .cast<Map<String, Object?>>()
+          .firstWhere((Map<String, Object?> e) => e['meal_type'] == 'dinner');
+
+      expect(dinner['ai_comment'], contains('비빔밥'));
+      // 업로드한 사진을 데모가 보관하지 않으므로 사진은 비워 둔다 — 남의 사진을
+      // 대신 보여 주는 것보다 없는 편이 정직하다.
+      expect(dinner['photo_asset'], isNull);
+    });
+
+    test('같은 멱등키로 다시 보내도 코멘트를 잃지 않는다', () async {
+      Future<Response<Map<String, Object?>>> send() => dio.post(
+        '/diet/analyze',
+        data: <String, Object?>{
+          'meal_type': 'dinner',
+          'idempotency_key': 'same-key',
+        },
+      );
+
+      final first = await send();
+      final second = await send();
+
+      final firstAnalysis = first.data!['analysis']! as Map<String, Object?>;
+      final secondAnalysis = second.data!['analysis']! as Map<String, Object?>;
+      expect(second.data!['entry_id'], first.data!['entry_id']);
+      expect(secondAnalysis['coach_comment'], firstAnalysis['coach_comment']);
+    });
+  });
+
+  group('실 백엔드가 분석했을 때', () {
+    late Dio realAnalyzeDio;
+
+    setUp(() async {
+      await seedIfEmpty(db);
+      realAnalyzeDio = Dio(BaseOptions(baseUrl: 'https://example.test'));
+      realAnalyzeDio.interceptors.add(
+        LocalApiInterceptor(
+          db,
+          Logger(level: Level.off),
+          // REAL_API=diet 과 같은 판정 — 분석만 실 백엔드로 나간다.
+          isRealApi: (String method, String path) =>
+              method == 'POST' && path.startsWith('/diet/analyze'),
+        ),
+      );
+      // 실 네트워크 대신 서버 응답을 흉내 내는 어댑터. 인터셉터의 응답 반영이
+      // 동작하는지가 확인 대상이라 서버는 흉내로 충분하다.
+      realAnalyzeDio.httpClientAdapter = _StubAdapter();
+    });
+
+    test('서버가 인식한 끼니가 로컬 오늘 식단에 나타난다', () async {
+      final before = await dio.get<Map<String, Object?>>('/diet/days/today');
+      final beforeCount = (before.data!['entries']! as List<Object?>).length;
+
+      await realAnalyzeDio.post<Map<String, Object?>>(
+        '/diet/analyze',
+        data: <String, Object?>{'meal_type': 'dinner'},
+      );
+
+      final after = await dio.get<Map<String, Object?>>('/diet/days/today');
+      final entries = (after.data!['entries']! as List<Object?>)
+          .cast<Map<String, Object?>>();
+      expect(entries, hasLength(beforeCount + 1));
+
+      final added = entries.firstWhere(
+        (Map<String, Object?> e) => e['id'] == 'server-entry-1',
+      );
+      expect(added['meal_type'], 'dinner');
+      expect(added['total_calories'], 420);
+      expect(added['ai_comment'], '서버가 만든 코멘트');
+    });
+
+    test('조회는 여전히 로컬이 답한다 — 데모 기록이 서버 것으로 바뀌지 않는다', () async {
+      final res = await realAnalyzeDio.get<Map<String, Object?>>(
+        '/diet/days/today',
+      );
+
+      // 어댑터가 답했다면 시드 끼니가 아니라 스텁 응답이 왔을 것이다.
+      expect(res.data!['ai_coach_message'], contains('짬뽕'));
+    });
+  });
+}
+
+/// `/diet/analyze` 에만 답하는 가짜 서버.
+class _StubAdapter implements HttpClientAdapter {
+  @override
+  void close({bool force = false}) {}
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    return ResponseBody.fromString(
+      jsonEncode(<String, Object?>{
+        'entry_id': 'server-entry-1',
+        'analysis': <String, Object?>{
+          'engine': 'gemini',
+          'foods': <Map<String, Object?>>[
+            <String, Object?>{
+              'name': '연어구이',
+              'calories': 420,
+              'sodium_mg': 500,
+              'sugar_g': 2.0,
+              'carbs_g': 4.0,
+              'protein_g': 38.0,
+              'fat_g': 26.0,
+            },
+          ],
+          'total_calories': 420,
+          'total_sodium_mg': 500,
+          'total_sugar_g': 2.0,
+          'coach_comment': '서버가 만든 코멘트',
+        },
+      }),
+      200,
+      headers: <String, List<String>>{
+        Headers.contentTypeHeader: <String>[Headers.jsonContentType],
+      },
+    );
+  }
+}

--- a/frontend/flutter/test/core/real_api_switch_test.dart
+++ b/frontend/flutter/test/core/real_api_switch_test.dart
@@ -1,10 +1,15 @@
-/// 기능별 실 백엔드 전환 스위치(`REAL_API`) — #457.
+/// 기능별 실 백엔드 전환 스위치(`REAL_API`) — #457, 입도 재설계 #616.
 ///
 /// `USE_MOCK_API` 는 전역이라 끄는 순간 로그인·홈·식단·운동·채팅이 한꺼번에 실서버로
 /// 넘어간다. 이 스위치는 준비된 기능만 골라 실연동할 수 있게 한다.
 ///
-/// **가장 중요한 계약은 "키를 주지 않으면 지금과 완전히 같다"**이다. 배포된 데모가
-/// 조용히 실서버를 치기 시작하면 안 된다.
+/// 계약이 두 개다.
+///
+///  1. **키를 주지 않으면 지금과 완전히 같다.** 배포된 데모가 조용히 실서버를 치기
+///     시작하면 안 된다.
+///  2. **켜도 열리는 것은 쓰기뿐이다.** 조회까지 열리면 화면의 초기 상태가 데모 것에서
+///     서버 것으로 바뀌고, 토큰 없는 데모는 방문자 전원이 계정 하나를 공유하므로
+///     남의 기록이 보인다.
 library;
 
 import 'package:dio/dio.dart';
@@ -21,57 +26,111 @@ AppConfig _config({Set<String> realApi = const <String>{}}) => AppConfig(
   realApiFeatures: realApi,
 );
 
+/// 쓰기로 인정하는 메서드. 이 밖의 것을 열려면 이유를 따로 적어야 한다.
+const Set<String> _writeMethods = <String>{'POST', 'PUT', 'PATCH', 'DELETE'};
+
 void main() {
-  group('AppConfig.isRealApiPath', () {
-    test('키를 주지 않으면 어떤 경로도 실 백엔드로 가지 않는다', () {
+  group('AppConfig.isRealApi', () {
+    test('키를 주지 않으면 어떤 요청도 실 백엔드로 가지 않는다', () {
       final AppConfig config = _config();
 
       // 데모 배포가 이 경로다 — 하나라도 true 면 조용히 실서버를 치기 시작한다.
-      for (final String path in <String>[
-        '/ai-coach/chat',
-        '/ai-coach/messages',
-        '/auth/login',
-        '/auth/social/kakao',
-        '/diet/days/today',
-        '/dashboard/summary',
+      for (final (String method, String path) in <(String, String)>[
+        ('POST', '/ai-coach/chat'),
+        ('GET', '/ai-coach/messages'),
+        ('POST', '/auth/login'),
+        ('POST', '/auth/social/kakao'),
+        ('POST', '/diet/analyze'),
+        ('GET', '/diet/days/today'),
+        ('GET', '/dashboard/summary'),
       ]) {
-        expect(config.isRealApiPath(path), isFalse, reason: path);
+        expect(config.isRealApi(method, path), isFalse, reason: '$method $path');
       }
     });
 
-    test('켠 기능의 경로만 실 백엔드로 간다', () {
+    test('AI 코치를 켜도 대화 전송만 열리고 이력 조회는 목업으로 남는다', () {
       final AppConfig config = _config(realApi: <String>{'ai-coach'});
 
-      expect(config.isRealApiPath('/ai-coach/chat'), isTrue);
-      expect(config.isRealApiPath('/ai-coach/messages'), isTrue);
+      expect(config.isRealApi('POST', '/ai-coach/chat'), isTrue);
+
+      // #616 의 핵심 회귀. 이력이 서버에서 오면 코치 화면의 초기 상태가 바뀌고,
+      // 공유 데모 계정에서는 앞 방문자의 질문이 그대로 보인다.
+      expect(config.isRealApi('GET', '/ai-coach/messages'), isFalse);
+      expect(config.isRealApi('GET', '/ai-coach/feedback'), isFalse);
+
       // 켜지 않은 기능은 그대로 목업
-      expect(config.isRealApiPath('/auth/login'), isFalse);
-      expect(config.isRealApiPath('/diet/days/today'), isFalse);
-      expect(config.isRealApiPath('/dashboard/summary'), isFalse);
+      expect(config.isRealApi('POST', '/auth/login'), isFalse);
+      expect(config.isRealApi('GET', '/diet/days/today'), isFalse);
+    });
+
+    test('식단을 켜도 사진 분석만 열리고 조회·수정·삭제는 목업으로 남는다', () {
+      final AppConfig config = _config(realApi: <String>{'diet'});
+
+      expect(config.isRealApi('POST', '/diet/analyze'), isTrue);
+
+      // 조회가 열리면 데모의 끼니 기록이 서버 시드로 바뀐다.
+      expect(config.isRealApi('GET', '/diet/days/today'), isFalse);
+      expect(config.isRealApi('GET', '/diet/days/2026-08-11'), isFalse);
+      expect(config.isRealApi('GET', '/diet/recommendations'), isFalse);
+      expect(config.isRealApi('PUT', '/diet/entries/abc'), isFalse);
+      expect(config.isRealApi('DELETE', '/diet/entries/abc'), isFalse);
     });
 
     test('여러 기능을 함께 켤 수 있다', () {
       final AppConfig config = _config(realApi: <String>{'ai-coach', 'auth'});
 
-      expect(config.isRealApiPath('/ai-coach/chat'), isTrue);
-      expect(config.isRealApiPath('/auth/social/google'), isTrue);
-      expect(config.isRealApiPath('/diet/days/today'), isFalse);
+      expect(config.isRealApi('POST', '/ai-coach/chat'), isTrue);
+      expect(config.isRealApi('POST', '/auth/social/google'), isTrue);
+      expect(config.isRealApi('POST', '/diet/analyze'), isFalse);
     });
 
-    test('알 수 없는 키는 아무 경로도 열지 않는다', () {
+    test('같은 경로라도 메서드가 다르면 열리지 않는다', () {
+      final AppConfig config = _config(realApi: <String>{'diet'});
+
+      expect(config.isRealApi('POST', '/diet/analyze'), isTrue);
+      expect(config.isRealApi('GET', '/diet/analyze'), isFalse);
+    });
+
+    test('메서드 대소문자는 가리지 않는다', () {
+      final AppConfig config = _config(realApi: <String>{'diet'});
+
+      expect(config.isRealApi('post', '/diet/analyze'), isTrue);
+    });
+
+    test('알 수 없는 키는 아무 요청도 열지 않는다', () {
       // 오타가 조용히 전 기능을 실서버로 보내면 최악이다.
       final AppConfig config = _config(realApi: <String>{'ai_coach', 'typo'});
 
-      expect(config.isRealApiPath('/ai-coach/chat'), isFalse);
-      expect(config.isRealApiPath('/auth/login'), isFalse);
+      expect(config.isRealApi('POST', '/ai-coach/chat'), isFalse);
+      expect(config.isRealApi('POST', '/auth/login'), isFalse);
     });
 
-    test('등록된 기능 키는 모두 경로가 정의돼 있다', () {
-      for (final MapEntry<String, List<String>> entry
+    test('등록된 기능 키는 모두 엔드포인트가 정의돼 있다', () {
+      for (final MapEntry<String, List<RealApiRoute>> entry
           in kRealApiFeatures.entries) {
-        expect(entry.value, isNotEmpty, reason: '${entry.key} 에 경로가 없다');
-        for (final String prefix in entry.value) {
-          expect(prefix.startsWith('/'), isTrue, reason: prefix);
+        expect(entry.value, isNotEmpty, reason: '${entry.key} 에 엔드포인트가 없다');
+        for (final RealApiRoute route in entry.value) {
+          expect(route.pathPrefix.startsWith('/'), isTrue, reason: route.pathPrefix);
+          expect(
+            route.method,
+            equals(route.method.toUpperCase()),
+            reason: '${route.method} 는 대문자로 적는다',
+          );
+        }
+      }
+    });
+
+    test('등록된 엔드포인트는 전부 쓰기다', () {
+      // 조회를 여는 순간 데모 화면의 초기 상태가 움직인다(#616). 정말 열어야 한다면
+      // 이 테스트를 고치면서 왜 열어도 되는지 함께 적는다.
+      for (final MapEntry<String, List<RealApiRoute>> entry
+          in kRealApiFeatures.entries) {
+        for (final RealApiRoute route in entry.value) {
+          expect(
+            _writeMethods,
+            contains(route.method),
+            reason: '${entry.key} 가 조회(${route.method} ${route.pathPrefix})를 연다',
+          );
         }
       }
     });
@@ -85,9 +144,10 @@ void main() {
     /// 인터셉터가 목업 응답으로 가로챘는지(resolve), 흘려보냈는지(next) 판정.
     Future<bool> intercepted(
       MockApiInterceptor interceptor,
-      String path,
-    ) async {
-      final options = RequestOptions(path: path, method: 'GET');
+      String path, {
+      String method = 'GET',
+    }) async {
+      final options = RequestOptions(path: path, method: method);
       bool resolved = false;
       final handler = _RecordingHandler(onResolve: () => resolved = true);
       interceptor.onRequest(options, handler);
@@ -99,12 +159,22 @@ void main() {
       expect(await intercepted(interceptor, '/ping'), isTrue);
     });
 
-    test('스위치가 켜진 경로는 가로채지 않고 흘려보낸다', () async {
+    test('스위치가 켜진 요청은 가로채지 않고 흘려보낸다', () async {
       final interceptor = MockApiInterceptor(
         logger,
-        isRealApiPath: (String path) => path.startsWith('/ping'),
+        isRealApi: (String method, String path) =>
+            method == 'GET' && path.startsWith('/ping'),
       );
       expect(await intercepted(interceptor, '/ping'), isFalse);
+    });
+
+    test('메서드가 다르면 스위치가 켜져 있어도 가로챈다', () async {
+      final interceptor = MockApiInterceptor(
+        logger,
+        isRealApi: (String method, String path) =>
+            method == 'POST' && path.startsWith('/ping'),
+      );
+      expect(await intercepted(interceptor, '/ping'), isTrue);
     });
   });
 }

--- a/frontend/flutter/test/core/storage/seed_data_test.dart
+++ b/frontend/flutter/test/core/storage/seed_data_test.dart
@@ -98,7 +98,7 @@ void main() {
         reason: 'exercise sessions for the current week must be seeded',
       );
 
-      expect(await db.readValue('seeded_v13'), today);
+      expect(await db.readValue('seeded_v14'), today);
     });
 
     test('same-day re-run is a no-op (does not duplicate rows)', () async {
@@ -164,7 +164,7 @@ void main() {
     test('stale flag (different date) re-seeds with today', () async {
       // Pretend the seed last ran a week ago.
       await seedIfEmpty(db);
-      await db.putValue('seeded_v13', '2020-01-01');
+      await db.putValue('seeded_v14', '2020-01-01');
 
       await seedIfEmpty(db);
 
@@ -172,7 +172,7 @@ void main() {
       final diet = await db.select(db.dietEntries).get();
       expect(diet, isNotEmpty);
       expect(diet.where((r) => r.date == today).length, 3);
-      expect(await db.readValue('seeded_v13'), today);
+      expect(await db.readValue('seeded_v14'), today);
     });
 
     test('legacy seeded_v2=true flag is migrated and cleared', () async {
@@ -199,7 +199,7 @@ void main() {
 
       // Legacy flag cleared, current flag set to today.
       expect(await db.readValue('seeded_v2'), isNull);
-      expect(await db.readValue('seeded_v13'), _todayString());
+      expect(await db.readValue('seeded_v14'), _todayString());
 
       // Stale seed-prefixed row was wiped and replaced with today's
       // seed batch.
@@ -229,7 +229,7 @@ void main() {
 
       await seedIfEmpty(db);
       // Force a re-seed by ageing the flag.
-      await db.putValue('seeded_v13', '2020-01-01');
+      await db.putValue('seeded_v14', '2020-01-01');
       await seedIfEmpty(db);
 
       final diet = await db.select(db.dietEntries).get();

--- a/frontend/flutter/test/features/auth/session_feature_reset_test.dart
+++ b/frontend/flutter/test/features/auth/session_feature_reset_test.dart
@@ -1,15 +1,16 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
 
 import 'package:oncare/app/session_feature_reset.dart';
 import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/core/logging/app_logger.dart';
 import 'package:oncare/core/session/session_feature_reset.dart';
 import 'package:oncare/features/ai_coach/domain/entities/ai_coach_state.dart';
 import 'package:oncare/features/ai_coach/domain/entities/chat_message.dart';
 import 'package:oncare/features/ai_coach/domain/repositories/ai_coach_repository.dart';
 import 'package:oncare/features/ai_coach/presentation/controllers/ai_coach_controller.dart';
 import 'package:oncare/features/ai_coach/presentation/controllers/chat_controller.dart';
-import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
 import 'package:oncare/features/member_coach/data/repositories/mock_member_coach_repository.dart';
 import 'package:oncare/features/member_coach/domain/entities/member_coach.dart';
@@ -64,6 +65,8 @@ void main() {
               ),
             ];
           }),
+          // 식단 저장소가 Dio 를 타면서 로거가 필요해졌다(#616).
+          appLoggerProvider.overrideWithValue(Logger(level: Level.off)),
           sessionFeatureResetOverride(),
         ],
       );
@@ -87,9 +90,6 @@ void main() {
       );
       await memberCoachBefore.sendMessage('A 사용자 트레이너 메시지');
 
-      final Object dietRepositoryBefore = container.read(
-        dietRepositoryProvider,
-      );
       final Object exerciseRepositoryBefore = container.read(
         exerciseRepositoryProvider,
       );
@@ -134,10 +134,10 @@ void main() {
       );
       expect(identical(memberCoachAfter, memberCoachBefore), isFalse);
       expect(await memberCoachAfter.fetchChat(), hasLength(seedLength));
-      expect(
-        identical(container.read(dietRepositoryProvider), dietRepositoryBefore),
-        isFalse,
-      );
+      // 식단 저장소는 여기서 검사하지 않는다. 인메모리 목업이던 시절에는 계정
+      // 사이에 편집이 새지 않도록 인스턴스를 다시 만들어야 했지만, 지금은 데모
+      // 데이터가 drift 에 있고 저장소는 상태를 들지 않는다(#616). 대신 식단
+      // 화면이 읽는 provider 들은 리셋 목록에 그대로 남아 다시 조회된다.
       expect(
         identical(
           container.read(exerciseRepositoryProvider),

--- a/frontend/flutter/test/features/auth/session_feature_reset_test.dart
+++ b/frontend/flutter/test/features/auth/session_feature_reset_test.dart
@@ -1,3 +1,4 @@
+import 'package:drift/native.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:logger/logger.dart';
@@ -6,17 +7,22 @@ import 'package:oncare/app/session_feature_reset.dart';
 import 'package:oncare/core/config/app_config.dart';
 import 'package:oncare/core/logging/app_logger.dart';
 import 'package:oncare/core/session/session_feature_reset.dart';
+import 'package:oncare/core/storage/app_database.dart';
 import 'package:oncare/features/ai_coach/domain/entities/ai_coach_state.dart';
 import 'package:oncare/features/ai_coach/domain/entities/chat_message.dart';
 import 'package:oncare/features/ai_coach/domain/repositories/ai_coach_repository.dart';
 import 'package:oncare/features/ai_coach/presentation/controllers/ai_coach_controller.dart';
 import 'package:oncare/features/ai_coach/presentation/controllers/chat_controller.dart';
+import 'package:oncare/features/diet/domain/entities/diet_day.dart';
+import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
 import 'package:oncare/features/member_coach/data/repositories/mock_member_coach_repository.dart';
 import 'package:oncare/features/member_coach/domain/entities/member_coach.dart';
 import 'package:oncare/features/member_coach/domain/repositories/member_coach_repository.dart';
 import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
 import 'package:oncare/features/notification/presentation/controllers/notification_controller.dart';
+
+import '../../helpers/fake_diet_repository.dart';
 
 const AppConfig _mockConfig = AppConfig(
   environment: Environment.dev,
@@ -42,14 +48,38 @@ class _FakeAiCoachRepository implements AiCoachRepository {
   }
 }
 
+/// 조회 횟수를 세는 식단 저장소 대역.
+///
+/// 세션 리셋이 식단 화면의 provider 를 실제로 무효화하는지 확인한다. 저장소
+/// 인스턴스가 다시 만들어지는지로는 더 이상 확인할 수 없다 — 지금 저장소는
+/// 상태를 들지 않으므로 리셋해도 같은 인스턴스가 그대로 쓰인다(#616).
+class _CountingDietRepository extends FakeDietRepository {
+  int fetchTodayCalls = 0;
+
+  @override
+  Future<DietDay> fetchToday() {
+    fetchTodayCalls++;
+    return super.fetchToday();
+  }
+}
+
 void main() {
+  // 리셋이 훑는 provider 중 일부가 drift 를 타므로(#616 이후 식단 계열 포함)
+  // 바인딩과 인메모리 DB 가 필요하다. 파일 DB 를 열면 기기 저장소에 의존한다.
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   test(
     'session reset clears mutable account state and recreates mock roots',
     () async {
       var accountId = 'account-a';
+      final _CountingDietRepository diet = _CountingDietRepository();
+      final AppDatabase db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
       final ProviderContainer container = ProviderContainer(
         overrides: <Override>[
           appConfigProvider.overrideWithValue(_mockConfig),
+          dietRepositoryProvider.overrideWithValue(diet),
+          appDatabaseProvider.overrideWithValue(db),
           aiCoachRepositoryProvider.overrideWith(
             (ref) => _FakeAiCoachRepository(),
           ),
@@ -90,6 +120,9 @@ void main() {
       );
       await memberCoachBefore.sendMessage('A 사용자 트레이너 메시지');
 
+      await container.read(dietTodayProvider.future);
+      expect(diet.fetchTodayCalls, 1);
+
       final Object exerciseRepositoryBefore = container.read(
         exerciseRepositoryProvider,
       );
@@ -108,6 +141,11 @@ void main() {
       final int seedLength =
           (await MockMemberCoachRepository().fetchChat()).length;
       expect(await memberCoachBefore.fetchChat(), hasLength(seedLength + 1));
+
+      // 리셋 직전 호출 수를 잡아 둔다. 홈 요약도 같은 저장소를 읽으므로 절대
+      // 횟수를 못 박으면 무관한 provider 가 늘 때마다 여기가 깨진다. 확인하려는
+      // 성질은 "리셋 뒤 다시 조회한다" 하나다.
+      final int dietFetchesBeforeReset = diet.fetchTodayCalls;
 
       accountId = 'account-b';
       container.read(sessionFeatureResetProvider)();
@@ -134,10 +172,11 @@ void main() {
       );
       expect(identical(memberCoachAfter, memberCoachBefore), isFalse);
       expect(await memberCoachAfter.fetchChat(), hasLength(seedLength));
-      // 식단 저장소는 여기서 검사하지 않는다. 인메모리 목업이던 시절에는 계정
-      // 사이에 편집이 새지 않도록 인스턴스를 다시 만들어야 했지만, 지금은 데모
-      // 데이터가 drift 에 있고 저장소는 상태를 들지 않는다(#616). 대신 식단
-      // 화면이 읽는 provider 들은 리셋 목록에 그대로 남아 다시 조회된다.
+      // 식단은 저장소 인스턴스가 아니라 **다시 조회하는지**로 확인한다. 저장소가
+      // 상태를 들지 않게 되면서(#616) 리셋해도 같은 인스턴스가 그대로 쓰이므로,
+      // 인스턴스 비교로는 리셋이 동작하는지 알 수 없다.
+      await container.read(dietTodayProvider.future);
+      expect(diet.fetchTodayCalls, greaterThan(dietFetchesBeforeReset));
       expect(
         identical(
           container.read(exerciseRepositoryProvider),

--- a/frontend/flutter/test/features/dashboard/dashboard_controller_test.dart
+++ b/frontend/flutter/test/features/dashboard/dashboard_controller_test.dart
@@ -9,9 +9,10 @@ import 'package:oncare/features/dashboard/data/repositories/mock_dashboard_repos
 import 'package:oncare/features/dashboard/domain/entities/dashboard_summary.dart';
 import 'package:oncare/features/dashboard/domain/repositories/dashboard_repository.dart';
 import 'package:oncare/features/dashboard/presentation/controllers/dashboard_controller.dart';
-import 'package:oncare/features/diet/data/repositories/mock_diet_repository.dart';
 import 'package:oncare/features/diet/domain/entities/diet_day.dart';
 import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
+
+import '../../helpers/fake_diet_repository.dart';
 
 class _FailingDashboardRepository implements DashboardRepository {
   const _FailingDashboardRepository();
@@ -29,7 +30,7 @@ void main() {
         // Default impl is DioDashboardRepository (Stage 9.8). For
         // this unit test the React-shaped mock is enough.
         dashboardRepositoryProvider.overrideWithValue(
-          MockDashboardRepository(MockDietRepository()),
+          MockDashboardRepository(FakeDietRepository()),
         ),
       ],
     );
@@ -63,7 +64,7 @@ void main() {
   });
 
   test('MockDashboardRepository marks sodium as over-budget', () async {
-    final repo = MockDashboardRepository(MockDietRepository());
+    final repo = MockDashboardRepository(FakeDietRepository());
     final s = await repo.fetchSummary();
     final sodium = s.indicators.firstWhere(
       (HealthIndicator h) => h.label == '나트륨',
@@ -91,7 +92,7 @@ void main() {
         dailyFatG: 50,
       );
       final DashboardSummary summary = await MockDashboardRepository(
-        MockDietRepository(),
+        FakeDietRepository(),
         fetchProfile: () async => profile,
       ).fetchSummary();
       final indicators = <String, HealthIndicator>{
@@ -110,7 +111,7 @@ void main() {
   // 홈이 영양 수치를 따로 들고 있다가 식단 탭과 어긋났다 — 홈 2,329mg·4끼 vs
   // 식단 3,428mg·3끼. 식단이 기준이므로 두 화면이 같은 값을 보는지 못박는다.
   test('홈 요약의 영양 수치는 식단 하루치와 일치한다', () async {
-    final MockDietRepository diet = MockDietRepository();
+    final FakeDietRepository diet = FakeDietRepository();
     final DietDay today = await diet.fetchToday();
     final DashboardSummary s = await MockDashboardRepository(
       diet,
@@ -142,7 +143,7 @@ void main() {
       apiBaseUrl: 'https://dev.api.test',
       useMockApi: true,
     );
-    final MockDietRepository diet = MockDietRepository();
+    final FakeDietRepository diet = FakeDietRepository();
     final ProviderContainer container = ProviderContainer(
       overrides: <Override>[
         appConfigProvider.overrideWithValue(config),
@@ -176,7 +177,7 @@ void main() {
 
   // 데모 중 식단을 지우면 홈도 따라 줄어야 한다 — 같은 인스턴스를 공유하는지.
   test('식단 CRUD 가 홈 요약에 반영된다', () async {
-    final MockDietRepository diet = MockDietRepository();
+    final FakeDietRepository diet = FakeDietRepository();
     final MockDashboardRepository dashboard = MockDashboardRepository(diet);
 
     final DashboardSummary before = await dashboard.fetchSummary();

--- a/frontend/flutter/test/features/dashboard/dashboard_page_test.dart
+++ b/frontend/flutter/test/features/dashboard/dashboard_page_test.dart
@@ -8,8 +8,9 @@ import 'package:oncare/core/config/app_config.dart';
 import 'package:oncare/core/logging/app_logger.dart';
 import 'package:oncare/features/dashboard/data/repositories/mock_dashboard_repository.dart';
 import 'package:oncare/features/dashboard/presentation/controllers/dashboard_controller.dart';
-import 'package:oncare/features/diet/data/repositories/mock_diet_repository.dart';
 import 'package:oncare/shared/services/locale_provider.dart';
+
+import '../../helpers/fake_diet_repository.dart';
 
 void main() {
   Future<void> pumpApp(WidgetTester tester) async {
@@ -29,7 +30,7 @@ void main() {
           appLoggerProvider.overrideWithValue(Logger(level: Level.off)),
           localeProvider.overrideWith((ref) => const Locale('ko')),
           dashboardRepositoryProvider.overrideWithValue(
-            MockDashboardRepository(MockDietRepository()),
+            MockDashboardRepository(FakeDietRepository()),
           ),
         ],
         child: const OncareApp(),

--- a/frontend/flutter/test/features/dashboard/dashboard_repository_mode_test.dart
+++ b/frontend/flutter/test/features/dashboard/dashboard_repository_mode_test.dart
@@ -1,9 +1,11 @@
+import 'package:drift/native.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:logger/logger.dart';
 
 import 'package:oncare/core/config/app_config.dart';
 import 'package:oncare/core/logging/app_logger.dart';
+import 'package:oncare/core/storage/app_database.dart';
 import 'package:oncare/features/account/data/repositories/mock_account_repository.dart';
 import 'package:oncare/features/account/presentation/controllers/account_controller.dart';
 import 'package:oncare/features/dashboard/data/repositories/dio_dashboard_repository.dart';
@@ -13,7 +15,16 @@ import 'package:oncare/features/dashboard/presentation/controllers/dashboard_con
 /// 이 분기가 두 번 유실되어 데모 홈이 "대시보드 정보를 불러오지 못했어요" 만
 /// 띄운 적이 있다. my_health 의 같은 이름 테스트와 짝을 이루는 회귀 방지용.
 void main() {
+  // 목업 대시보드가 식단 저장소를 통해 drift 를 타므로(#616) 바인딩과 인메모리
+  // DB 가 필요하다. 파일 DB 를 열면 테스트가 기기 저장소에 의존하게 된다.
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('dashboardRepositoryProvider 모드 분기', () {
+    late AppDatabase db;
+
+    setUp(() => db = AppDatabase.forTesting(NativeDatabase.memory()));
+    tearDown(() => db.close());
+
     ProviderContainer makeContainer({required bool useMockApi}) {
       final container = ProviderContainer(
         overrides: <Override>[
@@ -26,6 +37,7 @@ void main() {
           ),
           // Dio 저장소 경로는 dioProvider → appLogger 를 타므로 조용한 로거로 오버라이드.
           appLoggerProvider.overrideWithValue(Logger(level: Level.off)),
+          appDatabaseProvider.overrideWithValue(db),
           accountRepositoryProvider.overrideWithValue(MockAccountRepository()),
         ],
       );
@@ -54,6 +66,7 @@ void main() {
         overrides: <Override>[
           appConfigProvider.overrideWithValue(AppConfig.fromEnvironment()),
           appLoggerProvider.overrideWithValue(Logger(level: Level.off)),
+          appDatabaseProvider.overrideWithValue(db),
           accountRepositoryProvider.overrideWithValue(MockAccountRepository()),
         ],
       );

--- a/frontend/flutter/test/features/dashboard/home_ai_advice_test.dart
+++ b/frontend/flutter/test/features/dashboard/home_ai_advice_test.dart
@@ -15,7 +15,6 @@ import 'package:oncare/features/account/presentation/controllers/account_control
 import 'package:oncare/features/dashboard/data/repositories/mock_dashboard_repository.dart';
 import 'package:oncare/features/dashboard/domain/entities/dashboard_summary.dart';
 import 'package:oncare/features/dashboard/presentation/ai_advice_text.dart';
-import 'package:oncare/features/diet/data/repositories/mock_diet_repository.dart';
 import 'package:oncare/features/diet/domain/entities/diet_day.dart';
 import 'package:oncare/features/diet/domain/repositories/diet_repository.dart';
 import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
@@ -24,6 +23,8 @@ import 'package:oncare/features/exercise/domain/repositories/exercise_repository
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 import 'package:oncare/shared/services/locale_provider.dart';
+
+import '../../helpers/fake_diet_repository.dart';
 
 final RegExp _hangul = RegExp('[가-힣]');
 
@@ -48,7 +49,7 @@ DashboardSummary _summary({String? adviceKey, String? sodiumWarning}) =>
 void main() {
   test('데모 mock 요약은 문구가 아니라 키를 싣는다', () async {
     final DashboardSummary summary = await MockDashboardRepository(
-      MockDietRepository(),
+      FakeDietRepository(),
     ).fetchSummary();
 
     expect(summary.aiAdviceKey, kDailyCombinedAdviceKey);
@@ -132,7 +133,7 @@ void main() {
             appConfigProvider.overrideWithValue(config),
             appLoggerProvider.overrideWithValue(Logger(level: Level.off)),
             dietRepositoryProvider.overrideWithValue(
-              MockDietRepository() as DietRepository,
+              FakeDietRepository() as DietRepository,
             ),
             exerciseRepositoryProvider.overrideWithValue(
               MockExerciseRepository() as ExerciseRepository,

--- a/frontend/flutter/test/features/diet/diet_add_sheet_test.dart
+++ b/frontend/flutter/test/features/diet/diet_add_sheet_test.dart
@@ -5,13 +5,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:oncare/features/diet/data/repositories/mock_diet_repository.dart';
 import 'package:oncare/features/diet/domain/entities/diet_analysis.dart';
 import 'package:oncare/features/diet/domain/entities/meal_photo.dart';
 import 'package:oncare/features/diet/domain/repositories/meal_photo_picker.dart';
 import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
 import 'package:oncare/features/diet/presentation/widgets/diet_flows.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
+
+import '../../helpers/fake_diet_repository.dart';
 
 final Uint8List _jpegBytes = Uint8List.fromList(<int>[
   0xFF,
@@ -49,7 +50,7 @@ class _PendingMealPhotoPicker implements MealPhotoPicker {
   Future<MealPhoto?> pick(MealPhotoSource source) => completer.future;
 }
 
-class _RecordingDietRepository extends MockDietRepository {
+class _RecordingDietRepository extends FakeDietRepository {
   MealPhoto? uploaded;
 
   @override
@@ -357,7 +358,7 @@ void main() {
   });
 }
 
-class _FailingOnceDietRepository extends MockDietRepository {
+class _FailingOnceDietRepository extends FakeDietRepository {
   int calls = 0;
 
   @override

--- a/frontend/flutter/test/features/diet/diet_analysis_failure_sheet_test.dart
+++ b/frontend/flutter/test/features/diet/diet_analysis_failure_sheet_test.dart
@@ -9,13 +9,14 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:oncare/app/session_feature_reset.dart';
 import 'package:oncare/core/errors/app_error.dart';
 import 'package:oncare/features/auth/presentation/controllers/session_controller.dart';
-import 'package:oncare/features/diet/data/repositories/mock_diet_repository.dart';
 import 'package:oncare/features/diet/domain/entities/diet_analysis.dart';
 import 'package:oncare/features/diet/domain/entities/meal_photo.dart';
 import 'package:oncare/features/diet/domain/repositories/meal_photo_picker.dart';
 import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
 import 'package:oncare/features/diet/presentation/widgets/diet_flows.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
+
+import '../../helpers/fake_diet_repository.dart';
 
 final Uint8List _jpegBytes = Uint8List.fromList(<int>[
   0xFF,
@@ -35,7 +36,7 @@ class _FixedPicker implements MealPhotoPicker {
 
 /// Fails every analyze with the given HTTP status, counting attempts so a
 /// test can prove whether the button actually re-sent the request.
-class _FailingDietRepository extends MockDietRepository {
+class _FailingDietRepository extends FakeDietRepository {
   _FailingDietRepository(this.statusCode);
 
   final int statusCode;

--- a/frontend/flutter/test/features/diet/diet_controller_test.dart
+++ b/frontend/flutter/test/features/diet/diet_controller_test.dart
@@ -1,9 +1,10 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:oncare/features/diet/data/repositories/mock_diet_repository.dart';
 import 'package:oncare/features/diet/domain/entities/diet_day.dart';
 import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
+
+import '../../helpers/fake_diet_repository.dart';
 
 void main() {
   test('dietTodayProvider returns mock day (stub repo)', () async {
@@ -11,7 +12,7 @@ void main() {
       overrides: <Override>[
         // Default repo is DioDietRepository (needs db + dio overrides);
         // for this unit test the in-memory mock from stage 4 is enough.
-        dietRepositoryProvider.overrideWithValue(MockDietRepository()),
+        dietRepositoryProvider.overrideWithValue(FakeDietRepository()),
       ],
     );
     addTearDown(container.dispose);
@@ -80,7 +81,7 @@ void main() {
   );
 }
 
-class _DateRecordingDietRepository extends MockDietRepository {
+class _DateRecordingDietRepository extends FakeDietRepository {
   final List<DateTime> requestedDates = <DateTime>[];
 
   @override

--- a/frontend/flutter/test/features/diet/diet_macros_display_test.dart
+++ b/frontend/flutter/test/features/diet/diet_macros_display_test.dart
@@ -5,11 +5,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:oncare/design_system/figma/figma_kit.dart';
 import 'package:oncare/features/account/data/repositories/mock_account_repository.dart';
 import 'package:oncare/features/account/domain/entities/user_profile.dart';
-import 'package:oncare/features/diet/data/repositories/mock_diet_repository.dart';
 import 'package:oncare/features/diet/domain/entities/diet_day.dart';
 import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
 import 'package:oncare/features/diet/presentation/pages/diet_record_page.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
+
+import '../../helpers/fake_diet_repository.dart';
 
 Widget _app(Widget home, {List<Override> overrides = const <Override>[]}) {
   return ProviderScope(
@@ -23,7 +24,7 @@ Widget _app(Widget home, {List<Override> overrides = const <Override>[]}) {
   );
 }
 
-class _PastDateDietRepository extends MockDietRepository {
+class _PastDateDietRepository extends FakeDietRepository {
   _PastDateDietRepository({this.fail = false});
 
   final bool fail;
@@ -129,7 +130,7 @@ void main() {
     await tester.binding.setSurfaceSize(const Size(900, 1800));
     addTearDown(() => tester.binding.setSurfaceSize(null));
     final DietDay day =
-        await tester.runAsync(() => MockDietRepository().fetchToday())
+        await tester.runAsync(() => FakeDietRepository().fetchToday())
             as DietDay;
     const UserProfile profile = UserProfile(
       id: 'member',
@@ -166,7 +167,7 @@ void main() {
       await tester.binding.setSurfaceSize(const Size(340, 900));
       addTearDown(() => tester.binding.setSurfaceSize(null));
       final DietDay day =
-          await tester.runAsync(() => MockDietRepository().fetchToday())
+          await tester.runAsync(() => FakeDietRepository().fetchToday())
               as DietDay;
 
       await tester.pumpWidget(_app(Scaffold(body: NutritionSummary(day: day))));
@@ -265,7 +266,7 @@ void main() {
       _app(
         const DietRecordPage(),
         overrides: <Override>[
-          dietRepositoryProvider.overrideWithValue(MockDietRepository()),
+          dietRepositoryProvider.overrideWithValue(FakeDietRepository()),
         ],
       ),
     );
@@ -335,7 +336,7 @@ void main() {
       _app(
         const DietRecordPage(),
         overrides: <Override>[
-          dietRepositoryProvider.overrideWithValue(MockDietRepository()),
+          dietRepositoryProvider.overrideWithValue(FakeDietRepository()),
         ],
       ),
     );
@@ -367,7 +368,7 @@ void main() {
       _app(
         const DietRecordPage(),
         overrides: <Override>[
-          dietRepositoryProvider.overrideWithValue(MockDietRepository()),
+          dietRepositoryProvider.overrideWithValue(FakeDietRepository()),
         ],
       ),
     );

--- a/frontend/flutter/test/features/diet/fake_diet_repository_test.dart
+++ b/frontend/flutter/test/features/diet/fake_diet_repository_test.dart
@@ -403,6 +403,91 @@ void main() {
       }
     },
   );
+
+  group('하루 합계는 항상 항목에서 파생된다 (리뷰)', () {
+    // 예전에는 칼로리·나트륨·당류를 따로 캐시하고 CRUD 마다 증감을 더했다. 경로가
+    // 셋이라 하나만 빠져도 합계가 항목과 어긋나는데, 대역이 그런 상태를 돌려주면
+    // 화면 테스트가 실제와 다른 것을 검증하게 된다.
+
+    test('시드 상태에서 이미 일치한다', () async {
+      final repo = FakeDietRepository();
+
+      _expectTotalsMatchEntries(await repo.fetchToday());
+    });
+
+    test('분석으로 추가한 뒤에도 일치한다', () async {
+      final repo = FakeDietRepository();
+
+      await repo.analyze(photo: photo, mealType: 'dinner');
+
+      _expectTotalsMatchEntries(await repo.fetchToday());
+    });
+
+    test('수정한 뒤에도 일치한다', () async {
+      final repo = FakeDietRepository();
+      final DietDay before = await repo.fetchToday();
+
+      await repo.updateEntry(
+        id: before.entries.first.id!,
+        totalCalories: 999,
+        sodiumMg: 111,
+        sugarG: 4.5,
+      );
+
+      _expectTotalsMatchEntries(await repo.fetchToday());
+    });
+
+    test('삭제한 뒤에도 일치한다', () async {
+      final repo = FakeDietRepository();
+      final DietDay before = await repo.fetchToday();
+
+      await repo.deleteEntry(before.entries.first.id!);
+
+      _expectTotalsMatchEntries(await repo.fetchToday());
+    });
+
+    test('전부 지우면 0 이 된다 — 캐시가 남아 음수로 고정되지 않는다', () async {
+      final repo = FakeDietRepository();
+      for (final DietEntry entry in (await repo.fetchToday()).entries) {
+        await repo.deleteEntry(entry.id!);
+      }
+
+      final DietDay day = await repo.fetchToday();
+      expect(day.entries, isEmpty);
+      expect(day.totalCalories, 0);
+      expect(day.totalSodiumMg, 0);
+      expect(day.totalSugarG, 0);
+    });
+  });
+}
+
+/// 하루 합계 세 값이 그 날 항목의 합과 같은지 확인한다.
+void _expectTotalsMatchEntries(DietDay day) {
+  expect(
+    day.totalCalories,
+    day.entries.fold<int>(
+      0,
+      (int sum, DietEntry entry) => sum + entry.totalCalories,
+    ),
+  );
+  expect(
+    day.totalSodiumMg,
+    day.entries.fold<int>(
+      0,
+      (int sum, DietEntry entry) => sum + entry.sodiumMg,
+    ),
+  );
+  expect(
+    day.totalSugarG,
+    closeTo(
+      day.entries.fold<double>(
+        0,
+        (double sum, DietEntry entry) => sum + entry.sugarG,
+      ),
+      0.001,
+    ),
+  );
+  _expectMacrosMatchEntries(day);
 }
 
 void _expectMacrosMatchEntries(DietDay day) {

--- a/frontend/flutter/test/features/diet/fake_diet_repository_test.dart
+++ b/frontend/flutter/test/features/diet/fake_diet_repository_test.dart
@@ -2,20 +2,21 @@ import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:oncare/features/diet/data/repositories/mock_diet_repository.dart';
 import 'package:oncare/features/diet/domain/entities/diet_day.dart';
 import 'package:oncare/features/diet/domain/entities/meal_photo.dart';
+
+import '../../helpers/fake_diet_repository.dart';
 
 void main() {
   final MealPhoto photo = MealPhoto.fromBytes(
     Uint8List.fromList(<int>[0xFF, 0xD8, 0xFF, 0xE0]),
   )!;
 
-  group('MockDietRepository keeps CRUD in memory (#294)', () {
+  group('FakeDietRepository keeps CRUD in memory (#294)', () {
     test(
       'fetchByDate returns seeded history and keeps an older date empty',
       () async {
-        final repo = MockDietRepository();
+        final repo = FakeDietRepository();
         final now = DateTime.now();
 
         final today = await repo.fetchByDate(now);
@@ -90,7 +91,7 @@ void main() {
     );
 
     test('analyze appends an entry and updates the day totals', () async {
-      final repo = MockDietRepository();
+      final repo = FakeDietRepository();
       final DietDay before = await repo.fetchToday();
       expect(before.entries.length, 3);
       expect(before.totalCalories, 1067);
@@ -119,7 +120,7 @@ void main() {
     test(
       'analyze is idempotent on a repeated key (no duplicate entry)',
       () async {
-        final repo = MockDietRepository();
+        final repo = FakeDietRepository();
         final first = await repo.analyze(
           photo: photo,
           mealType: 'dinner',
@@ -139,7 +140,7 @@ void main() {
     );
 
     test('deleteEntry removes it and restores the totals', () async {
-      final repo = MockDietRepository();
+      final repo = FakeDietRepository();
       final result = await repo.analyze(
         photo: photo,
         mealType: 'snack',
@@ -159,7 +160,7 @@ void main() {
     test(
       'same key after delete re-adds the entry (cache purged on delete, 리뷰 #294)',
       () async {
-        final repo = MockDietRepository();
+        final repo = FakeDietRepository();
         final first = await repo.analyze(
           photo: photo,
           mealType: 'dinner',
@@ -188,7 +189,7 @@ void main() {
     );
 
     test('updateEntry re-derives day totals and macros', () async {
-      final repo = MockDietRepository();
+      final repo = FakeDietRepository();
       await repo.updateEntry(
         id: 'mock-lunch',
         foods: const <FoodItem>[
@@ -226,7 +227,7 @@ void main() {
     });
 
     test('deleteEntry re-derives day macros from remaining entries', () async {
-      final repo = MockDietRepository();
+      final repo = FakeDietRepository();
 
       await repo.deleteEntry('mock-lunch');
 
@@ -247,7 +248,7 @@ void main() {
     });
 
     test('empty entries return zero macros without throwing', () async {
-      final repo = MockDietRepository();
+      final repo = FakeDietRepository();
       final DietDay before = await repo.fetchToday();
 
       for (final entry in before.entries) {
@@ -268,7 +269,7 @@ void main() {
   test(
     'realistic seed keeps food, meal and daily nutrition totals aligned',
     () async {
-      final day = await MockDietRepository().fetchToday();
+      final day = await FakeDietRepository().fetchToday();
 
       for (final entry in day.entries) {
         expect(
@@ -351,7 +352,7 @@ void main() {
   );
 
   test('jjamppong is the largest sodium source', () async {
-    final day = await MockDietRepository().fetchToday();
+    final day = await FakeDietRepository().fetchToday();
     final foods = day.entries.expand((DietEntry entry) => entry.foods).toList()
       ..sort((FoodItem a, FoodItem b) => b.sodiumMg.compareTo(a.sodiumMg));
 
@@ -366,7 +367,7 @@ void main() {
   test(
     'historical photo analysis keeps food and meal totals aligned',
     () async {
-      final repo = MockDietRepository();
+      final repo = FakeDietRepository();
       final now = DateTime.now();
       for (final daysAgo in <int>[1, 2]) {
         final day = await repo.fetchByDate(

--- a/frontend/flutter/test/helpers/fake_diet_repository.dart
+++ b/frontend/flutter/test/helpers/fake_diet_repository.dart
@@ -14,9 +14,10 @@ import 'package:oncare/features/diet/domain/repositories/diet_repository.dart';
 /// 하루치를 시드하고 analyze(=추가)/수정/삭제를 메모리에 유지하므로, 식단 탭 목록과
 /// "오늘의 영양 요약" 합계가 앱을 통한 편집을 따라간다(#294).
 ///
-/// Per-food nutrition is the single source of truth for the seeded meal and
-/// daily totals. CRUD applies calories, sodium, and sugar deltas on top of the
-/// seed; macro totals are derived from the current entries.
+/// 하루 합계는 **항상 [_entries] 에서 계산한다.** 예전에는 칼로리·나트륨·당류만
+/// 따로 캐시해 두고 CRUD 마다 증감을 더했는데, 경로가 셋(추가·수정·삭제)이라 하나만
+/// 빠져도 대역이 항목과 어긋난 합계를 돌려주게 된다 — 매크로는 이미 항목에서 계산하고
+/// 있었으므로 표현이 둘로 갈려 있기도 했다(리뷰).
 class FakeDietRepository implements DietRepository {
   FakeDietRepository();
 
@@ -116,9 +117,14 @@ class FakeDietRepository implements DietRepository {
     ),
   ];
 
-  int _totalCalories = 1067;
-  int _totalSodiumMg = 3428;
-  double _totalSugarG = 17.8;
+  int get _totalCalories =>
+      _entries.fold<int>(0, (int sum, DietEntry e) => sum + e.totalCalories);
+
+  int get _totalSodiumMg =>
+      _entries.fold<int>(0, (int sum, DietEntry e) => sum + e.sodiumMg);
+
+  double get _totalSugarG =>
+      _entries.fold<double>(0, (double sum, DietEntry e) => sum + e.sugarG);
   int _seq = 0;
 
   // idempotencyKey → 이미 기록한 분석 결과. 응답 유실 후 재시도(같은 키)에
@@ -181,10 +187,6 @@ class FakeDietRepository implements DietRepository {
             .toList(),
       ),
     );
-    _totalCalories += cals;
-    _totalSodiumMg += sodium;
-    _totalSugarG += sugar;
-
     final DietAnalysisResult result = DietAnalysisResult(
       entryId: id,
       foods: foods,
@@ -250,10 +252,6 @@ class FakeDietRepository implements DietRepository {
     await Future<void>.delayed(const Duration(milliseconds: 100));
     final int idx = _entries.indexWhere((DietEntry e) => e.id == id);
     if (idx < 0) return;
-    final DietEntry e = _entries[idx];
-    _totalCalories = _nonNegInt(_totalCalories - e.totalCalories);
-    _totalSodiumMg = _nonNegInt(_totalSodiumMg - e.sodiumMg);
-    _totalSugarG = _nonNegDouble(_totalSugarG - e.sugarG);
     _entries.removeAt(idx);
     // 이 항목을 가리키던 멱등 캐시 키를 제거한다. 안 그러면 삭제 후 같은
     // idempotencyKey 로 재요청할 때 이미 사라진 항목의 낡은 결과만 반환되고
@@ -304,13 +302,6 @@ class FakeDietRepository implements DietRepository {
       foods: updatedFoods,
     );
     if (old != null) {
-      _totalCalories = _nonNegInt(
-        _totalCalories + updated.totalCalories - old.totalCalories,
-      );
-      _totalSodiumMg = _nonNegInt(
-        _totalSodiumMg + updated.sodiumMg - old.sodiumMg,
-      );
-      _totalSugarG = _nonNegDouble(_totalSugarG + updated.sugarG - old.sugarG);
       _entries[idx] = updated;
     }
     return updated;
@@ -330,8 +321,6 @@ class FakeDietRepository implements DietRepository {
     return '$hh:$mm';
   }
 
-  int _nonNegInt(int v) => v < 0 ? 0 : v;
-  double _nonNegDouble(double v) => v < 0 ? 0 : v;
 }
 
 const List<DietEntry> _yesterdayEntries = <DietEntry>[

--- a/frontend/flutter/test/helpers/fake_diet_repository.dart
+++ b/frontend/flutter/test/helpers/fake_diet_repository.dart
@@ -4,18 +4,21 @@ import 'package:oncare/features/diet/domain/entities/meal_photo.dart';
 import 'package:oncare/features/diet/domain/entities/meal_recommendation.dart';
 import 'package:oncare/features/diet/domain/repositories/diet_repository.dart';
 
-/// In-memory stateful mock for demo mode (`useMockApi`). Seeds a realistic day,
-/// then keeps analyze(=add)/update/delete in memory for
-/// the app session so the diet-tab list and the "오늘의 영양 요약" totals
-/// reflect edits made through the app (issue #294). A single instance is
-/// created by [dietRepositoryProvider] and lives for the session, so the drift
-/// persists until the app is restarted.
+/// 테스트용 인메모리 식단 저장소.
+///
+/// 예전에는 데모 모드(`useMockApi`)의 실제 구현이었다. 지금 데모 응답은
+/// `LocalApiInterceptor` 가 drift 에서 만들고 저장소는 항상 Dio 라(#616), 이 구현은
+/// **테스트 대역으로만** 남는다 — 위젯 테스트가 drift 를 세우지 않고 식단 화면의
+/// 상태 변화를 확인할 수 있게 해 준다.
+///
+/// 하루치를 시드하고 analyze(=추가)/수정/삭제를 메모리에 유지하므로, 식단 탭 목록과
+/// "오늘의 영양 요약" 합계가 앱을 통한 편집을 따라간다(#294).
 ///
 /// Per-food nutrition is the single source of truth for the seeded meal and
 /// daily totals. CRUD applies calories, sodium, and sugar deltas on top of the
 /// seed; macro totals are derived from the current entries.
-class MockDietRepository implements DietRepository {
-  MockDietRepository();
+class FakeDietRepository implements DietRepository {
+  FakeDietRepository();
 
   static const String _aiCoachMessage =
       '점심 짬뽕으로 오늘 나트륨 섭취가 많았어요. 저녁은 양념을 줄인 채소와 단백질 위주로 구성해 보세요.';

--- a/frontend/flutter/test/widget_test.dart
+++ b/frontend/flutter/test/widget_test.dart
@@ -55,16 +55,20 @@ void main() {
       apiBaseUrl: 'https://dev.api.test',
       useMockApi: true,
     );
+    // 식단 탭과 홈 요약이 같은 데이터를 본다 — 아래 두 override 가 공유한다.
+    final FakeDietRepository diet = FakeDietRepository();
     await tester.pumpWidget(
       ProviderScope(
         overrides: <Override>[
           appConfigProvider.overrideWithValue(config),
           appLoggerProvider.overrideWithValue(Logger(level: Level.off)),
           // Diet repo defaults to DioDietRepository (Stage 9) which
-          // needs a real dio+db. Swap to the in-memory mock here.
-          dietRepositoryProvider.overrideWithValue(
-            FakeDietRepository() as DietRepository,
-          ),
+          // needs a real dio+db. Swap to the in-memory fake here.
+          //
+          // 아래 대시보드 override 와 **같은 인스턴스**를 쓴다. 따로 만들면 식단
+          // 탭에서 추가·삭제한 끼니를 홈 요약이 못 보게 되어, 테스트가 실제와
+          // 다른 상태를 검증하게 된다(리뷰).
+          dietRepositoryProvider.overrideWithValue(diet as DietRepository),
           // Same reason — exercise repo defaults to DioExerciseRepository
           // (Stage 9.6); swap to the in-memory mock here.
           exerciseRepositoryProvider.overrideWithValue(
@@ -74,8 +78,7 @@ void main() {
           // 9.8); the smoke test only inspects the nav, so the mock is
           // plenty.
           dashboardRepositoryProvider.overrideWithValue(
-            MockDashboardRepository(FakeDietRepository())
-                as DashboardRepository,
+            MockDashboardRepository(diet) as DashboardRepository,
           ),
           if (memberCoachRepository != null)
             memberCoachRepositoryProvider.overrideWithValue(

--- a/frontend/flutter/test/widget_test.dart
+++ b/frontend/flutter/test/widget_test.dart
@@ -13,7 +13,6 @@ import 'package:oncare/core/logging/app_logger.dart';
 import 'package:oncare/features/dashboard/data/repositories/mock_dashboard_repository.dart';
 import 'package:oncare/features/dashboard/domain/repositories/dashboard_repository.dart';
 import 'package:oncare/features/dashboard/presentation/controllers/dashboard_controller.dart';
-import 'package:oncare/features/diet/data/repositories/mock_diet_repository.dart';
 import 'package:oncare/features/diet/domain/repositories/diet_repository.dart';
 import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
 import 'package:oncare/features/exercise/data/repositories/mock_exercise_repository.dart';
@@ -25,6 +24,8 @@ import 'package:oncare/features/member_coach/domain/repositories/member_coach_re
 import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 import 'package:oncare/shared/services/locale_provider.dart';
+
+import 'helpers/fake_diet_repository.dart';
 
 class _CountingMemberCoachRepository extends MockMemberCoachRepository {
   int routineLoads = 0;
@@ -62,7 +63,7 @@ void main() {
           // Diet repo defaults to DioDietRepository (Stage 9) which
           // needs a real dio+db. Swap to the in-memory mock here.
           dietRepositoryProvider.overrideWithValue(
-            MockDietRepository() as DietRepository,
+            FakeDietRepository() as DietRepository,
           ),
           // Same reason — exercise repo defaults to DioExerciseRepository
           // (Stage 9.6); swap to the in-memory mock here.
@@ -73,7 +74,7 @@ void main() {
           // 9.8); the smoke test only inspects the nav, so the mock is
           // plenty.
           dashboardRepositoryProvider.overrideWithValue(
-            MockDashboardRepository(MockDietRepository())
+            MockDashboardRepository(FakeDietRepository())
                 as DashboardRepository,
           ),
           if (memberCoachRepository != null)


### PR DESCRIPTION
Closes #616

## Summary

목업 빌드에서 식단만 인메모리 저장소로 갈라져 있어 `REAL_API=diet` 가 죽은 스위치였다.
그 구현은 Dio 를 타지 않으므로 요청 자체가 발생하지 않았고, 인터셉터의 통과 규칙에
닿을 일이 없었다. 식단도 AI 코치와 같은 구조로 옮겨 저장소는 항상 Dio 로 두고 데모
응답은 로컬 인터셉터가 만들게 했다.

작업 중 두 번째 문제가 드러났다. 스위치 키가 경로 접두사라 AI 코치를 켜면 대화
전송뿐 아니라 **이력 조회까지** 열렸다. 코치 화면은 열릴 때 이력을 먼저 읽으므로
화면의 초기 상태가 서버 것으로 바뀌고, 토큰 없는 배포 데모는 방문자 전원이 계정
하나를 공유해 앞 방문자의 질문이 그대로 보인다. 키가 여는 범위를 쓰기로 좁혔다.

## Changes

**스위치 입도** — 기능 키가 경로 접두사가 아니라 메서드+경로를 가리키게 했다. 여는
것은 AI 가 실제로 일하는 호출(대화 전송, 사진 분석)뿐이고 조회는 로컬이 계속 담당한다.
등록된 엔드포인트가 전부 쓰기인지 검사하는 테스트를 함께 뒀다 — 조회를 여는 변경은
그 테스트를 고치면서 이유를 적게 된다.

**식단 저장소 통일** — 저장소 분기를 없애고 데모 응답을 인터셉터로 옮겼다. 옮기면서
인터셉터 경로에 자리가 없던 세 가지를 채웠다.

- 끼니별 AI 코멘트: 테이블에 컬럼을 더하고 시드 문구를 기존 화면과 맞췄다.
- 끼니 사진: 인터셉터가 들고 있던 시드 id → 에셋 맵을 컬럼으로 옮겼다. 맵으로는 새로
  분석한 항목에 사진이 붙지 않았다.
- 하루 코치 문구: 수치 기반 분기 대신 시드가 정한 날짜별 문장을 먼저 본다. 시드가
  없는 날짜는 종전대로 수치를 보고 만든다.

빠져 있던 추천 조회 핸들러를 더했다. 개인화 근거가 없다고 밝히고 기본 순서를
돌려주므로 화면이 없는 근거를 그리지 않는다.

**실 분석 결과의 로컬 반영** — 분석만 실 서버로 나가면 목록은 여전히 로컬에서 읽으므로,
반영하지 않으면 방금 찍은 끼니가 목록에 나타나지 않는다. 서버가 준 id 를 그대로 써서
이어지는 수정·삭제가 같은 행을 가리키게 했다.

**정리** — 인메모리 구현은 테스트 대역으로만 남기고 test/ 로 옮겼다. 위젯 테스트가
drift 를 세우지 않고 식단 화면의 상태 변화를 확인하는 데 계속 쓰인다.

## Verification

데모 둘러보기로 진입해 브라우저에서 직접 확인했다. 옮기기 전과 같다.

- 식단 탭: 칼로리 1,067 · 나트륨 3,428 · 당류 17.8 · 탄단지 120/45/45
- 끼니 카드: 아침 08:20 스크램블 에그 사진과 코멘트, 점심 12:40 짬뽕 사진과 코멘트
- 하루 조언: "점심 짬뽕으로 오늘 나트륨 섭취가 많았어요…" (수치 분기였다면 다른 문장이 나온다)
- 홈: 같은 수치와 주간 칼로리 추이

`flutter analyze` 클린, 테스트 497개 통과(신규 회귀 테스트 15개 포함).

## Notes

- 데모에서 분석한 끼니가 **앱을 다시 열어도 남는다.** 인메모리 저장소는 새로고침하면
  잊었지만 지금은 로컬 DB 에 남기 때문이다. 시드 끼니와 초기 화면은 그대로이고 방문자
  각자의 브라우저에만 쌓인다. 종전처럼 매번 잊게 하려면 별도로 정리 경로를 두면 된다 —
  판단이 필요해 이 PR 에서는 건드리지 않았다.
- 스키마에 컬럼이 늘어 마이그레이션과 시드 플래그를 함께 올렸다. 기존 설치는 다음 실행에
  새 시드를 받는다.
- #605 가 사용자 앱에 요청 식별자 유틸을 들여온다. 식단 분석 멱등키는 기존 계약을 그대로
  두었고 건드리는 파일도 겹치지 않는다.
- 배포 데모에 스위치를 실제로 주입하는 일은 #617 이다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 식단 기록에 식사별 AI 코멘트와 사진 정보를 표시합니다.
  - 오늘·어제 등 날짜별 AI 코치 메시지를 제공합니다.
  - 식단 분석 결과와 추천 응답을 실제 API와 연동하고, 조회 데이터는 로컬 데이터와 함께 제공합니다.
  - 식단 수정·재시도 후에도 AI 코멘트와 사진 정보가 유지됩니다.

- **개선**
  - 데이터베이스 업데이트 시 기존 식단 정보를 보존하면서 새 정보를 자동으로 반영합니다.
  - API 요청 방식에 따라 안정적으로 처리되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->