### PR TITLE
fix(trainer-web): 주요 조회 오류 상태에 재시도 경로 추가

### DIFF
--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
@@ -8,7 +8,9 @@ import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/shared/widgets/icon_label.dart';
 import 'package:oncare_trainer/shared/services/chat_repository.dart';
 import 'package:oncare_trainer/shared/models/client_chat_message.dart';
+import 'package:oncare_trainer/shared/widgets/action_button.dart';
 import 'package:oncare_trainer/shared/widgets/client_avatar.dart';
+import 'package:oncare_trainer/shared/widgets/section_card.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 
 /// The 채팅 sub-tab: an AI-received system banner, the message thread
@@ -180,10 +182,15 @@ class _ChatViewState extends ConsumerState<ChatView> {
         Expanded(
           child: messages.when(
             loading: () => const Center(child: CircularProgressIndicator()),
-            error: (e, _) => Center(
-              child: Text(
-                l.chatLoadFailed,
-                style: TextStyle(color: AppColors.mutedForeground),
+            error: (e, _) => EmptyHint(
+              message: l.chatLoadFailed,
+              icon: Icons.error_outline,
+              action: ActionButton(
+                key: ValueKey<String>('chat-retry-${widget.clientId}'),
+                label: l.actionRetry,
+                onPressed: messages.isLoading
+                    ? null
+                    : () => ref.invalidate(chatThreadProvider(widget.clientId)),
               ),
             ),
             data: (list) {

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/diet_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/diet_view.dart
@@ -10,6 +10,7 @@ import 'package:oncare_trainer/shared/services/client_repository.dart';
 import 'package:oncare_trainer/features/clients/domain/entities/client_diet_entry.dart';
 import 'package:oncare_trainer/shared/models/trainer_client.dart';
 import 'package:oncare_trainer/shared/widgets/metric_tile.dart';
+import 'package:oncare_trainer/shared/widgets/action_button.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 import 'package:oncare_trainer/features/dashboard/domain/dashboard_summary.dart'
     show weekdayLabels;
@@ -31,10 +32,15 @@ class DietView extends ConsumerWidget {
 
     return diet.when(
       loading: () => const Center(child: CircularProgressIndicator()),
-      error: (e, _) => Center(
-        child: Text(
-          l.dietLoadFailed,
-          style: TextStyle(color: AppColors.mutedForeground),
+      error: (e, _) => EmptyHint(
+        message: l.dietLoadFailed,
+        icon: Icons.error_outline,
+        action: ActionButton(
+          key: ValueKey<String>('diet-retry-${client.id}'),
+          label: l.actionRetry,
+          onPressed: diet.isLoading
+              ? null
+              : () => ref.invalidate(clientDietProvider(client.id)),
         ),
       ),
       data: (meals) => ListView(

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/workout_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/workout_view.dart
@@ -17,6 +17,7 @@ import 'package:oncare_trainer/features/schedule/domain/entities/schedule_sessio
 import 'package:oncare_trainer/shared/services/client_repository.dart';
 import 'package:oncare_trainer/features/clients/domain/entities/routine_history_entry.dart';
 import 'package:oncare_trainer/shared/models/trainer_client.dart';
+import 'package:oncare_trainer/shared/widgets/action_button.dart';
 import 'package:oncare_trainer/shared/widgets/icon_label.dart';
 import 'package:oncare_trainer/shared/widgets/section_card.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
@@ -43,9 +44,8 @@ class WorkoutView extends ConsumerWidget {
     final AppLocalizations l = AppLocalizations.of(context);
     final history = ref.watch(clientHistoryProvider(client.id));
     final assigned = ref.watch(assignedRoutinesProvider(client.id));
-    final sessions = ref.watch(
-      clientSessionsProvider((id: client.id, name: client.name)),
-    );
+    final sessionKey = (id: client.id, name: client.name);
+    final sessions = ref.watch(clientSessionsProvider(sessionKey));
 
     // Each section owns its own async state. Gating the whole list on
     // the history provider would mean a failing /history takes the
@@ -56,7 +56,10 @@ class WorkoutView extends ConsumerWidget {
       children: <Widget>[
         _AssignedRoutinesCard(clientId: client.id, assigned: assigned),
         const SizedBox(height: AppSpacing.md),
-        _SessionsCard(sessions: sessions),
+        _SessionsCard(
+          sessions: sessions,
+          onRetry: () => ref.invalidate(clientSessionsProvider(sessionKey)),
+        ),
         const SizedBox(height: AppSpacing.md),
         _WeekCompletionCard(week: client.weekCompletion),
         const SizedBox(height: AppSpacing.lg),
@@ -77,7 +80,17 @@ class WorkoutView extends ConsumerWidget {
             ),
           ],
           error: (e, _) => <Widget>[
-            EmptyHint(message: l.workoutLoadFailed),
+            EmptyHint(
+              message: l.workoutLoadFailed,
+              icon: Icons.error_outline,
+              action: ActionButton(
+                key: ValueKey<String>('workout-history-retry-${client.id}'),
+                label: l.actionRetry,
+                onPressed: history.isLoading
+                    ? null
+                    : () => ref.invalidate(clientHistoryProvider(client.id)),
+              ),
+            ),
           ],
           data: (entries) => <Widget>[
             if (entries.isEmpty)
@@ -121,7 +134,17 @@ class _AssignedRoutinesCard extends ConsumerWidget {
           padding: EdgeInsets.symmetric(vertical: AppSpacing.lg),
           child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
         ),
-        error: (e, _) => EmptyHint(message: l.routinesLoadFailed),
+        error: (e, _) => EmptyHint(
+          message: l.routinesLoadFailed,
+          icon: Icons.error_outline,
+          action: ActionButton(
+            key: ValueKey<String>('assigned-routines-retry-$clientId'),
+            label: l.actionRetry,
+            onPressed: assigned.isLoading
+                ? null
+                : () => ref.invalidate(assignedRoutinesProvider(clientId)),
+          ),
+        ),
         data: (routines) => routines.isEmpty
             ? EmptyHint(
                 message: l.routinesEmpty,
@@ -200,9 +223,10 @@ class _AssignedRoutinesCard extends ConsumerWidget {
 /// completed. The 스케줄 tab answers the same question by date; this is
 /// the only place it's answered per client.
 class _SessionsCard extends StatelessWidget {
-  const _SessionsCard({required this.sessions});
+  const _SessionsCard({required this.sessions, required this.onRetry});
 
   final AsyncValue<List<ScheduleSession>> sessions;
+  final VoidCallback onRetry;
 
   @override
   Widget build(BuildContext context) {
@@ -217,7 +241,15 @@ class _SessionsCard extends StatelessWidget {
           padding: EdgeInsets.symmetric(vertical: AppSpacing.lg),
           child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
         ),
-        error: (e, _) => EmptyHint(message: l.scheduleLoadFailed),
+        error: (e, _) => EmptyHint(
+          message: l.scheduleLoadFailed,
+          icon: Icons.error_outline,
+          action: ActionButton(
+            key: const ValueKey<String>('client-sessions-retry'),
+            label: l.actionRetry,
+            onPressed: sessions.isLoading ? null : onRetry,
+          ),
+        ),
         data: (list) => list.isEmpty
             ? EmptyHint(
                 message: l.ptSessionsEmpty,

--- a/frontend/flutter_trainer/lib/features/dashboard/presentation/pages/dashboard_page.dart
+++ b/frontend/flutter_trainer/lib/features/dashboard/presentation/pages/dashboard_page.dart
@@ -60,10 +60,15 @@ class DashboardPage extends ConsumerWidget {
         ),
         error: (e, _) => Padding(
           padding: EdgeInsets.only(top: AppSpacing.xxxl),
-          child: Center(
-            child: Text(
-              l.dashLoadFailed,
-              style: const TextStyle(color: AppColors.mutedForeground),
+          child: EmptyHint(
+            message: l.dashLoadFailed,
+            icon: Icons.error_outline,
+            action: ActionButton(
+              key: const ValueKey<String>('dashboard-retry'),
+              label: l.actionRetry,
+              onPressed: summaryAsync.isLoading
+                  ? null
+                  : () => ref.invalidate(clientsProvider),
             ),
           ),
         ),

--- a/frontend/flutter_trainer/lib/features/notifications/presentation/pages/notifications_page.dart
+++ b/frontend/flutter_trainer/lib/features/notifications/presentation/pages/notifications_page.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:oncare_trainer/app/router/routes.dart';
-import 'package:oncare_trainer/core/errors/app_error.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
@@ -100,10 +99,15 @@ class NotificationsPage extends ConsumerWidget {
         error: (error, _) => Padding(
           padding: const EdgeInsets.only(top: AppSpacing.xxl),
           child: EmptyHint(
-            message:
-                (error is AppError ? error.message : null) ??
-                l.notifLoadFailed,
+            message: l.notifLoadFailed,
             icon: Icons.error_outline,
+            action: ActionButton(
+              key: const ValueKey<String>('notifications-retry'),
+              label: l.actionRetry,
+              onPressed: notifications.isLoading
+                  ? null
+                  : () => ref.invalidate(trainerNotificationsProvider),
+            ),
           ),
         ),
         data: (rows) {

--- a/frontend/flutter_trainer/lib/features/reports/presentation/pages/reports_page.dart
+++ b/frontend/flutter_trainer/lib/features/reports/presentation/pages/reports_page.dart
@@ -145,10 +145,15 @@ class _ReportsPageState extends ConsumerState<ReportsPage> {
         ),
         error: (e, _) => Padding(
           padding: EdgeInsets.only(top: AppSpacing.xxxl),
-          child: Center(
-            child: Text(
-              l.reportsLoadFailed,
-              style: TextStyle(color: AppColors.mutedForeground),
+          child: EmptyHint(
+            message: l.reportsLoadFailed,
+            icon: Icons.error_outline,
+            action: ActionButton(
+              key: const ValueKey<String>('reports-clients-retry'),
+              label: l.actionRetry,
+              onPressed: clientsAsync.isLoading
+                  ? null
+                  : () => ref.invalidate(clientsProvider),
             ),
           ),
         ),
@@ -194,11 +199,9 @@ class _ReportsPageState extends ConsumerState<ReportsPage> {
                   // The report itself comes from the repository: local
                   // in demo, server-aggregated against the real API
                   // (only the backend has the member's full history).
+                  final reportKey = (client: selected, weekStart: _weekStart);
                   final reportAsync = ref.watch(
-                    weeklyReportProvider((
-                      client: selected,
-                      weekStart: _weekStart,
-                    )),
+                    weeklyReportProvider(reportKey),
                   );
                   final report = reportAsync.when(
                     loading: () => SectionCard(
@@ -212,7 +215,19 @@ class _ReportsPageState extends ConsumerState<ReportsPage> {
                     error: (e, _) => SectionCard(
                       title: l.reportsWeekly,
                       icon: Icons.description_outlined,
-                      child: EmptyHint(message: l.reportsLoadFailed),
+                      child: EmptyHint(
+                        message: l.reportsLoadFailed,
+                        icon: Icons.error_outline,
+                        action: ActionButton(
+                          key: const ValueKey<String>('reports-weekly-retry'),
+                          label: l.actionRetry,
+                          onPressed: reportAsync.isLoading
+                              ? null
+                              : () => ref.invalidate(
+                                  weeklyReportProvider(reportKey),
+                                ),
+                        ),
+                      ),
                     ),
                     data: (data) => _ClientReport(
                       report: data,

--- a/frontend/flutter_trainer/lib/shared/widgets/section_card.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/section_card.dart
@@ -134,13 +134,16 @@ class CardLink extends StatelessWidget {
 /// Centered placeholder for an empty card body.
 class EmptyHint extends StatelessWidget {
   /// Creates the hint.
-  const EmptyHint({super.key, required this.message, this.icon});
+  const EmptyHint({super.key, required this.message, this.icon, this.action});
 
   /// What to tell the trainer.
   final String message;
 
   /// Optional glyph above the message.
   final IconData? icon;
+
+  /// Optional recovery action for an error state.
+  final Widget? action;
 
   @override
   Widget build(BuildContext context) {
@@ -161,6 +164,10 @@ class EmptyHint extends StatelessWidget {
               color: AppColors.subtleForeground,
             ),
           ),
+          if (action != null) ...<Widget>[
+            const SizedBox(height: AppSpacing.md),
+            action!,
+          ],
         ],
       ),
     );

--- a/frontend/flutter_trainer/test/features/clients/client_detail_chat_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_chat_test.dart
@@ -3,6 +3,7 @@ import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 
 import 'package:oncare_trainer/app/router/routes.dart';
 import 'package:oncare_trainer/core/config/app_config.dart';
@@ -86,6 +87,21 @@ class _StaticLiveChatRepository implements ChatRepository {
   @override
   Stream<Map<String, int>> watchUnreadCounts() =>
       Stream<Map<String, int>>.value(const <String, int>{});
+}
+
+class _ThreadFailsOnceRepository extends _StaticLiveChatRepository {
+  int watchCalls = 0;
+
+  @override
+  Stream<List<ClientChatMessage>> watchThread(String clientId) {
+    watchCalls++;
+    if (watchCalls == 1) {
+      return Stream<List<ClientChatMessage>>.error(
+        StateError('chat transport detail'),
+      );
+    }
+    return super.watchThread(clientId);
+  }
 }
 
 void main() {
@@ -294,6 +310,36 @@ void main() {
   });
 
   group('ClientDetailPage chat', () {
+    testWidgets('a failed thread retries without leaving the client chat', (
+      tester,
+    ) async {
+      final repository = _ThreadFailsOnceRepository();
+      await pumpTrainerApp(
+        tester,
+        token: 'demo-trainer-token',
+        at: AppRoutes.clientDetail('seed-client-1', section: 'chat'),
+        extraOverrides: <Override>[
+          chatRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+
+      expect(find.text('대화를 불러오지 못했어요'), findsOneWidget);
+      expect(find.text('chat transport detail'), findsNothing);
+      await tester.tap(
+        find.byKey(const ValueKey<String>('chat-retry-seed-client-1')),
+      );
+      await settle(tester);
+
+      final context = tester.element(find.byType(Navigator).first);
+      expect(
+        GoRouter.of(context).routeInformationProvider.value.uri.toString(),
+        AppRoutes.clientDetail('seed-client-1', section: 'chat'),
+      );
+      expect(repository.watchCalls, 2);
+      expect(find.text('실제 고객 답장'), findsOneWidget);
+      expect(find.byType(TextField), findsOneWidget);
+    });
+
     testWidgets('real chat omits demo-only analysis and sent banners', (
       tester,
     ) async {

--- a/frontend/flutter_trainer/test/features/clients/client_detail_diet_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_diet_test.dart
@@ -1,11 +1,13 @@
-import 'dart:ui' show Size;
-
 import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 
 import 'package:oncare_trainer/app/router/routes.dart';
 import 'package:oncare_trainer/core/storage/app_database.dart';
 import 'package:oncare_trainer/core/storage/seed_data.dart';
+import 'package:oncare_trainer/features/clients/domain/entities/client_diet_entry.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations_ko.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
 import 'package:oncare_trainer/shared/widgets/metric_tile.dart';
@@ -23,6 +25,23 @@ const Map<String, String> seedClientIds = <String, String>{
   // The brand-new client: no meals, no history, no sodium series.
   '임도현': 'seed-client-7',
 };
+
+class _DietFailsOnceRepository extends DriftClientRepository {
+  _DietFailsOnceRepository(super.db);
+
+  int watchDietCalls = 0;
+
+  @override
+  Stream<List<ClientDietEntry>> watchDiet(String clientId) {
+    watchDietCalls++;
+    if (watchDietCalls == 1) {
+      return Stream<List<ClientDietEntry>>.error(
+        StateError('diet transport detail'),
+      );
+    }
+    return super.watchDiet(clientId);
+  }
+}
 
 void main() {
   group('ClientRepository.watchDiet', () {
@@ -109,6 +128,49 @@ void main() {
         at: AppRoutes.clientDetail(seedClientIds[clientName]!, section: 'diet'),
       );
     }
+
+    testWidgets('a failed diet retries in place on a narrow viewport', (
+      tester,
+    ) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(480, 700);
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
+      final container = await pumpTrainerApp(
+        tester,
+        token: 'demo-trainer-token',
+        at: AppRoutes.clientDetail('seed-client-1', section: 'diet'),
+        extraOverrides: <Override>[
+          clientRepositoryProvider.overrideWith(
+            (ref) => _DietFailsOnceRepository(ref.watch(appDatabaseProvider)),
+          ),
+        ],
+      );
+
+      expect(find.text('식단을 불러오지 못했어요'), findsOneWidget);
+      expect(find.text('아직 기록된 식단이 없어요'), findsNothing);
+      expect(find.text('diet transport detail'), findsNothing);
+      expect(tester.takeException(), isNull);
+
+      await tester.tap(
+        find.byKey(const ValueKey<String>('diet-retry-seed-client-1')),
+      );
+      await settle(tester);
+
+      final repository =
+          container.read(clientRepositoryProvider) as _DietFailsOnceRepository;
+      final context = tester.element(find.byType(Navigator).first);
+      expect(repository.watchDietCalls, 2);
+      expect(
+        GoRouter.of(context).routeInformationProvider.value.uri.toString(),
+        AppRoutes.clientDetail('seed-client-1', section: 'diet'),
+      );
+      expect(find.text('오늘 영양 요약'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
 
     testWidgets('김민수 (sodium over target) shows warning + over AI comment', (
       tester,

--- a/frontend/flutter_trainer/test/features/clients/client_detail_workout_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_workout_test.dart
@@ -1,4 +1,5 @@
 import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -8,6 +9,11 @@ import 'package:oncare_trainer/app/router/routes.dart';
 import 'package:oncare_trainer/core/storage/app_database.dart';
 import 'package:oncare_trainer/core/storage/seed_data.dart';
 import 'package:oncare_trainer/features/clients/domain/entities/routine_history_entry.dart';
+import 'package:oncare_trainer/features/coaching/data/repositories/trainer_routine_repository.dart';
+import 'package:oncare_trainer/features/coaching/domain/entities/assigned_routine.dart';
+import 'package:oncare_trainer/features/schedule/data/repositories/schedule_repository.dart';
+import 'package:oncare_trainer/features/schedule/domain/entities/schedule_session.dart';
+import 'package:oncare_trainer/features/schedule/domain/entities/schedule_status.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
 
 import '../../helpers/pump_app.dart';
@@ -19,13 +25,76 @@ const Map<String, String> seedClientIds = <String, String>{
   '박성호': 'seed-client-3',
 };
 
-/// Fails only `watchHistory`; every other read still succeeds.
-class _HistoryFailsRepository extends DriftClientRepository {
-  const _HistoryFailsRepository(super.db);
+/// Fails the first `watchHistory`; every other read still succeeds.
+class _HistoryFailsOnceRepository extends DriftClientRepository {
+  _HistoryFailsOnceRepository(super.db);
+
+  int watchHistoryCalls = 0;
 
   @override
-  Stream<List<RoutineHistoryEntry>> watchHistory(String clientId) =>
-      Stream<List<RoutineHistoryEntry>>.error(Exception('history down'));
+  Stream<List<RoutineHistoryEntry>> watchHistory(String clientId) {
+    watchHistoryCalls++;
+    if (watchHistoryCalls == 1) {
+      return Stream<List<RoutineHistoryEntry>>.error(
+        Exception('history transport detail'),
+      );
+    }
+    return super.watchHistory(clientId);
+  }
+}
+
+class _AssignedFailsOnceRepository extends MockTrainerRoutineRepository {
+  int watchAssignedCalls = 0;
+
+  @override
+  Stream<List<AssignedRoutine>> watchAssignedRoutines(String memberId) {
+    watchAssignedCalls++;
+    if (watchAssignedCalls == 1) {
+      return Stream<List<AssignedRoutine>>.error(
+        Exception('routine transport detail'),
+      );
+    }
+    return Stream<List<AssignedRoutine>>.value(const <AssignedRoutine>[
+      AssignedRoutine(
+        id: 'routine-recovered',
+        name: '복구 루틴',
+        minutes: 40,
+        type: '근력',
+        reason: '재시도 검증',
+        source: 'trainer',
+      ),
+    ]);
+  }
+}
+
+class _SessionsFailsOnceRepository extends DriftScheduleRepository {
+  _SessionsFailsOnceRepository(super.db);
+
+  int watchSessionCalls = 0;
+
+  @override
+  Stream<List<ScheduleSession>> watchClientSessions(ScheduleClientKey client) {
+    watchSessionCalls++;
+    if (watchSessionCalls == 1) {
+      return Stream<List<ScheduleSession>>.error(
+        Exception('schedule transport detail'),
+      );
+    }
+    return Stream<List<ScheduleSession>>.value(const <ScheduleSession>[
+      ScheduleSession(
+        id: 'session-recovered',
+        date: '2026-08-11',
+        time: '10:00',
+        clientId: 'seed-client-1',
+        clientName: '김민수',
+        type: '복구 PT',
+        durationMinutes: 50,
+        status: ScheduleStatus.upcoming,
+        note: '',
+        program: <ProgramItem>[],
+      ),
+    ]);
+  }
 }
 
 void main() {
@@ -118,13 +187,14 @@ void main() {
       // 배정된 루틴 and the PT sessions used to be their own tab, so they
       // stayed reachable when the history endpoint was down. Gating the
       // whole list on the history provider silently undid that.
-      await pumpTrainerApp(
+      final container = await pumpTrainerApp(
         tester,
         token: 'demo-trainer-token',
         at: AppRoutes.clientDetail(seedClientIds['김민수']!, section: 'workout'),
         extraOverrides: <Override>[
           clientRepositoryProvider.overrideWith(
-            (ref) => _HistoryFailsRepository(ref.watch(appDatabaseProvider)),
+            (ref) =>
+                _HistoryFailsOnceRepository(ref.watch(appDatabaseProvider)),
           ),
         ],
       );
@@ -138,6 +208,75 @@ void main() {
       // The failure is reported in place, where the history would be.
       await tester.scrollUntilVisible(find.text('운동 기록을 불러오지 못했어요'), 150);
       expect(find.text('운동 기록을 불러오지 못했어요'), findsOneWidget);
+      expect(find.text('history transport detail'), findsNothing);
+
+      await tester.tap(
+        find.byKey(
+          const ValueKey<String>('workout-history-retry-seed-client-1'),
+        ),
+      );
+      await settle(tester);
+      await tester.scrollUntilVisible(find.text('7/12 (오늘)'), 150);
+
+      final repository =
+          container.read(clientRepositoryProvider)
+              as _HistoryFailsOnceRepository;
+      expect(repository.watchHistoryCalls, 2);
+      expect(find.text('7/12 (오늘)'), findsOneWidget);
+    });
+
+    testWidgets('배정 루틴 실패만 재시도해 다른 영역을 보존한다', (tester) async {
+      final repository = _AssignedFailsOnceRepository();
+      await pumpTrainerApp(
+        tester,
+        token: 'demo-trainer-token',
+        at: AppRoutes.clientDetail('seed-client-1', section: 'workout'),
+        extraOverrides: <Override>[
+          trainerRoutineRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+
+      expect(find.text('루틴을 불러오지 못했어요'), findsOneWidget);
+      expect(find.text('PT 프로그램 이력'), findsOneWidget);
+      await tester.tap(
+        find.byKey(
+          const ValueKey<String>('assigned-routines-retry-seed-client-1'),
+        ),
+      );
+      await settle(tester);
+
+      expect(repository.watchAssignedCalls, 2);
+      expect(find.text('복구 루틴'), findsOneWidget);
+      expect(find.text('PT 프로그램 이력'), findsOneWidget);
+    });
+
+    testWidgets('PT 일정 실패만 재시도해 다른 영역을 보존한다', (tester) async {
+      final container = await pumpTrainerApp(
+        tester,
+        token: 'demo-trainer-token',
+        at: AppRoutes.clientDetail('seed-client-1', section: 'workout'),
+        extraOverrides: <Override>[
+          scheduleRepositoryProvider.overrideWith(
+            (ref) =>
+                _SessionsFailsOnceRepository(ref.watch(appDatabaseProvider)),
+          ),
+        ],
+      );
+
+      expect(find.text('일정을 불러오지 못했어요'), findsOneWidget);
+      expect(find.text('배정된 루틴'), findsOneWidget);
+      final retry = find.byKey(const ValueKey<String>('client-sessions-retry'));
+      await tester.drag(find.byType(ListView).last, const Offset(0, -180));
+      await tester.pump();
+      await tester.tap(retry);
+      await settle(tester);
+
+      final repository =
+          container.read(scheduleRepositoryProvider)
+              as _SessionsFailsOnceRepository;
+      expect(repository.watchSessionCalls, 2);
+      expect(find.textContaining('복구 PT'), findsOneWidget);
+      expect(find.text('이번 주 완료율'), findsOneWidget);
     });
   });
 }

--- a/frontend/flutter_trainer/test/features/dashboard/dashboard_page_test.dart
+++ b/frontend/flutter_trainer/test/features/dashboard/dashboard_page_test.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 
@@ -6,7 +9,10 @@ import 'package:oncare_trainer/app/router/routes.dart';
 import 'package:oncare_trainer/features/dashboard/presentation/widgets/attention_card.dart';
 import 'package:oncare_trainer/shared/widgets/stat_card.dart';
 import 'package:oncare_trainer/shared/models/client_alerts.dart';
+import 'package:oncare_trainer/shared/models/trainer_client.dart';
+import 'package:oncare_trainer/shared/services/client_repository.dart';
 
+import '../../helpers/client_factory.dart';
 import '../../helpers/pump_app.dart';
 
 /// The 대시보드 against the seeded roster.
@@ -37,6 +43,47 @@ void main() {
   testWidgets('is the landing page after a restored session', (tester) async {
     await openDashboard(tester);
     expect(find.text('대시보드'), findsWidgets);
+  });
+
+  testWidgets('a failed summary retries once and renders fresh data', (
+    tester,
+  ) async {
+    final retryGate = Completer<List<TrainerClient>>();
+    int attempts = 0;
+    await pumpTrainerApp(
+      tester,
+      token: 'demo-trainer-token',
+      at: AppRoutes.dashboard,
+      extraOverrides: <Override>[
+        clientsProvider.overrideWith((ref) {
+          attempts++;
+          if (attempts == 1) {
+            return Stream<List<TrainerClient>>.error(
+              StateError('internal transport detail'),
+            );
+          }
+          return Stream<List<TrainerClient>>.fromFuture(retryGate.future);
+        }),
+      ],
+    );
+
+    expect(find.text('대시보드를 불러오지 못했어요'), findsOneWidget);
+    expect(find.text('internal transport detail'), findsNothing);
+
+    final retry = find.byKey(const ValueKey<String>('dashboard-retry'));
+    await tester.tap(retry);
+    await tester.pump();
+    await tester.tap(retry, warnIfMissed: false);
+    await tester.pump();
+    expect(attempts, 2, reason: '재시도 중 중복 요청이 시작됐어요');
+
+    retryGate.complete(<TrainerClient>[
+      makeClient(name: '복구 고객', sodiumMg: 2500),
+    ]);
+    await settle(tester);
+
+    expect(find.text('복구 고객'), findsOneWidget);
+    expect(find.text('대시보드를 불러오지 못했어요'), findsNothing);
   });
 
   testWidgets('the KPI row reports the seeded numbers', (tester) async {

--- a/frontend/flutter_trainer/test/features/notifications/notifications_page_test.dart
+++ b/frontend/flutter_trainer/test/features/notifications/notifications_page_test.dart
@@ -37,9 +37,11 @@ TrainerNotification _notification({
 
 /// 실 API 처럼 동작하는 페이크 — 읽음 처리 호출을 기록한다.
 class _FakeNotificationRepository implements TrainerNotificationRepository {
-  _FakeNotificationRepository(this._rows);
+  _FakeNotificationRepository(this._rows, {this.fetchFailures = 0});
 
   List<TrainerNotification> _rows;
+  int fetchFailures;
+  int fetchCalls = 0;
   final List<String> readCalls = <String>[];
   int readAllCalls = 0;
 
@@ -47,7 +49,14 @@ class _FakeNotificationRepository implements TrainerNotificationRepository {
   bool get supportsInbox => true;
 
   @override
-  Future<List<TrainerNotification>> fetch() async => _rows;
+  Future<List<TrainerNotification>> fetch() async {
+    fetchCalls++;
+    if (fetchFailures > 0) {
+      fetchFailures--;
+      throw StateError('DioException internal detail');
+    }
+    return _rows;
+  }
 
   @override
   Future<int> unreadCount() async =>
@@ -132,6 +141,31 @@ void main() {
     );
 
     expect(find.text('아직 받은 알림이 없어요'), findsOneWidget);
+    expect(find.text('다시 시도'), findsNothing);
+  });
+
+  testWidgets('알림 오류는 empty와 구분되고 재시도 후 복구한다', (tester) async {
+    final repo = _FakeNotificationRepository(<TrainerNotification>[
+      _notification(title: '재시도로 복구된 알림'),
+    ], fetchFailures: 1);
+    await pumpTrainerApp(
+      tester,
+      token: 'demo-token',
+      at: AppRoutes.notifications,
+      extraOverrides: <Override>[
+        trainerNotificationRepositoryProvider.overrideWithValue(repo),
+      ],
+    );
+
+    expect(find.text('알림을 불러오지 못했어요'), findsOneWidget);
+    expect(find.text('아직 받은 알림이 없어요'), findsNothing);
+    expect(find.text('DioException internal detail'), findsNothing);
+
+    await tester.tap(find.byKey(const ValueKey<String>('notifications-retry')));
+    await settle(tester);
+
+    expect(repo.fetchCalls, 2);
+    expect(find.text('재시도로 복구된 알림'), findsOneWidget);
   });
 
   testWidgets('알림을 누르면 읽음 처리된다', (tester) async {

--- a/frontend/flutter_trainer/test/features/reports/reports_page_test.dart
+++ b/frontend/flutter_trainer/test/features/reports/reports_page_test.dart
@@ -4,9 +4,47 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:oncare_trainer/app/router/routes.dart';
 import 'package:oncare_trainer/core/storage/app_database.dart';
+import 'package:oncare_trainer/features/reports/data/repositories/report_repository.dart';
+import 'package:oncare_trainer/features/reports/domain/weekly_report.dart';
 import 'package:oncare_trainer/shared/services/chat_repository.dart';
+import 'package:oncare_trainer/shared/services/client_repository.dart';
+import 'package:oncare_trainer/shared/models/trainer_client.dart';
 
+import '../../helpers/client_factory.dart';
 import '../../helpers/pump_app.dart';
+
+class _ReportFailsOncePerKeyRepository implements ReportRepository {
+  final Map<String, int> _attempts = <String, int>{};
+  final List<ReportKey> calls = <ReportKey>[];
+
+  @override
+  Stream<WeeklyReport> watch({
+    required TrainerClient client,
+    required DateTime weekStart,
+  }) {
+    final key = '${client.id}/${weekStart.toIso8601String()}';
+    calls.add((client: client, weekStart: weekStart));
+    final attempt = (_attempts[key] ?? 0) + 1;
+    _attempts[key] = attempt;
+    if (attempt == 1) {
+      return Stream<WeeklyReport>.error(StateError('report transport detail'));
+    }
+    return Stream<WeeklyReport>.value(
+      buildWeeklyReport(
+        client: client,
+        sessions: const [],
+        weekStart: weekStart,
+      ),
+    );
+  }
+
+  @override
+  Future<void> send({
+    required String clientId,
+    required DateTime weekStart,
+    required String message,
+  }) async {}
+}
 
 /// 리포트 against the seeded roster — the trainer's own week plus one
 /// client's report, and sending it into their chat thread.
@@ -14,6 +52,7 @@ void main() {
   Future<ProviderContainer> openReports(
     WidgetTester tester, {
     String? clientId,
+    List<Override> extraOverrides = const <Override>[],
   }) async {
     tester.view.devicePixelRatio = 1.0;
     tester.view.physicalSize = const Size(1600, 1200);
@@ -23,6 +62,7 @@ void main() {
       tester,
       token: 'demo-trainer-token',
       at: clientId == null ? AppRoutes.reports : AppRoutes.reportFor(clientId),
+      extraOverrides: extraOverrides,
     );
   }
 
@@ -42,6 +82,70 @@ void main() {
   testWidgets('the client query parameter focuses that client', (tester) async {
     await openReports(tester, clientId: 'seed-client-3');
     expect(find.text('박성호님 주간 리포트'), findsOneWidget);
+  });
+
+  testWidgets('a failed client roster retries independently', (tester) async {
+    int attempts = 0;
+    await openReports(
+      tester,
+      clientId: 'seed-client-3',
+      extraOverrides: <Override>[
+        clientsProvider.overrideWith((ref) {
+          attempts++;
+          return attempts == 1
+              ? Stream<List<TrainerClient>>.error(
+                  StateError('client transport detail'),
+                )
+              : Stream<List<TrainerClient>>.value(<TrainerClient>[
+                  makeClient(id: 'seed-client-1', name: '첫 고객'),
+                  makeClient(id: 'seed-client-3', name: '복구 고객'),
+                ]);
+        }),
+      ],
+    );
+
+    expect(find.text('리포트를 불러오지 못했어요'), findsOneWidget);
+    expect(find.text('client transport detail'), findsNothing);
+    await tester.tap(
+      find.byKey(const ValueKey<String>('reports-clients-retry')),
+    );
+    await settle(tester);
+
+    expect(attempts, 2);
+    expect(find.text('복구 고객님 주간 리포트'), findsOneWidget);
+  });
+
+  testWidgets('weekly report retry keeps the selected client and week', (
+    tester,
+  ) async {
+    final repository = _ReportFailsOncePerKeyRepository();
+    await openReports(
+      tester,
+      clientId: 'seed-client-3',
+      extraOverrides: <Override>[
+        reportRepositoryProvider.overrideWithValue(repository),
+      ],
+    );
+
+    await tester.tap(find.text('이전 주'));
+    await settle(tester);
+    await tester.tap(
+      find.byKey(const ValueKey<String>('reports-weekly-retry')),
+    );
+    await settle(tester);
+
+    final retryCalls = repository.calls.sublist(repository.calls.length - 2);
+    expect(retryCalls.map((call) => call.client.id), <String>[
+      'seed-client-3',
+      'seed-client-3',
+    ]);
+    expect(retryCalls.first.weekStart, retryCalls.last.weekStart);
+    expect(
+      retryCalls.last.weekStart,
+      weekStartOf(DateTime.now()).subtract(const Duration(days: 7)),
+    );
+    expect(find.text('박성호님 주간 리포트'), findsOneWidget);
+    expect(find.text('report transport detail'), findsNothing);
   });
 
   testWidgets('picking another client swaps the report', (tester) async {


### PR DESCRIPTION
Closes #625

## 요약

- 대시보드·리포트·알림함·고객 채팅·식단·운동 조회 오류 상태에 명시적인 `다시 시도` 경로를 추가했습니다.
- loading·empty·error를 구분하고, 재시도 시 실패한 provider만 다시 조회합니다.
- 선택 고객, 고객 상세 section, 리포트 주차와 route를 유지합니다.
- 재시도 중 provider loading 상태로 CTA를 비활성화해 중복 요청을 막습니다.

## 원인

기존 주요 조회 화면은 provider 오류를 안내 문구로만 렌더링했고, 같은 화면에서 스트림을 재구독할 수단이 없었습니다. 알림함은 `AppError.message`를 직접 표시할 수 있어 내부 네트워크 예외가 노출될 여지도 있었습니다.

## 변경 사항

- 기존 `EmptyHint`에 optional action 슬롯을 추가하고 `ActionButton`을 재사용했습니다.
- 대시보드는 요약의 실제 소스인 `clientsProvider`만 재조회합니다.
- 리포트는 고객 목록과 선택 고객·주차의 `weeklyReportProvider` `family` 인스턴스를 독립적으로 재조회합니다.
- 알림함은 정상 0건과 조회 오류를 분리하고 지역화된 오류 문구만 표시합니다.
- 고객 상세는 현재 고객의 채팅 thread·식단·운동 기록을 각각 재조회합니다.
- 운동 화면은 운동 기록·배정 루틴·PT 일정 오류를 영역별로 독립 복구합니다.
- #520의 `activePollingStream` 및 기존 데이터 보존 정책은 변경하지 않았습니다.

## 중복 범위

- Issue #623 / PR #629와 다음 production 파일이 겹칩니다.
  - `dashboard_page.dart`
  - `reports_page.dart`
  - `chat_view.dart`
- #629는 통합 고객 검색·헤더 구성, 이 PR은 최초 조회 오류·재시도 분기를 다룹니다. 나중에 merge되는 PR에서 두 변경을 모두 보존해야 합니다.
- 열린 PR #627은 회원 앱 세션 복구 범위로, 이 PR과 겹치지 않습니다.

## 검증

- [x] 대상 위젯 테스트 60개 통과
- [x] Trainer Web 전체 Flutter 테스트 478개 통과
- [x] `flutter analyze` 무이슈(한글 경로의 Flutter 3.44 LSP 충돌을 피해 동일 소스를 ASCII 임시 경로에서 검증)
- [x] `flutter build web --no-pub` 성공
- [x] `git diff --check` 통과
- [x] 480px viewport에서 긴 오류 문구·재시도 CTA overflow 없음

## 범위 확인

- navigation, breakpoint, polling, 채팅 전송·읽음, 루틴/PT mutation은 변경하지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 채팅, 식단, 운동, 대시보드, 알림 및 리포트 오류 화면에 재시도 버튼을 추가했습니다.
  - 재시도 중에는 버튼이 비활성화되며, 해당 데이터만 다시 불러옵니다.
  - 오류 발생 시 내부 상세 정보 대신 사용자 친화적인 안내를 표시합니다.
  - 공통 빈 상태 화면에서 선택적 액션 버튼을 지원합니다.

- **테스트**
  - 각 화면의 오류 발생, 재시도 및 정상 복구 동작을 검증하는 테스트를 추가했습니다.
  - 재시도 후 현재 화면과 선택 상태가 유지되는지 확인합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->