### PR TITLE
fix(trainer): 웹 콘솔 전반의 텍스트 가독성 개선

### DIFF
--- a/frontend/flutter_trainer/lib/app/shell/app_shell.dart
+++ b/frontend/flutter_trainer/lib/app/shell/app_shell.dart
@@ -129,7 +129,7 @@ class _CompactBar extends StatelessWidget implements PreferredSizeWidget {
                 style: TextStyle(color: AppColors.primary),
               ),
             ],
-            style: TextStyle(fontSize: 15, fontWeight: FontWeight.w800),
+            style: TextStyle(fontSize: 16, fontWeight: FontWeight.w800),
           ),
         ),
       ),

--- a/frontend/flutter_trainer/lib/app/shell/app_sidebar.dart
+++ b/frontend/flutter_trainer/lib/app/shell/app_sidebar.dart
@@ -217,7 +217,7 @@ class _Brand extends StatelessWidget {
                         ),
                       ],
                       style: TextStyle(
-                        fontSize: 18,
+                        fontSize: 19,
                         fontWeight: FontWeight.w800,
                       ),
                     ),
@@ -226,7 +226,10 @@ class _Brand extends StatelessWidget {
                 ),
               ],
             )
-          : Tooltip(message: AppLocalizations.of(context).appTitle, child: logo),
+          : Tooltip(
+              message: AppLocalizations.of(context).appTitle,
+              child: logo,
+            ),
     );
   }
 }
@@ -273,7 +276,7 @@ class _NavTile extends StatelessWidget {
                     label,
                     overflow: TextOverflow.ellipsis,
                     style: TextStyle(
-                      fontSize: 13.5,
+                      fontSize: 14.5,
                       fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
                       color: selected
                           ? AppColors.foreground
@@ -323,9 +326,7 @@ class _NavTile extends StatelessWidget {
                   ),
                 ),
               ),
-              child: expanded
-                  ? row
-                  : Tooltip(message: label, child: row),
+              child: expanded ? row : Tooltip(message: label, child: row),
             ),
           ),
         ),
@@ -400,7 +401,7 @@ class _ProfileFooter extends StatelessWidget {
             ? AppLocalizations.of(context).appAvatarFallback
             : String.fromCharCode(name.runes.first),
         style: const TextStyle(
-          fontSize: 12,
+          fontSize: 13,
           fontWeight: FontWeight.w800,
           color: AppColors.primary,
         ),
@@ -437,7 +438,7 @@ class _ProfileFooter extends StatelessWidget {
                               name,
                               overflow: TextOverflow.ellipsis,
                               style: const TextStyle(
-                                fontSize: 12.5,
+                                fontSize: 13.5,
                                 fontWeight: FontWeight.w700,
                                 color: AppColors.foreground,
                               ),
@@ -446,7 +447,7 @@ class _ProfileFooter extends StatelessWidget {
                               gym,
                               overflow: TextOverflow.ellipsis,
                               style: const TextStyle(
-                                fontSize: 11,
+                                fontSize: 12,
                                 color: AppColors.subtleForeground,
                               ),
                             ),
@@ -461,9 +462,11 @@ class _ProfileFooter extends StatelessWidget {
                     ],
                   )
                 : Tooltip(
-                  message: AppLocalizations.of(context).sidebarMyTooltip(name),
-                  child: avatar,
-                ),
+                    message: AppLocalizations.of(
+                      context,
+                    ).sidebarMyTooltip(name),
+                    child: avatar,
+                  ),
           ),
         ),
       ),

--- a/frontend/flutter_trainer/lib/design_system/tokens/colors.dart
+++ b/frontend/flutter_trainer/lib/design_system/tokens/colors.dart
@@ -58,14 +58,18 @@ class AppColors {
   /// Primary text.
   static const Color foreground = Color(0xFF1A1A1A);
 
-  /// Secondary body text (slate-ish `#5A6A7A`).
-  static const Color mutedForeground = Color(0xFF5A6A7A);
+  /// Secondary body text. Dark enough to stay readable on white and the
+  /// app's pale surfaces (white contrast 7.61:1).
+  static const Color mutedForeground = Color(0xFF465568);
 
-  /// Tertiary / placeholder text (`#A0A8B5`).
-  static const Color subtleForeground = Color(0xFFA0A8B5);
+  /// Tertiary / placeholder text (white contrast 4.72:1, WCAG AA for
+  /// normal text). It remains lighter than [mutedForeground] without
+  /// fading into the card background.
+  static const Color subtleForeground = Color(0xFF667585);
 
-  /// Disabled / hairline text (`#C0CDD6`).
-  static const Color disabledForeground = Color(0xFFC0CDD6);
+  /// Disabled text. Visibly inactive but still legible (white contrast
+  /// 3.77:1) when a trainer needs to understand why an action is disabled.
+  static const Color disabledForeground = Color(0xFF768596);
 
   // --- Semantic ---
   /// Success / "완료" green (`#34C759`).

--- a/frontend/flutter_trainer/lib/design_system/tokens/typography.dart
+++ b/frontend/flutter_trainer/lib/design_system/tokens/typography.dart
@@ -7,34 +7,68 @@ class AppTypography {
   AppTypography._();
 
   static TextTheme buildTextTheme(TextTheme base) {
-    // 사용자 앱(design_system/tokens/typography.dart)의 가중치 스케일과 일치.
+    // 사용자 앱(design_system/tokens/typography.dart)의 크기·가중치
+    // 스케일과 일치시킨다. Material 기본 bodyMedium(14px)은 정보가 많은
+    // 데스크톱 콘솔에서 작으므로 본문 기준을 16px로 둔다.
     return base.copyWith(
       displayLarge: base.displayLarge?.copyWith(
+        fontSize: 33,
         fontWeight: FontWeight.w700,
         height: 1.2,
       ),
       displayMedium: base.displayMedium?.copyWith(
+        fontSize: 30,
+        fontWeight: FontWeight.w700,
+        height: 1.25,
+      ),
+      displaySmall: base.displaySmall?.copyWith(
+        fontSize: 28,
+        fontWeight: FontWeight.w700,
+        height: 1.2,
+      ),
+      headlineLarge: base.headlineLarge?.copyWith(
+        fontSize: 26,
+        fontWeight: FontWeight.w700,
+        height: 1.25,
+      ),
+      headlineMedium: base.headlineMedium?.copyWith(
+        fontSize: 24,
         fontWeight: FontWeight.w700,
         height: 1.25,
       ),
       headlineSmall: base.headlineSmall?.copyWith(
+        fontSize: 22,
         fontWeight: FontWeight.w700,
-        height: 1.25,
+        height: 1.3,
       ),
       titleLarge: base.titleLarge?.copyWith(
+        fontSize: 20,
         fontWeight: FontWeight.w600,
         height: 1.3,
       ),
       titleMedium: base.titleMedium?.copyWith(
+        fontSize: 18,
         fontWeight: FontWeight.w600,
         height: 1.3,
       ),
+      titleSmall: base.titleSmall?.copyWith(
+        fontSize: 16,
+        fontWeight: FontWeight.w600,
+        height: 1.35,
+      ),
       bodyLarge: base.bodyLarge?.copyWith(
+        fontSize: 17,
         fontWeight: FontWeight.w500,
         height: 1.45,
       ),
-      bodyMedium: base.bodyMedium?.copyWith(height: 1.5),
-      labelLarge: base.labelLarge?.copyWith(fontWeight: FontWeight.w600),
+      bodyMedium: base.bodyMedium?.copyWith(fontSize: 16, height: 1.5),
+      bodySmall: base.bodySmall?.copyWith(fontSize: 14, height: 1.45),
+      labelLarge: base.labelLarge?.copyWith(
+        fontSize: 16,
+        fontWeight: FontWeight.w600,
+      ),
+      labelMedium: base.labelMedium?.copyWith(fontSize: 14),
+      labelSmall: base.labelSmall?.copyWith(fontSize: 13),
     );
   }
 }

--- a/frontend/flutter_trainer/lib/features/auth/presentation/pages/trainer_sign_in_page.dart
+++ b/frontend/flutter_trainer/lib/features/auth/presentation/pages/trainer_sign_in_page.dart
@@ -58,7 +58,9 @@ class _TrainerSignInPageState extends ConsumerState<TrainerSignInPage> {
       if (!mounted) return;
       setState(() => _loading = false);
       messenger.showSnackBar(
-        SnackBar(content: Text(AppLocalizations.of(context).authErrSocialFailed)),
+        SnackBar(
+          content: Text(AppLocalizations.of(context).authErrSocialFailed),
+        ),
       );
     }
   }
@@ -70,7 +72,9 @@ class _TrainerSignInPageState extends ConsumerState<TrainerSignInPage> {
     final password = _password.text;
     if (email.isEmpty || password.isEmpty) {
       messenger.showSnackBar(
-        SnackBar(content: Text(AppLocalizations.of(context).authErrEmptyCredentials)),
+        SnackBar(
+          content: Text(AppLocalizations.of(context).authErrEmptyCredentials),
+        ),
       );
       return;
     }
@@ -90,7 +94,9 @@ class _TrainerSignInPageState extends ConsumerState<TrainerSignInPage> {
       if (!mounted) return;
       setState(() => _loading = false);
       messenger.showSnackBar(
-        SnackBar(content: Text(AppLocalizations.of(context).authErrSignInFailed)),
+        SnackBar(
+          content: Text(AppLocalizations.of(context).authErrSignInFailed),
+        ),
       );
     }
   }
@@ -250,7 +256,7 @@ class _OrDivider extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
           child: Text(
             AppLocalizations.of(context).authOr,
-            style: const TextStyle(color: Color(0xFF64748B), fontSize: 13),
+            style: const TextStyle(color: Color(0xFF64748B), fontSize: 14),
           ),
         ),
         const Expanded(child: Divider(color: Color(0x1A000000))),

--- a/frontend/flutter_trainer/lib/features/auth/presentation/pages/trainer_sign_up_page.dart
+++ b/frontend/flutter_trainer/lib/features/auth/presentation/pages/trainer_sign_up_page.dart
@@ -67,23 +67,33 @@ class _TrainerSignUpPageState extends ConsumerState<TrainerSignUpPage> {
     final inviteCode = _inviteCode.text.trim();
     if (email.isEmpty || password.isEmpty) {
       messenger.showSnackBar(
-        SnackBar(content: Text(AppLocalizations.of(context).authErrEmptyCredentials)),
+        SnackBar(
+          content: Text(AppLocalizations.of(context).authErrEmptyCredentials),
+        ),
       );
       return;
     }
     if (password.length < 8) {
       messenger.showSnackBar(
-        SnackBar(content: Text(AppLocalizations.of(context).authErrPasswordTooShort)),
+        SnackBar(
+          content: Text(AppLocalizations.of(context).authErrPasswordTooShort),
+        ),
       );
       return;
     }
     if (password != confirm) {
-      messenger.showSnackBar(SnackBar(content: Text(AppLocalizations.of(context).authErrPasswordMismatch)));
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(AppLocalizations.of(context).authErrPasswordMismatch),
+        ),
+      );
       return;
     }
     if (requiresInviteCode && inviteCode.isEmpty) {
       messenger.showSnackBar(
-        SnackBar(content: Text(AppLocalizations.of(context).authErrInviteCodeRequired)),
+        SnackBar(
+          content: Text(AppLocalizations.of(context).authErrInviteCodeRequired),
+        ),
       );
       return;
     }
@@ -110,7 +120,9 @@ class _TrainerSignUpPageState extends ConsumerState<TrainerSignUpPage> {
       if (!mounted) return;
       setState(() => _loading = false);
       messenger.showSnackBar(
-        SnackBar(content: Text(AppLocalizations.of(context).authErrSignUpFailed)),
+        SnackBar(
+          content: Text(AppLocalizations.of(context).authErrSignUpFailed),
+        ),
       );
     }
   }
