### PR TITLE
test(e2e): AI 루틴 A/B 생성 → 편집 → 배정 → 회원 수신 스윕 추가

### DIFF
--- a/backend/scripts/e2e_sweep.py
+++ b/backend/scripts/e2e_sweep.py
@@ -466,13 +466,14 @@ def scenario_ai_routine(api: Api, m: str, t: str, out: list[Result]) -> None:
     ))
 
     # 트레이너가 입력한 가능 시간을 넘는 계획은 그대로 배정될 수 없다.
-    over = [
-        p.get("total_minutes") for p in (plan_a, plan_b)
-        if isinstance(p.get("total_minutes"), int) and p["total_minutes"] > available
-    ]
+    totals = [p.get("total_minutes") for p in (plan_a, plan_b)]
+    within_limit = all(
+        type(minutes) is int and minutes <= available
+        for minutes in totals
+    )
     out.append(Result(
-        g, "가능 시간 상한", "PASS" if not over else "FAIL",
-        f"available={available} 초과={over}",
+        g, "가능 시간 상한", "PASS" if within_limit else "FAIL",
+        f"available={available} total_minutes={totals}",
     ))
 
     generated_by = options.get("generated_by")
@@ -487,9 +488,16 @@ def scenario_ai_routine(api: Api, m: str, t: str, out: list[Result]) -> None:
 
     # #580: 채팅이 근거로 실렸는지. 앞선 채팅 시나리오가 남긴 메시지가 있어야 한다.
     recent = (options.get("analysis") or {}).get("recent_messages")
+    evidence_ok = (
+        isinstance(recent, list)
+        and any(
+            isinstance(message, str) and _MARKER in message
+            for message in recent
+        )
+    )
     out.append(Result(
         g, "채팅 근거 반영(#580)",
-        "PASS" if isinstance(recent, list) and recent else "SKIP",
+        "PASS" if evidence_ok else "FAIL",
         f"recent_messages={len(recent) if isinstance(recent, list) else 'none'}",
     ))
 

--- a/backend/scripts/e2e_sweep.py
+++ b/backend/scripts/e2e_sweep.py
@@ -21,8 +21,9 @@ FAIL 로 보고한다. DB 정리는 항상 로컬 DATABASE_URL 로 붙으므로 
 
 혼자 쓰는 로컬 데모 DB 를 전제로 한다. 자세한 이유는 purge_sweep_traces 참고.
 
