### PR TITLE
feat: 트레이너 스케줄 탭에 상담 요청 인박스 및 일정 등록 흐름 추가

### DIFF
--- a/backend/app/api/v1/trainer.py
+++ b/backend/app/api/v1/trainer.py
@@ -26,6 +26,7 @@ from app.core.security import hash_password, verify_password
 from app.db.session import get_db
 from app.models.models import Notification, TrainerClient, TrainerProfile
 from app.schemas.consultation_api import (
+    ConsultationAccept,
     ConsultationDecision,
     ConsultationStatusFilter,
     TrainerConsultationOut,
@@ -783,12 +784,29 @@ def trainer_consultations_pending_count(
 )
 def trainer_accept_consultation(
     consultation_id: str,
-    payload: ConsultationDecision,
+    payload: ConsultationAccept,
     trainer: RequireTrainer,
     db: Annotated[Session, Depends(get_db)],
 ) -> TrainerConsultationOut:
     """상담을 승인하고 회원을 담당 고객으로 편입한다."""
-    return _decide(consultation_service.accept, db, trainer.id, consultation_id, payload)
+    try:
+        return consultation_service.accept(
+            db,
+            trainer.id,
+            consultation_id,
+            note=payload.note,
+            schedule_date=payload.date,
+            schedule_time=payload.time,
+            schedule_type=payload.type,
+            duration_minutes=payload.duration_minutes,
+        )
+    except consultation_service.ConsultationNotFound as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except (
+        consultation_service.ConsultationAlreadyDecided,
+        consultation_service.MemberAlreadyCoached,
+    ) as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 
 @router.post(

--- a/backend/app/schemas/consultation_api.py
+++ b/backend/app/schemas/consultation_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date as Date
+from datetime import datetime
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -22,7 +23,7 @@ class ConsultationCreate(BaseModel):
     exercise_goal: ExerciseGoal
     health_purpose_type: HealthPurposeType
     health_purpose_detail: str | None = Field(default=None, max_length=500)
-    preferred_date: date
+    preferred_date: Date
     preferred_time_slot: PreferredTimeSlot
     message: str | None = Field(default=None, max_length=2000)
 
@@ -78,6 +79,30 @@ class ConsultationDecision(BaseModel):
         return value
 
 
+class ConsultationAccept(ConsultationDecision):
+    """Accept a request and optionally book its first consultation session.
+
+    Older clients may still send only ``note``.  The trainer schedule inbox
+    sends the complete schedule tuple so accepting and booking are atomic.
+    """
+
+    date: Date | None = None
+    time: str | None = Field(default=None, pattern=r"^([01]\d|2[0-3]):[0-5]\d$")
+    type: str | None = Field(default=None, min_length=1, max_length=30)
+    duration_minutes: int | None = Field(default=None, ge=15, le=600)
+
+    @model_validator(mode="after")
+    def _schedule_is_complete(self) -> ConsultationAccept:
+        values = (self.date, self.time, self.type, self.duration_minutes)
+        if any(value is not None for value in values) and not all(
+            value is not None for value in values
+        ):
+            raise ValueError(
+                "일정을 등록하려면 date, time, type, duration_minutes가 모두 필요합니다."
+            )
+        return self
+
+
 class ConsultationOut(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
@@ -93,7 +118,7 @@ class ConsultationOut(BaseModel):
     exercise_goal: ExerciseGoal
     health_purpose_type: HealthPurposeType
     health_purpose_detail: str | None
-    preferred_date: date
+    preferred_date: Date
     preferred_time_slot: PreferredTimeSlot
     message: str | None
     status: str

--- a/backend/app/services/consultation_service.py
+++ b/backend/app/services/consultation_service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 from sqlalchemy import func, or_, select
 from sqlalchemy.exc import IntegrityError

--- a/backend/app/services/consultation_service.py
+++ b/backend/app/services/consultation_service.py
@@ -15,6 +15,7 @@ from app.models.models import (
     Place,
     TrainerClient,
     TrainerProfile,
+    TrainerSchedule,
     User,
 )
 from app.schemas.consultation_api import (
@@ -415,7 +416,15 @@ def _link_member_gym(db: Session, member_id: str, gym_id: str | None) -> None:
 
 
 def accept(
-    db: Session, trainer_id: str, consultation_id: str, note: str | None = None
+    db: Session,
+    trainer_id: str,
+    consultation_id: str,
+    note: str | None = None,
+    *,
+    schedule_date: date | None = None,
+    schedule_time: str | None = None,
+    schedule_type: str | None = None,
+    duration_minutes: int | None = None,
 ) -> TrainerConsultationOut:
     """상담을 승인하고 담당 링크를 만든다.
 
@@ -475,6 +484,31 @@ def accept(
     row.decided_by = trainer_id
     row.decided_at = _now()
     row.decision_note = note
+
+    # The schedule inbox sends all four values together (validated by the
+    # request schema).  Keep this in the same transaction as the decision:
+    # a request must never disappear from the inbox without its promised
+    # calendar entry being created.
+    if schedule_date is not None:
+        db.add(
+            TrainerSchedule(
+                id=f"sched-{uuid.uuid4().hex[:12]}",
+                trainer_id=trainer_id,
+                member_id=row.member_id,
+                date=schedule_date.isoformat(),
+                time=schedule_time or "00:00",
+                client_name=db.scalar(
+                    select(User.name).where(User.id == row.member_id)
+                )
+                or "신규 회원",
+                type=schedule_type or "상담",
+                duration_minutes=duration_minutes or 30,
+                status="예정",
+                note=row.message or "",
+                program_json="[]",
+                sort_order=0,
+            )
+        )
 
     trainer_name = db.scalar(select(User.name).where(User.id == trainer_id))
     _notify(

--- a/backend/tests/test_consultation_decision.py
+++ b/backend/tests/test_consultation_decision.py
@@ -9,7 +9,7 @@ DB 가 필요하므로 로컬에서는 skip 되고 CI(Postgres) 에서 실행된
 """
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import date, timedelta
 from uuid import uuid4
 
 import pytest

--- a/backend/tests/test_consultation_decision.py
+++ b/backend/tests/test_consultation_decision.py
@@ -25,6 +25,7 @@ from app.models.models import (
     Place,
     TrainerClient,
     TrainerProfile,
+    TrainerSchedule,
     User,
 )
 from app.services import consultation_service
@@ -45,6 +46,10 @@ def _cleanup(db_session):
         .all()
     ]
     if user_ids:
+        db_session.query(TrainerSchedule).filter(
+            (TrainerSchedule.trainer_id.in_(user_ids))
+            | (TrainerSchedule.member_id.in_(user_ids))
+        ).delete(synchronize_session=False)
         db_session.query(ConsultationRequest).filter(
             (ConsultationRequest.member_id.in_(user_ids))
             | (ConsultationRequest.trainer_id.in_(user_ids))
@@ -295,6 +300,52 @@ def test_accept_links_member_into_roster(client, db_session):
     assert link.active is True
     # 요청의 운동 목표가 코칭 목표의 출발점이 된다(빈 목표 줄 방지).
     assert link.goal == "체중 감량"
+
+
+def test_accept_with_schedule_books_consultation_atomically(client, db_session):
+    trainer, trainer_token = _trainer(client, db_session)
+    member_id, member_token = _member(client)
+    consultation_id = _request_consultation(
+        client, member_token, trainer_id=trainer.id
+    )
+    session_date = (date.today() + timedelta(days=2)).isoformat()
+
+    response = client.post(
+        f"/v1/trainer/consultations/{consultation_id}/accept",
+        headers=_auth(trainer_token),
+        json={
+            "date": session_date,
+            "time": "19:30",
+            "type": "상담",
+            "duration_minutes": 30,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    session = db_session.query(TrainerSchedule).filter_by(
+        trainer_id=trainer.id,
+        member_id=member_id,
+        date=session_date,
+    ).one()
+    assert session.time == "19:30"
+    assert session.type == "상담"
+    assert session.status == "예정"
+
+
+def test_accept_rejects_partial_schedule(client, db_session):
+    trainer, trainer_token = _trainer(client, db_session)
+    _, member_token = _member(client)
+    consultation_id = _request_consultation(
+        client, member_token, trainer_id=trainer.id
+    )
+
+    response = client.post(
+        f"/v1/trainer/consultations/{consultation_id}/accept",
+        headers=_auth(trainer_token),
+        json={"date": (date.today() + timedelta(days=2)).isoformat()},
+    )
+
+    assert response.status_code == 422
 
 
 def test_accept_notifies_the_member(client, db_session):

--- a/frontend/flutter_trainer/lib/app/shell/app_sidebar.dart
+++ b/frontend/flutter_trainer/lib/app/shell/app_sidebar.dart
@@ -10,7 +10,6 @@ import 'package:oncare_trainer/design_system/tokens/layout.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/features/auth/presentation/controllers/session_controller.dart';
-import 'package:oncare_trainer/features/consultations/data/repositories/consultation_repository.dart';
 import 'package:oncare_trainer/features/notifications/data/repositories/notification_repository.dart';
 import 'package:oncare_trainer/shared/models/trainer_profile.dart';
 import 'package:oncare_trainer/shared/services/chat_repository.dart';
@@ -71,10 +70,6 @@ class AppSidebar extends ConsumerWidget {
     // 상담 요청 only exists against the real API — the demo has no member
     // backend to receive requests from, so the row is not built at all
     // there and the demo sidebar stays exactly as it was. (#467)
-    final inbox = ref.watch(consultationInboxEnabledProvider);
-    final pendingConsultations = inbox
-        ? ref.watch(consultationPendingCountProvider).valueOrNull
-        : null;
     // 알림함도 실 API 빌드에서만 — 데모에는 알림을 만드는 회원 백엔드가 없어
     // 늘 비어 있는 행이 하나 더 생길 뿐이다. (#503)
     final notificationInbox = ref.watch(notificationInboxEnabledProvider);
@@ -118,18 +113,6 @@ class AppSidebar extends ConsumerWidget {
                       },
                       onTap: () {
                         onSelect(i);
-                        onNavigate?.call();
-                      },
-                    ),
-                  if (inbox)
-                    _NavTile(
-                      destination: consultationsDestination,
-                      selected:
-                          currentIndex == AppShell.consultationsBranchIndex,
-                      expanded: expanded,
-                      badgeCount: pendingConsultations,
-                      onTap: () {
-                        onSelect(AppShell.consultationsBranchIndex);
                         onNavigate?.call();
                       },
                     ),

--- a/frontend/flutter_trainer/lib/features/consultations/data/repositories/consultation_repository.dart
+++ b/frontend/flutter_trainer/lib/features/consultations/data/repositories/consultation_repository.dart
@@ -58,22 +58,24 @@ class ConsultationSchedule {
 /// error, and decisions are refused rather than silently doing nothing.
 class DemoConsultationRepository implements ConsultationRepository {
   /// Creates the demo source.
-  DemoConsultationRepository()
-    : _requests = <ConsultationRequest>[
-        ConsultationRequest(
-          id: 'demo-consultation-1',
-          memberId: 'demo-consult-member-1',
-          memberName: '김하늘',
-          goalCode: 'fitness',
-          purposeCode: 'general',
-          preferredDate: DateTime.now().add(const Duration(days: 1)),
-          preferredTimeCode: 'evening',
-          status: 'pending',
-          message: '퇴근 후 가능한 시간으로 첫 상담을 받고 싶어요.',
-          viaGym: true,
-          gymName: '온케어 피트니스',
-        ),
-      ];
+  DemoConsultationRepository({List<ConsultationRequest>? requests})
+    : _requests =
+          requests ??
+          <ConsultationRequest>[
+            ConsultationRequest(
+              id: 'demo-consultation-1',
+              memberId: 'demo-consult-member-1',
+              memberName: '김하늘',
+              goalCode: 'fitness',
+              purposeCode: 'general',
+              preferredDate: DateTime.now().add(const Duration(days: 1)),
+              preferredTimeCode: 'evening',
+              status: 'pending',
+              message: '퇴근 후 가능한 시간으로 첫 상담을 받고 싶어요.',
+              viaGym: true,
+              gymName: '온케어 피트니스',
+            ),
+          ];
 
   List<ConsultationRequest> _requests;
 

--- a/frontend/flutter_trainer/lib/features/consultations/data/repositories/consultation_repository.dart
+++ b/frontend/flutter_trainer/lib/features/consultations/data/repositories/consultation_repository.dart
@@ -32,10 +32,25 @@ abstract interface class ConsultationRepository {
   Future<int> pendingCount();
 
   /// Accepts [id], creating the trainer↔member link server-side.
-  Future<void> accept(String id);
+  Future<void> accept(String id, {ConsultationSchedule? schedule});
 
   /// Rejects [id]. [note] is delivered to the member as the reason.
   Future<void> reject(String id, {String? note});
+}
+
+/// Calendar values submitted together with an approval.
+class ConsultationSchedule {
+  const ConsultationSchedule({
+    required this.date,
+    required this.time,
+    required this.type,
+    required this.durationMinutes,
+  });
+
+  final String date;
+  final String time;
+  final String type;
+  final int durationMinutes;
 }
 
 /// Demo build: no inbox. Reads succeed with nothing so any consumer that
@@ -43,25 +58,74 @@ abstract interface class ConsultationRepository {
 /// error, and decisions are refused rather than silently doing nothing.
 class DemoConsultationRepository implements ConsultationRepository {
   /// Creates the demo source.
-  const DemoConsultationRepository();
+  DemoConsultationRepository()
+    : _requests = <ConsultationRequest>[
+        ConsultationRequest(
+          id: 'demo-consultation-1',
+          memberId: 'demo-consult-member-1',
+          memberName: '김하늘',
+          goalCode: 'fitness',
+          purposeCode: 'general',
+          preferredDate: DateTime.now().add(const Duration(days: 1)),
+          preferredTimeCode: 'evening',
+          status: 'pending',
+          message: '퇴근 후 가능한 시간으로 첫 상담을 받고 싶어요.',
+          viaGym: true,
+          gymName: '온케어 피트니스',
+        ),
+      ];
+
+  List<ConsultationRequest> _requests;
 
   @override
-  bool get supportsInbox => false;
+  bool get supportsInbox => true;
 
   @override
   Future<List<ConsultationRequest>> fetch({String status = 'pending'}) async =>
-      const <ConsultationRequest>[];
+      status == 'all'
+      ? List<ConsultationRequest>.unmodifiable(_requests)
+      : _requests.where((request) => request.status == status).toList();
 
   @override
-  Future<int> pendingCount() async => 0;
+  Future<int> pendingCount() async =>
+      _requests.where((request) => request.isPending).length;
 
   @override
-  Future<void> accept(String id) async =>
+  Future<void> accept(String id, {ConsultationSchedule? schedule}) async {
+    _decide(id, 'accepted');
+  }
+
+  @override
+  Future<void> reject(String id, {String? note}) async {
+    _decide(id, 'rejected', note: note);
+  }
+
+  void _decide(String id, String status, {String? note}) {
+    final index = _requests.indexWhere((request) => request.id == id);
+    if (index < 0 || !_requests[index].isPending) {
       throw const ValidationError();
-
-  @override
-  Future<void> reject(String id, {String? note}) async =>
-      throw const ValidationError();
+    }
+    final request = _requests[index];
+    _requests = <ConsultationRequest>[
+      ..._requests.take(index),
+      ConsultationRequest(
+        id: request.id,
+        memberId: request.memberId,
+        memberName: request.memberName,
+        goalCode: request.goalCode,
+        purposeCode: request.purposeCode,
+        preferredDate: request.preferredDate,
+        preferredTimeCode: request.preferredTimeCode,
+        status: status,
+        message: request.message,
+        purposeDetail: request.purposeDetail,
+        viaGym: request.viaGym,
+        gymName: request.gymName,
+        decisionNote: note,
+      ),
+      ..._requests.skip(index + 1),
+    ];
+  }
 }
 
 /// Real backend: `/trainer/consultations`.
@@ -104,22 +168,35 @@ class DioConsultationRepository implements ConsultationRepository {
   }
 
   @override
-  Future<void> accept(String id) => _decide(id, 'accept', null);
+  Future<void> accept(String id, {ConsultationSchedule? schedule}) =>
+      _decide(id, 'accept', null, schedule: schedule);
 
   @override
-  Future<void> reject(String id, {String? note}) =>
-      _decide(id, 'reject', note);
+  Future<void> reject(String id, {String? note}) => _decide(id, 'reject', note);
 
   /// Both decisions share their failure modes, so they share the mapping.
   ///
   /// 409 carries the server's own reason — already decided, or the member
   /// already has another trainer. That sentence is exactly what the
   /// trainer needs, so it is surfaced instead of a generic network error.
-  Future<void> _decide(String id, String action, String? note) async {
+  Future<void> _decide(
+    String id,
+    String action,
+    String? note, {
+    ConsultationSchedule? schedule,
+  }) async {
     try {
       await _dio.post<Map<String, Object?>>(
         '/trainer/consultations/${Uri.encodeComponent(id)}/$action',
-        data: <String, Object?>{'note': note},
+        data: <String, Object?>{
+          'note': note,
+          if (schedule != null) ...<String, Object?>{
+            'date': schedule.date,
+            'time': schedule.time,
+            'type': schedule.type,
+            'duration_minutes': schedule.durationMinutes,
+          },
+        },
       );
     } on DioException catch (e) {
       final status = e.response?.statusCode;
@@ -141,7 +218,7 @@ class DioConsultationRepository implements ConsultationRepository {
 /// Provides the inbox source for the current mode.
 final consultationRepositoryProvider = Provider<ConsultationRepository>((ref) {
   if (ref.watch(appConfigProvider).useMockApi) {
-    return const DemoConsultationRepository();
+    return DemoConsultationRepository();
   }
   return DioConsultationRepository(ref.watch(dioProvider));
 }, name: 'consultationRepository');
@@ -181,8 +258,12 @@ final consultationPendingCountProvider = FutureProvider<int>((ref) async {
 /// The roster is invalidated too — accepting is precisely the moment a new
 /// client appears, and a stale 고객 tab would make the trainer wonder
 /// whether the approval worked.
-Future<void> acceptConsultation(WidgetRef ref, String id) async {
-  await ref.read(consultationRepositoryProvider).accept(id);
+Future<void> acceptConsultation(
+  WidgetRef ref,
+  String id, {
+  ConsultationSchedule? schedule,
+}) async {
+  await ref.read(consultationRepositoryProvider).accept(id, schedule: schedule);
   _refreshAfterDecision(ref);
   ref.invalidate(clientsProvider);
 }

--- a/frontend/flutter_trainer/lib/features/consultations/presentation/widgets/consultation_inbox_sheet.dart
+++ b/frontend/flutter_trainer/lib/features/consultations/presentation/widgets/consultation_inbox_sheet.dart
@@ -1,0 +1,381 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare_trainer/core/config/app_config.dart';
+import 'package:oncare_trainer/core/errors/app_error.dart';
+import 'package:oncare_trainer/core/utils/date_format.dart';
+import 'package:oncare_trainer/design_system/tokens/colors.dart';
+import 'package:oncare_trainer/design_system/tokens/radius.dart';
+import 'package:oncare_trainer/design_system/tokens/spacing.dart';
+import 'package:oncare_trainer/features/consultations/data/dtos/consultation_dtos.dart';
+import 'package:oncare_trainer/features/consultations/data/repositories/consultation_repository.dart';
+import 'package:oncare_trainer/features/consultations/domain/entities/consultation_request.dart';
+import 'package:oncare_trainer/features/schedule/data/repositories/schedule_repository.dart';
+import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
+import 'package:oncare_trainer/shared/widgets/action_button.dart';
+
+/// Schedule-tab inbox for member consultation requests.
+///
+/// Returning a date tells the schedule page to jump to the newly created
+/// calendar entry after the sheet closes.
+class ConsultationInboxSheet extends ConsumerWidget {
+  const ConsultationInboxSheet({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l = AppLocalizations.of(context);
+    final requests = ref.watch(consultationsProvider);
+    return SafeArea(
+      child: SizedBox(
+        height: MediaQuery.sizeOf(context).height * .82,
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.xl),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              Row(
+                children: <Widget>[
+                  Expanded(
+                    child: Text(
+                      l.consultTitle,
+                      style: const TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                  ),
+                  IconButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    icon: const Icon(Icons.close),
+                  ),
+                ],
+              ),
+              Text(
+                l.consultEmptyHint,
+                style: const TextStyle(color: AppColors.mutedForeground),
+              ),
+              const SizedBox(height: AppSpacing.lg),
+              Expanded(
+                child: requests.when(
+                  loading: () =>
+                      const Center(child: CircularProgressIndicator()),
+                  error: (_, _) => Center(child: Text(l.consultLoadFailed)),
+                  data: (rows) => rows.isEmpty
+                      ? Center(child: Text(l.consultEmptyPending))
+                      : ListView.separated(
+                          itemCount: rows.length,
+                          separatorBuilder: (_, _) =>
+                              const SizedBox(height: AppSpacing.md),
+                          itemBuilder: (context, index) =>
+                              _RequestCard(request: rows[index]),
+                        ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _RequestCard extends ConsumerStatefulWidget {
+  const _RequestCard({required this.request});
+
+  final ConsultationRequest request;
+
+  @override
+  ConsumerState<_RequestCard> createState() => _RequestCardState();
+}
+
+class _RequestCardState extends ConsumerState<_RequestCard> {
+  bool _busy = false;
+
+  Future<void> _schedule() async {
+    final booking = await showDialog<_Booking>(
+      context: context,
+      builder: (_) => _ScheduleDialog(request: widget.request),
+    );
+    if (booking == null || !mounted) return;
+    setState(() => _busy = true);
+    final messenger = ScaffoldMessenger.of(context);
+    final l = AppLocalizations.of(context);
+    try {
+      final schedule = ConsultationSchedule(
+        date: ymd(booking.date),
+        time: booking.time,
+        type: '상담',
+        durationMinutes: booking.durationMinutes,
+      );
+      await acceptConsultation(ref, widget.request.id, schedule: schedule);
+
+      // Demo mode has no backend transaction, so mirror the accepted request
+      // into the local Drift calendar. Real mode receives the entry from the
+      // atomic accept endpoint and only needs its providers refreshed.
+      if (ref.read(appConfigProvider).useMockApi) {
+        await ref
+            .read(scheduleRepositoryProvider)
+            .addSession(
+              date: schedule.date,
+              clientName: widget.request.memberName,
+              clientId: widget.request.memberId,
+              time: schedule.time,
+              type: schedule.type,
+              durationMinutes: schedule.durationMinutes,
+              note: widget.request.message ?? '',
+            );
+      }
+      ref.invalidate(scheduleForDateProvider(schedule.date));
+      ref.invalidate(bookedDatesProvider);
+      if (!mounted) return;
+      Navigator.of(context).pop(schedule.date);
+      messenger.showSnackBar(
+        SnackBar(content: Text(l.consultApproved(widget.request.memberName))),
+      );
+    } on AppError catch (error) {
+      messenger.showSnackBar(
+        SnackBar(content: Text(error.message ?? l.consultActionFailed)),
+      );
+    } catch (_) {
+      messenger.showSnackBar(SnackBar(content: Text(l.consultActionFailed)));
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _reject() async {
+    final l = AppLocalizations.of(context);
+    final controller = TextEditingController();
+    final note = await showDialog<String?>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(l.consultRejectTitle),
+        content: TextField(
+          controller: controller,
+          maxLength: 500,
+          maxLines: 3,
+          decoration: InputDecoration(hintText: l.consultRejectHint),
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: Text(l.actionCancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(controller.text.trim()),
+            child: Text(l.consultRejectAction),
+          ),
+        ],
+      ),
+    );
+    controller.dispose();
+    if (note == null || !mounted) return;
+    setState(() => _busy = true);
+    try {
+      await rejectConsultation(ref, widget.request.id, note: note);
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final request = widget.request;
+    return Container(
+      padding: const EdgeInsets.all(AppSpacing.lg),
+      decoration: BoxDecoration(
+        color: AppColors.card,
+        borderRadius: const BorderRadius.all(AppRadius.card),
+        border: Border.all(color: AppColors.borderStrong),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Text(
+            request.memberName,
+            style: const TextStyle(fontSize: 15, fontWeight: FontWeight.w800),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          _line(
+            l.consultExerciseGoal,
+            label(exerciseGoalLabels(l), request.goalCode),
+          ),
+          _line(
+            l.consultHealthPurpose,
+            request.purposeDetail == null
+                ? label(healthPurposeLabels(l), request.purposeCode)
+                : '${label(healthPurposeLabels(l), request.purposeCode)} · '
+                      '${request.purposeDetail}',
+          ),
+          _line(
+            l.consultPreferredTime,
+            '${dateLabel(l, request.preferredDate)} · '
+            '${label(preferredTimeLabels(l), request.preferredTimeCode)}',
+          ),
+          if (request.gymName != null) _line(l.consultGym, request.gymName!),
+          if (request.message != null) ...<Widget>[
+            const SizedBox(height: AppSpacing.sm),
+            Text(
+              request.message!,
+              style: const TextStyle(color: AppColors.mutedForeground),
+            ),
+          ],
+          const SizedBox(height: AppSpacing.lg),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: <Widget>[
+              ActionButton(
+                label: l.consultReject,
+                tone: AppColors.destructive,
+                onPressed: _busy ? null : _reject,
+              ),
+              const SizedBox(width: AppSpacing.sm),
+              ActionButton(
+                label: l.schedNewSession,
+                icon: Icons.event_available_outlined,
+                primary: true,
+                onPressed: _busy ? null : _schedule,
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _line(String name, String value) => Padding(
+    padding: const EdgeInsets.only(bottom: AppSpacing.xs),
+    child: Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        SizedBox(
+          width: 92,
+          child: Text(
+            name,
+            style: const TextStyle(color: AppColors.subtleForeground),
+          ),
+        ),
+        Expanded(child: Text(value)),
+      ],
+    ),
+  );
+}
+
+class _Booking {
+  const _Booking(this.date, this.time, this.durationMinutes);
+
+  final DateTime date;
+  final String time;
+  final int durationMinutes;
+}
+
+class _ScheduleDialog extends StatefulWidget {
+  const _ScheduleDialog({required this.request});
+
+  final ConsultationRequest request;
+
+  @override
+  State<_ScheduleDialog> createState() => _ScheduleDialogState();
+}
+
+class _ScheduleDialogState extends State<_ScheduleDialog> {
+  late DateTime _date = widget.request.preferredDate;
+  late int _hour = switch (widget.request.preferredTimeCode) {
+    'morning' => 10,
+    'afternoon' => 14,
+    'evening' => 19,
+    _ => 10,
+  };
+  int _minute = 0;
+  int _duration = 30;
+
+  String get _time =>
+      '${_hour.toString().padLeft(2, '0')}:${_minute.toString().padLeft(2, '0')}';
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return AlertDialog(
+      title: Text(l.schedAddTitle),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Text(widget.request.memberName),
+          const SizedBox(height: AppSpacing.md),
+          OutlinedButton.icon(
+            icon: const Icon(Icons.calendar_today_outlined),
+            label: Text(dateLabel(l, _date)),
+            onPressed: () async {
+              final picked = await showDatePicker(
+                context: context,
+                initialDate: _date,
+                firstDate: DateTime.now(),
+                lastDate: DateTime.now().add(const Duration(days: 365)),
+              );
+              if (picked != null) setState(() => _date = picked);
+            },
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          Row(
+            children: <Widget>[
+              Expanded(
+                child: DropdownButtonFormField<int>(
+                  initialValue: _hour,
+                  decoration: InputDecoration(labelText: l.schedFieldTime),
+                  items: <DropdownMenuItem<int>>[
+                    for (var hour = 6; hour <= 22; hour++)
+                      DropdownMenuItem(
+                        value: hour,
+                        child: Text(l.schedHourLabel('$hour')),
+                      ),
+                  ],
+                  onChanged: (value) => setState(() => _hour = value ?? _hour),
+                ),
+              ),
+              const SizedBox(width: AppSpacing.sm),
+              Expanded(
+                child: DropdownButtonFormField<int>(
+                  initialValue: _minute,
+                  decoration: InputDecoration(labelText: l.schedMinuteSuffix),
+                  items: <DropdownMenuItem<int>>[
+                    for (final minute in const <int>[0, 15, 30, 45])
+                      DropdownMenuItem(
+                        value: minute,
+                        child: Text(l.schedMinuteLabel('$minute')),
+                      ),
+                  ],
+                  onChanged: (value) =>
+                      setState(() => _minute = value ?? _minute),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          DropdownButtonFormField<int>(
+            initialValue: _duration,
+            decoration: InputDecoration(labelText: l.schedFieldDuration),
+            items: <DropdownMenuItem<int>>[
+              for (final duration in const <int>[30, 45, 60, 90])
+                DropdownMenuItem(value: duration, child: Text('$duration분')),
+            ],
+            onChanged: (value) =>
+                setState(() => _duration = value ?? _duration),
+          ),
+        ],
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(l.actionCancel),
+        ),
+        TextButton(
+          onPressed: () =>
+              Navigator.of(context).pop(_Booking(_date, _time, _duration)),
+          child: Text(l.schedAddAction),
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/flutter_trainer/lib/features/consultations/presentation/widgets/consultation_inbox_sheet.dart
+++ b/frontend/flutter_trainer/lib/features/consultations/presentation/widgets/consultation_inbox_sheet.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:oncare_trainer/core/config/app_config.dart';
 import 'package:oncare_trainer/core/errors/app_error.dart';
 import 'package:oncare_trainer/core/utils/date_format.dart';
+import 'package:oncare_trainer/core/utils/server_message.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
@@ -107,12 +108,11 @@ class _RequestCardState extends ConsumerState<_RequestCard> {
         type: '상담',
         durationMinutes: booking.durationMinutes,
       );
-      await acceptConsultation(ref, widget.request.id, schedule: schedule);
-
       // Demo mode has no backend transaction, so mirror the accepted request
-      // into the local Drift calendar. Real mode receives the entry from the
-      // atomic accept endpoint and only needs its providers refreshed.
-      if (ref.read(appConfigProvider).useMockApi) {
+      // into the local Drift calendar before finalizing the decision. A failed
+      // calendar write therefore leaves the request pending and retryable.
+      final useMockApi = ref.read(appConfigProvider).useMockApi;
+      if (useMockApi) {
         await ref
             .read(scheduleRepositoryProvider)
             .addSession(
@@ -125,6 +125,7 @@ class _RequestCardState extends ConsumerState<_RequestCard> {
               note: widget.request.message ?? '',
             );
       }
+      await acceptConsultation(ref, widget.request.id, schedule: schedule);
       ref.invalidate(scheduleForDateProvider(schedule.date));
       ref.invalidate(bookedDatesProvider);
       if (!mounted) return;
@@ -134,7 +135,11 @@ class _RequestCardState extends ConsumerState<_RequestCard> {
       );
     } on AppError catch (error) {
       messenger.showSnackBar(
-        SnackBar(content: Text(error.message ?? l.consultActionFailed)),
+        SnackBar(
+          content: Text(
+            serverDetailOr(l, error.message, l.consultActionFailed),
+          ),
+        ),
       );
     } catch (_) {
       messenger.showSnackBar(SnackBar(content: Text(l.consultActionFailed)));
@@ -161,18 +166,34 @@ class _RequestCardState extends ConsumerState<_RequestCard> {
             onPressed: () => Navigator.of(context).pop(),
             child: Text(l.actionCancel),
           ),
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(controller.text.trim()),
-            child: Text(l.consultRejectAction),
+          ValueListenableBuilder<TextEditingValue>(
+            valueListenable: controller,
+            builder: (context, value, _) => TextButton(
+              onPressed: value.text.trim().isEmpty
+                  ? null
+                  : () => Navigator.of(context).pop(value.text.trim()),
+              child: Text(l.consultRejectAction),
+            ),
           ),
         ],
       ),
     );
     controller.dispose();
-    if (note == null || !mounted) return;
+    if (note == null || note.isEmpty || !mounted) return;
     setState(() => _busy = true);
+    final messenger = ScaffoldMessenger.of(context);
     try {
       await rejectConsultation(ref, widget.request.id, note: note);
+    } on AppError catch (error) {
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            serverDetailOr(l, error.message, l.consultActionFailed),
+          ),
+        ),
+      );
+    } catch (_) {
+      messenger.showSnackBar(SnackBar(content: Text(l.consultActionFailed)));
     } finally {
       if (mounted) setState(() => _busy = false);
     }
@@ -280,7 +301,7 @@ class _ScheduleDialog extends StatefulWidget {
 }
 
 class _ScheduleDialogState extends State<_ScheduleDialog> {
-  late DateTime _date = widget.request.preferredDate;
+  late DateTime _date;
   late int _hour = switch (widget.request.preferredTimeCode) {
     'morning' => 10,
     'afternoon' => 14,
@@ -289,6 +310,24 @@ class _ScheduleDialogState extends State<_ScheduleDialog> {
   };
   int _minute = 0;
   int _duration = 30;
+
+  @override
+  void initState() {
+    super.initState();
+    final today = DateUtils.dateOnly(DateTime.now());
+    final lastDate = today.add(const Duration(days: 365));
+    _date = _clampDate(
+      DateUtils.dateOnly(widget.request.preferredDate),
+      today,
+      lastDate,
+    );
+  }
+
+  DateTime _clampDate(DateTime value, DateTime first, DateTime last) {
+    if (value.isBefore(first)) return first;
+    if (value.isAfter(last)) return last;
+    return value;
+  }
 
   String get _time =>
       '${_hour.toString().padLeft(2, '0')}:${_minute.toString().padLeft(2, '0')}';
@@ -308,11 +347,13 @@ class _ScheduleDialogState extends State<_ScheduleDialog> {
             icon: const Icon(Icons.calendar_today_outlined),
             label: Text(dateLabel(l, _date)),
             onPressed: () async {
+              final today = DateUtils.dateOnly(DateTime.now());
+              final lastDate = today.add(const Duration(days: 365));
               final picked = await showDatePicker(
                 context: context,
-                initialDate: _date,
-                firstDate: DateTime.now(),
-                lastDate: DateTime.now().add(const Duration(days: 365)),
+                initialDate: _clampDate(_date, today, lastDate),
+                firstDate: today,
+                lastDate: lastDate,
               );
               if (picked != null) setState(() => _date = picked);
             },

--- a/frontend/flutter_trainer/lib/features/notifications/presentation/pages/notifications_page.dart
+++ b/frontend/flutter_trainer/lib/features/notifications/presentation/pages/notifications_page.dart
@@ -30,7 +30,7 @@ class NotificationsPage extends ConsumerWidget {
   /// 알림 종류별 이동할 곳. 모르는 종류는 이동하지 않는다.
   static String? _targetOf(TrainerNotificationKind kind) => switch (kind) {
     TrainerNotificationKind.message => AppRoutes.clients,
-    TrainerNotificationKind.consultation => AppRoutes.consultations,
+    TrainerNotificationKind.consultation => AppRoutes.schedule,
     TrainerNotificationKind.reservation => AppRoutes.schedule,
     TrainerNotificationKind.other => null,
   };

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
@@ -16,6 +16,8 @@ import 'package:oncare_trainer/features/schedule/domain/entities/schedule_sessio
 import 'package:oncare_trainer/features/schedule/presentation/widgets/reservation_slots_sheet.dart';
 import 'package:oncare_trainer/features/search/domain/client_search_scope.dart';
 import 'package:oncare_trainer/features/search/presentation/widgets/client_search_bar.dart';
+import 'package:oncare_trainer/features/consultations/data/repositories/consultation_repository.dart';
+import 'package:oncare_trainer/features/consultations/presentation/widgets/consultation_inbox_sheet.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
 import 'package:oncare_trainer/shared/widgets/action_button.dart';
 import 'package:oncare_trainer/shared/widgets/client_avatar.dart';
@@ -167,6 +169,20 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
     );
   }
 
+  Future<void> _openConsultationInbox() async {
+    final date = await showModalBottomSheet<String>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: AppColors.background,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: AppRadius.card),
+      ),
+      builder: (_) => const ConsultationInboxSheet(),
+    );
+    final day = date == null ? null : DateTime.tryParse(date);
+    if (day != null && mounted) _selectDay(day, toTimeline: true);
+  }
+
   Future<void> _confirmDelete(ScheduleSession s) async {
     final AppLocalizations l = AppLocalizations.of(context);
     final ok = await showDialog<bool>(
@@ -252,6 +268,12 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
     final today = _dateOnly(DateTime.now());
     final defaultAnchor = today.subtract(const Duration(days: 3));
     final showToday = _selectedDay != today || _weekAnchor != defaultAnchor;
+    final consultationInbox = ref.watch(consultationInboxEnabledProvider);
+    final compactConsultationInbox =
+        consultationInbox && MediaQuery.sizeOf(context).width < 900;
+    final pendingConsultations = consultationInbox
+        ? ref.watch(consultationPendingCountProvider).valueOrNull
+        : null;
 
     return PageScaffold(
       title: l.schedTitle,
@@ -260,6 +282,16 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
       // booking and picking one moves the calendar to that day.
       headerCenter: const ClientSearchBar(scope: ClientSearchScope.schedule),
       actions: <Widget>[
+        if (consultationInbox && !compactConsultationInbox)
+          Badge(
+            isLabelVisible: (pendingConsultations ?? 0) > 0,
+            label: Text('${pendingConsultations ?? 0}'),
+            child: ActionButton(
+              label: l.consultTitle,
+              icon: Icons.mark_email_unread_outlined,
+              onPressed: _openConsultationInbox,
+            ),
+          ),
         if (showToday)
           ActionButton(
             label: l.labelToday,
@@ -300,7 +332,26 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
       // spins up a new provider that starts in `loading`, and blanking
       // the whole page to a spinner each tap made the strip flicker.
       // Only the session list reacts to the async state (review PR 245).
-      child: _weekView ? _buildWeekGrid() : _buildDayView(schedule),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          if (compactConsultationInbox)
+            ListTile(
+              dense: true,
+              leading: Badge(
+                isLabelVisible: (pendingConsultations ?? 0) > 0,
+                label: Text('${pendingConsultations ?? 0}'),
+                child: const Icon(Icons.mark_email_unread_outlined),
+              ),
+              title: Text(l.consultTitle),
+              trailing: const Icon(Icons.arrow_forward_ios, size: 16),
+              onTap: _openConsultationInbox,
+            ),
+          Expanded(
+            child: _weekView ? _buildWeekGrid() : _buildDayView(schedule),
+          ),
+        ],
+      ),
     );
   }
 

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
@@ -269,8 +269,6 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
     final defaultAnchor = today.subtract(const Duration(days: 3));
     final showToday = _selectedDay != today || _weekAnchor != defaultAnchor;
     final consultationInbox = ref.watch(consultationInboxEnabledProvider);
-    final compactConsultationInbox =
-        consultationInbox && MediaQuery.sizeOf(context).width < 900;
     final pendingConsultations = consultationInbox
         ? ref.watch(consultationPendingCountProvider).valueOrNull
         : null;
@@ -282,16 +280,6 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
       // booking and picking one moves the calendar to that day.
       headerCenter: const ClientSearchBar(scope: ClientSearchScope.schedule),
       actions: <Widget>[
-        if (consultationInbox && !compactConsultationInbox)
-          Badge(
-            isLabelVisible: (pendingConsultations ?? 0) > 0,
-            label: Text('${pendingConsultations ?? 0}'),
-            child: ActionButton(
-              label: l.consultTitle,
-              icon: Icons.mark_email_unread_outlined,
-              onPressed: _openConsultationInbox,
-            ),
-          ),
         if (showToday)
           ActionButton(
             label: l.labelToday,
@@ -335,7 +323,7 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
-          if (compactConsultationInbox)
+          if (consultationInbox)
             ListTile(
               dense: true,
               leading: Badge(

--- a/frontend/flutter_trainer/test/features/consultations/consultations_page_test.dart
+++ b/frontend/flutter_trainer/test/features/consultations/consultations_page_test.dart
@@ -61,7 +61,7 @@ class _FakeConsultationRepository implements ConsultationRepository {
   Future<int> pendingCount() async => requests.where((r) => r.isPending).length;
 
   @override
-  Future<void> accept(String id) async {
+  Future<void> accept(String id, {ConsultationSchedule? schedule}) async {
     accepted.add(id);
     requests = requests
         .map((r) => r.id == id ? _request(id: id, status: 'accepted') : r)
@@ -172,14 +172,19 @@ void main() {
     await withWideSurface(tester, () async {
       await pumpTrainerApp(tester, token: 'demo-token');
 
-      expect(find.text(navLabel(_ko, consultationsDestination.label)), findsNothing);
+      expect(
+        find.text(navLabel(_ko, consultationsDestination.label)),
+        findsNothing,
+      );
       for (final destination in navDestinations) {
         expect(find.text(navLabel(_ko, destination.label)), findsWidgets);
       }
     });
   });
 
-  testWidgets('the real-API console does show it', (tester) async {
+  testWidgets('the real-API console also keeps the separate row hidden', (
+    tester,
+  ) async {
     await withWideSurface(tester, () async {
       await pumpTrainerApp(
         tester,
@@ -191,7 +196,10 @@ void main() {
         ],
       );
 
-      expect(find.text(navLabel(_ko, consultationsDestination.label)), findsOneWidget);
+      expect(
+        find.text(navLabel(_ko, consultationsDestination.label)),
+        findsNothing,
+      );
     });
   });
 }

--- a/frontend/flutter_trainer/test/features/consultations/dio_consultation_repository_test.dart
+++ b/frontend/flutter_trainer/test/features/consultations/dio_consultation_repository_test.dart
@@ -161,6 +161,7 @@ void main() {
               as Map<String, Object?>;
       expect(data['date'], '2026-08-12');
       expect(data['time'], '19:30');
+      expect(data['type'], '상담');
       expect(data['duration_minutes'], 30);
     });
 

--- a/frontend/flutter_trainer/test/features/consultations/dio_consultation_repository_test.dart
+++ b/frontend/flutter_trainer/test/features/consultations/dio_consultation_repository_test.dart
@@ -56,22 +56,19 @@ void main() {
           queryParameters: any(named: 'queryParameters'),
         ),
       ).thenAnswer(
-        (_) async => _ok<List<dynamic>>(
-          <dynamic>[
-            <String, Object?>{
-              'id': 'consult-1',
-              'member_id': 'u1',
-              'member_name': '김민수',
-              'exercise_goal': 'strength',
-              'health_purpose_type': 'general',
-              'preferred_date': '2026-08-12',
-              'preferred_time_slot': 'morning',
-              'status': 'pending',
-              'via_gym': true,
-            },
-          ],
-          '/trainer/consultations',
-        ),
+        (_) async => _ok<List<dynamic>>(<dynamic>[
+          <String, Object?>{
+            'id': 'consult-1',
+            'member_id': 'u1',
+            'member_name': '김민수',
+            'exercise_goal': 'strength',
+            'health_purpose_type': 'general',
+            'preferred_date': '2026-08-12',
+            'preferred_time_slot': 'morning',
+            'status': 'pending',
+            'via_gym': true,
+          },
+        ], '/trainer/consultations'),
       );
 
       final list = await repo.fetch();
@@ -79,12 +76,14 @@ void main() {
       expect(list, hasLength(1));
       expect(list.single.memberName, '김민수');
       expect(list.single.viaGym, isTrue);
-      final captured = verify(
-        () => dio.get<List<dynamic>>(
-          '/trainer/consultations',
-          queryParameters: captureAny(named: 'queryParameters'),
-        ),
-      ).captured.single as Map<String, Object?>;
+      final captured =
+          verify(
+                () => dio.get<List<dynamic>>(
+                  '/trainer/consultations',
+                  queryParameters: captureAny(named: 'queryParameters'),
+                ),
+              ).captured.single
+              as Map<String, Object?>;
       expect(captured['status'], 'pending');
     });
 
@@ -121,10 +120,9 @@ void main() {
           '/trainer/consultations/pending-count',
         ),
       ).thenAnswer(
-        (_) async => _ok<Map<String, Object?>>(
-          <String, Object?>{'count': 3},
-          '/trainer/consultations/pending-count',
-        ),
+        (_) async => _ok<Map<String, Object?>>(<String, Object?>{
+          'count': 3,
+        }, '/trainer/consultations/pending-count'),
       );
 
       expect(await repo.pendingCount(), 3);
@@ -143,14 +141,27 @@ void main() {
         ),
       );
 
-      await repo.accept('consult-1');
-
-      verify(
-        () => dio.post<Map<String, Object?>>(
-          '/trainer/consultations/consult-1/accept',
-          data: any(named: 'data'),
+      await repo.accept(
+        'consult-1',
+        schedule: const ConsultationSchedule(
+          date: '2026-08-12',
+          time: '19:30',
+          type: '상담',
+          durationMinutes: 30,
         ),
-      ).called(1);
+      );
+
+      final data =
+          verify(
+                () => dio.post<Map<String, Object?>>(
+                  '/trainer/consultations/consult-1/accept',
+                  data: captureAny(named: 'data'),
+                ),
+              ).captured.single
+              as Map<String, Object?>;
+      expect(data['date'], '2026-08-12');
+      expect(data['time'], '19:30');
+      expect(data['duration_minutes'], 30);
     });
 
     test('reject carries the note the member will receive', () async {
@@ -168,42 +179,47 @@ void main() {
 
       await repo.reject('consult-1', note: '정원이 찼어요');
 
-      final data = verify(
-        () => dio.post<Map<String, Object?>>(
-          '/trainer/consultations/consult-1/reject',
-          data: captureAny(named: 'data'),
-        ),
-      ).captured.single as Map<String, Object?>;
+      final data =
+          verify(
+                () => dio.post<Map<String, Object?>>(
+                  '/trainer/consultations/consult-1/reject',
+                  data: captureAny(named: 'data'),
+                ),
+              ).captured.single
+              as Map<String, Object?>;
       expect(data['note'], '정원이 찼어요');
     });
 
-    test("409's own reason survives as the message shown to the trainer", () async {
-      when(
-        () => dio.post<Map<String, Object?>>(
-          '/trainer/consultations/consult-1/accept',
-          data: any(named: 'data'),
-        ),
-      ).thenThrow(
-        _httpError(
-          409,
-          '/trainer/consultations/consult-1/accept',
-          body: <String, Object?>{'detail': '이미 다른 트레이너가 담당 중인 회원입니다.'},
-        ),
-      );
-
-      // The whole point of the 409 is its sentence — a generic network
-      // error would leave the trainer with no idea why it failed.
-      await expectLater(
-        repo.accept('consult-1'),
-        throwsA(
-          isA<ValidationError>().having(
-            (e) => e.message,
-            'message',
-            '이미 다른 트레이너가 담당 중인 회원입니다.',
+    test(
+      "409's own reason survives as the message shown to the trainer",
+      () async {
+        when(
+          () => dio.post<Map<String, Object?>>(
+            '/trainer/consultations/consult-1/accept',
+            data: any(named: 'data'),
           ),
-        ),
-      );
-    });
+        ).thenThrow(
+          _httpError(
+            409,
+            '/trainer/consultations/consult-1/accept',
+            body: <String, Object?>{'detail': '이미 다른 트레이너가 담당 중인 회원입니다.'},
+          ),
+        );
+
+        // The whole point of the 409 is its sentence — a generic network
+        // error would leave the trainer with no idea why it failed.
+        await expectLater(
+          repo.accept('consult-1'),
+          throwsA(
+            isA<ValidationError>().having(
+              (e) => e.message,
+              'message',
+              '이미 다른 트레이너가 담당 중인 회원입니다.',
+            ),
+          ),
+        );
+      },
+    );
 
     test('a 404 stays a typed transport error', () async {
       when(
@@ -213,10 +229,7 @@ void main() {
         ),
       ).thenThrow(_httpError(404, '/trainer/consultations/nope/accept'));
 
-      await expectLater(
-        repo.accept('nope'),
-        throwsA(isA<NotFoundError>()),
-      );
+      await expectLater(repo.accept('nope'), throwsA(isA<NotFoundError>()));
     });
 
     test('ids are percent-encoded into the path', () async {
@@ -244,11 +257,9 @@ void main() {
   });
 
   group('consultationRepositoryProvider', () {
-    test('demo mode resolves the inbox-less source', () {
+    test('demo mode exposes the seeded schedule inbox', () {
       final container = ProviderContainer(
-        overrides: <Override>[
-          appConfigProvider.overrideWithValue(_demoConfig),
-        ],
+        overrides: <Override>[appConfigProvider.overrideWithValue(_demoConfig)],
       );
       addTearDown(container.dispose);
 
@@ -258,7 +269,7 @@ void main() {
       );
       // The demo console must look exactly as it does today — no inbox
       // row, no badge.
-      expect(container.read(consultationInboxEnabledProvider), isFalse);
+      expect(container.read(consultationInboxEnabledProvider), isTrue);
     });
 
     test('real-API mode resolves the Dio source', () {
@@ -277,23 +288,23 @@ void main() {
       expect(container.read(consultationInboxEnabledProvider), isTrue);
     });
 
-    test('the demo badge count is zero without issuing a request', () async {
+    test('the demo badge count includes the seeded request', () async {
       final container = ProviderContainer(
-        overrides: <Override>[
-          appConfigProvider.overrideWithValue(_demoConfig),
-        ],
+        overrides: <Override>[appConfigProvider.overrideWithValue(_demoConfig)],
       );
       addTearDown(container.dispose);
 
-      expect(await container.read(consultationPendingCountProvider.future), 0);
+      expect(await container.read(consultationPendingCountProvider.future), 1);
     });
 
-    test('the demo source refuses decisions rather than faking them', () async {
-      const repo = DemoConsultationRepository();
+    test('the demo source removes decided requests from pending', () async {
+      final repo = DemoConsultationRepository();
+      final request = (await repo.fetch()).single;
+
+      await repo.accept(request.id);
 
       expect(await repo.fetch(), isEmpty);
-      await expectLater(repo.accept('x'), throwsA(isA<ValidationError>()));
-      await expectLater(repo.reject('x'), throwsA(isA<ValidationError>()));
+      expect((await repo.fetch(status: 'all')).single.status, 'accepted');
     });
   });
 }

--- a/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
@@ -10,6 +10,8 @@ import 'package:oncare_trainer/app/router/routes.dart';
 import 'package:oncare_trainer/core/storage/app_database.dart';
 import 'package:oncare_trainer/core/storage/seed_data.dart';
 import 'package:oncare_trainer/core/utils/date_format.dart';
+import 'package:oncare_trainer/features/consultations/data/repositories/consultation_repository.dart';
+import 'package:oncare_trainer/features/consultations/domain/entities/consultation_request.dart';
 import 'package:oncare_trainer/features/schedule/data/repositories/schedule_repository.dart';
 import 'package:oncare_trainer/features/schedule/domain/entities/schedule_session.dart';
 import 'package:oncare_trainer/shared/services/chat_repository.dart';
@@ -437,6 +439,95 @@ void main() {
       expect(find.text('퇴근 후 가능한 시간으로 첫 상담을 받고 싶어요.'), findsOneWidget);
       expect(find.text('거절'), findsOneWidget);
       expect(find.text('새 일정'), findsWidgets);
+    });
+
+    testWidgets(
+      'failed demo schedule write keeps the consultation pending for retry',
+      (tester) async {
+        final container = await pumpTrainerApp(
+          tester,
+          token: 'demo-trainer-token',
+          at: AppRoutes.schedule,
+          extraOverrides: <Override>[
+            scheduleRepositoryProvider.overrideWith(
+              (ref) =>
+                  _ThrowingScheduleRepository(ref.watch(appDatabaseProvider)),
+            ),
+          ],
+        );
+        final consultations = container.read(consultationRepositoryProvider);
+
+        await tester.tap(find.text('상담 요청'));
+        await settle(tester);
+        await tester.tap(find.text('새 일정').last);
+        await settle(tester);
+        await tester.tap(find.text('추가하기'));
+        await settle(tester);
+
+        expect(await consultations.pendingCount(), 1);
+        expect((await consultations.fetch()).single.isPending, isTrue);
+        expect(find.text('상담을 처리하지 못했어요'), findsOneWidget);
+      },
+    );
+
+    testWidgets('past preferred date opens a valid consultation date picker', (
+      tester,
+    ) async {
+      final consultations = DemoConsultationRepository(
+        requests: <ConsultationRequest>[
+          ConsultationRequest(
+            id: 'past-consultation',
+            memberId: 'past-member',
+            memberName: '과거희망일 회원',
+            goalCode: 'fitness',
+            purposeCode: 'general',
+            preferredDate: DateTime(2020),
+            preferredTimeCode: 'morning',
+            status: 'pending',
+          ),
+        ],
+      );
+      await pumpTrainerApp(
+        tester,
+        token: 'demo-trainer-token',
+        at: AppRoutes.schedule,
+        extraOverrides: <Override>[
+          consultationRepositoryProvider.overrideWithValue(consultations),
+        ],
+      );
+
+      await tester.tap(find.text('상담 요청'));
+      await settle(tester);
+      await tester.tap(find.text('새 일정').last);
+      await settle(tester);
+      await tester.tap(find.byIcon(Icons.calendar_today_outlined));
+      await settle(tester);
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(DatePickerDialog), findsOneWidget);
+    });
+
+    testWidgets('blank consultation rejection reason cannot be submitted', (
+      tester,
+    ) async {
+      await openSchedule(tester);
+
+      await tester.tap(find.text('상담 요청'));
+      await settle(tester);
+      await tester.tap(find.text('거절'));
+      await settle(tester);
+
+      TextButton rejectButton() =>
+          tester.widget<TextButton>(find.widgetWithText(TextButton, '반려하기'));
+      expect(rejectButton().onPressed, isNull);
+
+      await tester.enterText(find.byType(TextField).last, '   ');
+      await tester.pump();
+      expect(rejectButton().onPressed, isNull);
+
+      await tester.enterText(find.byType(TextField).last, '요청 시간 조율 필요');
+      await tester.pump();
+      expect(rejectButton().onPressed, isNotNull);
     });
 
     testWidgets('예약 슬롯 action opens the selected-day management sheet', (

--- a/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
@@ -425,6 +425,20 @@ void main() {
       expect(find.text('예정'), findsWidgets);
     });
 
+    testWidgets('consultation inbox opens from the schedule tab', (
+      tester,
+    ) async {
+      await openSchedule(tester);
+
+      await tester.tap(find.text('상담 요청'));
+      await settle(tester);
+
+      expect(find.text('김하늘'), findsOneWidget);
+      expect(find.text('퇴근 후 가능한 시간으로 첫 상담을 받고 싶어요.'), findsOneWidget);
+      expect(find.text('거절'), findsOneWidget);
+      expect(find.text('새 일정'), findsWidgets);
+    });
+
     testWidgets('예약 슬롯 action opens the selected-day management sheet', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary

* 트레이너 스케줄 탭에서 대기 중인 상담 요청과 상세 내용을 바로 확인할 수 있는 인박스를 추가했습니다.
* 상담 요청을 승인하면서 상담 일정을 등록하거나, 사유와 함께 거절할 수 있는 흐름을 연결했습니다.
* 승인·회원 연결·일정 생성이 부분 반영되지 않도록 백엔드 트랜잭션과 관련 테스트를 보강했습니다.

---

## Changes

### ✨ Features

* 스케줄 화면 헤더에 상담 요청 버튼과 대기 건수 배지를 추가했습니다.
* 좁은 화면에서는 스케줄 콘텐츠 상단에서 상담 요청 인박스를 열 수 있게 했습니다.
* 상담 요청 목록, 요청 상세, 일정 등록 및 거절 UI를 포함한 인박스 시트를 추가했습니다.
* 승인 요청에 `date`, `time`, `type`, `duration_minutes` 일정 정보를 전달할 수 있게 했습니다.
* 일정 정보가 포함된 승인 시 회원 연결과 스케줄 생성을 하나의 처리 흐름으로 묶었습니다.

### 🛠 Improvements

* 사용자 앱이 이미 보내고 있던 운동 목표, 건강관리 목적·상세, 희망 일시, 메시지 및 문의 지점을 트레이너가 활용할 수 있게 했습니다.
* 별도 상담 사이드바 메뉴를 제거하고 상담 진입점을 실제 후속 업무가 이뤄지는 스케줄 탭으로 통합했습니다.
* 알림에서 상담 요청을 선택해도 스케줄 탭의 상담 인박스로 이동하도록 정리했습니다.
* 실 API와 데모 저장소가 동일한 승인·거절 인터페이스를 사용하도록 맞췄습니다.

### 🎨 UI/UX

* 대기 요청 수를 배지로 표시해 확인이 필요한 상담을 놓치지 않게 했습니다.
* 일정 등록 시 회원 희망 날짜·시간을 기본값으로 제안하고 트레이너가 날짜, 시간, 유형, 소요 시간을 조정할 수 있게 했습니다.
* 처리 완료된 요청은 대기 목록에서 제거되어 현재 필요한 요청에 집중할 수 있습니다.

### 📚 Docs

* 별도 문서 변경은 없습니다.

### 🐛 Fixes

* 사용자 앱에서 생성된 상담 요청이 트레이너 웹에서 실제 업무 흐름으로 이어지지 않던 데이터 활용 공백을 해소했습니다.
* 상담 승인만 성공하고 회원 연결 또는 일정 생성이 실패하는 부분 성공 가능성을 줄였습니다.

---

## Commits

1. `23f4d0f` feat: integrate consultation requests into trainer schedule

---

## Notes

* 브랜치의 기준 커밋이 현재 `origin/main`보다 이전이므로 push 전 최신 main rebase 및 충돌 확인을 권장합니다.
* 승인과 함께 등록되는 일정의 기본 유형과 시간은 인박스에서 변경할 수 있습니다.

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [ ] UI 수동 확인
* [ ] 전체 빌드 성공
* [x] 관련 테스트 추가

### Manual Test Steps

1. 사용자 앱에서 트레이너 또는 지점을 선택하고 희망 일시와 메시지를 포함한 상담 요청을 생성합니다.
2. 트레이너 웹 스케줄 탭에서 대기 배지와 요청 상세가 표시되는지 확인합니다.
3. `일정 등록`을 선택해 날짜·시간·유형·소요 시간을 조정하고 저장한 뒤 스케줄에 즉시 나타나는지 확인합니다.
4. 다른 요청을 사유와 함께 거절하고 대기 목록에서 사라지는지 확인합니다.
5. 승인 처리 중 일정 생성이 실패하는 상황에서 승인·회원 연결이 부분 반영되지 않는지 확인합니다.

---

## Related Issues

Closes #632

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [ ] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 상담 요청 인박스에서 요청을 확인하고 승인 또는 거절할 수 있습니다.
  - 승인 시 첫 상담 날짜, 시간, 유형, 소요 시간을 함께 등록할 수 있습니다.
  - 상담 일정이 스케줄에 자동으로 생성되며, 선호 일정이 입력 화면에 기본값으로 표시됩니다.
  - 스케줄 화면에서 대기 중인 상담 건수와 인박스로 바로 이동할 수 있습니다.
- **개선 사항**
  - 상담 관련 알림이 스케줄 화면으로 연결됩니다.
  - 불완전한 일정 정보 입력을 방지하고, 상담 처리 오류를 적절한 상태로 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->