### PR TITLE
fix(trainer): 고객 상세 전환 시 목록 깜빡임 제거

### DIFF
--- a/frontend/flutter_trainer/lib/app/router/app_router.dart
+++ b/frontend/flutter_trainer/lib/app/router/app_router.dart
@@ -95,10 +95,12 @@ GoRouter buildAppRouter({
                   // a pushed screen — one widget owns the layout choice.
                   GoRoute(
                     path: AppRoutes.clientDetailPattern,
-                    builder: (context, state) => ClientsPage(
-                      selectedId: state.pathParameters['id'],
-                      section: state.pathParameters['section'],
-                      filter: state.uri.queryParameters['f'],
+                    pageBuilder: (context, state) => NoTransitionPage<void>(
+                      child: ClientsPage(
+                        selectedId: state.pathParameters['id'],
+                        section: state.pathParameters['section'],
+                        filter: state.uri.queryParameters['f'],
+                      ),
                     ),
                   ),
                 ],

--- a/frontend/flutter_trainer/test/features/clients/clients_split_view_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/clients_split_view_test.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import 'package:oncare_trainer/app/router/routes.dart';
 import 'package:oncare_trainer/design_system/tokens/layout.dart';
+import 'package:oncare_trainer/features/clients/presentation/pages/clients_page.dart';
 import 'package:oncare_trainer/features/clients/presentation/widgets/client_card.dart';
 
 import '../../helpers/pump_app.dart';
@@ -67,6 +68,22 @@ void main() {
     expect(find.text('채팅'), findsOneWidget);
     expect(find.text('식단'), findsOneWidget);
     expect(find.byIcon(Icons.arrow_back_ios_new), findsNothing);
+  });
+
+  testWidgets('picking a client does not expose the parent roster during '
+      'the route change', (tester) async {
+    await openWide(tester);
+
+    await tester.tap(card('김민수'));
+    await tester.pump();
+    await tester.pump();
+
+    // The detail route is nested under `/clients`. A default Material page
+    // transition leaves the parent roster exposed while the new page enters,
+    // which appears as a brief roster flash. The router consumes the first
+    // pump; the second is the first frame that contains the detail route.
+    expect(find.byType(ClientsPage), findsOneWidget);
+    expect(find.text('오늘 영양 요약'), findsOneWidget);
   });
 
   testWidgets('the close button collapses the panel back to the list', (


### PR DESCRIPTION
## Summary

* 트레이너 웹 고객 목록에서 고객을 선택할 때 목록 화면이 한 프레임 다시 노출되던 깜빡임을 제거했습니다.
* 고객 상세 중첩 라우트의 기본 Material 전환을 `NoTransitionPage`로 변경했습니다.
* URL 기반 고객·하위 탭 상태, 넓은 화면의 master-detail, 좁은 화면의 상세 대체 구조는 유지합니다.

---

## Changes

### ✨ Features

* 없음

### 🔧 Improvements

* 고객 상세 라우트를 즉시 교체되는 무전환 페이지로 구성했습니다.

### 🎨 UI/UX

* 고객 선택 직후 부모 고객 목록과 상세 페이지가 동시에 화면에 올라오지 않도록 했습니다.

### 📝 Docs

* 없음

### 🐛 Fixes

* 최초 목록 로딩 후 고객을 누르면 상세 표시 전에 고객 목록이 잠깐 다시 보이던 문제를 수정했습니다.
* 수정 전에는 상세 라우트의 첫 프레임에서 `ClientsPage`가 2개 노출됐고, 수정 후에는 1개만 노출되는 회귀 테스트를 추가했습니다.

---

## Commits

1. `88d9abf7` fix(trainer): remove client detail route flicker

---

## Notes

* 라우트 경로와 내비게이션 스택은 바꾸지 않고 전환 애니메이션만 제거했습니다.
* 회귀 테스트는 라우터가 상세 페이지를 만든 첫 프레임을 직접 검사합니다.

---

## Screenshots (Optional)

| Before | After |
| ------ | ----- |
| 고객 상세 전환 직전에 목록이 짧게 노출됨 | 목록 재노출 없이 상세가 즉시 표시됨 |

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 트레이너 웹에서 고객 탭을 열고 목록 로딩이 끝날 때까지 기다립니다.
2. 고객 카드를 선택해 목록이 다시 비치지 않고 상세가 즉시 열리는지 확인합니다.
3. 다른 고객 선택, 상세 닫기, 하위 탭 변경, 브라우저 뒤로/앞으로 이동이 기존대로 동작하는지 확인합니다.
4. 좁은 화면에서도 고객 선택 시 목록 깜빡임 없이 상세 화면으로 대체되는지 확인합니다.

---

## Related Issues

Closes #650

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인