### PR TITLE
fix(auth): 트레이너 웹 갱신 실패에서 일시적 오류와 세션 만료를 구분

### DIFF
--- a/frontend/flutter_trainer/lib/features/auth/presentation/controllers/session_controller.dart
+++ b/frontend/flutter_trainer/lib/features/auth/presentation/controllers/session_controller.dart
@@ -106,15 +106,46 @@ class SessionController extends StateNotifier<SessionState> {
       } else {
         await _expire();
       }
-    } on AuthException {
+    } on AuthException catch (e) {
       if (_userActionStarted) return;
-      await _expire();
+      // 인증 계열 실패라도 **명시적으로 거부된 것만** 세션의 끝이다. 같은 예외로
+      // 실려 오는 연결 실패·서버 오류를 만료로 처리하면, 잠깐 끊긴 사용자에게
+      // 재로그인을 요구하게 된다.
+      if (_endsSession(e.failure)) {
+        await _expire();
+      } else {
+        _keepTokensAndSignOut();
+      }
     } catch (_) {
       // Transient (network/server) — keep tokens, just show signed out.
       if (!mounted || _userActionStarted) return;
-      _setAccessToken(null);
-      state = const SessionState(status: SessionStatus.signedOut);
+      _keepTokensAndSignOut();
     }