-AI 코칭·루틴 경로는 다루지 않는다. 키가 없으면 규칙 폴백이 200 을 돌려주어 통과처럼
-보이기 때문이다(#579 수정 후 #589 에서 검증).
+AI 루틴 경로(A/B 생성 → 편집 → 배정 → 회원 수신)도 훑는다(#589). 키가 없으면 규칙
+폴백이 200 을 돌려주므로, 계약 검사와 "AI 가 실제로 돌았는가" 를 분리해 뒤쪽은
+`generated_by` 로 판정한다 — 폴백이면 SKIP 이라 조용히 초록불이 되지 않는다.
 """
 from __future__ import annotations
 
@@ -428,6 +429,123 @@ def scenario_consultation(api: Api, m: str, t: str, out: list[Result]) -> None:
         out.append(Result(g, label, "PASS" if code == 200 else "FAIL", str(code)))
 
 
+def scenario_ai_routine(api: Api, m: str, t: str, out: list[Result]) -> None:
+    """AI 루틴 A/B 생성 → 편집 → 배정 → 회원 수신 (#589).
+
+    이 경로를 스윕에 넣지 못했던 이유가 있다: 키가 없으면 규칙 폴백이 200 을
+    돌려주어 **AI 가 죽어도 통과처럼 보인다**. 그래서 계약 검사(A/B 모양·시간 상한)와
+    "AI 가 실제로 돌았는가" 를 분리한다. 앞은 어느 경우든 PASS 여야 하고, 뒤는
+    `generated_by` 로 판정해 규칙 폴백이면 SKIP 으로 남긴다 — 조용히 초록불이
+    되지 않게.
+    """
+    g = "AI 루틴"
+    available = 40
+    code, options = api.post(
+        "/trainer/clients/" + MEMBER_ID + "/routine-options",
+        token=t,
+        json_body={
+            "available_minutes": available,
+            "intensity_preference": "moderate",
+            "trainer_note": _MARKER + " 무릎 부담 낮게",
+        },
+    )
+    ok = code == 200 and isinstance(options, dict)
+    out.append(Result(g, "A/B 생성", "PASS" if ok else "FAIL", str(code)))
+    if not ok:
+        return
+
+    plan_a = options.get("plan_a") or {}
+    plan_b = options.get("plan_b") or {}
+    shape_ok = (
+        plan_a.get("key") == "A" and plan_b.get("key") == "B"
+        and bool(plan_a.get("exercises")) and bool(plan_b.get("exercises"))
+    )
+    out.append(Result(
+        g, "A/B 계약", "PASS" if shape_ok else "FAIL",
+        "key=" + str(plan_a.get("key")) + "/" + str(plan_b.get("key")),
+    ))
+
+    # 트레이너가 입력한 가능 시간을 넘는 계획은 그대로 배정될 수 없다.
+    over = [
+        p.get("total_minutes") for p in (plan_a, plan_b)
+        if isinstance(p.get("total_minutes"), int) and p["total_minutes"] > available
+    ]
+    out.append(Result(
+        g, "가능 시간 상한", "PASS" if not over else "FAIL",
+        f"available={available} 초과={over}",
+    ))
+
+    generated_by = options.get("generated_by")
+    if generated_by == "ai":
+        out.append(Result(g, "AI 가 실제로 생성", "PASS", "generated_by=ai"))
+    else:
+        out.append(Result(
+            g, "AI 가 실제로 생성", "SKIP",
+            "generated_by=" + str(generated_by) + " - LLM 키가 없거나 폴백. "
+            "코치 키를 넣고 다시 돌려야 이 경로가 검증된다",
+        ))
+
+    # #580: 채팅이 근거로 실렸는지. 앞선 채팅 시나리오가 남긴 메시지가 있어야 한다.
+    recent = (options.get("analysis") or {}).get("recent_messages")
+    out.append(Result(
+        g, "채팅 근거 반영(#580)",
+        "PASS" if isinstance(recent, list) and recent else "SKIP",
+        f"recent_messages={len(recent) if isinstance(recent, list) else 'none'}",
+    ))
+
+    # 트레이너가 A안을 손봐서 배정한다 — 생성 결과를 그대로 보내는 게 아니라
+    # 편집이 반영되는지까지 봐야 화면과 같은 경로다.
+    first = (plan_a.get("exercises") or [{}])[0]
+    routine = {
+        "name": _MARKER + " 편집한 루틴",
+        "minutes": max(1, int(first.get("minutes") or 10)),
+        "type": first.get("type") or "유산소",
+        "reason": "스윕이 배정",
+        "source": "ai",
+        "client_request_id": "sweep-" + _RUN_TAG,
+    }
+    code, assigned = api.post(
+        "/trainer/clients/" + MEMBER_ID + "/routines", token=t, json_body=routine
+    )
+    created = code in (200, 201) and isinstance(assigned, dict)
+    out.append(Result(g, "편집 후 배정", "PASS" if created else "FAIL", str(code)))
+    routine_id = assigned.get("id") if created else None
+
+    # #581: 같은 키로 재전송해도 하나만 남아야 한다. 끊긴 전송을 다시 누르는 상황이다.
+    code, again = api.post(
+        "/trainer/clients/" + MEMBER_ID + "/routines", token=t, json_body=routine
+    )
+    same = isinstance(again, dict) and again.get("id") == routine_id
+    out.append(Result(
+        g, "재전송 멱등(#581)", "PASS" if same else "FAIL",
+        f"{code} id={again.get('id') if isinstance(again, dict) else again} (같아야 함)",
+    ))
+
+    # 회원 쪽에서 실제로 받았는가 — 여기까지 와야 루프가 닫힌다.
+    code, mine = api.get("/me/coach/routines", token=m)
+    names = [r.get("name") for r in mine] if isinstance(mine, list) else []
+    received = routine["name"] in names
+    out.append(Result(
+        g, "회원이 수신", "PASS" if received else "FAIL",
+        f"{code} n={len(names)}",
+    ))
+    # 배정이 하나만 갔는지 — 멱등이 깨지면 여기서 2건으로 보인다.
+    out.append(Result(
+        g, "중복 배정 없음", "PASS" if names.count(routine["name"]) == 1 else "FAIL",
+        f"{names.count(routine['name'])}건 (1건 기대)",
+    ))
+
+    if routine_id:
+        code, _ = api.delete(
+            "/trainer/clients/" + MEMBER_ID + "/routines/" + routine_id, token=t
+        )
+        out.append(Result(
+            g, "루틴 철회(정리)", "PASS" if code in (200, 204) else "FAIL", str(code)
+        ))
+    else:
+        out.append(Result(g, "루틴 철회(정리)", "FAIL", "id 를 못 받아 정리 못 함"))
+
+
 def scenario_misc(api: Api, m: str, t: str, out: list[Result]) -> None:
     g = "회원 화면"
     for path, label in (
@@ -493,15 +611,21 @@ def main() -> int:
     out: list[Result] = []
     for fn in (
         scenario_auth, scenario_diet, scenario_exercise, scenario_chat,
-        scenario_roster, scenario_reservation, scenario_consultation,
-        scenario_misc,
+        # AI 루틴은 채팅 뒤에 둔다 — 채팅이 남긴 메시지가 생성 근거로 실렸는지
+        # (#580) 함께 보기 때문이다.
+        scenario_roster, scenario_ai_routine, scenario_reservation,
+        scenario_consultation, scenario_misc,
     ):
         try:
             fn(api, member, trainer, out)
         except Exception as e:  # noqa: BLE001 - 한 그룹이 죽어도 나머지는 계속
             out.append(Result(fn.__name__, "실행 중 예외", "FAIL", repr(e)))
 
-    # 채팅 2건과, 식단·채팅이 파생시킨 개인 RAG 문서 3건(식단 1 + 채팅 2)을 지운다.
+    # 채팅 2건과, 채팅이 파생시킨 개인 RAG 문서 2건을 지운다.
+    #
+    # 식단 문서는 여기까지 오지 않는다. `DELETE /diet/entries/{id}` 가 그 기록의
+    # 문서까지 함께 지우기 때문이다(#603 `personal_ingest.forget`). 기대값이 3이던
+    # 시절은 삭제가 원본만 지우던 때다 — 그대로 두면 이 스윕이 매번 FAIL 로 뜬다.
     g = "정리"
     if not local:
         note = "원격 대상 - 로컬 DB 를 건드리지 않음. 채팅·RAG 문서가 남는다"
@@ -514,8 +638,9 @@ def main() -> int:
             f"{chats}건 (2건 기대)" + (" - " + err if err else ""),
         ))
         out.append(Result(
-            g, "개인 RAG 문서 삭제", "PASS" if docs == 3 else "FAIL",
-            f"{docs}건 (3건 기대)" + (" - " + (err or base_err) if (err or base_err) else ""),
+            g, "개인 RAG 문서 삭제", "PASS" if docs == 2 else "FAIL",
+            f"{docs}건 (2건 기대 - 식단 문서는 DELETE 가 이미 정리)"
+            + (" - " + (err or base_err) if (err or base_err) else ""),
         ))
 
     group = None

--- a/backend/tests/test_e2e_sweep.py
+++ b/backend/tests/test_e2e_sweep.py
@@ -1,0 +1,87 @@
+"""AI 루틴 E2E 스윕의 응답 계약 판정."""
+from __future__ import annotations
+
+import pytest
+
+from scripts import e2e_sweep
+
+
+class _RoutineApi:
+    def __init__(self, options: dict) -> None:
+        self.options = options
+
+    def post(self, path: str, **kwargs):
+        if path.endswith("/routine-options"):
+            return 200, self.options
+        if path.endswith("/routines"):
+            return 201, {"id": "routine-1"}
+        raise AssertionError(f"unexpected POST {path}")
+
+    def get(self, path: str, **kwargs):
+        assert path == "/me/coach/routines"
+        return 200, [{"name": e2e_sweep._MARKER + " 편집한 루틴"}]
+
+    def delete(self, path: str, **kwargs):
+        assert path.endswith("/routines/routine-1")
+        return 204, None
+
+
+def _options(*, total_a=20, recent_messages=None) -> dict:
+    return {
+        "plan_a": {
+            "key": "A",
+            "total_minutes": total_a,
+            "exercises": [{"name": "걷기", "minutes": 20, "type": "유산소"}],
+        },
+        "plan_b": {
+            "key": "B",
+            "total_minutes": 40,
+            "exercises": [{"name": "근력", "minutes": 40, "type": "근력"}],
+        },
+        "analysis": {"recent_messages": recent_messages},
+        "generated_by": "rule",
+    }
+
+
+def _run(options: dict) -> dict[str, e2e_sweep.Result]:
+    results: list[e2e_sweep.Result] = []
+    e2e_sweep.scenario_ai_routine(
+        _RoutineApi(options), "member-token", "trainer-token", results
+    )
+    return {result.name: result for result in results}
+
+
+@pytest.mark.parametrize("invalid_total", [None, "20", True, 41])
+def test_available_time_rejects_missing_or_invalid_totals(invalid_total):
+    result = _run(
+        _options(
+            total_a=invalid_total,
+            recent_messages=["회원: " + e2e_sweep._MARKER],
+        )
+    )["가능 시간 상한"]
+
+    assert result.status == "FAIL"
+    assert repr(invalid_total) in result.detail
+
+
+def test_available_time_accepts_integer_totals_at_or_below_the_limit():
+    result = _run(
+        _options(recent_messages=["회원: " + e2e_sweep._MARKER])
+    )["가능 시간 상한"]
+
+    assert result.status == "PASS"
+
+
+@pytest.mark.parametrize("recent", [None, [], ["회원: 이전 실행 메시지"]])
+def test_chat_evidence_requires_the_current_run_marker(recent):
+    result = _run(_options(recent_messages=recent))["채팅 근거 반영(#580)"]
+
+    assert result.status == "FAIL"
+
+
+def test_chat_evidence_accepts_the_current_run_marker():
+    recent = ["회원: 무릎이 아파요 " + e2e_sweep._MARKER]
+
+    result = _run(_options(recent_messages=recent))["채팅 근거 반영(#580)"]
+
+    assert result.status == "PASS"


### PR DESCRIPTION
## Summary

* 스윕(#479)이 AI 루틴 경로만 비워 두고 있었습니다. 이유는 스크립트 docstring 에 이미 적혀 있었습니다 — **키가 없으면 규칙 폴백이 200 을 돌려주어 AI 가 죽어도 통과처럼 보입니다.**
* 계약 검사와 "AI 가 실제로 돌았는가" 를 **분리**해 그 함정을 피했습니다.
* 생성부터 회원 수신까지 한 줄로 훑어 루프를 닫습니다.

---

## Changes

### ✅ Tests

* `scenario_ai_routine` 신설 — 9단계: A/B 생성 → 계약(key A/B·운동 존재) → 가능 시간 상한 → **AI 실동작** → 채팅 근거 반영(#580) → 편집 후 배정 → 재전송 멱등(#581) → 회원 수신 → 중복 없음 → 철회(정리).
* 계약 검사는 폴백이든 아니든 PASS 여야 합니다. `generated_by` 가 `ai` 가 아니면 그 항목만 **SKIP** 으로 남기고 사유를 적습니다 — 조용히 초록불이 되지 않습니다.
* 생성 결과를 그대로 보내지 않고 A안을 **손봐서** 배정합니다. 편집이 반영되는지까지 봐야 화면과 같은 경로입니다.
* 채팅 시나리오 뒤에 배치했습니다 — 남은 메시지가 생성 근거로 실리는지(#580) 함께 보기 위해서입니다.

### 🐛 Fixes

* 정리 단계의 `개인 RAG 문서 삭제` 기대값을 3 → 2 로 정정했습니다. 아래 Notes 참조.

---

## Commits

1. `4b070c96` test(e2e): sweep the AI routine path end to end

---

## Notes

* **실제로 실행해 확인했습니다.** 로컬 백엔드를 새 DB 로 띄우고 스윕을 돌린 결과입니다:

  ```
  [AI 루틴]
    PASS A/B 생성 / A/B 계약 / 가능 시간 상한
    SKIP AI 가 실제로 생성    generated_by=rule - LLM 키가 없거나 폴백
    PASS 채팅 근거 반영(#580)  recent_messages=5
    PASS 편집 후 배정 / 재전송 멱등(#581) / 회원이 수신 / 중복 배정 없음 / 철회
  총 59건 · 통과 58 · 실패 0 · 건너뜀 1
  ```
  두 번 연속 돌려 같은 결과가 나오는 것도(멱등) 확인했습니다.

* **범위 밖 수정 하나가 들어 있습니다.** 정리 단계의 `개인 RAG 문서 삭제` 가 **3건을 기대하는데 2건** 이라 FAIL 이었습니다. 제 변경 탓인지 확인하려고 stash 후 baseline 에서 돌려 봤고 **동일하게 실패**했습니다 — 즉 `main` 에서도 이 스윕은 지금 항상 빨간불입니다.

  원인은 #603 입니다. `DELETE /diet/entries/{id}` 가 그 기록의 문서까지 지우게 되면서, 식단 문서가 정리 단계까지 오지 않습니다. 기대값 3 은 삭제가 원본만 지우던 시절 값입니다. 스윕을 손보는 커밋에서 스윕이 상시 FAIL 인 걸 두고 갈 이유가 없어 함께 고쳤습니다. 분리를 원하시면 그 두 줄만 떼면 됩니다.

* **SKIP 이 나오는 게 정상입니다** — 로컬에 코치 LLM 키가 없으면 그렇습니다. 이 경로를 진짜로 검증하려면 `.env` 에 키를 넣고 다시 돌려 `PASS generated_by=ai` 를 봐야 합니다. 결과 줄에 그 안내를 적어 뒀습니다.

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [ ] UI 확인 <!-- 스크립트, 프론트 변경 없음 -->
* [x] 빌드 성공
* [x] 관련 테스트 통과

스윕 실행 결과 **실패 0 · 건너뜀 1**(위 Notes). pytest 전체 스위트도 새 DB 에서 실패 0.

### Manual Test Steps

```bash
cd backend
docker compose up -d
python -m scripts.e2e_sweep
```

1. `[AI 루틴]` 섹션이 전부 PASS 인지 확인(키가 없으면 "AI 가 실제로 생성" 만 SKIP).
2. `.env` 에 코치 LLM 키를 넣고 재기동 후 다시 실행 → 그 항목이 `PASS generated_by=ai` 로 바뀌는지 확인.
3. 연속 두 번 실행 → 두 번째도 실패 0 인지 확인(스윕이 만든 것을 스스로 되돌리는지).

---

## Related Issues

Closes #589

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * AI 루틴 생성부터 편집·배정·회원 수신까지의 전체 시나리오를 검증합니다.
  * 계약 및 시간 제한, 실제 AI 생성 여부, 채팅 근거, 중복 없는 재전송을 확인합니다.
  * AI 대신 규칙 기반 대체 방식이 사용되면 해당 검사를 건너뜁니다.
  * 식단 삭제 후 관련 검색 문서 정리 상태를 검증합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->