@@ -213,7 +225,7 @@ class _TrainerSignUpPageState extends ConsumerState<TrainerSignUpPage> {
                         Text(
                           l.authInviteCodeHelp,
                           style: const TextStyle(
-                            fontSize: 12,
+                            fontSize: 13,
                             color: Color(0xFF64748B),
                           ),
                         ),

--- a/frontend/flutter_trainer/lib/features/auth/presentation/widgets/auth_fields.dart
+++ b/frontend/flutter_trainer/lib/features/auth/presentation/widgets/auth_fields.dart
@@ -149,7 +149,7 @@ class AuthGradientButton extends StatelessWidget {
                     label,
                     style: const TextStyle(
                       color: AppColors.primaryForeground,
-                      fontSize: 16,
+                      fontSize: 17,
                       fontWeight: FontWeight.w600,
                     ),
                   ),

--- a/frontend/flutter_trainer/lib/features/clients/presentation/pages/clients_page.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/pages/clients_page.dart
@@ -281,7 +281,7 @@ class _NoSelection extends StatelessWidget {
             l.clientsPickHint,
             textAlign: TextAlign.center,
             style: TextStyle(
-              fontSize: 12.5,
+              fontSize: 13.5,
               height: 1.6,
               fontWeight: FontWeight.w500,
               color: AppColors.subtleForeground,
@@ -394,7 +394,7 @@ class _FilterBanner extends StatelessWidget {
             child: Text(
               l.clientsFilterSummary(filter.label(l), shown, total),
               style: const TextStyle(
-                fontSize: 11.5,
+                fontSize: 12.5,
                 fontWeight: FontWeight.w700,
                 color: AppColors.primary,
               ),
@@ -408,7 +408,7 @@ class _FilterBanner extends StatelessWidget {
               child: Text(
                 l.clientsSeeAll,
                 style: TextStyle(
-                  fontSize: 11,
+                  fontSize: 12,
                   fontWeight: FontWeight.w700,
                   color: AppColors.mutedForeground,
                 ),
@@ -507,7 +507,7 @@ class _AddClientSheetState extends ConsumerState<_AddClientSheet> {
           Text(
             l.clientsAddTitle,
             style: TextStyle(
-              fontSize: 15,
+              fontSize: 16,
               fontWeight: FontWeight.w800,
               color: AppColors.foreground,
             ),
@@ -565,7 +565,7 @@ class _AddClientSheetState extends ConsumerState<_AddClientSheet> {
                 child: Text(
                   l.clientsAddAction,
                   style: TextStyle(
-                    fontSize: 13,
+                    fontSize: 14,
                     fontWeight: FontWeight.w700,
                     color: AppColors.primaryForeground,
                   ),

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
@@ -264,7 +264,7 @@ class _SystemBanner extends StatelessWidget {
               l.chatDemoReportSent,
               textAlign: TextAlign.center,
               style: TextStyle(
-                fontSize: 9.5,
+                fontSize: 10.5,
                 color: AppColors.mutedForeground,
                 fontWeight: FontWeight.w500,
               ),
@@ -310,7 +310,7 @@ class _SentBanner extends StatelessWidget {
               l.chatDemoNotified,
               textAlign: TextAlign.center,
               style: TextStyle(
-                fontSize: 9.5,
+                fontSize: 10.5,
                 color: AppColors.mutedForeground,
                 fontWeight: FontWeight.w500,
               ),
@@ -356,7 +356,7 @@ class _Bubble extends StatelessWidget {
           child: Text(
             message.body,
             style: TextStyle(
-              fontSize: 12.5,
+              fontSize: 13.5,
               height: 1.4,
               fontWeight: FontWeight.w500,
               color: fromTrainer
@@ -369,7 +369,7 @@ class _Bubble extends StatelessWidget {
         Text(
           message.timeLabel,
           style: const TextStyle(
-            fontSize: 9,
+            fontSize: 10,
             color: AppColors.disabledForeground,
           ),
         ),

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_card.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_card.dart
@@ -79,7 +79,7 @@ class ClientCard extends StatelessWidget {
                                 child: Text(
                                   client.name,
                                   style: const TextStyle(
-                                    fontSize: 15,
+                                    fontSize: 16,
                                     fontWeight: FontWeight.w700,
                                     color: AppColors.foreground,
                                   ),
@@ -88,7 +88,7 @@ class ClientCard extends StatelessWidget {
                               Text(
                                 client.lastTime,
                                 style: const TextStyle(
-                                  fontSize: 11,
+                                  fontSize: 12,
                                   color: AppColors.disabledForeground,
                                 ),
                               ),
@@ -98,7 +98,7 @@ class ClientCard extends StatelessWidget {
                           Text(
                             client.goal,
                             style: const TextStyle(
-                              fontSize: 11.5,
+                              fontSize: 12.5,
                               color: AppColors.subtleForeground,
                               fontWeight: FontWeight.w500,
                             ),
@@ -112,7 +112,7 @@ class ClientCard extends StatelessWidget {
                                   maxLines: 1,
                                   overflow: TextOverflow.ellipsis,
                                   style: TextStyle(
-                                    fontSize: 12,
+                                    fontSize: 13,
                                     color: unread > 0
                                         ? AppColors.foreground
                                         : AppColors.mutedForeground,
@@ -140,7 +140,7 @@ class ClientCard extends StatelessWidget {
                                   child: Text(
                                     '$unread',
                                     style: const TextStyle(
-                                      fontSize: 10,
+                                      fontSize: 11,
                                       fontWeight: FontWeight.w800,
                                       color: AppColors.accentForeground,
                                     ),
@@ -164,13 +164,19 @@ class ClientCard extends StatelessWidget {
                 ),
                 Row(
                   children: <Widget>[
-                    _Metric(label: l.metricCalories, value: '${client.calories}kcal'),
+                    _Metric(
+                      label: l.metricCalories,
+                      value: '${client.calories}kcal',
+                    ),
                     _Metric(
                       label: l.metricSodium,
                       value: '${client.sodiumMg}mg',
                       warn: client.sodiumOverBudget,
                     ),
-                    _Metric(label: l.clientLastRoutine, value: client.lastRoutine),
+                    _Metric(
+                      label: l.clientLastRoutine,
+                      value: client.lastRoutine,
+                    ),
                   ],
                 ),
               ],
@@ -197,7 +203,7 @@ class _Metric extends StatelessWidget {
           Text(
             label,
             style: const TextStyle(
-              fontSize: 10,
+              fontSize: 11,
               color: AppColors.subtleForeground,
               fontWeight: FontWeight.w500,
             ),
@@ -206,7 +212,7 @@ class _Metric extends StatelessWidget {
           Text(
             value,
             style: TextStyle(
-              fontSize: 11.5,
+              fontSize: 12.5,
               fontWeight: FontWeight.w700,
               color: warn ? AppColors.overTarget : AppColors.foreground,
             ),

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_coach_sheet.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_coach_sheet.dart
@@ -142,7 +142,7 @@ class _ClientCoachSheetState extends ConsumerState<_ClientCoachSheet> {
               Text(
                 l.coachSheetSubtitle,
                 style: TextStyle(
-                  fontSize: 12.5,
+                  fontSize: 13.5,
                   color: AppColors.mutedForeground,
                 ),
               ),
@@ -165,7 +165,7 @@ class _ClientCoachSheetState extends ConsumerState<_ClientCoachSheet> {
                   Text(
                     l.coachSheetSources,
                     style: const TextStyle(
-                      fontSize: 11,
+                      fontSize: 12,
                       fontWeight: FontWeight.w700,
                       color: AppColors.subtleForeground,
                     ),
@@ -175,7 +175,7 @@ class _ClientCoachSheetState extends ConsumerState<_ClientCoachSheet> {
                     Text(
                       '· $source',
                       style: const TextStyle(
-                        fontSize: 12,
+                        fontSize: 13,
                         color: AppColors.mutedForeground,
                       ),
                     ),
@@ -240,7 +240,7 @@ class _Note extends StatelessWidget {
       child: Text(
         text,
         style: const TextStyle(
-          fontSize: 13,
+          fontSize: 14,
           height: 1.5,
           color: AppColors.foreground,
         ),

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_detail_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_detail_view.dart
@@ -213,7 +213,7 @@ class _StatusView extends StatelessWidget {
           Text(
             message,
             style: const TextStyle(
-              fontSize: 13,
+              fontSize: 14,
               fontWeight: FontWeight.w600,
               color: AppColors.mutedForeground,
             ),
@@ -351,7 +351,7 @@ class _Header extends ConsumerWidget {
                       client.name,
                       overflow: TextOverflow.ellipsis,
                       style: const TextStyle(
-                        fontSize: 14,
+                        fontSize: 15,
                         fontWeight: FontWeight.w700,
                         color: AppColors.foreground,
                       ),
@@ -396,7 +396,7 @@ class _Header extends ConsumerWidget {
                 client.goal,
                 overflow: TextOverflow.ellipsis,
                 style: const TextStyle(
-                  fontSize: 10.5,
+                  fontSize: 11.5,
                   color: AppColors.subtleForeground,
                   fontWeight: FontWeight.w500,
                 ),
@@ -487,7 +487,7 @@ class _ChatSegment extends StatelessWidget {
                 Text(
                   l.clientChat,
                   style: TextStyle(
-                    fontSize: 12,
+                    fontSize: 13,
                     fontWeight: FontWeight.w700,
                     color: fg,
                   ),
@@ -508,7 +508,7 @@ class _ChatSegment extends StatelessWidget {
                     child: Text(
                       '$unread',
                       style: TextStyle(
-                        fontSize: 10,
+                        fontSize: 11,
                         fontWeight: FontWeight.w800,
                         color: selected
                             ? AppColors.accent
@@ -599,7 +599,7 @@ class _SubTabs extends StatelessWidget {
                         child: Text(
                           clientSectionLabels(l)[i],
                           style: TextStyle(
-                            fontSize: 12,
+                            fontSize: 13,
                             fontWeight: FontWeight.w700,
                             color: current == i
                                 ? AppColors.accentForeground

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/diet_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/diet_view.dart
@@ -90,7 +90,7 @@ class _NutritionSummary extends StatelessWidget {
           Text(
             l.dietTodaySummary,
             style: TextStyle(
-              fontSize: 12.5,
+              fontSize: 13.5,
               fontWeight: FontWeight.w700,
               color: AppColors.foreground,
             ),
@@ -205,7 +205,7 @@ class _SodiumTrendCard extends StatelessWidget {
                 child: Text(
                   l.dietSodiumTrend,
                   style: TextStyle(
-                    fontSize: 12.5,
+                    fontSize: 13.5,
                     fontWeight: FontWeight.w700,
                     color: AppColors.foreground,
                   ),
@@ -215,7 +215,7 @@ class _SodiumTrendCard extends StatelessWidget {
                 Text(
                   l.dietAverageMg(avg),
                   style: const TextStyle(
-                    fontSize: 10.5,
+                    fontSize: 11.5,
                     fontWeight: FontWeight.w600,
                     color: AppColors.subtleForeground,
                   ),
@@ -224,7 +224,7 @@ class _SodiumTrendCard extends StatelessWidget {
           ),
           const SizedBox(height: AppSpacing.md),
           SizedBox(
-            height: 84,
+            height: 88,
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.end,
               children: <Widget>[
@@ -246,7 +246,7 @@ class _SodiumTrendCard extends StatelessWidget {
                 ? l.dietSodiumOverDays(overDays, sodiumTargetMg)
                 : l.dietSodiumAllWithin(sodiumTargetMg),
             style: TextStyle(
-              fontSize: 10.5,
+              fontSize: 11.5,
               fontWeight: FontWeight.w600,
               color: overDays > 0 ? AppColors.overTarget : AppColors.success,
             ),
@@ -282,7 +282,7 @@ class _TrendBar extends StatelessWidget {
         Text(
           '$value',
           style: const TextStyle(
-            fontSize: 7.5,
+            fontSize: 9,
             fontWeight: FontWeight.w600,
             color: AppColors.subtleForeground,
           ),
@@ -300,7 +300,7 @@ class _TrendBar extends StatelessWidget {
         Text(
           label,
           style: const TextStyle(
-            fontSize: 9,
+            fontSize: 10,
             fontWeight: FontWeight.w600,
             color: AppColors.subtleForeground,
           ),
@@ -347,7 +347,7 @@ class _MealCard extends StatelessWidget {
                 child: Text(
                   entry.meal,
                   style: const TextStyle(
-                    fontSize: 11,
+                    fontSize: 12,
                     fontWeight: FontWeight.w700,
                     color: AppColors.accent,
                   ),
@@ -357,7 +357,7 @@ class _MealCard extends StatelessWidget {
               Text(
                 '${entry.calories} kcal',
                 style: const TextStyle(
-                  fontSize: 12,
+                  fontSize: 13,
                   fontWeight: FontWeight.w700,
                   color: AppColors.accent,
                 ),
@@ -368,7 +368,7 @@ class _MealCard extends StatelessWidget {
           Text(
             entry.items,
             style: const TextStyle(
-              fontSize: 12,
+              fontSize: 13,
               fontWeight: FontWeight.w500,
               color: AppColors.mutedForeground,
             ),
@@ -377,7 +377,7 @@ class _MealCard extends StatelessWidget {
           Text(
             l.dietSodiumValue(entry.sodiumMg),
             style: const TextStyle(
-              fontSize: 10.5,
+              fontSize: 11.5,
               color: AppColors.subtleForeground,
             ),
           ),
@@ -426,7 +426,7 @@ class _AiComment extends StatelessWidget {
             icon: Icons.auto_awesome,
             label: l.dietAiAnalysis,
             color: AppColors.accent,
-            fontSize: 10,
+            fontSize: 11,
           ),
           const SizedBox(height: AppSpacing.xs),
           Text(
@@ -434,7 +434,7 @@ class _AiComment extends StatelessWidget {
                 ? l.dietAiOverSodium(sodiumMg - sodiumTargetMg)
                 : l.dietAiBalanced,
             style: const TextStyle(
-              fontSize: 12,
+              fontSize: 13,
               height: 1.55,
               fontWeight: FontWeight.w500,
               color: AppColors.foreground,

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/workout_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/workout_view.dart
@@ -63,7 +63,7 @@ class WorkoutView extends ConsumerWidget {
         Text(
           l.workoutRecords,
           style: TextStyle(
-            fontSize: 11.5,
+            fontSize: 12.5,
             fontWeight: FontWeight.w600,
             color: AppColors.subtleForeground,
           ),
@@ -76,9 +76,7 @@ class WorkoutView extends ConsumerWidget {
               child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
             ),
           ],
-          error: (e, _) => <Widget>[
-            EmptyHint(message: l.workoutLoadFailed),
-          ],
+          error: (e, _) => <Widget>[EmptyHint(message: l.workoutLoadFailed)],
           data: (entries) => <Widget>[
             if (entries.isEmpty)
               EmptyHint(
@@ -148,7 +146,7 @@ class _AssignedRoutinesCard extends ConsumerWidget {
                                   maxLines: 1,
                                   overflow: TextOverflow.ellipsis,
                                   style: const TextStyle(
-                                    fontSize: 12.5,
+                                    fontSize: 13.5,
                                     fontWeight: FontWeight.w700,
                                     color: AppColors.foreground,
                                   ),
@@ -159,7 +157,7 @@ class _AssignedRoutinesCard extends ConsumerWidget {
                                     maxLines: 1,
                                     overflow: TextOverflow.ellipsis,
                                     style: const TextStyle(
-                                      fontSize: 10.5,
+                                      fontSize: 11.5,
                                       color: AppColors.subtleForeground,
                                       fontWeight: FontWeight.w500,
                                     ),
@@ -170,7 +168,7 @@ class _AssignedRoutinesCard extends ConsumerWidget {
                           Text(
                             l.minutesShort(routine.minutes),
                             style: const TextStyle(
-                              fontSize: 11.5,
+                              fontSize: 12.5,
                               fontWeight: FontWeight.w700,
                               color: AppColors.primary,
                             ),
@@ -178,10 +176,7 @@ class _AssignedRoutinesCard extends ConsumerWidget {
                           // 배정 뒤 정정·철회. 전에는 잘못 넣어도 고칠 수 없어
                           // 새 루틴을 하나 더 배정했고, 회원 앱에는 둘 다
                           // 그대로 보였다. (#504)
-                          _RoutineActions(
-                            clientId: clientId,
-                            routine: routine,
-                          ),
+                          _RoutineActions(clientId: clientId, routine: routine),
                         ],
                       ),
                     ),
@@ -257,7 +252,7 @@ class _SessionRow extends StatelessWidget {
             child: Text(
               session.date == today ? l.labelToday : label,
               style: TextStyle(
-                fontSize: 11,
+                fontSize: 12,
                 fontWeight: FontWeight.w700,
                 color: session.date == today
                     ? AppColors.primary
@@ -270,9 +265,12 @@ class _SessionRow extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
                 Text(
-                  l.sessionTypeAndDuration(sessionTypeLabel(l, session.type), session.durationMinutes),
+                  l.sessionTypeAndDuration(
+                    sessionTypeLabel(l, session.type),
+                    session.durationMinutes,
+                  ),
                   style: const TextStyle(
-                    fontSize: 12,
+                    fontSize: 13,
                     fontWeight: FontWeight.w700,
                     color: AppColors.foreground,
                   ),
@@ -282,7 +280,7 @@ class _SessionRow extends StatelessWidget {
                   maxLines: 2,
                   overflow: TextOverflow.ellipsis,
                   style: TextStyle(
-                    fontSize: 10.5,
+                    fontSize: 11.5,
                     height: 1.4,
                     fontWeight: FontWeight.w500,
                     color: exercises.isEmpty
@@ -297,7 +295,7 @@ class _SessionRow extends StatelessWidget {
           Text(
             scheduleStatusLabel(l, session.status),
             style: TextStyle(
-              fontSize: 10.5,
+              fontSize: 11.5,
               fontWeight: FontWeight.w800,
               color: session.isDone ? AppColors.success : AppColors.primary,
             ),
@@ -330,13 +328,13 @@ class _TypeChip extends StatelessWidget {
               icon: Icons.auto_awesome,
               label: label,
               color: color,
-              fontSize: 10,
+              fontSize: 11,
               fontWeight: FontWeight.w800,
             )
           : Text(
               label,
               style: TextStyle(
-                fontSize: 10,
+                fontSize: 11,
                 fontWeight: FontWeight.w800,
                 color: color,
               ),
@@ -390,7 +388,7 @@ class _WeekCompletionCard extends StatelessWidget {
                 child: Text(
                   l.weekCompletionRate,
                   style: TextStyle(
-                    fontSize: 12.5,
+                    fontSize: 13.5,
                     fontWeight: FontWeight.w700,
                     color: AppColors.foreground,
                   ),
@@ -399,7 +397,7 @@ class _WeekCompletionCard extends StatelessWidget {
               Text(
                 '$avg%',
                 style: const TextStyle(
-                  fontSize: 18,
+                  fontSize: 19,
                   fontWeight: FontWeight.w800,
                   color: AppColors.primary,
                 ),
@@ -433,7 +431,7 @@ class _WeekCompletionCard extends StatelessWidget {
                         Text(
                           _days(l)[i],
                           style: TextStyle(
-                            fontSize: 9,
+                            fontSize: 10,
                             fontWeight: FontWeight.w600,
                             color: i >= elapsed
                                 ? AppColors.disabledForeground
@@ -484,7 +482,7 @@ class _LegendDot extends StatelessWidget {
         Text(
           label,
           style: const TextStyle(
-            fontSize: 9,
+            fontSize: 10,
             color: AppColors.subtleForeground,
           ),
         ),
@@ -523,7 +521,7 @@ class _HistoryCard extends StatelessWidget {
                     Text(
                       entry.dateLabel,
                       style: const TextStyle(
-                        fontSize: 12,
+                        fontSize: 13,
                         fontWeight: FontWeight.w700,
                         color: AppColors.foreground,
                       ),
@@ -531,7 +529,7 @@ class _HistoryCard extends StatelessWidget {
                     Text(
                       entry.label,
                       style: const TextStyle(
-                        fontSize: 10,
+                        fontSize: 11,
                         fontWeight: FontWeight.w500,
                         color: AppColors.subtleForeground,
                       ),
@@ -605,7 +603,7 @@ class _ExerciseLine extends StatelessWidget {
             child: Text(
               text,
               style: TextStyle(
-                fontSize: 11.5,
+                fontSize: 12.5,
                 fontWeight: FontWeight.w500,
                 color: color,
                 decoration: skipped ? TextDecoration.lineThrough : null,
@@ -642,7 +640,7 @@ class _CompletionDonut extends StatelessWidget {
           Text(
             '$rate%',
             style: TextStyle(
-              fontSize: 8,
+              fontSize: 9.5,
               fontWeight: FontWeight.w800,
               color: rate == 0 ? AppColors.disabledForeground : color,
             ),
@@ -686,7 +684,7 @@ class _NoteBox extends StatelessWidget {
           Text(
             title,
             style: TextStyle(
-              fontSize: 9,
+              fontSize: 10,
               fontWeight: FontWeight.w700,
               color: color,
             ),
@@ -695,7 +693,7 @@ class _NoteBox extends StatelessWidget {
           Text(
             body,
             style: const TextStyle(
-              fontSize: 11,
+              fontSize: 12,
               fontWeight: FontWeight.w500,
               color: AppColors.mutedForeground,
             ),
@@ -728,10 +726,11 @@ class _RoutineActionsState extends ConsumerState<_RoutineActions> {
     // messenger 와 함께 await 전에 잡아 둔다 — 실패 경로가 await 뒤에 있다.
     final messenger = ScaffoldMessenger.of(context);
     final AppLocalizations l = AppLocalizations.of(context);
-    final result = await showDialog<({String name, int minutes, String reason})>(
-      context: context,
-      builder: (_) => _RoutineEditDialog(routine: widget.routine),
-    );
+    final result =
+        await showDialog<({String name, int minutes, String reason})>(
+          context: context,
+          builder: (_) => _RoutineEditDialog(routine: widget.routine),
+        );
     if (result == null || !mounted) return;
 
     setState(() => _busy = true);
@@ -753,15 +752,11 @@ class _RoutineActionsState extends ConsumerState<_RoutineActions> {
         setState(() => _busy = false);
         ref.invalidate(assignedRoutinesProvider(widget.clientId));
       }
-      messenger.showSnackBar(
-        SnackBar(content: Text(l.routineAlreadyGone)),
-      );
+      messenger.showSnackBar(SnackBar(content: Text(l.routineAlreadyGone)));
       return;
     } catch (_) {
       if (mounted) setState(() => _busy = false);
-      messenger.showSnackBar(
-        SnackBar(content: Text(l.routineUpdateFailed)),
-      );
+      messenger.showSnackBar(SnackBar(content: Text(l.routineUpdateFailed)));
       return;
     }
     if (!mounted) return;
@@ -808,15 +803,11 @@ class _RoutineActionsState extends ConsumerState<_RoutineActions> {
         setState(() => _busy = false);
         ref.invalidate(assignedRoutinesProvider(widget.clientId));
       }
-      messenger.showSnackBar(
-        SnackBar(content: Text(l.routineAlreadyGone)),
-      );
+      messenger.showSnackBar(SnackBar(content: Text(l.routineAlreadyGone)));
       return;
     } catch (_) {
       if (mounted) setState(() => _busy = false);
-      messenger.showSnackBar(
-        SnackBar(content: Text(l.routineDeleteFailed)),
-      );
+      messenger.showSnackBar(SnackBar(content: Text(l.routineDeleteFailed)));
       return;
     }
     if (!mounted) return;
@@ -965,7 +956,7 @@ class _RoutineEditDialogState extends State<_RoutineEditDialog> {
             Text(
               _error!,
               style: const TextStyle(
-                fontSize: 12,
+                fontSize: 13,
                 color: AppColors.destructive,
               ),
             ),

--- a/frontend/flutter_trainer/lib/features/coaching/presentation/pages/ai_routine_options_flow.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/pages/ai_routine_options_flow.dart
@@ -290,7 +290,10 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
       (best, entry) => best == null || entry.value > best.value ? entry : best,
     );
     final exerciseSummary = _edited
-        .map((exercise) => l.aiExerciseWithMinutes(exercise.name, exercise.minutes))
+        .map(
+          (exercise) =>
+              l.aiExerciseWithMinutes(exercise.name, exercise.minutes),
+        )
         .join(', ');
     final memo = _trainerMemo.text.trim();
     final rationale = memo.isEmpty ? _selectedChoiceOf(l).reason : memo;
@@ -402,7 +405,7 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
           _analysisRow(
             l.aiTodaySodium,
             '${client.sodiumMg}mg'
-                '${client.sodiumOverBudget ? l.aiOverTarget : l.aiWithinTarget}',
+            '${client.sodiumOverBudget ? l.aiOverTarget : l.aiWithinTarget}',
             warn: client.sodiumOverBudget,
           ),
           _analysisRow(l.aiRecentRoutine, client.lastRoutine),
@@ -421,7 +424,7 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
           const SizedBox(height: AppSpacing.xs),
           Text(
             l.aiNotePlaceholderHint,
-            style: TextStyle(fontSize: 9.5, color: AppColors.mutedForeground),
+            style: TextStyle(fontSize: 10.5, color: AppColors.mutedForeground),
           ),
         ],
       ),
@@ -467,7 +470,7 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
               ) +
               (options.generatedBy == 'rule' ? l.aiBasisRuleBased : ''),
           style: const TextStyle(
-            fontSize: 10.5,
+            fontSize: 11.5,
             color: AppColors.mutedForeground,
           ),
         ),
@@ -585,7 +588,7 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
                     child: Text(
                       '$optionName · ${choice.label}',
                       style: const TextStyle(
-                        fontSize: 13,
+                        fontSize: 14,
                         fontWeight: FontWeight.w800,
                         color: AppColors.foreground,
                       ),
@@ -597,7 +600,7 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
               Text(
                 l.aiTotalAndIntensity(total, choice.intensity),
                 style: const TextStyle(
-                  fontSize: 10.5,
+                  fontSize: 11.5,
                   fontWeight: FontWeight.w700,
                   color: AppColors.accent,
                 ),
@@ -610,7 +613,7 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
                     '${l.aiBulletExercise(exercise.name, exercise.minutes)}'
                     '(${routineTypeLabel(l, exercise.type)})',
                     style: const TextStyle(
-                      fontSize: 11,
+                      fontSize: 12,
                       color: AppColors.foreground,
                     ),
                   ),
@@ -621,7 +624,7 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
                 maxLines: 3,
                 overflow: TextOverflow.ellipsis,
                 style: const TextStyle(
-                  fontSize: 10,
+                  fontSize: 11,
                   height: 1.35,
                   color: AppColors.mutedForeground,
                 ),
@@ -643,7 +646,7 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
         const SizedBox(height: 3),
         Text(
           l.aiEditBlurb,
-          style: TextStyle(fontSize: 10, color: AppColors.mutedForeground),
+          style: TextStyle(fontSize: 11, color: AppColors.mutedForeground),
         ),
         const SizedBox(height: AppSpacing.md),
         for (int index = 0; index < _edited.length; index++) ...<Widget>[
@@ -707,7 +710,7 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
             ),
             initialValue: exercise.name,
             style: const TextStyle(
-              fontSize: 12.5,
+              fontSize: 13.5,
               fontWeight: FontWeight.w700,
               color: AppColors.foreground,
             ),
@@ -835,7 +838,7 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
         const SizedBox(height: 3),
         Text(
           l.aiEditsApplied,
-          style: TextStyle(fontSize: 10, color: AppColors.mutedForeground),
+          style: TextStyle(fontSize: 11, color: AppColors.mutedForeground),
         ),
         const SizedBox(height: AppSpacing.md),
         for (final exercise in _edited) ...<Widget>[
@@ -854,7 +857,7 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
                   child: Text(
                     routineTypeLabel(l, exercise.type),
                     style: const TextStyle(
-                      fontSize: 9.5,
+                      fontSize: 10.5,
                       fontWeight: FontWeight.w700,
                       color: AppColors.accent,
                     ),
@@ -865,7 +868,7 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
                   child: Text(
                     exercise.name,
                     style: const TextStyle(
-                      fontSize: 12.5,
+                      fontSize: 13.5,
                       fontWeight: FontWeight.w700,
                       color: AppColors.foreground,
                     ),
@@ -874,7 +877,7 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
                 Text(
                   l.minutesShort(exercise.minutes),
                   style: const TextStyle(
-                    fontSize: 11.5,
+                    fontSize: 12.5,
                     fontWeight: FontWeight.w700,
                     color: AppColors.accent,
                   ),
@@ -902,7 +905,7 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
                       Text(
                         l.schedNote,
                         style: TextStyle(
-                          fontSize: 10,
+                          fontSize: 11,
                           fontWeight: FontWeight.w700,
                           color: AppColors.warning,
                         ),
@@ -911,7 +914,7 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
                       Text(
                         memo,
                         style: const TextStyle(
-                          fontSize: 11.5,
+                          fontSize: 12.5,
                           height: 1.4,
                           color: AppColors.foreground,
                         ),
@@ -980,7 +983,7 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
             l.aiRoutineSent(widget.client.name),
             textAlign: TextAlign.center,
             style: const TextStyle(
-              fontSize: 13,
+              fontSize: 14,
               fontWeight: FontWeight.w800,
               color: AppColors.foreground,
             ),
@@ -989,7 +992,7 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
           Text(
             l.aiGoToChatHint,
             textAlign: TextAlign.center,
-            style: TextStyle(fontSize: 10.5, color: AppColors.mutedForeground),
+            style: TextStyle(fontSize: 11.5, color: AppColors.mutedForeground),
           ),
         ],
       ),
@@ -1024,7 +1027,7 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
             child: Text(
               value,
               style: TextStyle(
-                fontSize: 12.5,
+                fontSize: 13.5,
                 fontWeight: FontWeight.w600,
                 color: warn ? AppColors.overTarget : AppColors.foreground,
               ),
@@ -1205,7 +1208,7 @@ class _ProgressStepper extends StatelessWidget {
                                   : Text(
                                       _steps(l)[index].$1,
                                       style: TextStyle(
-                                        fontSize: 11,
+                                        fontSize: 12,
                                         fontWeight: FontWeight.w800,
                                         color: index <= maxReachedStage
                                             ? AppColors.accentForeground
@@ -1220,7 +1223,7 @@ class _ProgressStepper extends StatelessWidget {
                       Text(
                         _steps(l)[index].$2,
                         style: TextStyle(
-                          fontSize: 9.5,
+                          fontSize: 10.5,
                           fontWeight: index == stage
                               ? FontWeight.w800
                               : FontWeight.w600,
@@ -1297,7 +1300,7 @@ class _ChatEvidence extends StatelessWidget {
               child: Text(
                 line,
                 style: const TextStyle(
-                  fontSize: 10.5,
+                  fontSize: 11.5,
                   color: AppColors.mutedForeground,
                 ),
               ),
@@ -1309,13 +1312,13 @@ class _ChatEvidence extends StatelessWidget {
 }
 
 const TextStyle _sectionTitleStyle = TextStyle(
-  fontSize: 13,
+  fontSize: 14,
   fontWeight: FontWeight.w800,
   color: AppColors.foreground,
 );
 
 const TextStyle _labelStyle = TextStyle(
-  fontSize: 10.5,
+  fontSize: 11.5,
   fontWeight: FontWeight.w700,
   color: AppColors.mutedForeground,
 );

--- a/frontend/flutter_trainer/lib/features/coaching/presentation/pages/coaching_page.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/pages/coaching_page.dart
@@ -289,9 +289,7 @@ class _CoachingPageState extends ConsumerState<CoachingPage> {
       final AppLocalizations l = AppLocalizations.of(context);
       // Every exercise was removed — tell the trainer instead of a
       // silent no-op (review PR 220).
-      messenger.showSnackBar(
-        SnackBar(content: Text(l.coachNeedOneExercise)),
-      );
+      messenger.showSnackBar(SnackBar(content: Text(l.coachNeedOneExercise)));
       return;
     }
     final date = ymd(DateTime.now().add(Duration(days: _registerOffset)));
@@ -324,9 +322,7 @@ class _CoachingPageState extends ConsumerState<CoachingPage> {
       // Only surface the error if that client is still on screen.
       if (_isStillSelected(registeredFor)) {
         final AppLocalizations l = AppLocalizations.of(context);
-        messenger.showSnackBar(
-          SnackBar(content: Text(l.coachScheduleFailed)),
-        );
+        messenger.showSnackBar(SnackBar(content: Text(l.coachScheduleFailed)));
       }
       return;
     }
@@ -685,7 +681,7 @@ class _CoachingPageState extends ConsumerState<CoachingPage> {
                         l.coachClientNotified,
                         textAlign: TextAlign.center,
                         style: TextStyle(
-                          fontSize: 10.5,
+                          fontSize: 11.5,
                           fontWeight: FontWeight.w600,
                           color: AppColors.success,
                         ),
@@ -723,7 +719,9 @@ class _CoachingPageState extends ConsumerState<CoachingPage> {
                         ? Icons.check_rounded
                         : Icons.calendar_today_outlined,
                     label: _registered
-                        ? l.coachRegisteredOn(_dateChipLabel(l, _registerOffset))
+                        ? l.coachRegisteredOn(
+                            _dateChipLabel(l, _registerOffset),
+                          )
                         : l.coachRegisterOn(_dateChipLabel(l, _registerOffset)),
                     onTap: () => _registerToSchedule(
                       client,
@@ -737,10 +735,12 @@ class _CoachingPageState extends ConsumerState<CoachingPage> {
                         // Match the button's day label — 오늘/내일/'M/D' — so a
                         // future-day registration isn't described as 오늘
                         // (CodeRabbit review).
-                        l.coachFindInSchedule(_dateChipLabel(l, _registerOffset)),
+                        l.coachFindInSchedule(
+                          _dateChipLabel(l, _registerOffset),
+                        ),
                         textAlign: TextAlign.center,
                         style: const TextStyle(
-                          fontSize: 10.5,
+                          fontSize: 11.5,
                           fontWeight: FontWeight.w600,
                           color: AppColors.success,
                         ),
@@ -756,7 +756,7 @@ class _CoachingPageState extends ConsumerState<CoachingPage> {
     return Text(
       text,
       style: const TextStyle(
-        fontSize: 11.5,
+        fontSize: 12.5,
         fontWeight: FontWeight.w600,
         color: AppColors.subtleForeground,
       ),
@@ -807,7 +807,7 @@ class _ClientChip extends StatelessWidget {
                         style: const TextStyle(
                           color: AppColors.primaryForeground,
                           fontWeight: FontWeight.w800,
-                          fontSize: 12,
+                          fontSize: 13,
                         ),
                       ),
                     )
@@ -816,7 +816,7 @@ class _ClientChip extends StatelessWidget {
               Text(
                 client.name,
                 style: TextStyle(
-                  fontSize: 11,
+                  fontSize: 12,
                   fontWeight: FontWeight.w700,
                   color: selected
                       ? AppColors.primaryForeground
@@ -890,11 +890,9 @@ class _DietSummaryCard extends StatelessWidget {
             ),
             child: IconLabel(
               icon: Icons.auto_awesome,
-              label: over
-                  ? l.coachVerdictSodium
-                  : l.coachVerdictBalanced,
+              label: over ? l.coachVerdictSodium : l.coachVerdictBalanced,
               color: AppColors.accent,
-              fontSize: 11,
+              fontSize: 12,
               fontWeight: FontWeight.w600,
             ),
           ),
@@ -949,7 +947,7 @@ class _AiAssistantPrompt extends StatelessWidget {
                     Text(
                       l.coachRequestCustom,
                       style: TextStyle(
-                        fontSize: 13,
+                        fontSize: 14,
                         fontWeight: FontWeight.w800,
                         color: AppColors.foreground,
                       ),
@@ -958,7 +956,7 @@ class _AiAssistantPrompt extends StatelessWidget {
                     Text(
                       l.coachRequestBlurb(clientName),
                       style: const TextStyle(
-                        fontSize: 10.5,
+                        fontSize: 11.5,
                         height: 1.35,
                         color: AppColors.mutedForeground,
                       ),
@@ -1037,7 +1035,7 @@ class _RoutineCard extends StatelessWidget {
                   child: Text(
                     type,
                     style: TextStyle(
-                      fontSize: 9.5,
+                      fontSize: 10.5,
                       fontWeight: FontWeight.w700,
                       color: accent,
                     ),
@@ -1059,7 +1057,7 @@ class _RoutineCard extends StatelessWidget {
                             Text(
                               name,
                               style: const TextStyle(
-                                fontSize: 12.5,
+                                fontSize: 13.5,
                                 fontWeight: FontWeight.w700,
                                 color: AppColors.foreground,
                               ),
@@ -1068,7 +1066,7 @@ class _RoutineCard extends StatelessWidget {
                               Text(
                                 l.coachTapToEdit,
                                 style: TextStyle(
-                                  fontSize: 8.5,
+                                  fontSize: 10,
                                   color: AppColors.disabledForeground,
                                 ),
                               ),
@@ -1107,7 +1105,7 @@ class _RoutineCard extends StatelessWidget {
                 child: Text(
                   reason,
                   style: const TextStyle(
-                    fontSize: 10,
+                    fontSize: 11,
                     fontWeight: FontWeight.w500,
                     color: AppColors.subtleForeground,
                   ),
@@ -1134,7 +1132,7 @@ class _RoutineCard extends StatelessWidget {
             Text(
               l.minutesShort(minutes),
               style: const TextStyle(
-                fontSize: 11.5,
+                fontSize: 12.5,
                 fontWeight: FontWeight.w700,
                 color: AppColors.accent,
               ),
@@ -1183,7 +1181,7 @@ class _NameEditFieldState extends State<_NameEditField> {
       onSubmitted: (_) => widget.onDone?.call(),
       onTapOutside: (_) => widget.onDone?.call(),
       style: const TextStyle(
-        fontSize: 12.5,
+        fontSize: 13.5,
         fontWeight: FontWeight.w700,
         color: AppColors.foreground,
       ),
@@ -1228,7 +1226,7 @@ class _AddExerciseButton extends StatelessWidget {
           child: Text(
             l.coachAddExerciseManually,
             style: TextStyle(
-              fontSize: 12,
+              fontSize: 13,
               fontWeight: FontWeight.w700,
               color: AppColors.accent,
             ),
@@ -1278,7 +1276,7 @@ class _AddExerciseFormState extends State<_AddExerciseForm> {
           Text(
             l.progAddExercise,
             style: TextStyle(
-              fontSize: 12,
+              fontSize: 13,
               fontWeight: FontWeight.w700,
               color: AppColors.foreground,
             ),
@@ -1376,7 +1374,7 @@ class _FormButton extends StatelessWidget {
           child: Text(
             label,
             style: TextStyle(
-              fontSize: 12,
+              fontSize: 13,
               fontWeight: FontWeight.w700,
               color: foreground,
             ),
@@ -1423,7 +1421,7 @@ class _DateChip extends StatelessWidget {
         child: Text(
           _dateChipLabel(AppLocalizations.of(context), offset),
           style: TextStyle(
-            fontSize: 10.5,
+            fontSize: 11.5,
             fontWeight: FontWeight.w700,
             color: selected
                 ? AppColors.primaryForeground
@@ -1477,7 +1475,7 @@ class _RegisterButton extends StatelessWidget {
                   label,
                   overflow: TextOverflow.ellipsis,
                   style: TextStyle(
-                    fontSize: 12.5,
+                    fontSize: 13.5,
                     fontWeight: FontWeight.w700,
                     color: color,
                   ),
@@ -1516,9 +1514,11 @@ class _SendButton extends StatelessWidget {
           alignment: Alignment.center,
           child: IconLabel(
             icon: sent ? Icons.check_circle : Icons.send_outlined,
-            label: sent ? l.coachSentToClient(clientName) : l.coachReviewAndSend(clientName),
+            label: sent
+                ? l.coachSentToClient(clientName)
+                : l.coachReviewAndSend(clientName),
             color: AppColors.primaryForeground,
-            fontSize: 14,
+            fontSize: 15,
           ),
         ),
       ),
@@ -1570,7 +1570,7 @@ class _TemplateCard extends StatelessWidget {
                                 maxLines: 1,
                                 overflow: TextOverflow.ellipsis,
                                 style: const TextStyle(
-                                  fontSize: 12.5,
+                                  fontSize: 13.5,
                                   fontWeight: FontWeight.w700,
                                   color: AppColors.foreground,
                                 ),
@@ -1584,7 +1584,7 @@ class _TemplateCard extends StatelessWidget {
                                 maxLines: 1,
                                 overflow: TextOverflow.ellipsis,
                                 style: const TextStyle(
-                                  fontSize: 10.5,
+                                  fontSize: 11.5,
                                   fontWeight: FontWeight.w500,
                                   color: AppColors.subtleForeground,
                                 ),
@@ -1667,7 +1667,7 @@ class _SendHistoryCard extends ConsumerWidget {
                         child: Text(
                           l.coachHomework,
                           style: TextStyle(
-                            fontSize: 10.5,
+                            fontSize: 11.5,
                             fontWeight: FontWeight.w700,
                             color: AppColors.brandOrange,
                           ),
@@ -1679,7 +1679,7 @@ class _SendHistoryCard extends ConsumerWidget {
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                           style: const TextStyle(
-                            fontSize: 11.5,
+                            fontSize: 12.5,
                             fontWeight: FontWeight.w600,
                             color: AppColors.foreground,
                           ),
@@ -1690,13 +1690,13 @@ class _SendHistoryCard extends ConsumerWidget {
                               icon: Icons.auto_awesome,
                               label: 'AI',
                               color: AppColors.primary,
-                              fontSize: 10,
+                              fontSize: 11,
                               fontWeight: FontWeight.w800,
                             )
                           : Text(
                               l.coachTrainer,
                               style: TextStyle(
-                                fontSize: 10,
+                                fontSize: 11,
                                 fontWeight: FontWeight.w800,
                                 color: AppColors.primary,
                               ),
@@ -1716,7 +1716,7 @@ class _SendHistoryCard extends ConsumerWidget {
                               ? l.labelToday
                               : s.date.substring(5).replaceAll('-', '/'),
                           style: TextStyle(
-                            fontSize: 10.5,
+                            fontSize: 11.5,
                             fontWeight: FontWeight.w700,
                             color: s.date == today
                                 ? AppColors.primary
@@ -1726,11 +1726,14 @@ class _SendHistoryCard extends ConsumerWidget {
                       ),
                       Expanded(
                         child: Text(
-                          l.coachSessionExercises(sessionTypeLabel(l, s.type), s.program.length),
+                          l.coachSessionExercises(
+                            sessionTypeLabel(l, s.type),
+                            s.program.length,
+                          ),
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                           style: const TextStyle(
-                            fontSize: 11.5,
+                            fontSize: 12.5,
                             fontWeight: FontWeight.w600,
                             color: AppColors.foreground,
                           ),
@@ -1739,7 +1742,7 @@ class _SendHistoryCard extends ConsumerWidget {
                       Text(
                         scheduleStatusLabel(l, s.status),
                         style: TextStyle(
-                          fontSize: 10,
+                          fontSize: 11,
                           fontWeight: FontWeight.w800,
                           color: s.isDone
                               ? AppColors.success

--- a/frontend/flutter_trainer/lib/features/coaching/presentation/widgets/routine_form_fields.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/widgets/routine_form_fields.dart
@@ -36,7 +36,7 @@ class RoutineCategoryChips extends StatelessWidget {
         Text(
           l.routineFieldType,
           style: TextStyle(
-            fontSize: 11,
+            fontSize: 12,
             fontWeight: FontWeight.w600,
             color: AppColors.subtleForeground,
           ),
@@ -90,7 +90,7 @@ class RoutineMinutesSlider extends StatelessWidget {
             Text(
               label ?? l.routineFieldMinutes,
               style: TextStyle(
-                fontSize: 11,
+                fontSize: 12,
                 fontWeight: FontWeight.w600,
                 color: AppColors.subtleForeground,
               ),
@@ -99,7 +99,7 @@ class RoutineMinutesSlider extends StatelessWidget {
             Text(
               l.minutesShort(minutes),
               style: const TextStyle(
-                fontSize: 14,
+                fontSize: 15,
                 fontWeight: FontWeight.w800,
                 color: AppColors.accent,
               ),
@@ -148,7 +148,7 @@ class RoutineIntensityChips extends StatelessWidget {
         Text(
           l.routineFieldIntensity,
           style: TextStyle(
-            fontSize: 11,
+            fontSize: 12,
             fontWeight: FontWeight.w600,
             color: AppColors.subtleForeground,
           ),
@@ -156,7 +156,11 @@ class RoutineIntensityChips extends StatelessWidget {
         const SizedBox(height: AppSpacing.sm),
         Row(
           children: <Widget>[
-            for (var index = 0; index < _choices(l).length; index++) ...<Widget>[
+            for (
+              var index = 0;
+              index < _choices(l).length;
+              index++
+            ) ...<Widget>[
               Builder(
                 builder: (BuildContext context) {
                   final (String label, String wire) = _choices(l)[index];
@@ -219,7 +223,7 @@ class _ChoiceButton extends StatelessWidget {
           child: Text(
             label,
             style: TextStyle(
-              fontSize: 11.5,
+              fontSize: 12.5,
               fontWeight: FontWeight.w700,
               color: selected ? AppColors.accent : AppColors.subtleForeground,
             ),

--- a/frontend/flutter_trainer/lib/features/consultations/presentation/pages/consultations_page.dart
+++ b/frontend/flutter_trainer/lib/features/consultations/presentation/pages/consultations_page.dart
@@ -47,9 +47,8 @@ class ConsultationsPage extends ConsumerWidget {
         ActionButton(
           label: filter == 'pending' ? l.consultShowAll : l.consultShowPending,
           icon: Icons.filter_list,
-          onPressed: () => ref
-              .read(consultationFilterProvider.notifier)
-              .state = filter == 'pending' ? 'all' : 'pending',
+          onPressed: () => ref.read(consultationFilterProvider.notifier).state =
+              filter == 'pending' ? 'all' : 'pending',
         ),
       ],
       child: requests.when(
@@ -60,7 +59,8 @@ class ConsultationsPage extends ConsumerWidget {
         error: (error, _) => _InboxMessage(
           icon: Icons.error_outline,
           title: l.consultLoadFailed,
-          detail: (error is AppError ? error.message : null) ?? l.consultRetryLater,
+          detail:
+              (error is AppError ? error.message : null) ?? l.consultRetryLater,
           action: ActionButton(
             label: l.actionRetry,
             onPressed: () => ref.invalidate(consultationsProvider),
@@ -124,9 +124,7 @@ class _RequestCardState extends ConsumerState<_RequestCard> {
       ref.invalidate(consultationPendingCountProvider);
       // 409 carries the server's reason (이미 처리됨 / 다른 트레이너가 담당 중)
       // — that sentence is the whole point, so it is shown verbatim.
-      messenger.showSnackBar(
-        SnackBar(content: Text(e.message ?? failureText)),
-      );
+      messenger.showSnackBar(SnackBar(content: Text(e.message ?? failureText)));
     } finally {
       if (mounted) setState(() => _busy = false);
     }
@@ -177,7 +175,10 @@ class _RequestCardState extends ConsumerState<_RequestCard> {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: <Widget>[
-                    _Field(label: l.consultExerciseGoal, value: label(exerciseGoalLabels(l), request.goalCode)),
+                    _Field(
+                      label: l.consultExerciseGoal,
+                      value: label(exerciseGoalLabels(l), request.goalCode),
+                    ),
                     _Field(
                       label: l.consultHealthPurpose,
                       value: request.purposeDetail == null
@@ -262,7 +263,7 @@ class _RejectDialogState extends State<_RejectDialog> {
         children: <Widget>[
           Text(
             l.consultRejectNotice,
-            style: TextStyle(fontSize: 12.5, color: AppColors.mutedForeground),
+            style: TextStyle(fontSize: 13.5, color: AppColors.mutedForeground),
           ),
           const SizedBox(height: AppSpacing.md),
           TextField(
@@ -320,7 +321,7 @@ class _DecisionSummary extends StatelessWidget {
                       ? l.consultStatusRejected
                       : l.consultStatusRejectedWithNote(request.decisionNote!)),
             style: const TextStyle(
-              fontSize: 12.5,
+              fontSize: 13.5,
               color: AppColors.mutedForeground,
               fontWeight: FontWeight.w600,
             ),
@@ -349,7 +350,7 @@ class _Field extends StatelessWidget {
             child: Text(
               label,
               style: const TextStyle(
-                fontSize: 12,
+                fontSize: 13,
                 color: AppColors.subtleForeground,
                 fontWeight: FontWeight.w600,
               ),
@@ -359,7 +360,7 @@ class _Field extends StatelessWidget {
             child: Text(
               value,
               style: const TextStyle(
-                fontSize: 13,
+                fontSize: 14,
                 color: AppColors.foreground,
                 fontWeight: FontWeight.w600,
               ),
@@ -389,7 +390,7 @@ class _Quote extends StatelessWidget {
       child: Text(
         text,
         style: const TextStyle(
-          fontSize: 13,
+          fontSize: 14,
           height: 1.5,
           color: AppColors.foreground,
         ),
@@ -418,7 +419,7 @@ class _Tag extends StatelessWidget {
       child: Text(
         label,
         style: TextStyle(
-          fontSize: 11,
+          fontSize: 12,
           fontWeight: FontWeight.w700,
           color: tone,
         ),
@@ -453,7 +454,7 @@ class _InboxMessage extends StatelessWidget {
             title,
             textAlign: TextAlign.center,
             style: const TextStyle(
-              fontSize: 15,
+              fontSize: 16,
               fontWeight: FontWeight.w700,
               color: AppColors.foreground,
             ),
@@ -463,7 +464,7 @@ class _InboxMessage extends StatelessWidget {
             detail,
             textAlign: TextAlign.center,
             style: const TextStyle(
-              fontSize: 12.5,
+              fontSize: 13.5,
               color: AppColors.mutedForeground,
             ),
           ),

--- a/frontend/flutter_trainer/lib/features/dashboard/presentation/pages/dashboard_page.dart
+++ b/frontend/flutter_trainer/lib/features/dashboard/presentation/pages/dashboard_page.dart
@@ -205,7 +205,9 @@ class _KpiRow extends StatelessWidget {
         tone: summary.healthAttentionCount == 0
             ? StatTone.positive
             : StatTone.warn,
-        hint: summary.healthAttentionCount == 0 ? l.dashNoIssues : l.dashCheckSodiumCompletion,
+        hint: summary.healthAttentionCount == 0
+            ? l.dashNoIssues
+            : l.dashCheckSodiumCompletion,
         onTap: () => context.go(AppRoutes.clientsFiltered('attention')),
       ),
     ];
@@ -272,7 +274,7 @@ class _WeeklyCompletionCard extends StatelessWidget {
           : Text(
               l.dashAveragePercent(average),
               style: const TextStyle(
-                fontSize: 11.5,
+                fontSize: 12.5,
                 fontWeight: FontWeight.w700,
                 color: AppColors.primary,
               ),

--- a/frontend/flutter_trainer/lib/features/dashboard/presentation/widgets/ai_summary_card.dart
+++ b/frontend/flutter_trainer/lib/features/dashboard/presentation/widgets/ai_summary_card.dart
@@ -74,7 +74,7 @@ class AiSummaryCard extends StatelessWidget {
               Text(
                 l.dashAiSummaryTitle,
                 style: const TextStyle(
-                  fontSize: 13,
+                  fontSize: 14,
                   fontWeight: FontWeight.w800,
                   color: AppColors.foreground,
                 ),
@@ -89,7 +89,7 @@ class AiSummaryCard extends StatelessWidget {
                 child: Text(
                   l.dashToday,
                   style: const TextStyle(
-                    fontSize: 10,
+                    fontSize: 11,
                     fontWeight: FontWeight.w800,
                     color: AppColors.primary,
                   ),
@@ -101,7 +101,7 @@ class AiSummaryCard extends StatelessWidget {
           Text(
             messageFor(l, summary),
             style: const TextStyle(
-              fontSize: 12.5,
+              fontSize: 13.5,
               height: 1.55,
               fontWeight: FontWeight.w500,
               color: AppColors.foreground,

--- a/frontend/flutter_trainer/lib/features/dashboard/presentation/widgets/attention_card.dart
+++ b/frontend/flutter_trainer/lib/features/dashboard/presentation/widgets/attention_card.dart
@@ -96,7 +96,7 @@ class _Row extends StatelessWidget {
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     style: const TextStyle(
-                      fontSize: 12.5,
+                      fontSize: 13.5,
                       fontWeight: FontWeight.w700,
                       color: AppColors.foreground,
                     ),
@@ -106,7 +106,7 @@ class _Row extends StatelessWidget {
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     style: const TextStyle(
-                      fontSize: 10.5,
+                      fontSize: 11.5,
                       color: AppColors.subtleForeground,
                       fontWeight: FontWeight.w500,
                     ),

--- a/frontend/flutter_trainer/lib/features/dashboard/presentation/widgets/today_timeline_card.dart
+++ b/frontend/flutter_trainer/lib/features/dashboard/presentation/widgets/today_timeline_card.dart
@@ -89,7 +89,7 @@ class _Row extends StatelessWidget {
                 child: Text(
                   session.time,
                   style: const TextStyle(
-                    fontSize: 11.5,
+                    fontSize: 12.5,
                     fontWeight: FontWeight.w700,
                     color: AppColors.subtleForeground,
                   ),
@@ -106,11 +106,13 @@ class _Row extends StatelessWidget {
               ),
               Expanded(
                 child: Text(
-                  muted ? l.dashEmptySlot : '${session.clientName} · ${session.type}',
+                  muted
+                      ? l.dashEmptySlot
+                      : '${session.clientName} · ${session.type}',
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                   style: TextStyle(
-                    fontSize: 12.5,
+                    fontSize: 13.5,
                     fontWeight: muted ? FontWeight.w500 : FontWeight.w600,
                     color: muted
                         ? AppColors.subtleForeground
@@ -123,7 +125,7 @@ class _Row extends StatelessWidget {
                   // 저장된 계약값이 아니라 표시 문구를 그린다. (#501)
                   scheduleStatusLabel(l, session.status),
                   style: TextStyle(
-                    fontSize: 11,
+                    fontSize: 12,
                     fontWeight: FontWeight.w700,
                     color: _statusColor,
                   ),

--- a/frontend/flutter_trainer/lib/features/my/presentation/pages/my_page.dart
+++ b/frontend/flutter_trainer/lib/features/my/presentation/pages/my_page.dart
@@ -131,9 +131,9 @@ class _MyPageState extends ConsumerState<MyPage> {
     final careerYears = int.tryParse(careerMatch?.group(1) ?? '');
     if (careerYears == null || careerYears < 0 || careerYears > 80) {
       final AppLocalizations l = AppLocalizations.of(context);
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(l.myCareerInvalid)),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(l.myCareerInvalid)));
       return;
     }
 
@@ -347,7 +347,7 @@ class _MyPageState extends ConsumerState<MyPage> {
             child: Text(
               l.mySaved,
               style: TextStyle(
-                fontSize: 11,
+                fontSize: 12,
                 fontWeight: FontWeight.w700,
                 color: AppColors.success,
               ),
@@ -405,7 +405,9 @@ class _MyPageState extends ConsumerState<MyPage> {
     if (controller.lastError) {
       controller.clearError();
       messenger.showSnackBar(
-        SnackBar(content: Text(AppLocalizations.of(context).mySettingsSaveFailed)),
+        SnackBar(
+          content: Text(AppLocalizations.of(context).mySettingsSaveFailed),
+        ),
       );
     }
   }
@@ -448,7 +450,7 @@ class _MyPageState extends ConsumerState<MyPage> {
                       child: Text(
                         l.myReminderLead,
                         style: TextStyle(
-                          fontSize: 12.5,
+                          fontSize: 13.5,
                           fontWeight: FontWeight.w600,
                           color: AppColors.mutedForeground,
                         ),
@@ -456,7 +458,8 @@ class _MyPageState extends ConsumerState<MyPage> {
                     ),
                     SegmentedSwitch(
                       labels: <String>[
-                        for (final m in reminderLeadOptions) l.myMinutesBefore(m),
+                        for (final m in reminderLeadOptions)
+                          l.myMinutesBefore(m),
                       ],
                       selected: reminderLeadOptions.indexOf(
                         settings.reminderLeadMinutes,
@@ -488,7 +491,7 @@ class _MyPageState extends ConsumerState<MyPage> {
                         Text(
                           l.myChangePassword,
                           style: TextStyle(
-                            fontSize: 12.5,
+                            fontSize: 13.5,
                             fontWeight: FontWeight.w600,
                             color: AppColors.mutedForeground,
                           ),
@@ -498,7 +501,7 @@ class _MyPageState extends ConsumerState<MyPage> {
                               ? l.myChangePasswordHint
                               : l.myChangePasswordDemo,
                           style: const TextStyle(
-                            fontSize: 10.5,
+                            fontSize: 11.5,
                             fontWeight: FontWeight.w500,
                             color: AppColors.disabledForeground,
                           ),
@@ -552,7 +555,7 @@ class _MyPageState extends ConsumerState<MyPage> {
     return Text(
       text,
       style: const TextStyle(
-        fontSize: 11.5,
+        fontSize: 12.5,
         fontWeight: FontWeight.w600,
         color: AppColors.subtleForeground,
       ),
@@ -600,17 +603,15 @@ class _DeleteAccountRow extends StatelessWidget {
               Text(
                 l.myDeleteAccount,
                 style: TextStyle(
-                  fontSize: 12.5,
+                  fontSize: 13.5,
                   fontWeight: FontWeight.w600,
                   color: AppColors.mutedForeground,
                 ),
               ),
               Text(
-                enabled
-                    ? l.myDeleteHint
-                    : l.myDeleteDemo,
+                enabled ? l.myDeleteHint : l.myDeleteDemo,
                 style: const TextStyle(
-                  fontSize: 10.5,
+                  fontSize: 11.5,
                   fontWeight: FontWeight.w500,
                   color: AppColors.disabledForeground,
                 ),
@@ -621,12 +622,10 @@ class _DeleteAccountRow extends StatelessWidget {
         TextButton(
           key: const ValueKey<String>('delete-account'),
           onPressed: enabled ? onTap : null,
-          style: TextButton.styleFrom(
-            foregroundColor: AppColors.destructive,
-          ),
+          style: TextButton.styleFrom(foregroundColor: AppColors.destructive),
           child: Text(
             l.myDeleteAction,
-            style: const TextStyle(fontSize: 12.5, fontWeight: FontWeight.w700),
+            style: const TextStyle(fontSize: 13.5, fontWeight: FontWeight.w700),
           ),
         ),
       ],
@@ -672,12 +671,12 @@ class _DeleteAccountDialogState extends State<_DeleteAccountDialog> {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
-          Text(l.myDeleteBody, style: const TextStyle(fontSize: 12.5)),
+          Text(l.myDeleteBody, style: const TextStyle(fontSize: 13.5)),
           const SizedBox(height: AppSpacing.md),
           Text(
             l.myDeleteConfirmPrompt(widget.name),
             style: const TextStyle(
-              fontSize: 11.5,
+              fontSize: 12.5,
               color: AppColors.mutedForeground,
             ),
           ),
@@ -737,7 +736,7 @@ class _ChipButton extends StatelessWidget {
           child: Text(
             label,
             style: TextStyle(
-              fontSize: 11.5,
+              fontSize: 12.5,
               fontWeight: FontWeight.w700,
               color: foreground,
             ),
@@ -795,7 +794,7 @@ class _ProfileCard extends StatelessWidget {
                 child: Text(
                   profile.name.isNotEmpty ? profile.name.substring(0, 1) : '·',
                   style: const TextStyle(
-                    fontSize: 18,
+                    fontSize: 19,
                     fontWeight: FontWeight.w800,
                     color: Colors.white,
                   ),
@@ -809,7 +808,7 @@ class _ProfileCard extends StatelessWidget {
                     Text(
                       profile.name,
                       style: const TextStyle(
-                        fontSize: 15,
+                        fontSize: 16,
                         fontWeight: FontWeight.w800,
                         color: AppColors.foreground,
                       ),
@@ -817,7 +816,7 @@ class _ProfileCard extends StatelessWidget {
                     Text(
                       profile.email,
                       style: const TextStyle(
-                        fontSize: 11,
+                        fontSize: 12,
                         fontWeight: FontWeight.w500,
                         color: AppColors.subtleForeground,
                       ),
@@ -899,7 +898,7 @@ class _Tag extends StatelessWidget {
       child: Text(
         text,
         style: TextStyle(
-          fontSize: 9.5,
+          fontSize: 10.5,
           fontWeight: FontWeight.w700,
           color: color,
         ),
@@ -933,7 +932,7 @@ class _EditField extends StatelessWidget {
           Text(
             label,
             style: const TextStyle(
-              fontSize: 9.5,
+              fontSize: 10.5,
               fontWeight: FontWeight.w600,
               color: AppColors.subtleForeground,
             ),
@@ -945,7 +944,7 @@ class _EditField extends StatelessWidget {
             enabled: enabled,
             maxLines: maxLines,
             style: const TextStyle(
-              fontSize: 12.5,
+              fontSize: 13.5,
               fontWeight: FontWeight.w600,
               color: AppColors.foreground,
             ),
@@ -1023,7 +1022,7 @@ class _CertsCard extends StatelessWidget {
                     child: Text(
                       certs[i],
                       style: const TextStyle(
-                        fontSize: 12,
+                        fontSize: 13,
                         fontWeight: FontWeight.w600,
                         color: AppColors.foreground,
                       ),
@@ -1157,7 +1156,7 @@ class _Stat extends StatelessWidget {
           Text(
             unit,
             style: const TextStyle(
-              fontSize: 9,
+              fontSize: 10,
               fontWeight: FontWeight.w700,
               color: AppColors.primary,
             ),
@@ -1165,7 +1164,7 @@ class _Stat extends StatelessWidget {
           Text(
             label,
             style: const TextStyle(
-              fontSize: 9.5,
+              fontSize: 10.5,
               fontWeight: FontWeight.w500,
               color: AppColors.mutedForeground,
             ),
@@ -1265,7 +1264,7 @@ class _GymCard extends StatelessWidget {
                           Text(
                             gym.name,
                             style: const TextStyle(
-                              fontSize: 13,
+                              fontSize: 14,
                               fontWeight: FontWeight.w700,
                               color: AppColors.foreground,
                             ),
@@ -1273,7 +1272,7 @@ class _GymCard extends StatelessWidget {
                           Text(
                             gym.address,
                             style: const TextStyle(
-                              fontSize: 10.5,
+                              fontSize: 11.5,
                               fontWeight: FontWeight.w500,
                               color: AppColors.subtleForeground,
                             ),
@@ -1327,7 +1326,7 @@ class _GymChoiceField extends StatelessWidget {
           Text(
             l.myGym,
             style: TextStyle(
-              fontSize: 9.5,
+              fontSize: 10.5,
               fontWeight: FontWeight.w600,
               color: AppColors.subtleForeground,
             ),
@@ -1337,7 +1336,7 @@ class _GymChoiceField extends StatelessWidget {
             loading: () => const LinearProgressIndicator(minHeight: 2),
             error: (_, _) => Text(
               l.myGymListFailed,
-              style: TextStyle(color: AppColors.destructive, fontSize: 11),
+              style: TextStyle(color: AppColors.destructive, fontSize: 12),
             ),
             data: (items) {
               final currentId = selectedGymId;
@@ -1358,10 +1357,7 @@ class _GymChoiceField extends StatelessWidget {
                   ),
                 ),
                 items: <DropdownMenuItem<String>>[
-                  DropdownMenuItem<String>(
-                    value: '',
-                    child: Text(l.myNoGym),
-                  ),
+                  DropdownMenuItem<String>(value: '', child: Text(l.myNoGym)),
                   if (!hasCurrent)
                     DropdownMenuItem<String>(
                       value: currentId,
@@ -1403,7 +1399,7 @@ class _GymDetail extends StatelessWidget {
           Text(
             label,
             style: const TextStyle(
-              fontSize: 9,
+              fontSize: 10,
               fontWeight: FontWeight.w600,
               color: AppColors.subtleForeground,
             ),
@@ -1412,7 +1408,7 @@ class _GymDetail extends StatelessWidget {
           Text(
             value,
             style: const TextStyle(
-              fontSize: 11.5,
+              fontSize: 12.5,
               fontWeight: FontWeight.w600,
               color: AppColors.foreground,
             ),
@@ -1454,7 +1450,7 @@ class _LogoutButton extends StatelessWidget {
               Text(
                 l.mySignOut,
                 style: TextStyle(
-                  fontSize: 12.5,
+                  fontSize: 13.5,
                   fontWeight: FontWeight.w700,
                   color: AppColors.destructive,
                 ),
@@ -1496,7 +1492,7 @@ class _SwitchRow extends StatelessWidget {
                 Text(
                   label,
                   style: const TextStyle(
-                    fontSize: 12.5,
+                    fontSize: 13.5,
                     fontWeight: FontWeight.w600,
                     color: AppColors.mutedForeground,
                   ),
@@ -1504,7 +1500,7 @@ class _SwitchRow extends StatelessWidget {
                 Text(
                   hint,
                   style: const TextStyle(
-                    fontSize: 10.5,
+                    fontSize: 11.5,
                     fontWeight: FontWeight.w500,
                     color: AppColors.disabledForeground,
                   ),
@@ -1660,7 +1656,7 @@ class _PasswordSheetState extends ConsumerState<_PasswordSheet> {
           Text(
             l.myChangePassword,
             style: TextStyle(
-              fontSize: 15,
+              fontSize: 16,
               fontWeight: FontWeight.w800,
               color: AppColors.foreground,
             ),
@@ -1699,7 +1695,7 @@ class _PasswordSheetState extends ConsumerState<_PasswordSheet> {
                 child: Text(
                   _saving ? l.myPwChanging : l.myPwChangeAction,
                   style: const TextStyle(
-                    fontSize: 13,
+                    fontSize: 14,
                     fontWeight: FontWeight.w700,
                     color: AppColors.primaryForeground,
                   ),
@@ -1771,7 +1767,7 @@ class _InfoRow extends StatelessWidget {
             child: Text(
               label,
               style: const TextStyle(
-                fontSize: 12,
+                fontSize: 13,
                 fontWeight: FontWeight.w500,
                 color: AppColors.subtleForeground,
               ),
@@ -1780,7 +1776,7 @@ class _InfoRow extends StatelessWidget {
           Text(
             value,
             style: const TextStyle(
-              fontSize: 12,
+              fontSize: 13,
               fontWeight: FontWeight.w700,
               color: AppColors.foreground,
             ),

--- a/frontend/flutter_trainer/lib/features/notifications/presentation/pages/notifications_page.dart
+++ b/frontend/flutter_trainer/lib/features/notifications/presentation/pages/notifications_page.dart
@@ -101,8 +101,7 @@ class NotificationsPage extends ConsumerWidget {
           padding: const EdgeInsets.only(top: AppSpacing.xxl),
           child: EmptyHint(
             message:
-                (error is AppError ? error.message : null) ??
-                l.notifLoadFailed,
+                (error is AppError ? error.message : null) ?? l.notifLoadFailed,
             icon: Icons.error_outline,
           ),
         ),
@@ -176,7 +175,7 @@ class _NotificationTile extends StatelessWidget {
                     Text(
                       notification.title,
                       style: TextStyle(
-                        fontSize: 13.5,
+                        fontSize: 14.5,
                         fontWeight: unread ? FontWeight.w700 : FontWeight.w600,
                         color: AppColors.foreground,
                       ),
@@ -188,7 +187,7 @@ class _NotificationTile extends StatelessWidget {
                         maxLines: 2,
                         overflow: TextOverflow.ellipsis,
                         style: const TextStyle(
-                          fontSize: 12.5,
+                          fontSize: 13.5,
                           color: AppColors.mutedForeground,
                         ),
                       ),
@@ -200,7 +199,7 @@ class _NotificationTile extends StatelessWidget {
               Text(
                 notification.timeAgo,
                 style: const TextStyle(
-                  fontSize: 11.5,
+                  fontSize: 12.5,
                   fontWeight: FontWeight.w600,
                   color: AppColors.subtleForeground,
                 ),

--- a/frontend/flutter_trainer/lib/features/reports/presentation/pages/reports_page.dart
+++ b/frontend/flutter_trainer/lib/features/reports/presentation/pages/reports_page.dart
@@ -100,9 +100,7 @@ class _ReportsPageState extends ConsumerState<ReportsPage> {
     } catch (_) {
       if (!mounted) return;
       setState(() => _sending = null);
-      messenger.showSnackBar(
-        SnackBar(content: Text(l.reportsSendFailed)),
-      );
+      messenger.showSnackBar(SnackBar(content: Text(l.reportsSendFailed)));
       return;
     }
     if (!mounted) return;
@@ -127,7 +125,9 @@ class _ReportsPageState extends ConsumerState<ReportsPage> {
 
     return PageScaffold(
       title: l.reportsTitle,
-      subtitle: l.reportsSubtitle(l.dateMonthDay(_weekStart.month, _weekStart.day)),
+      subtitle: l.reportsSubtitle(
+        l.dateMonthDay(_weekStart.month, _weekStart.day),
+      ),
       // 리포트 asks how the week went, so the rows lead with this week's
       // completion and picking one opens that client's report.
       headerCenter: const ClientSearchBar(scope: ClientSearchScope.reports),
@@ -253,7 +253,7 @@ class _ReportsPageState extends ConsumerState<ReportsPage> {
                   child: Text(
                     l.reportsScheduleWarning,
                     style: TextStyle(
-                      fontSize: 11.5,
+                      fontSize: 12.5,
                       color: AppColors.warning,
                       fontWeight: FontWeight.w600,
                     ),
@@ -295,7 +295,9 @@ class _TrainerStats extends StatelessWidget {
             unit: l.unitTimes,
             icon: Icons.check_circle_outline,
             tone: StatTone.positive,
-            hint: rate == null || loading ? null : l.reportsCompletionRate(rate),
+            hint: rate == null || loading
+                ? null
+                : l.reportsCompletionRate(rate),
           ),
           StatCard(
             label: l.reportsProgramReady,
@@ -399,7 +401,7 @@ class _ClientPicker extends StatelessWidget {
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,
                             style: TextStyle(
-                              fontSize: 12.5,
+                              fontSize: 13.5,
                               fontWeight: client.id == selectedId
                                   ? FontWeight.w800
                                   : FontWeight.w600,
@@ -451,7 +453,7 @@ class _ClientReport extends StatelessWidget {
       trailing: Text(
         report.rangeLabel(l),
         style: const TextStyle(
-          fontSize: 11,
+          fontSize: 12,
           fontWeight: FontWeight.w600,
           color: AppColors.subtleForeground,
         ),
@@ -495,7 +497,7 @@ class _ClientReport extends StatelessWidget {
           Text(
             l.reportsCompletionByDay,
             style: TextStyle(
-              fontSize: 11.5,
+              fontSize: 12.5,
               fontWeight: FontWeight.w700,
               color: AppColors.subtleForeground,
             ),
@@ -521,7 +523,7 @@ class _ClientReport extends StatelessWidget {
           Text(
             l.reportsSodiumTrend,
             style: TextStyle(
-              fontSize: 11.5,
+              fontSize: 12.5,
               fontWeight: FontWeight.w700,
               color: AppColors.subtleForeground,
             ),
@@ -548,7 +550,7 @@ class _ClientReport extends StatelessWidget {
             child: Text(
               reportMessage(l, report),
               style: const TextStyle(
-                fontSize: 12,
+                fontSize: 13,
                 height: 1.6,
                 fontWeight: FontWeight.w500,
                 color: AppColors.mutedForeground,
@@ -559,7 +561,9 @@ class _ClientReport extends StatelessWidget {
           Align(
             alignment: Alignment.centerRight,
             child: ActionButton(
-              label: sent ? l.reportsSendStateSent : (sending ? l.reportsSendStateSending : l.reportsSendAction),
+              label: sent
+                  ? l.reportsSendStateSent
+                  : (sending ? l.reportsSendStateSending : l.reportsSendAction),
               icon: sent ? Icons.check : Icons.send_outlined,
               primary: true,
               onPressed: sent || sending ? null : () => onSend(report),
@@ -593,7 +597,7 @@ class _Figure extends StatelessWidget {
           Text(
             label,
             style: const TextStyle(
-              fontSize: 11,
+              fontSize: 12,
               fontWeight: FontWeight.w600,
               color: AppColors.subtleForeground,
             ),
@@ -615,7 +619,7 @@ class _Figure extends StatelessWidget {
               Text(
                 unit,
                 style: const TextStyle(
-                  fontSize: 11,
+                  fontSize: 12,
                   fontWeight: FontWeight.w600,
                   color: AppColors.subtleForeground,
                 ),

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
@@ -173,10 +173,10 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
       context: context,
       builder: (context) => AlertDialog(
         backgroundColor: AppColors.card,
-        title: Text(l.schedDeleteTitle, style: TextStyle(fontSize: 16)),
+        title: Text(l.schedDeleteTitle, style: TextStyle(fontSize: 17)),
         content: Text(
           l.schedDeleteConfirm(s.time, s.clientName),
-          style: const TextStyle(fontSize: 13),
+          style: const TextStyle(fontSize: 14),
         ),
         actions: <Widget>[
           TextButton(
@@ -199,9 +199,7 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
       await ref.read(scheduleRepositoryProvider).deleteSession(s.id);
     } catch (_) {
       if (!mounted) return;
-      messenger.showSnackBar(
-        SnackBar(content: Text(l.schedDeleteFailed)),
-      );
+      messenger.showSnackBar(SnackBar(content: Text(l.schedDeleteFailed)));
     }
   }
 
@@ -224,9 +222,7 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
       // A DB or programJson-decode failure must not escape to the UI —
       // the session stays 예정 and the trainer is told (review PR 237).
       if (!mounted) return;
-      messenger.showSnackBar(
-        SnackBar(content: Text(l.schedCompleteFailed)),
-      );
+      messenger.showSnackBar(SnackBar(content: Text(l.schedCompleteFailed)));
     }
   }
 
@@ -443,7 +439,7 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
             l.schedEmptyDay,
             textAlign: TextAlign.center,
             style: TextStyle(
-              fontSize: 12,
+              fontSize: 13,
               fontWeight: FontWeight.w500,
               color: AppColors.mutedForeground,
               height: 1.5,
@@ -526,7 +522,7 @@ class _CompleteDialogState extends State<_CompleteDialog> {
     final s = widget.session;
     return AlertDialog(
       backgroundColor: AppColors.card,
-      title: Text(l.schedCompleteTitle, style: TextStyle(fontSize: 16)),
+      title: Text(l.schedCompleteTitle, style: TextStyle(fontSize: 17)),
       content: SizedBox(
         width: 320,
         child: Column(
@@ -535,7 +531,7 @@ class _CompleteDialogState extends State<_CompleteDialog> {
           children: <Widget>[
             Text(
               l.schedCompleteBody(s.time, s.clientName),
-              style: const TextStyle(fontSize: 13),
+              style: const TextStyle(fontSize: 14),
             ),
             const SizedBox(height: AppSpacing.md),
             TextField(
@@ -687,9 +683,7 @@ class _SessionSheetState extends ConsumerState<_SessionSheet> {
       // Surface the failure and keep the sheet open so the input isn't
       // lost (review PR 218).
       if (mounted) setState(() => _saving = false);
-      messenger.showSnackBar(
-        SnackBar(content: Text(l.schedSaveFailed)),
-      );
+      messenger.showSnackBar(SnackBar(content: Text(l.schedSaveFailed)));
       return;
     }
     if (mounted) setState(() => _saving = false);
@@ -727,7 +721,7 @@ class _SessionSheetState extends ConsumerState<_SessionSheet> {
             Text(
               widget.existing == null ? l.schedAddTitle : l.schedEditTitle,
               style: const TextStyle(
-                fontSize: 15,
+                fontSize: 16,
                 fontWeight: FontWeight.w800,
                 color: AppColors.foreground,
               ),
@@ -776,7 +770,9 @@ class _SessionSheetState extends ConsumerState<_SessionSheet> {
                         for (final h in _hourOptions)
                           DropdownMenuItem<int>(
                             value: h,
-                            child: Text(l.schedHourLabel(h.toString().padLeft(2, '0'))),
+                            child: Text(
+                              l.schedHourLabel(h.toString().padLeft(2, '0')),
+                            ),
                           ),
                       ],
                       onChanged: (v) => setState(() => _hour = v ?? _hour),
@@ -792,7 +788,9 @@ class _SessionSheetState extends ConsumerState<_SessionSheet> {
                         for (final m in _minuteOptions)
                           DropdownMenuItem<int>(
                             value: m,
-                            child: Text(l.schedMinuteLabel(m.toString().padLeft(2, '0'))),
+                            child: Text(
+                              l.schedMinuteLabel(m.toString().padLeft(2, '0')),
+                            ),
                           ),
                       ],
                       onChanged: (v) => setState(() => _minute = v ?? _minute),
@@ -809,7 +807,10 @@ class _SessionSheetState extends ConsumerState<_SessionSheet> {
                 underline: const SizedBox.shrink(),
                 items: <DropdownMenuItem<int>>[
                   for (final d in _durationOptions)
-                    DropdownMenuItem<int>(value: d, child: Text(l.minutesShort(d))),
+                    DropdownMenuItem<int>(
+                      value: d,
+                      child: Text(l.minutesShort(d)),
+                    ),
                 ],
                 onChanged: (v) => setState(() => _duration = v ?? _duration),
               ),
@@ -853,9 +854,11 @@ class _SessionSheetState extends ConsumerState<_SessionSheet> {
                         height: 44,
                         alignment: Alignment.center,
                         child: Text(
-                          widget.existing == null ? l.schedAddAction : l.schedSaveAction,
+                          widget.existing == null
+                              ? l.schedAddAction
+                              : l.schedSaveAction,
                           style: const TextStyle(
-                            fontSize: 13,
+                            fontSize: 14,
                             fontWeight: FontWeight.w700,
                             color: AppColors.primaryForeground,
                           ),
@@ -878,7 +881,7 @@ class _SessionSheetState extends ConsumerState<_SessionSheet> {
     bool stacked = false,
   }) {
     const labelStyle = TextStyle(
-      fontSize: 12,
+      fontSize: 13,
       fontWeight: FontWeight.w600,
       color: AppColors.subtleForeground,
     );
@@ -988,9 +991,9 @@ class _ProgramEditorState extends ConsumerState<_ProgramEditor> {
     } catch (_) {
       if (mounted) setState(() => _saving = false);
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(l.progSaveFailed)),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(l.progSaveFailed)));
       return;
     }
     if (!mounted) return;
@@ -1014,7 +1017,7 @@ class _ProgramEditorState extends ConsumerState<_ProgramEditor> {
           Text(
             l.progEditTitle,
             style: TextStyle(
-              fontSize: 15,
+              fontSize: 16,
               fontWeight: FontWeight.w800,
               color: AppColors.foreground,
             ),
@@ -1036,7 +1039,7 @@ class _ProgramEditorState extends ConsumerState<_ProgramEditor> {
           const SizedBox(height: AppSpacing.md),
           Text(
             l.schedNote,
-            style: TextStyle(fontSize: 11, fontWeight: FontWeight.w700),
+            style: TextStyle(fontSize: 12, fontWeight: FontWeight.w700),
           ),
           const SizedBox(height: AppSpacing.xs),
           TextField(
@@ -1232,9 +1235,12 @@ class _WeekNav extends StatelessWidget {
           _ChevronButton(icon: Icons.chevron_left, onTap: () => onShift(-1)),
           const SizedBox(width: AppSpacing.sm),
           Text(
-            l.dateRange(l.dateMonthDay(start.month, start.day), l.dateMonthDay(end.month, end.day)),
+            l.dateRange(
+              l.dateMonthDay(start.month, start.day),
+              l.dateMonthDay(end.month, end.day),
+            ),
             style: const TextStyle(
-              fontSize: 13,
+              fontSize: 14,
               fontWeight: FontWeight.w800,
               color: AppColors.foreground,
             ),
@@ -1351,7 +1357,7 @@ class _DayColumn extends StatelessWidget {
                   Text(
                     weekdayNames(l)[day.weekday - 1],
                     style: TextStyle(
-                      fontSize: 10.5,
+                      fontSize: 11.5,
                       fontWeight: FontWeight.w700,
                       color: weekend
                           ? AppColors.subtleForeground
@@ -1362,7 +1368,7 @@ class _DayColumn extends StatelessWidget {
                   Text(
                     '${day.day}',
                     style: TextStyle(
-                      fontSize: 15,
+                      fontSize: 16,
                       fontWeight: FontWeight.w800,
                       color: isToday ? AppColors.primary : AppColors.foreground,
                     ),
@@ -1378,7 +1384,7 @@ class _DayColumn extends StatelessWidget {
                     child: Text(
                       l.schedEmptySlotShort,
                       style: TextStyle(
-                        fontSize: 10,
+                        fontSize: 11,
                         fontWeight: FontWeight.w500,
                         color: AppColors.disabledForeground,
                       ),
@@ -1427,7 +1433,7 @@ class _WeekChip extends StatelessWidget {
                 Text(
                   session.time,
                   style: TextStyle(
-                    fontSize: 10,
+                    fontSize: 11,
                     fontWeight: FontWeight.w800,
                     color: color,
                   ),
@@ -1437,7 +1443,7 @@ class _WeekChip extends StatelessWidget {
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                   style: const TextStyle(
-                    fontSize: 10.5,
+                    fontSize: 11.5,
                     fontWeight: FontWeight.w600,
                     color: AppColors.foreground,
                   ),
@@ -1580,7 +1586,7 @@ class _DayCell extends StatelessWidget {
             Text(
               label,
               style: TextStyle(
-                fontSize: 10,
+                fontSize: 11,
                 fontWeight: FontWeight.w600,
                 color: labelColor,
               ),
@@ -1589,7 +1595,7 @@ class _DayCell extends StatelessWidget {
             Text(
               '${date.day}',
               style: TextStyle(
-                fontSize: 12.5,
+                fontSize: 13.5,
                 fontWeight: FontWeight.w700,
                 color: dayColor,
               ),
@@ -1660,7 +1666,7 @@ class _TimelineRow extends StatelessWidget {
             child: Text(
               session.time,
               style: TextStyle(
-                fontSize: 11,
+                fontSize: 12,
                 fontWeight: FontWeight.w700,
                 color: session.isDone
                     ? AppColors.disabledForeground
@@ -1710,7 +1716,7 @@ class _GapSlot extends StatelessWidget {
       child: Text(
         l.dashEmptySlot,
         style: TextStyle(
-          fontSize: 11,
+          fontSize: 12,
           fontWeight: FontWeight.w500,
           color: AppColors.disabledForeground,
         ),
@@ -1797,15 +1803,18 @@ class _SessionCard extends StatelessWidget {
                         Text(
                           s.clientName,
                           style: const TextStyle(
-                            fontSize: 13,
+                            fontSize: 14,
                             fontWeight: FontWeight.w700,
                             color: AppColors.foreground,
                           ),
                         ),
                         Text(
-                          l.sessionTypeAndDuration(sessionTypeLabel(l, s.type), s.durationMinutes),
+                          l.sessionTypeAndDuration(
+                            sessionTypeLabel(l, s.type),
+                            s.durationMinutes,
+                          ),
                           style: const TextStyle(
-                            fontSize: 10.5,
+                            fontSize: 11.5,
                             fontWeight: FontWeight.w500,
                             color: AppColors.subtleForeground,
                           ),
@@ -1920,7 +1929,11 @@ class _StatusChip extends StatelessWidget {
       child: Text(
         // 색은 계약값(`status`)으로 고르고, 글자는 로케일 문구로 그린다.
         scheduleStatusLabel(AppLocalizations.of(context), status),
-        style: TextStyle(fontSize: 9.5, fontWeight: FontWeight.w700, color: fg),
+        style: TextStyle(
+          fontSize: 10.5,
+          fontWeight: FontWeight.w700,
+          color: fg,
+        ),
       ),
     );
   }
@@ -1959,7 +1972,7 @@ class _ProgramRow extends StatelessWidget {
             child: Text(
               '$index',
               style: const TextStyle(
-                fontSize: 9.5,
+                fontSize: 10.5,
                 fontWeight: FontWeight.w800,
                 color: AppColors.secondary,
               ),
@@ -1973,7 +1986,7 @@ class _ProgramRow extends StatelessWidget {
                 Text(
                   item.name,
                   style: const TextStyle(
-                    fontSize: 12,
+                    fontSize: 13,
                     fontWeight: FontWeight.w700,
                     color: AppColors.foreground,
                   ),
@@ -1981,7 +1994,7 @@ class _ProgramRow extends StatelessWidget {
                 Text(
                   detail.toString(),
                   style: const TextStyle(
-                    fontSize: 10,
+                    fontSize: 11,
                     fontWeight: FontWeight.w500,
                     color: AppColors.subtleForeground,
                   ),
@@ -2018,7 +2031,7 @@ class _NoPlanBox extends StatelessWidget {
           Text(
             l.progEmpty,
             style: TextStyle(
-              fontSize: 12,
+              fontSize: 13,
               fontWeight: FontWeight.w700,
               color: AppColors.mutedForeground,
             ),
@@ -2027,7 +2040,7 @@ class _NoPlanBox extends StatelessWidget {
           Text(
             l.progEmptyHint,
             style: TextStyle(
-              fontSize: 10.5,
+              fontSize: 11.5,
               fontWeight: FontWeight.w500,
               color: AppColors.subtleForeground,
             ),
@@ -2081,7 +2094,11 @@ class _ManageRow extends StatelessWidget {
           color: AppColors.secondary,
           onTap: onEditProgram,
         ),
-        _ActionChip(label: l.actionDelete, color: AppColors.destructive, onTap: onDelete),
+        _ActionChip(
+          label: l.actionDelete,
+          color: AppColors.destructive,
+          onTap: onDelete,
+        ),
         _ActionChip(
           key: const ValueKey<String>('session-chat-chip'),
           icon: Icons.chat_bubble_outline,
@@ -2109,7 +2126,7 @@ class _SentBadge extends StatelessWidget {
         Text(
           l.schedSent,
           style: TextStyle(
-            fontSize: 9.5,
+            fontSize: 10.5,
             fontWeight: FontWeight.w700,
             color: AppColors.success,
           ),
@@ -2142,7 +2159,7 @@ class _ActionChip extends StatelessWidget {
     final text = Text(
       label,
       style: TextStyle(
-        fontSize: 10.5,
+        fontSize: 11.5,
         fontWeight: FontWeight.w700,
         color: color,
       ),
@@ -2203,7 +2220,7 @@ class _NoteBox extends StatelessWidget {
           Text(
             l.schedNote,
             style: TextStyle(
-              fontSize: 9,
+              fontSize: 10,
               fontWeight: FontWeight.w700,
               color: AppColors.warning,
             ),
@@ -2212,7 +2229,7 @@ class _NoteBox extends StatelessWidget {
           Text(
             note,
             style: const TextStyle(
-              fontSize: 11,
+              fontSize: 12,
               fontWeight: FontWeight.w500,
               color: AppColors.mutedForeground,
             ),
@@ -2272,7 +2289,7 @@ class _SendButton extends StatelessWidget {
                   label,
                   overflow: TextOverflow.ellipsis,
                   style: TextStyle(
-                    fontSize: 12,
+                    fontSize: 13,
                     fontWeight: FontWeight.w700,
                     color: fg,
                   ),

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/reservation_slots_sheet.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/reservation_slots_sheet.dart
@@ -249,7 +249,12 @@ class _ReservationSlotsSheetState extends ConsumerState<ReservationSlotsSheet> {
               ),
               const SizedBox(height: AppSpacing.sm),
               Text(
-                l.slotIntro(l.dateMonthDay(widget.selectedDay.month, widget.selectedDay.day)),
+                l.slotIntro(
+                  l.dateMonthDay(
+                    widget.selectedDay.month,
+                    widget.selectedDay.day,
+                  ),
+                ),
                 style: const TextStyle(color: AppColors.mutedForeground),
               ),
               const SizedBox(height: AppSpacing.lg),
@@ -355,7 +360,10 @@ class _ReservationSlotsSheetState extends ConsumerState<ReservationSlotsSheet> {
                                 child: Text(
                                   slot.isClosed
                                       ? l.slotClosedSummary(slot.booked)
-                                      : l.slotOpenSummary(slot.booked, slot.remaining),
+                                      : l.slotOpenSummary(
+                                          slot.booked,
+                                          slot.remaining,
+                                        ),
                                   style: TextStyle(
                                     color: slot.isClosed
                                         ? AppColors.subtleForeground

--- a/frontend/flutter_trainer/lib/features/search/presentation/widgets/client_search_bar.dart
+++ b/frontend/flutter_trainer/lib/features/search/presentation/widgets/client_search_bar.dart
@@ -309,7 +309,7 @@ class _ClientSearchBarState extends ConsumerState<ClientSearchBar> {
         focusNode: _focus,
         textInputAction: TextInputAction.search,
         style: const TextStyle(
-          fontSize: 15,
+          fontSize: 16,
           fontWeight: FontWeight.w500,
           color: AppColors.foreground,
         ),
@@ -319,7 +319,7 @@ class _ClientSearchBarState extends ConsumerState<ClientSearchBar> {
           fillColor: AppColors.inputBackground,
           hintText: l.searchClientsHint,
           hintStyle: const TextStyle(
-            fontSize: 15,
+            fontSize: 16,
             color: AppColors.subtleForeground,
           ),
           prefixIcon: const Icon(
@@ -444,7 +444,7 @@ class _ResultsCard extends StatelessWidget {
               child: Text(
                 l.searchNoResults(query.trim()),
                 style: const TextStyle(
-                  fontSize: 12,
+                  fontSize: 13,
                   color: AppColors.mutedForeground,
                 ),
               ),
@@ -542,7 +542,7 @@ class _ResultRowState extends State<_ResultRow> {
                                 widget.client.name,
                                 overflow: TextOverflow.ellipsis,
                                 style: const TextStyle(
-                                  fontSize: 15,
+                                  fontSize: 16,
                                   fontWeight: FontWeight.w700,
                                   color: AppColors.foreground,
                                 ),
@@ -552,7 +552,7 @@ class _ResultRowState extends State<_ResultRow> {
                                 widget.detail,
                                 overflow: TextOverflow.ellipsis,
                                 style: const TextStyle(
-                                  fontSize: 13,
+                                  fontSize: 14,
                                   fontWeight: FontWeight.w500,
                                   color: AppColors.subtleForeground,
                                 ),
@@ -652,7 +652,7 @@ class _ResultRowState extends State<_ResultRow> {
             vertical: AppSpacing.sm,
           ),
           textStyle: const TextStyle(
-            fontSize: 12.5,
+            fontSize: 13.5,
             fontWeight: FontWeight.w600,
           ),
           side: const BorderSide(color: AppColors.borderStrong),
@@ -693,7 +693,7 @@ class _Footer extends StatelessWidget {
               text,
               overflow: TextOverflow.ellipsis,
               style: const TextStyle(
-                fontSize: 12,
+                fontSize: 13,
                 fontWeight: FontWeight.w500,
                 color: AppColors.subtleForeground,
               ),
@@ -797,7 +797,7 @@ class _ClientSearchDialogState extends ConsumerState<_ClientSearchDialog> {
                   autofocus: true,
                   textInputAction: TextInputAction.search,
                   style: const TextStyle(
-                    fontSize: 15,
+                    fontSize: 16,
                     fontWeight: FontWeight.w500,
                     color: AppColors.foreground,
                   ),
@@ -807,7 +807,7 @@ class _ClientSearchDialogState extends ConsumerState<_ClientSearchDialog> {
                     fillColor: AppColors.card,
                     hintText: l.searchClientsHint,
                     hintStyle: const TextStyle(
-                      fontSize: 15,
+                      fontSize: 16,
                       color: AppColors.subtleForeground,
                     ),
                     prefixIcon: const Icon(

--- a/frontend/flutter_trainer/lib/shared/widgets/action_button.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/action_button.dart
@@ -74,7 +74,7 @@ class ActionButton extends StatelessWidget {
               Text(
                 label,
                 style: TextStyle(
-                  fontSize: 12.5,
+                  fontSize: 13.5,
                   fontWeight: FontWeight.w700,
                   color: fg,
                 ),
@@ -137,7 +137,7 @@ class SegmentedSwitch extends StatelessWidget {
                     child: Text(
                       labels[i],
                       style: TextStyle(
-                        fontSize: 12,
+                        fontSize: 13,
                         fontWeight: FontWeight.w700,
                         color: selected == i
                             ? AppColors.primary

--- a/frontend/flutter_trainer/lib/shared/widgets/labeled_field.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/labeled_field.dart
@@ -30,7 +30,7 @@ class LabeledField extends StatelessWidget {
         Text(
           label,
           style: const TextStyle(
-            fontSize: 11,
+            fontSize: 12,
             fontWeight: FontWeight.w600,
             color: AppColors.subtleForeground,
           ),

--- a/frontend/flutter_trainer/lib/shared/widgets/metric_tile.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/metric_tile.dart
@@ -51,7 +51,7 @@ class MetricTile extends StatelessWidget {
             Text(
               label,
               style: const TextStyle(
-                fontSize: 9.5,
+                fontSize: 10.5,
                 fontWeight: FontWeight.w600,
                 color: AppColors.subtleForeground,
               ),
@@ -60,7 +60,7 @@ class MetricTile extends StatelessWidget {
             Text(
               _displayValue(value),
               style: TextStyle(
-                fontSize: 16,
+                fontSize: 17,
                 fontWeight: FontWeight.w800,
                 color: warn ? AppColors.overTarget : color,
               ),
@@ -68,7 +68,7 @@ class MetricTile extends StatelessWidget {
             Text(
               warn ? l.metricOverBy(unit) : unit,
               style: TextStyle(
-                fontSize: 9,
+                fontSize: 10,
                 fontWeight: warn ? FontWeight.w700 : FontWeight.w400,
                 color: warn ? AppColors.overTarget : AppColors.subtleForeground,
               ),

--- a/frontend/flutter_trainer/lib/shared/widgets/mini_charts.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/mini_charts.dart
@@ -100,7 +100,7 @@ class BarSeriesChart extends StatelessWidget {
                   maxLines: 1,
                   overflow: TextOverflow.clip,
                   style: TextStyle(
-                    fontSize: 10,
+                    fontSize: 11,
                     fontWeight: highlightIndex == i
                         ? FontWeight.w800
                         : FontWeight.w500,
@@ -171,7 +171,7 @@ class _Bar extends StatelessWidget {
                   child: Text(
                     label!,
                     style: const TextStyle(
-                      fontSize: 9.5,
+                      fontSize: 10.5,
                       fontWeight: FontWeight.w700,
                       color: AppColors.mutedForeground,
                     ),
@@ -224,7 +224,7 @@ class Sparkline extends StatelessWidget {
         child: Center(
           child: Text(
             l.chartNotEnoughData,
-            style: TextStyle(fontSize: 11, color: AppColors.subtleForeground),
+            style: TextStyle(fontSize: 12, color: AppColors.subtleForeground),
           ),
         ),
       );

--- a/frontend/flutter_trainer/lib/shared/widgets/page_scaffold.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/page_scaffold.dart
@@ -131,7 +131,7 @@ class _Header extends StatelessWidget {
                       title,
                       overflow: TextOverflow.ellipsis,
                       style: const TextStyle(
-                        fontSize: 17,
+                        fontSize: 18,
                         fontWeight: FontWeight.w800,
                         color: AppColors.foreground,
                       ),
@@ -141,7 +141,7 @@ class _Header extends StatelessWidget {
                         subtitle!,
                         overflow: TextOverflow.ellipsis,
                         style: const TextStyle(
-                          fontSize: 11.5,
+                          fontSize: 12.5,
                           color: AppColors.subtleForeground,
                           fontWeight: FontWeight.w500,
                         ),

--- a/frontend/flutter_trainer/lib/shared/widgets/section_card.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/section_card.dart
@@ -72,7 +72,7 @@ class SectionCard extends StatelessWidget {
                     title,
                     overflow: TextOverflow.ellipsis,
                     style: const TextStyle(
-                      fontSize: 13.5,
+                      fontSize: 14.5,
                       fontWeight: FontWeight.w800,
                       color: AppColors.foreground,
                     ),
@@ -118,7 +118,7 @@ class CardLink extends StatelessWidget {
             Text(
               label,
               style: const TextStyle(
-                fontSize: 11.5,
+                fontSize: 12.5,
                 fontWeight: FontWeight.w700,
                 color: AppColors.primary,
               ),
@@ -156,7 +156,7 @@ class EmptyHint extends StatelessWidget {
             message,
             textAlign: TextAlign.center,
             style: const TextStyle(
-              fontSize: 12,
+              fontSize: 13,
               fontWeight: FontWeight.w500,
               color: AppColors.subtleForeground,
             ),

--- a/frontend/flutter_trainer/lib/shared/widgets/stat_card.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/stat_card.dart
@@ -89,6 +89,10 @@ class StatCard extends StatelessWidget {
           onTap: onTap,
           borderRadius: const BorderRadius.all(AppRadius.card),
           child: Container(
+            // Browser text metrics can round the intrinsic Column height
+            // down by one physical pixel. Keep a small floor so enlarged
+            // labels and hints never paint past the KPI card.
+            constraints: const BoxConstraints(minHeight: 124),
             padding: const EdgeInsets.all(AppSpacing.lg),
             decoration: BoxDecoration(
               borderRadius: const BorderRadius.all(AppRadius.card),
@@ -116,7 +120,7 @@ class StatCard extends StatelessWidget {
                         label,
                         overflow: TextOverflow.ellipsis,
                         style: const TextStyle(
-                          fontSize: 12,
+                          fontSize: 13,
                           fontWeight: FontWeight.w600,
                           color: AppColors.mutedForeground,
                         ),
@@ -154,7 +158,7 @@ class StatCard extends StatelessWidget {
                         Text(
                           unit!,
                           style: const TextStyle(
-                            fontSize: 12,
+                            fontSize: 13,
                             fontWeight: FontWeight.w600,
                             color: AppColors.subtleForeground,
                           ),
@@ -170,7 +174,7 @@ class StatCard extends StatelessWidget {
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     style: const TextStyle(
-                      fontSize: 11,
+                      fontSize: 12,
                       color: AppColors.subtleForeground,
                       fontWeight: FontWeight.w500,
                     ),

--- a/frontend/flutter_trainer/lib/shared/widgets/status_dot_label.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/status_dot_label.dart
@@ -44,7 +44,7 @@ class StatusDotLabel extends StatelessWidget {
         Text(
           label,
           style: TextStyle(
-            fontSize: 10,
+            fontSize: 11,
             fontWeight: FontWeight.w700,
             color: color,
           ),

--- a/frontend/flutter_trainer/test/design_system/readability_tokens_test.dart
+++ b/frontend/flutter_trainer/test/design_system/readability_tokens_test.dart
@@ -1,0 +1,52 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare_trainer/design_system/tokens/colors.dart';
+import 'package:oncare_trainer/design_system/tokens/typography.dart';
+
+void main() {
+  test('본문과 라벨 타이포그래피는 웹 콘솔 가독성 기준을 유지한다', () {
+    final textTheme = AppTypography.buildTextTheme(
+      ThemeData(useMaterial3: true).textTheme,
+    );
+
+    expect(textTheme.bodyLarge!.fontSize, 17);
+    expect(textTheme.bodyMedium!.fontSize, 16);
+    expect(textTheme.bodySmall!.fontSize, 14);
+    expect(textTheme.labelLarge!.fontSize, 16);
+    expect(textTheme.labelMedium!.fontSize, 14);
+    expect(textTheme.labelSmall!.fontSize, 13);
+  });
+
+  test('회색 텍스트 토큰은 흰 배경에서 의도한 대비를 유지한다', () {
+    expect(_contrast(AppColors.mutedForeground, Colors.white), greaterThan(7));
+    expect(
+      _contrast(AppColors.subtleForeground, Colors.white),
+      greaterThanOrEqualTo(4.5),
+    );
+    expect(
+      _contrast(AppColors.disabledForeground, Colors.white),
+      greaterThanOrEqualTo(3),
+    );
+  });
+}
+
+double _contrast(Color first, Color second) {
+  final lighter = math.max(_luminance(first), _luminance(second));
+  final darker = math.min(_luminance(first), _luminance(second));
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+double _luminance(Color color) {
+  final argb = color.toARGB32();
+  final channels = <int>[(argb >> 16) & 0xff, (argb >> 8) & 0xff, argb & 0xff];
+  final linear = channels.map((channel) {
+    final value = channel / 255;
+    return value <= 0.03928
+        ? value / 12.92
+        : math.pow((value + 0.055) / 1.055, 2.4).toDouble();
+  }).toList();
+  return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2];
+}

--- a/frontend/flutter_trainer/test/shared/widgets/stat_card_test.dart
+++ b/frontend/flutter_trainer/test/shared/widgets/stat_card_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare_trainer/shared/widgets/stat_card.dart';
+
+void main() {
+  testWidgets('확대된 라벨과 도움말을 담을 최소 높이를 유지한다', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: SizedBox(
+              width: 486,
+              child: StatCard(
+                label: '오늘 예약',
+                value: '4',
+                unit: '건',
+                hint: '스케줄에서 보기',
+                icon: Icons.event_available_outlined,
+                onTap: () {},
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(
+      tester.getSize(find.byType(StatCard)).height,
+      greaterThanOrEqualTo(124),
+    );
+  });
+}


### PR DESCRIPTION
## Summary

* 트레이너 웹 콘솔의 기본 본문과 주요 라벨 크기를 전반적으로 키웠습니다.
* 화면별로 직접 지정된 작은 글씨 245곳을 함께 조정해 검색·카드·표·목록·폼의 가독성을 일관되게 개선했습니다.
* 회색 보조 텍스트를 더 진하게 조정해 흰색 및 연회색 배경에서 잘 보이도록 했습니다.
* 글씨 확대 후 브라우저에서 발견된 KPI 카드와 식단 차트의 overflow를 수정했습니다.

---

## Changes

### ✨ Features

* 없음

### 🔧 Improvements

* 공통 타이포그래피 스케일을 명시적으로 정의했습니다.

  | 역할 | 변경 후 크기 |
  | --- | ---: |
  | `bodyLarge` | 17px |
  | `bodyMedium` | 16px |
  | `bodySmall` | 14px |
  | `labelLarge` | 16px |
  | `labelMedium` | 14px |
  | `labelSmall` | 13px |
  | `titleLarge` | 20px |
  | `titleMedium` | 18px |
  | `titleSmall` | 16px |

* Material 기본 `bodyMedium` 14px에 의존하던 부분을 16px 본문 기준으로 변경했습니다.
* 헤더·사이드바·고객 관리·스케줄·AI 코칭·리포트·검색·내 정보 등에서 직접 지정한 작은 글씨 245곳을 확대했습니다.
* 기존 7.5px이던 최솟값을 9px로 올렸습니다.
* 사용자 앱의 타이포그래피 위계와 크기 체계를 참고해 두 앱의 읽기 경험을 맞췄습니다.

### 🎨 UI/UX

* 회색 텍스트 토큰을 다음과 같이 변경했습니다.

  | 용도 | 기존 | 변경 | 흰 배경 대비 |
  | --- | --- | --- | ---: |
  | 보조 본문 | `#5A6A7A` | `#465568` | 7.61:1 |
  | 연한 보조 정보·placeholder | `#A0A8B5` | `#667585` | 4.72:1 |
  | 비활성 텍스트 | `#C0CDD6` | `#768596` | 3.77:1 |

* 연한 보조 텍스트도 일반 텍스트 WCAG AA 기준인 4.5:1 이상의 대비를 갖도록 조정했습니다.
* 검색 결과의 고객명·상세 정보·안내 문구를 포함한 검색 UI 글씨를 추가로 키웠습니다.
* 중요 정보와 보조 정보의 굵기·색상 위계는 유지했습니다.

### 📝 Docs

* 없음
* 타이포그래피 및 색상 토큰 주석에 크기 기준과 대비 의도를 기록했습니다.

### 🐛 Fixes

* 글씨 확대 후 대시보드 KPI 카드가 실제 웹 글꼴 메트릭에서 세로로 1px overflow되던 문제를 수정했습니다.
  * KPI 카드에 124px 최소 높이를 지정했습니다.
  * 브라우저별 글꼴 높이 반올림 차이에도 내용이 잘리지 않도록 했습니다.
* 식단의 주간 나트륨 차트가 확대된 값·요일 라벨로 인해 세로 2px overflow되던 문제를 수정했습니다.
  * 차트 높이를 84px에서 88px로 늘렸습니다.

---

## Commits

1. `4228a07f` fix(trainer): improve web text readability

---

## Notes

* 브랜드 컬러나 레이아웃 구조를 개편하지 않고 텍스트 크기와 명도 대비를 중심으로 조정했습니다.
* 사용자 앱의 타이포그래피는 변경하지 않았습니다.
* 다크 모드는 이번 작업 범위에 포함하지 않았습니다.
* 로그인·대시보드·고객·스케줄·AI 코칭·리포트·내 정보 등 트레이너 웹 전반의 명시적 글꼴 크기를 함께 조정했습니다.
* 브라우저 검증에서 발견된 KPI 카드 및 식단 차트 overflow를 수정하고 각각 회귀 테스트를 추가했습니다.
* 로컬 브라우저 검증에 사용한 `sqlite3.wasm`과 `drift_worker.js`는 Git 추적 대상에 포함되지 않습니다.

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 관련 테스트 통과
* [x] 전체 Flutter 테스트 통과
* [x] 정적 분석 통과

### Manual Test Steps

1. `cd frontend/flutter_trainer`에서 `flutter run -d chrome`으로 웹을 실행합니다.
2. 로그인 화면에서 제목·설명·입력 placeholder·버튼 글씨의 크기와 회색 대비를 확인합니다.
3. 대시보드에서 사이드바, 헤더, 검색바, KPI 카드, 오늘의 일정, 주의 고객 정보를 확인합니다.
4. KPI 카드 하단에 노란색·검은색 overflow 표시가 나타나지 않는지 확인합니다.
5. 고객 상세의 식단 탭에서 주간 나트륨 차트의 값과 요일 라벨이 잘리지 않는지 확인합니다.
6. 고객·스케줄·AI 코칭·리포트·내 정보 화면을 이동하며 제목, 본문, 캡션, 비활성 텍스트를 확인합니다.
7. 화면 폭을 줄여 사이드바가 드로어로 바뀌고 검색이 아이콘으로 접힐 때 텍스트 overflow가 없는지 확인합니다.
8. 검색 결과를 열어 고객명·탭별 상세 정보·빠른 이동 버튼이 정상적으로 표시되는지 확인합니다.

### Automated Test Results

* `flutter analyze --no-pub` 통과
* 전체 Flutter 테스트 503개 통과
* 최종 KPI 카드 및 대시보드 관련 테스트 12개 통과
* 타이포그래피 크기 회귀 테스트 추가
* 회색 텍스트 대비 회귀 테스트 추가
* KPI 카드 최소 높이 회귀 테스트 추가

---

## Related Issues

Closes #631

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] 최신 `main` 기반 작업
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인
* [x] 반응형 화면 영향 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 앱 전반의 글꼴 크기와 줄 간격을 확대해 가독성을 개선했습니다.
  * 보조·비활성 텍스트 색상을 조정해 대비와 가독성을 높였습니다.
  * 통계 카드의 최소 높이를 보장해 화면 구성을 안정화했습니다.
  * 로그인, 대시보드, 고객 관리, 코칭, 일정, 리포트 등 주요 화면의 텍스트 표시를 개선했습니다.

* **테스트**
  * 텍스트 크기와 색상 대비를 검증하는 테스트를 추가했습니다.
  * 통계 카드의 레이아웃과 상호작용을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->