+  }
+
+  /// 이 실패가 **세션의 끝**인가.
+  ///
+  /// 서버가 자격을 거부한 것(만료·잘못된 자격·트레이너 아님)만 해당한다. 연결 실패나
+  /// 계약이 깨진 응답은 다음 실행에서 다시 시도할 여지가 있으므로 토큰을 남긴다.
+  bool _endsSession(AuthFailure failure) => switch (failure) {
+    AuthFailure.sessionExpired ||
+    AuthFailure.invalidCredentials ||
+    AuthFailure.notTrainer => true,
+    AuthFailure.network ||
+    AuthFailure.emptyResponse ||
+    AuthFailure.unknown ||
+    AuthFailure.emailTaken ||
+    AuthFailure.inviteCodeInvalid ||
+    AuthFailure.noSocialToken ||
+    AuthFailure.emptyCredentials => false,
+  };
+
+  /// 이번에는 못 들어갔지만 세션이 끝난 것은 아니다 — 저장된 토큰을 남긴 채 로그인
+  /// 화면으로 보낸다. 다음 실행에서 다시 시도한다.
+  void _keepTokensAndSignOut() {
+    if (!mounted || _userActionStarted) return;
+    _setAccessToken(null);
+    state = const SessionState(status: SessionStatus.signedOut);
   }
 
   Future<void> _refreshAndResolve(String refresh) async {
@@ -122,12 +153,21 @@ class SessionController extends StateNotifier<SessionState> {
     final TrainerAuthTokens tokens;
     try {
       tokens = await _repo.refresh(refresh);
-    } catch (_) {
+    } on AuthException catch (e) {
       // The refresh failed — but a user action (login/demo/sign-out) may
-      // have landed during the slow call; don't clobber it. Otherwise the
-      // session really is expired.
+      // have landed during the slow call; don't clobber it.
       if (_userActionStarted) return;
-      await _expire();
+      // 확인 요청과 같은 기준을 쓴다. 예전에는 여기서 모든 실패를 만료로 보내,
+      // 갱신이 연결 실패나 서버 오류로 끝나도 저장된 토큰을 지웠다.
+      if (_endsSession(e.failure)) {
+        await _expire();
+      } else {
+        _keepTokensAndSignOut();
+      }
+      return;
+    } catch (_) {
+      if (_userActionStarted) return;
+      _keepTokensAndSignOut();
       return;
     }
     // Re-check the race guard after the await, like every _resolveSession
@@ -203,7 +243,9 @@ class SessionController extends StateNotifier<SessionState> {
         profile: profile,
       );
     } catch (e) {
-      await _expire();
+      // 로그인·가입·소셜이 실패한 것이라 이 만료도 그 사용자 행동의 일부다 —
+      // 사용자 행동 가드에 막히면 거부된 자격이 저장소에 남는다.
+      await _expire(userInitiated: true);
       if (e is AuthException) rethrow;
       throw const AuthException(AuthFailure.unknown);
     }
@@ -237,7 +279,8 @@ class SessionController extends StateNotifier<SessionState> {
   /// Signs out — clears persisted tokens and returns to the login screen.
   Future<void> signOut() async {
     _userActionStarted = true;
-    await _expire();
+    // 사용자가 직접 요청한 만료다 — 자기 자신의 가드에 막히면 안 된다.
+    await _expire(userInitiated: true);
   }
 
   // --- helpers ------------------------------------------------------------
@@ -271,11 +314,25 @@ class SessionController extends StateNotifier<SessionState> {
   }
 
   /// Clears tokens + in-memory state and lands signed out.
-  Future<void> _expire() async {
+  /// 세션을 끝내고 저장된 토큰을 지운다.
+  ///
+  /// [userInitiated] 는 **이 만료가 지금 진행 중인 사용자 행동의 일부인가**다.
+  /// 로그아웃, 그리고 로그인·가입·소셜이 거부되어 방금 받은 자격을 지우는 경우가
+  /// 여기 해당한다. 이때 사용자 행동 가드를 적용하면 그 행동이 자기 자신의 가드에
+  /// 막혀 아무 일도 일어나지 않는다.
+  ///
+  /// 기본값(false)은 복구가 만료로 흘러가는 경우다. 이때는 **지우기 전에** 확인한다.
+  /// 느린 복구 중에 로그인이 끝났다면 저장소에는 방금 받은 토큰이 들어 있고, 저장소
+  /// 작업은 큐로 직렬화되어 나중에 들어간 것이 뒤에 실행되므로, 뒤늦은 만료의 `clear`
+  /// 는 그 저장을 **확실히** 덮어쓴다 — 화면은 로그인 상태인데 다음 실행에서 로그아웃된다.
+  Future<void> _expire({bool userInitiated = false}) async {
+    if (!mounted) return;
+    if (!userInitiated && _userActionStarted) return;
     await _clearPersistedTokens();
     // `_setAccessToken` reads a provider — guard it behind the mounted check
     // so it never runs against a disposed container during teardown.
     if (!mounted) return;
+    if (!userInitiated && _userActionStarted) return;
     _setAccessToken(null);
     state = const SessionState(status: SessionStatus.signedOut);
   }

--- a/frontend/flutter_trainer/test/features/auth/session_controller_test.dart
+++ b/frontend/flutter_trainer/test/features/auth/session_controller_test.dart
@@ -149,6 +149,42 @@ void main() {
       );
     });
 
+    // 갱신 요청 자체가 실패하는 갈래 — 예전에는 원인을 가리지 않고 만료로 처리해
+    // 저장 토큰을 지웠다. 확인 요청과 같은 기준(명시적 거부만 만료)을 쓴다. (#641)
+    for (final (String, AuthFailure) row in <(String, AuthFailure)>[
+      ('연결 실패', AuthFailure.network),
+      ('응답 본문 없음', AuthFailure.emptyResponse),
+      ('알 수 없는 전송 실패', AuthFailure.unknown),
+    ]) {
+      final String name = row.$1;
+      final AuthFailure failure = row.$2;
+      test('갱신이 $name 로 끝나면 저장 토큰을 지우지 않는다', () async {
+        final fake = _FakeAuthRepository()
+          ..profileFailuresBeforeSuccess = 1
+          ..refreshThrows = true
+          ..refreshFailure = failure;
+        final container = _makeContainer(
+          tokens: <String, String>{
+            'access_token': 'stale',
+            'refresh_token': 'valid-refresh',
+          },
+          repoOverride: trainerAuthRepositoryProvider.overrideWithValue(fake),
+        );
+        container.read(sessionControllerProvider.notifier);
+        await _settle();
+
+        expect(
+          container.read(sessionControllerProvider).status,
+          SessionStatus.signedOut,
+        );
+        // 접근 토큰이 만료됐어도 갱신이 **거부된 것은 아니다.** 지우면 잠깐 끊긴
+        // 사용자에게 재로그인을 요구하게 된다.
+        final store = container.read(secureTokenStoreProvider);
+        expect(await store.readAccessToken(), 'stale');
+        expect(await store.readRefreshToken(), 'valid-refresh');
+      });
+    }
+
     test(
       'keeps the stored tokens on a transient network failure at restore',
       () async {
@@ -385,6 +421,9 @@ class _FakeAuthRepository implements TrainerAuthRepository {
   bool profileThrowsNotTrainer = false;
   bool profileThrowsNetwork = false;
   bool refreshThrows = false;
+
+  /// `refreshThrows` 일 때 던질 실패 코드. 기본은 실제 만료.
+  AuthFailure refreshFailure = AuthFailure.sessionExpired;
   bool refreshReturnsEmptyRefresh = false;
   Duration profileDelay = Duration.zero;
   Duration refreshDelay = Duration.zero;
@@ -423,7 +462,7 @@ class _FakeAuthRepository implements TrainerAuthRepository {
     refreshCalls++;
     if (!onRefreshEntered.isCompleted) onRefreshEntered.complete();
     if (refreshDelay > Duration.zero) await Future<void>.delayed(refreshDelay);
-    if (refreshThrows) throw const AuthException(AuthFailure.sessionExpired);
+    if (refreshThrows) throw AuthException(refreshFailure);
     return TrainerAuthTokens(
       access: 'rotated-access',
       refresh: refreshReturnsEmptyRefresh ? '' : 'rotated-refresh',


### PR DESCRIPTION
Closes #641

## Summary

트레이너 웹의 세션 복구가 갱신 요청의 **일시적 실패와 세션 만료를 구분하지 않았다.**
`catch (_)` 가 모든 실패를 만료로 보내 저장된 토큰을 지우므로, 네트워크가 잠깐 끊기거나
서버가 오류를 줘도 재로그인을 요구하게 된다.

사용자 앱에서 같은 결함을 먼저 고쳤고(#618 / PR #627), 그때 참조 구현으로 삼았던 원본이
여기다.

## Changes

**저장소는 이미 실패를 구분해서 던지고 있었다.** 상태 코드를 다시 볼 필요 없이
`AuthFailure` 로 갈랐다.

| `AuthFailure` | 처리 |
| --- | --- |
| `sessionExpired` · `invalidCredentials` · `notTrainer` | 세션의 끝 — 토큰을 지운다 |
| `network` · `emptyResponse` · `unknown` 등 | 토큰을 남기고 로그아웃 상태로만 |

같은 파일의 확인 요청 경로는 이미 이 기준을 지키고 있었다 — `fetchProfile` 이 전송 실패를
`AuthException` 이 아닌 `AppError` 로 던지고 그 이유를 주석에 남겨 두었다. **한 경로만
어긋나 있던 것**을 맞춘 셈이다.

**만료가 지우기 전에 사용자 행동을 확인한다.** 느린 복구가 만료로 흘러가는 사이 로그인이
끝나면 저장소에는 방금 받은 토큰이 들어 있다. 저장소 작업이 큐로 직렬화되어 나중에 들어간
것이 뒤에 실행되므로, 뒤늦은 만료의 지우기는 그 저장을 **확실히** 덮어쓴다(사용자 앱에서는
타이밍에 따라 갈렸지만 여기서는 결정적이다).

다만 만료를 **일으킨 주체**를 구분해야 했다. 로그아웃, 그리고 로그인·가입·소셜이 거부되어
방금 받은 자격을 지우는 경우는 그 사용자 행동의 일부라 가드를 적용하면 자기 자신에게
막힌다. **기존 테스트 두 개가 이것을 잡아냈다** — 처음 구현에서 로그아웃과 비트레이너
계정 거부가 동작하지 않았다.

## Verification

- 갱신이 연결 실패·응답 본문 없음·알 수 없는 전송 실패로 끝나는 세 갈래에 회귀 테스트를
  더했다. **수정 전 컨트롤러에서 정확히 이 셋이 실패하는 것을 확인**했다.
- 트레이너 웹 테스트 512개 통과.

## Notes

`flutter analyze` 가 트레이너 웹에서 오류 4건을 낸다 — `test_driver/integration_test.dart`
가 `integration_test` 패키지를 참조하는데 dev 의존성에 없다. **main 에서도 동일하게 재현되며
이 PR 과 무관**하다(#629 / #630 의 e2e 작업 관련). 건드리지 않았고, 담당자가 보는 편이 맞다고
판단해 남겨 둔다.
