### PR TITLE
fix(exercise): 운동 탭 이번 주 운동 요약 일수 카드 제거

### DIFF
--- a/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
@@ -257,19 +257,6 @@ class _RecordTabState extends ConsumerState<_RecordTab> {
                 children: <Widget>[
                   Expanded(
                     child: _StatCard(
-                      label: l.exStatDays,
-                      // 운동 일수 = 운동한 활성 일수(workoutCount). 하루에 유형을
-                      // 나눠 여러 세션으로 기록해도 1일로 센다(요일 수).
-                      // 홈 운동 카드의 '주간 운동 일수'와 동일한 정의.
-                      value: '${week.workoutCount}',
-                      unit: l.unitDays,
-                      goal: '${goals.workouts}',
-                      accent: true,
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: _StatCard(
                       label: l.exStatTime,
                       value: '${week.totalMinutes}',
                       unit: l.unitMinutes,

--- a/frontend/flutter/test/features/exercise/exercise_health_goals_test.dart
+++ b/frontend/flutter/test/features/exercise/exercise_health_goals_test.dart
@@ -148,7 +148,9 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  testWidgets('운동 탭은 프로필의 운동 목표 3종을 표시한다', (WidgetTester tester) async {
+  testWidgets('운동 탭 요약은 일수 카드를 제외한 운동 목표를 표시한다', (
+    WidgetTester tester,
+  ) async {
     await pumpExercise(
       tester,
       profile: const UserProfile(
@@ -161,9 +163,11 @@ void main() {
       ),
     );
 
-    expect(find.text('2 /5일'), findsOneWidget);
+    expect(find.text('일수'), findsNothing);
+    expect(find.text('2 /5일'), findsNothing);
     expect(find.text('100 /240분'), findsOneWidget);
     expect(find.text('300 /900kcal'), findsOneWidget);
+    expect(find.text('연속'), findsOneWidget);
   });
 
   testWidgets('운동 목표가 없으면 필드별 기본값을 표시한다', (WidgetTester tester) async {
@@ -178,7 +182,7 @@ void main() {
       ),
     );
 
-    expect(find.text('2 /4일'), findsOneWidget);
+    expect(find.text('2 /4일'), findsNothing);
     expect(find.text('100 /150분'), findsOneWidget);
     expect(find.text('300 /800kcal'), findsOneWidget);
   });
@@ -295,7 +299,7 @@ void main() {
 
     await tester.tap(find.byKey(const Key('showExercise')));
     await tester.pumpAndSettle();
-    expect(find.text('2 /5일'), findsOneWidget);
+    expect(find.text('2 /5일'), findsNothing);
     expect(find.text('100 /240분'), findsOneWidget);
     expect(find.text('300 /900kcal'), findsOneWidget);
 


### PR DESCRIPTION
## Summary

* 사용자 앱 운동 탭의 `이번 주 운동 요약`에서 첫 번째 `일수` 카드를 제거했습니다.
* 시간·칼로리·연속 카드는 기존 정보를 유지하면서 동일한 너비의 3열로 배치했습니다.
* 일수 카드가 다시 노출되지 않도록 관련 위젯 회귀 테스트를 수정했습니다.

---

## Changes

### ✨ Features

* 해당 없음

### 🔧 Improvements

* 운동 요약 위젯 테스트가 `일수` 카드 미노출을 검증하도록 수정했습니다.
* 사용자 운동 목표 변경 후에도 시간·칼로리 카드가 정상적으로 갱신되는지 기존 검증을 유지했습니다.

### 🎨 UI/UX

* `이번 주 운동 요약`의 첫 번째 `일수` 카드를 제거했습니다.
* 일수 카드 뒤에 있던 불필요한 가로 간격을 함께 제거했습니다.
* 시간·칼로리·연속 카드가 요약 영역의 전체 너비를 3등분하도록 정리했습니다.

### 📝 Docs

* 해당 없음

### 🐛 Fixes

* 변경된 화면 요구사항과 다르게 운동 일수 카드가 계속 노출되던 문제를 수정했습니다.

---

## Commits

1. `4228a07` `fix(exercise): 운동 요약 일수 카드 제거`

---

## Notes

* 이번 변경은 운동 탭의 표시 구성만 변경합니다.
* `ExerciseWeek.workoutCount`를 포함한 운동 일수 계산 로직은 변경하지 않았습니다.
* 홈 화면의 운동 일수와 MY 화면의 주간 운동 횟수 목표는 기존대로 유지됩니다.
* 백엔드 API 및 운동 요약 데이터 구조 변경은 없습니다.

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [ ] UI 확인
* [ ] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 사용자 앱을 실행하고 운동 탭으로 이동합니다.
2. `이번 주 운동 요약` 영역에 `일수` 카드가 표시되지 않는지 확인합니다.
3. 시간·칼로리·연속 카드가 동일한 너비의 3열로 표시되는지 확인합니다.
4. 각 카드의 값과 단위가 기존과 동일하게 표시되는지 확인합니다.
5. MY에서 주간 운동 목표를 변경한 뒤 시간·칼로리 목표가 운동 탭에 반영되는지 확인합니다.

### Automated Test Results

* [x] `flutter test test/features/exercise`
  - 운동 기능 테스트 111개 통과
* [x] `flutter analyze --no-pub`
  - `No issues found`
* [x] `git diff --check`
  - 오류 없음

---

## Related Issues

Closes #633

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [ ] 데모 시나리오 영향 확인