### PR TITLE
feat(ui): add chart entry animations and motion system

### DIFF
--- a/frontend/flutter/lib/design_system/charts/chart_reveal.dart
+++ b/frontend/flutter/lib/design_system/charts/chart_reveal.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+
+import 'package:oncare/design_system/tokens/motion.dart';
+
+/// Builder signature for [ChartReveal]. [t] runs 0 → 1 over the reveal.
+typedef ChartRevealBuilder = Widget Function(BuildContext context, double t);
+
+/// Drives a one-shot 0 → 1 progress value for chart entry animations: bars
+/// grow up from the baseline, donuts sweep around the circle, lines draw
+/// left-to-right.
+///
+/// Pass [replayKey] when a control (period toggle, metric tab) swaps the
+/// underlying data — the reveal restarts so the new numbers register as a
+/// change instead of a silent redraw. Leave it null for charts whose data
+/// only arrives once.
+///
+/// When the platform asks for reduced motion the builder is called once with
+/// `t = 1`, so the chart renders in its final state with no animation. Widget
+/// tests get the same treatment via `MediaQuery(disableAnimations: true)`.
+class ChartReveal extends StatelessWidget {
+  const ChartReveal({
+    required this.builder,
+    this.duration = AppMotion.chartDraw,
+    this.curve = AppMotion.chartCurve,
+    this.replayKey,
+    super.key,
+  });
+
+  final ChartRevealBuilder builder;
+  final Duration duration;
+
+  /// Applied to [t] before it reaches the builder. Staggered charts should
+  /// pass [Curves.linear] here and let [chartStagger] ease each item instead,
+  /// otherwise the curve gets applied twice.
+  final Curve curve;
+
+  final Object? replayKey;
+
+  /// A NaN key never equals itself, so it would rebuild — and therefore
+  /// restart — the tween on every frame, leaving the chart stuck at 0. Callers
+  /// pass ratios here, so fold any non-finite double onto one stable sentinel.
+  Object? get _stableReplayKey {
+    final Object? k = replayKey;
+    if (k is double && !k.isFinite) return '_nonFinite';
+    return k;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (MediaQuery.maybeDisableAnimationsOf(context) ?? false) {
+      return builder(context, 1);
+    }
+    final Object? key = _stableReplayKey;
+    return TweenAnimationBuilder<double>(
+      // Rebuilding under a new key restarts the tween from 0.
+      key: key == null ? null : ValueKey<Object>(key),
+      tween: Tween<double>(begin: 0, end: 1),
+      duration: duration,
+      curve: curve,
+      builder: (BuildContext context, double t, Widget? _) =>
+          builder(context, t),
+    );
+  }
+}
+
+/// Slices a linear master progress [t] into a per-item window so a bar chart
+/// ripples across the axis instead of every bar rising at once.
+///
+/// Item [index] of [count] starts once the earlier items are underway and
+/// then runs its own eased 0 → 1. Feed this the raw progress from a
+/// [ChartReveal] built with [Curves.linear].
+///
+/// The result is clamped to 0..1 — painters multiply it into bar heights and
+/// pass it straight to `Color.withValues(alpha:)`, which asserts on values
+/// outside that range, so an overshooting [curve] must not leak through.
+double chartStagger(
+  double t,
+  int index,
+  int count, {
+  double spread = AppMotion.barStagger,
+  Curve curve = AppMotion.chartCurve,
+}) {
+  final double clamped = t.clamp(0.0, 1.0);
+  final double span = 1 - spread;
+  if (count <= 1 || spread <= 0 || span <= 0) {
+    return curve.transform(clamped).clamp(0.0, 1.0);
+  }
+  final double start = (spread / (count - 1)) * index;
+  final double local = ((clamped - start) / span).clamp(0.0, 1.0);
+  return curve.transform(local).clamp(0.0, 1.0);
+}

--- a/frontend/flutter/lib/design_system/tokens/motion.dart
+++ b/frontend/flutter/lib/design_system/tokens/motion.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/animation.dart';
+
+/// Motion tokens. Keeping durations and curves here stops each chart from
+/// inventing its own timing — the whole dashboard should feel like one
+/// coordinated reveal, not five widgets racing each other.
+class AppMotion {
+  AppMotion._();
+
+  /// Charts that draw along a path (donut sweep, trend line) — long enough
+  /// to read as "being drawn", short enough not to delay the screen.
+  static const Duration chartDraw = Duration(milliseconds: 750);
+
+  /// Bar charts. Slightly longer because the per-bar stagger eats into the
+  /// time any single bar actually spends growing.
+  static const Duration chartGrow = Duration(milliseconds: 850);
+
+  /// Small inline meters (nutrition progress bars) — these sit next to text,
+  /// so they should settle before the eye moves on.
+  static const Duration meterFill = Duration(milliseconds: 600);
+
+  /// Decelerating curve: values shoot out from zero, then ease into place.
+  static const Curve chartCurve = Curves.easeOutCubic;
+
+  /// How much of a staggered chart's timeline is spent handing off between
+  /// items. 0 = every bar grows in lockstep, 1 = strictly one after another.
+  static const double barStagger = 0.45;
+}

--- a/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
@@ -520,10 +520,10 @@ class _DietNutritionCardState extends State<_DietNutritionCard> {
                                 SizedBox(
                                   height: 68,
                                   // 지표를 바꾸면 선을 처음부터 다시 그려 값이
-                                  // 바뀐 것을 눈으로 따라가게 한다.
+                                  // 바뀐 것을 눈으로 따라가게 한다. stagger 가
+                                  // 없는 차트라 커브는 기본값(감속)을 쓴다.
                                   child: ChartReveal(
                                     replayKey: _tab,
-                                    curve: Curves.linear,
                                     builder: (BuildContext context, double t) =>
                                         CustomPaint(
                                           size: Size.infinite,

--- a/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
@@ -7,8 +7,10 @@ import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 
 import 'package:oncare/app/router/routes.dart';
+import 'package:oncare/design_system/charts/chart_reveal.dart';
 import 'package:oncare/design_system/figma/figma_kit.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
+import 'package:oncare/design_system/tokens/motion.dart';
 import 'package:oncare/features/dashboard/domain/entities/dashboard_summary.dart';
 import 'package:oncare/features/dashboard/presentation/ai_advice_text.dart';
 import 'package:oncare/features/dashboard/presentation/controllers/dashboard_controller.dart';
@@ -517,16 +519,24 @@ class _DietNutritionCardState extends State<_DietNutritionCard> {
                               children: <Widget>[
                                 SizedBox(
                                   height: 68,
-                                  child: CustomPaint(
-                                    size: Size.infinite,
-                                    painter: _TrendChartPainter(
-                                      cur: cfg.cur,
-                                      goal: cfg.goal,
-                                      ticks: cfg.ticks,
-                                      lo: lo,
-                                      hi: hi,
-                                      todayIndex: todayIdx,
-                                    ),
+                                  // 지표를 바꾸면 선을 처음부터 다시 그려 값이
+                                  // 바뀐 것을 눈으로 따라가게 한다.
+                                  child: ChartReveal(
+                                    replayKey: _tab,
+                                    curve: Curves.linear,
+                                    builder: (BuildContext context, double t) =>
+                                        CustomPaint(
+                                          size: Size.infinite,
+                                          painter: _TrendChartPainter(
+                                            cur: cfg.cur,
+                                            goal: cfg.goal,
+                                            ticks: cfg.ticks,
+                                            lo: lo,
+                                            hi: hi,
+                                            todayIndex: todayIdx,
+                                            progress: t,
+                                          ),
+                                        ),
                                   ),
                                 ),
                                 const SizedBox(height: 6),
@@ -928,15 +938,23 @@ class _ExerciseCard extends ConsumerWidget {
                       SizedBox(
                         key: const ValueKey<String>('dashboard-exercise-chart'),
                         height: 96,
-                        child: CustomPaint(
-                          size: Size.infinite,
-                          painter: _ExerciseBarPainter(
-                            data: week,
-                            lo: lo,
-                            hi: hi,
-                            todayIndex: todayIdx,
-                            color: FigmaColors.primary,
-                          ),
+                        child: ChartReveal(
+                          duration: AppMotion.chartGrow,
+                          // 막대마다 시작 시점을 어긋나게 하므로(chartStagger)
+                          // 마스터 진행도는 선형으로 받는다.
+                          curve: Curves.linear,
+                          builder: (BuildContext context, double t) =>
+                              CustomPaint(
+                                size: Size.infinite,
+                                painter: _ExerciseBarPainter(
+                                  data: week,
+                                  lo: lo,
+                                  hi: hi,
+                                  todayIndex: todayIdx,
+                                  color: FigmaColors.primary,
+                                  progress: t,
+                                ),
+                              ),
                         ),
                       ),
                       const SizedBox(height: 6),
@@ -1329,6 +1347,7 @@ class _TrendChartPainter extends CustomPainter {
     required this.lo,
     required this.hi,
     required this.todayIndex,
+    this.progress = 1,
   });
 
   final List<double> cur;
@@ -1339,6 +1358,10 @@ class _TrendChartPainter extends CustomPainter {
 
   /// 이번 주 꺾은선은 오늘까지만 그린다(미래 요일의 0값이 급락처럼 보이지 않도록).
   final int todayIndex;
+
+  /// 0 → 1 진입 애니메이션 진행도. 선은 월요일부터 오늘 쪽으로 이어지고,
+  /// 각 데이터 포인트와 값 라벨은 선이 도달하는 순간 나타난다.
+  final double progress;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -1369,40 +1392,79 @@ class _TrendChartPainter extends CustomPainter {
 
     // 이번 주 꺾은선은 회색(얇게), 데이터 포인트는 목표 대비 상태색으로 강조하고
     // 포인트마다 값을 같은 색으로 표기한다.
-    final Path line = Path()..moveTo(pts.first.dx, pts.first.dy);
-    for (final Offset p in pts.skip(1)) {
-      line.lineTo(p.dx, p.dy);
+    // 진입 애니메이션: 펜이 월요일에서 오늘 쪽으로 이동하는 만큼만 선을 잇는다.
+    // drawn 은 "그려진 구간 수"(0 = 첫 점만, lastIdx = 전체).
+    final double p = progress.clamp(0.0, 1.0);
+    final double drawn = lastIdx * p;
+    if (lastIdx > 0) {
+      final Path line = Path()..moveTo(pts.first.dx, pts.first.dy);
+      final int whole = drawn.floor().clamp(0, lastIdx);
+      for (int i = 1; i <= whole; i++) {
+        line.lineTo(pts[i].dx, pts[i].dy);
+      }
+      if (whole < lastIdx) {
+        final Offset tip = Offset.lerp(
+          pts[whole],
+          pts[whole + 1],
+          drawn - whole,
+        )!;
+        line.lineTo(tip.dx, tip.dy);
+      }
+      canvas.drawPath(
+        line,
+        Paint()
+          ..color = _nutLineGray
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = 1.6
+          ..strokeJoin = StrokeJoin.round
+          ..strokeCap = StrokeCap.round,
+      );
     }
-    canvas.drawPath(
-      line,
-      Paint()
-        ..color = _nutLineGray
-        ..style = PaintingStyle.stroke
-        ..strokeWidth = 1.6
-        ..strokeJoin = StrokeJoin.round
-        ..strokeCap = StrokeCap.round,
-    );
 
     for (int i = 0; i <= lastIdx; i++) {
+      // 선이 이 점에 닿기 직전부터 짧게 페이드인한다.
+      final double a = lastIdx == 0
+          ? p
+          : ((drawn - i) / 0.35 + 1).clamp(0.0, 1.0);
+      if (a <= 0) continue;
       final Color sc = _nutStatusColor(cur[i], goal);
-      _dot(canvas, pts[i], sc, r: i == cur.length - 1 ? 5.0 : 4.2);
-      _text(canvas, _metricNumber(cur[i]), pts[i], w, sc);
+      _dot(canvas, pts[i], sc, r: i == cur.length - 1 ? 5.0 : 4.2, alpha: a);
+      _text(canvas, _metricNumber(cur[i]), pts[i], w, sc, alpha: a);
     }
   }
 
-  void _dot(Canvas c, Offset o, Color color, {double r = 3.0}) {
-    c.drawCircle(o, r + 1.3, Paint()..color = Colors.white); // 흰 테두리(halo)
-    c.drawCircle(o, r, Paint()..color = color); // 상태색으로 채운 데이터 포인트
+  void _dot(
+    Canvas c,
+    Offset o,
+    Color color, {
+    double r = 3.0,
+    double alpha = 1,
+  }) {
+    // 흰 테두리(halo)
+    c.drawCircle(
+      o,
+      r + 1.3,
+      Paint()..color = Colors.white.withValues(alpha: alpha),
+    );
+    // 상태색으로 채운 데이터 포인트
+    c.drawCircle(o, r, Paint()..color = color.withValues(alpha: alpha));
   }
 
-  void _text(Canvas c, String s, Offset at, double w, Color color) {
+  void _text(
+    Canvas c,
+    String s,
+    Offset at,
+    double w,
+    Color color, {
+    double alpha = 1,
+  }) {
     final TextPainter tp = TextPainter(
       text: TextSpan(
         text: s,
         style: TextStyle(
           fontSize: 10,
           fontWeight: FontWeight.w700,
-          color: color,
+          color: color.withValues(alpha: alpha),
         ),
       ),
       textDirection: ui.TextDirection.ltr,
@@ -1421,7 +1483,8 @@ class _TrendChartPainter extends CustomPainter {
       old.ticks != ticks ||
       old.lo != lo ||
       old.hi != hi ||
-      old.todayIndex != todayIndex;
+      old.todayIndex != todayIndex ||
+      old.progress != progress;
 }
 
 /// The weekly exercise bar chart. Bars sit on a [lo]/[hi] scale whose baseline
@@ -1434,6 +1497,7 @@ class _ExerciseBarPainter extends CustomPainter {
     required this.hi,
     required this.todayIndex,
     required this.color,
+    this.progress = 1,
   });
 
   final List<double> data;
@@ -1443,6 +1507,10 @@ class _ExerciseBarPainter extends CustomPainter {
   /// 오늘 요일 인덱스(0=월 … 6=일). 마지막 막대 고정이 아니라 이 막대를 강조한다.
   final int todayIndex;
   final Color color;
+
+  /// 0 → 1 진입 애니메이션 진행도(선형). 막대는 월요일부터 차례로 바닥에서
+  /// 자라 오르고, 값 라벨은 해당 막대와 함께 페이드인한다.
+  final double progress;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -1464,7 +1532,10 @@ class _ExerciseBarPainter extends CustomPainter {
 
     for (int i = 0; i < n; i++) {
       final double v = data[i];
-      final double bh = ((v - lo) / span) * (h - labelGap);
+      // 막대별 진행도. 높이와 라벨 투명도를 같이 몰아 올리면 막대가
+      // 자라면서 값이 따라 붙는 것처럼 보인다.
+      final double t = chartStagger(progress, i, n);
+      final double bh = ((v - lo) / span) * (h - labelGap) * t;
       final double cx = slot * i + slot / 2;
       final double top = h - bh;
       final bool today = i == todayIndex;
@@ -1483,7 +1554,9 @@ class _ExerciseBarPainter extends CustomPainter {
           style: TextStyle(
             fontSize: 12,
             fontWeight: FontWeight.w800,
-            color: today ? color : const Color(0xFF9AA6B2),
+            color: (today ? color : const Color(0xFF9AA6B2)).withValues(
+              alpha: t,
+            ),
           ),
         ),
         textDirection: ui.TextDirection.ltr,
@@ -1500,7 +1573,8 @@ class _ExerciseBarPainter extends CustomPainter {
       old.lo != lo ||
       old.hi != hi ||
       old.todayIndex != todayIndex ||
-      old.color != color;
+      old.color != color ||
+      old.progress != progress;
 }
 
 // ───────────────────────────────────────────────────── recommended meals ──
@@ -1842,11 +1916,7 @@ class _ScheduleCard extends ConsumerWidget {
                 session.date!.day,
               ) ==
               today)
-            ScheduleItem(
-              time: session.time,
-              title: session.type,
-              emoji: '🏋️',
-            ),
+            ScheduleItem(time: session.time, title: session.type, emoji: '🏋️'),
     ];
   }
 

--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -3,8 +3,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:oncare/app/router/routes.dart';
+import 'package:oncare/design_system/charts/chart_reveal.dart';
 import 'package:oncare/design_system/figma/figma_kit.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
+import 'package:oncare/design_system/tokens/motion.dart';
 import 'package:oncare/features/account/domain/entities/user_profile.dart';
 import 'package:oncare/features/account/presentation/controllers/account_controller.dart';
 import 'package:oncare/features/diet/domain/entities/diet_day.dart';
@@ -833,10 +835,17 @@ class _NutritionProgressBar extends StatelessWidget {
                 ),
                 Align(
                   alignment: Alignment.centerLeft,
-                  child: SizedBox(
-                    width: constraints.maxWidth * progress.clamp(0.0, 1.0),
-                    height: barHeight,
-                    child: ColoredBox(color: color),
+                  // 날짜를 옮기거나 식단을 추가해 값이 바뀌면 0에서 다시
+                  // 채운다 — 숫자만 조용히 갈리지 않도록.
+                  child: ChartReveal(
+                    duration: AppMotion.meterFill,
+                    replayKey: progress,
+                    builder: (BuildContext context, double t) => SizedBox(
+                      width:
+                          constraints.maxWidth * progress.clamp(0.0, 1.0) * t,
+                      height: barHeight,
+                      child: ColoredBox(color: color),
+                    ),
                   ),
                 ),
               ],
@@ -1067,10 +1076,14 @@ class _VerticalNutritionProgressBar extends StatelessWidget {
             const Positioned.fill(child: ColoredBox(color: FigmaColors.track)),
             Align(
               alignment: Alignment.bottomCenter,
-              child: SizedBox(
-                width: barWidth,
-                height: barHeight * progress.clamp(0.0, 1.0),
-                child: ColoredBox(color: color),
+              child: ChartReveal(
+                duration: AppMotion.meterFill,
+                replayKey: progress,
+                builder: (BuildContext context, double t) => SizedBox(
+                  width: barWidth,
+                  height: barHeight * progress.clamp(0.0, 1.0) * t,
+                  child: ColoredBox(color: color),
+                ),
               ),
             ),
           ],

--- a/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
@@ -8,8 +8,10 @@ import 'package:intl/intl.dart' show NumberFormat;
 
 import 'package:oncare/app/router/routes.dart';
 import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/design_system/charts/chart_reveal.dart';
 import 'package:oncare/design_system/figma/figma_kit.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
+import 'package:oncare/design_system/tokens/motion.dart';
 import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
 import 'package:oncare/features/exercise/presentation/widgets/exercise_flows.dart';
@@ -850,6 +852,9 @@ class _ActivityStatusState extends State<_ActivityStatus> {
                 bars: data.bars,
                 dayLabels: data.labels,
                 todayIndex: data.todayIndex,
+                // 주 ↔ 월 전환은 같은 위젯이 데이터만 갈아끼우므로,
+                // 기간을 재생 키로 넘겨 막대를 다시 자라게 한다.
+                replayKey: _period,
               );
             },
           ),
@@ -894,9 +899,11 @@ class _TodayDonut extends StatelessWidget {
                 child: Stack(
                   alignment: Alignment.center,
                   children: <Widget>[
-                    CustomPaint(
-                      size: const Size.square(116),
-                      painter: _DonutPainter(segs),
+                    ChartReveal(
+                      builder: (BuildContext context, double t) => CustomPaint(
+                        size: const Size.square(116),
+                        painter: _DonutPainter(segs, progress: t),
+                      ),
                     ),
                     Column(
                       mainAxisSize: MainAxisSize.min,
@@ -1004,8 +1011,12 @@ class _DonutLegendRow extends StatelessWidget {
 }
 
 class _DonutPainter extends CustomPainter {
-  const _DonutPainter(this.segs);
+  const _DonutPainter(this.segs, {this.progress = 1});
   final List<_DonutSeg> segs;
+
+  /// 0 → 1 진입 애니메이션 진행도. 12시 방향에서 시계 방향으로, 세그먼트
+  /// 경계와 무관하게 한 자루의 펜이 원을 따라 그려 나가는 것처럼 보이게 한다.
+  final double progress;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -1020,25 +1031,38 @@ class _DonutPainter extends CustomPainter {
     final Rect rect = Rect.fromCircle(center: center, radius: radius);
     const double gap = 0.06; // radians of spacing between segments
     const double full = 2 * math.pi;
+    // 원 전체 중 지금까지 그려진 각도. 각 세그먼트는 자기 구간에 해당하는
+    // 만큼만 잘라 쓴다.
+    final double drawn = progress.clamp(0.0, 1.0) * full;
     double start = -math.pi / 2; // top (12 o'clock)
+    double consumed = 0; // 시작점에서 이 세그먼트까지의 누적 각도
     for (final _DonutSeg s in segs) {
+      final double share = (s.minutes / total) * full;
+      final double sweep = share - gap;
       // Skip 0-minute categories (a checked routine may zero one out); a
       // negative sweep would otherwise paint a stray rounded dot.
-      if (s.minutes <= 0) continue;
-      final double sweep = (s.minutes / total) * full - gap;
-      final Paint p = Paint()
-        ..style = PaintingStyle.stroke
-        ..strokeWidth = stroke
-        ..strokeCap = StrokeCap.round
-        ..color = s.color;
-      canvas.drawArc(rect, start + gap / 2, sweep, false, p);
-      start += (s.minutes / total) * full;
+      if (s.minutes <= 0 || sweep <= 0) {
+        start += share;
+        consumed += share;
+        continue;
+      }
+      final double visible = (drawn - consumed - gap / 2).clamp(0.0, sweep);
+      if (visible > 0) {
+        final Paint p = Paint()
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = stroke
+          ..strokeCap = StrokeCap.round
+          ..color = s.color;
+        canvas.drawArc(rect, start + gap / 2, visible, false, p);
+      }
+      start += share;
+      consumed += share;
     }
   }
 
   @override
   bool shouldRepaint(covariant _DonutPainter oldDelegate) =>
-      oldDelegate.segs != segs;
+      oldDelegate.segs != segs || oldDelegate.progress != progress;
 }
 
 /// Compact segmented control (오늘 / 이번 주 / 이번 달) matching the app's
@@ -1102,11 +1126,15 @@ class _ActivityChart extends StatelessWidget {
     required this.bars,
     required this.dayLabels,
     required this.todayIndex,
+    this.replayKey,
   });
 
   final List<_Bar> bars;
   final List<String> dayLabels;
   final int todayIndex;
+
+  /// 값이 바뀌면 막대 성장 애니메이션을 처음부터 다시 재생하기 위한 키.
+  final Object? replayKey;
 
   /// Hover tooltip content for a bar — one line per activity type as
   /// [color square] 종류   N분 (see the legend).
@@ -1176,12 +1204,19 @@ class _ActivityChart extends StatelessWidget {
             child: Stack(
               children: <Widget>[
                 Positioned.fill(
-                  child: CustomPaint(
-                    painter: _StackedBarPainter(
-                      bars: bars,
-                      dayLabels: dayLabels,
-                      todayIndex: todayIndex,
-                      todayLabel: l.exToday,
+                  child: ChartReveal(
+                    replayKey: replayKey,
+                    duration: AppMotion.chartGrow,
+                    // 막대별 stagger 는 painter 안에서 곡선을 적용한다.
+                    curve: Curves.linear,
+                    builder: (BuildContext context, double t) => CustomPaint(
+                      painter: _StackedBarPainter(
+                        bars: bars,
+                        dayLabels: dayLabels,
+                        todayIndex: todayIndex,
+                        todayLabel: l.exToday,
+                        progress: t,
+                      ),
                     ),
                   ),
                 ),
@@ -1288,6 +1323,7 @@ class _StackedBarPainter extends CustomPainter {
     required this.dayLabels,
     required this.todayIndex,
     required this.todayLabel,
+    this.progress = 1,
   });
 
   final List<_Bar> bars;
@@ -1296,6 +1332,10 @@ class _StackedBarPainter extends CustomPainter {
 
   /// Resolved in the widget's build (CustomPainter has no BuildContext).
   final String todayLabel;
+
+  /// 0 → 1 진입 애니메이션 진행도(선형). 막대는 왼쪽부터 차례로 바닥에서
+  /// 자라 오른다. 눈금선과 요일 라벨은 처음부터 그대로 둔다.
+  final double progress;
 
   /// Round the busiest day up to the next 20-minute step so bars never clip;
   /// falls back to 90 when there's no data yet.
@@ -1357,10 +1397,13 @@ class _StackedBarPainter extends CustomPainter {
       final bool cardioTop = b.cardio > 0;
       final bool strengthTop = !cardioTop && b.strength > 0;
       final bool stretchTop = !cardioTop && !strengthTop && b.stretch > 0;
+      // 막대별 진행도 — 각 구간 높이에 함께 곱해 스택 전체가 비율을 유지한 채
+      // 바닥에서 자라 오르게 한다.
+      final double t = chartStagger(progress, i, bars.length);
       double yBottom = chartH;
       double h;
       // stretch (light, bottom)
-      h = (b.stretch / max) * chartH;
+      h = (b.stretch / max) * chartH * t;
       if (h > 0) {
         _rrect(
           canvas,
@@ -1374,7 +1417,7 @@ class _StackedBarPainter extends CustomPainter {
         yBottom -= h;
       }
       // strength (dark mid)
-      h = (b.strength / max) * chartH;
+      h = (b.strength / max) * chartH * t;
       if (h > 0) {
         _rrect(
           canvas,
@@ -1388,7 +1431,7 @@ class _StackedBarPainter extends CustomPainter {
         yBottom -= h;
       }
       // cardio (blue top)
-      h = (b.cardio / max) * chartH;
+      h = (b.cardio / max) * chartH * t;
       if (h > 0) {
         _rrect(
           canvas,
@@ -1406,9 +1449,9 @@ class _StackedBarPainter extends CustomPainter {
         _rrect(
           canvas,
           x,
-          chartH - 3,
+          chartH - 3 * t,
           barW,
-          3,
+          3 * t,
           const Color(0xFFEEF2F6),
           topRadius: 1.5,
         );
@@ -1465,7 +1508,8 @@ class _StackedBarPainter extends CustomPainter {
       oldDelegate.bars != bars ||
       oldDelegate.dayLabels != dayLabels ||
       oldDelegate.todayIndex != todayIndex ||
-      oldDelegate.todayLabel != todayLabel;
+      oldDelegate.todayLabel != todayLabel ||
+      oldDelegate.progress != progress;
 }
 
 class _ExerciseFeedback extends StatelessWidget {

--- a/frontend/flutter/test/design_system/chart_reveal_test.dart
+++ b/frontend/flutter/test/design_system/chart_reveal_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/design_system/charts/chart_reveal.dart';
+import 'package:oncare/design_system/tokens/motion.dart';
+
+/// Renders [ChartReveal] and records every progress value it hands the
+/// builder, so tests can assert on the shape of the reveal rather than on
+/// pixels.
+Widget _harness({
+  required List<double> log,
+  Object? replayKey,
+  Curve curve = Curves.linear,
+  bool disableAnimations = false,
+}) {
+  return MediaQuery(
+    data: MediaQueryData(disableAnimations: disableAnimations),
+    child: Directionality(
+      textDirection: TextDirection.ltr,
+      child: ChartReveal(
+        replayKey: replayKey,
+        curve: curve,
+        duration: const Duration(milliseconds: 400),
+        builder: (BuildContext context, double t) {
+          log.add(t);
+          return const SizedBox(width: 10, height: 10);
+        },
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('ChartReveal', () {
+    testWidgets('runs progress from 0 to 1 over the reveal', (
+      WidgetTester tester,
+    ) async {
+      final List<double> log = <double>[];
+      await tester.pumpWidget(_harness(log: log));
+
+      expect(log.first, 0);
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(log.last, greaterThan(0));
+      expect(log.last, lessThan(1));
+
+      await tester.pumpAndSettle();
+      expect(log.last, 1);
+    });
+
+    testWidgets('renders the final state immediately when animations are off', (
+      WidgetTester tester,
+    ) async {
+      final List<double> log = <double>[];
+      await tester.pumpWidget(_harness(log: log, disableAnimations: true));
+
+      // No tween at all — the builder is called once with the end value, so
+      // reduced-motion users (and golden tests) see the finished chart.
+      expect(log, <double>[1]);
+      expect(find.byType(TweenAnimationBuilder<double>), findsNothing);
+    });
+
+    testWidgets('replays from 0 when replayKey changes', (
+      WidgetTester tester,
+    ) async {
+      final List<double> log = <double>[];
+      await tester.pumpWidget(_harness(log: log, replayKey: 'week'));
+      await tester.pumpAndSettle();
+      expect(log.last, 1);
+
+      log.clear();
+      await tester.pumpWidget(_harness(log: log, replayKey: 'month'));
+      expect(log.first, 0);
+
+      await tester.pumpAndSettle();
+      expect(log.last, 1);
+    });
+
+    testWidgets(
+      'keeps running without restarting when replayKey is unchanged',
+      (WidgetTester tester) async {
+        final List<double> log = <double>[];
+        await tester.pumpWidget(_harness(log: log, replayKey: 'week'));
+        await tester.pumpAndSettle();
+
+        log.clear();
+        await tester.pumpWidget(_harness(log: log, replayKey: 'week'));
+        await tester.pump();
+        expect(log.every((double t) => t == 1), isTrue);
+      },
+    );
+  });
+
+  group('chartStagger', () {
+    test('leaves the first item leading and the last item trailing', () {
+      // Halfway through the master timeline the left-most bar is further
+      // along than the right-most one — that offset is the ripple.
+      final double first = chartStagger(0.5, 0, 7);
+      final double last = chartStagger(0.5, 6, 7);
+      expect(first, greaterThan(last));
+    });
+
+    test('every item starts at 0 and finishes at 1', () {
+      for (int i = 0; i < 7; i++) {
+        expect(chartStagger(0, i, 7), 0);
+        expect(chartStagger(1, i, 7), 1);
+      }
+    });
+
+    test('a single item just follows the master progress', () {
+      expect(chartStagger(0.5, 0, 1), AppMotion.chartCurve.transform(0.5));
+    });
+
+    test('clamps progress outside 0..1', () {
+      expect(chartStagger(-1, 3, 7), 0);
+      expect(chartStagger(2, 3, 7), 1);
+    });
+  });
+}

--- a/frontend/flutter/test/features/dashboard/home_chart_animation_test.dart
+++ b/frontend/flutter/test/features/dashboard/home_chart_animation_test.dart
@@ -5,9 +5,6 @@
 /// 가 다시 거짓이 되는 것으로 "그리고 멈춘다"를 못박는다.
 library;
 
-import 'dart:typed_data';
-import 'dart:ui' as ui;
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -23,6 +20,8 @@ import 'package:oncare/features/diet/domain/entities/diet_day.dart';
 import 'package:oncare/features/member_coach/data/repositories/mock_member_coach_repository.dart';
 import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
+
+import '../../helpers/painter_ink.dart';
 
 void main() {
   const DashboardSummary summary = DashboardSummary(
@@ -99,25 +98,6 @@ void main() {
         .painter!;
   }
 
-  /// painter 를 실제로 래스터화해 칠해진 픽셀 수를 센다. 막대가 자라 오르면
-  /// 잉크가 늘어나므로, "정말 커지고 있는가"를 좌표가 아니라 그림으로 확인한다.
-  /// `toImage` 는 진짜 비동기라 반드시 `runAsync` 안에서 불러야 한다.
-  Future<int> inkOf(CustomPainter painter, Size size) async {
-    final ui.PictureRecorder recorder = ui.PictureRecorder();
-    painter.paint(Canvas(recorder), size);
-    final ui.Image image = await recorder.endRecording().toImage(
-      size.width.ceil(),
-      size.height.ceil(),
-    );
-    final ByteData pixels = (await image.toByteData())!;
-    image.dispose();
-    int ink = 0;
-    for (int i = 3; i < pixels.lengthInBytes; i += 4) {
-      if (pixels.getUint8(i) > 0) ink++;
-    }
-    return ink;
-  }
-
   testWidgets('주간 운동 막대는 바닥에서 위로 자란다', (WidgetTester tester) async {
     await pumpHome(tester);
     final Size size = tester.getSize(exerciseChart);
@@ -130,9 +110,9 @@ void main() {
 
     final List<int> ink = (await tester.runAsync(() async {
       return <int>[
-        await inkOf(atStart, size),
-        await inkOf(midway, size),
-        await inkOf(settled, size),
+        await painterInk(atStart, size),
+        await painterInk(midway, size),
+        await painterInk(settled, size),
       ];
     }))!;
 

--- a/frontend/flutter/test/features/dashboard/home_chart_animation_test.dart
+++ b/frontend/flutter/test/features/dashboard/home_chart_animation_test.dart
@@ -1,0 +1,237 @@
+/// 홈 카드의 그래프 진입 애니메이션 (#653).
+///
+/// 그래프는 `CustomPaint` 라 위젯 트리만 봐서는 모양을 알 수 없다. painter 를
+/// 직접 래스터화해 칠해진 픽셀이 늘어나는 것으로 "자라 오른다"를, `shouldRepaint`
+/// 가 다시 거짓이 되는 것으로 "그리고 멈춘다"를 못박는다.
+library;
+
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/design_system/charts/chart_reveal.dart';
+import 'package:oncare/features/account/data/repositories/mock_account_repository.dart';
+import 'package:oncare/features/account/domain/entities/user_profile.dart';
+import 'package:oncare/features/account/presentation/controllers/account_controller.dart';
+import 'package:oncare/features/dashboard/domain/entities/dashboard_summary.dart';
+import 'package:oncare/features/dashboard/presentation/controllers/dashboard_controller.dart';
+import 'package:oncare/features/dashboard/presentation/widgets/dashboard_content.dart';
+import 'package:oncare/features/diet/domain/entities/diet_day.dart';
+import 'package:oncare/features/member_coach/data/repositories/mock_member_coach_repository.dart';
+import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+void main() {
+  const DashboardSummary summary = DashboardSummary(
+    indicators: <HealthIndicator>[
+      HealthIndicator(label: '칼로리', current: 1860, max: 2000, unit: 'kcal'),
+      HealthIndicator(label: '나트륨', current: 2329, max: 2000, unit: 'mg'),
+      HealthIndicator(label: '당류', current: 43, max: 50, unit: 'g'),
+    ],
+    macros: DietMacros(
+      carbsG: 203.6,
+      proteinG: 109.3,
+      fatG: 66.5,
+      carbsPct: 44,
+      proteinPct: 24,
+      fatPct: 32,
+    ),
+    dietEntries: 4,
+    exerciseMinutes: 45,
+    exerciseCalories: 520,
+    exerciseCount: 4,
+    todaySchedule: <ScheduleItem>[],
+    weekScore: 85,
+    weekScoreDelta: 12,
+    sodiumWarning: null,
+  );
+
+  /// 홈을 띄우되 `pumpAndSettle` 은 하지 않는다 — 진입 애니메이션이 도는 중을
+  /// 봐야 하므로, 데이터 로딩만 끝나도록 한 프레임씩 진행한다.
+  Future<void> pumpHome(WidgetTester tester) async {
+    await tester.binding.setSurfaceSize(const Size(800, 1600));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          accountRepositoryProvider.overrideWithValue(
+            MockAccountRepository(
+              profile: const UserProfile(
+                id: 'member',
+                name: '테스트',
+                email: 'member@example.com',
+              ),
+            ),
+          ),
+          dashboardSummaryProvider.overrideWith((ref) async => summary),
+          memberCoachRepositoryProvider.overrideWithValue(
+            MockMemberCoachRepository(),
+          ),
+        ],
+        child: const MaterialApp(
+          locale: Locale('ko'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: DashboardContent()),
+        ),
+      ),
+    );
+    // 요약 provider 가 풀리고 카드가 붙을 때까지만.
+    await tester.pump();
+    await tester.pump();
+  }
+
+  final Finder exerciseChart = find.byKey(
+    const ValueKey<String>('dashboard-exercise-chart'),
+  );
+  final Finder nutritionChart = find.byKey(
+    const ValueKey<String>('dashboard-nutrition-chart'),
+  );
+
+  CustomPainter painterIn(WidgetTester tester, Finder scope) {
+    return tester
+        .widget<CustomPaint>(
+          find.descendant(of: scope, matching: find.byType(CustomPaint)).first,
+        )
+        .painter!;
+  }
+
+  /// painter 를 실제로 래스터화해 칠해진 픽셀 수를 센다. 막대가 자라 오르면
+  /// 잉크가 늘어나므로, "정말 커지고 있는가"를 좌표가 아니라 그림으로 확인한다.
+  /// `toImage` 는 진짜 비동기라 반드시 `runAsync` 안에서 불러야 한다.
+  Future<int> inkOf(CustomPainter painter, Size size) async {
+    final ui.PictureRecorder recorder = ui.PictureRecorder();
+    painter.paint(Canvas(recorder), size);
+    final ui.Image image = await recorder.endRecording().toImage(
+      size.width.ceil(),
+      size.height.ceil(),
+    );
+    final ByteData pixels = (await image.toByteData())!;
+    image.dispose();
+    int ink = 0;
+    for (int i = 3; i < pixels.lengthInBytes; i += 4) {
+      if (pixels.getUint8(i) > 0) ink++;
+    }
+    return ink;
+  }
+
+  testWidgets('주간 운동 막대는 바닥에서 위로 자란다', (WidgetTester tester) async {
+    await pumpHome(tester);
+    final Size size = tester.getSize(exerciseChart);
+
+    final CustomPainter atStart = painterIn(tester, exerciseChart);
+    await tester.pump(const Duration(milliseconds: 350));
+    final CustomPainter midway = painterIn(tester, exerciseChart);
+    await tester.pumpAndSettle();
+    final CustomPainter settled = painterIn(tester, exerciseChart);
+
+    final List<int> ink = (await tester.runAsync(() async {
+      return <int>[
+        await inkOf(atStart, size),
+        await inkOf(midway, size),
+        await inkOf(settled, size),
+      ];
+    }))!;
+
+    expect(ink[1], greaterThan(ink[0]), reason: '막대가 커지지 않았다');
+    expect(ink[2], greaterThan(ink[1]), reason: '막대가 끝까지 자라지 않았다');
+  });
+
+  testWidgets('주간 운동 막대는 진입 애니메이션 동안 계속 다시 그려진다', (WidgetTester tester) async {
+    await pumpHome(tester);
+    expect(exerciseChart, findsOneWidget);
+
+    final CustomPainter atStart = painterIn(tester, exerciseChart);
+    await tester.pump(const Duration(milliseconds: 300));
+    final CustomPainter midway = painterIn(tester, exerciseChart);
+
+    // 진행도가 올라갔다 = 막대 높이가 달라졌다.
+    expect(midway.shouldRepaint(atStart), isTrue);
+
+    await tester.pumpAndSettle();
+    final CustomPainter settled = painterIn(tester, exerciseChart);
+    expect(settled.shouldRepaint(midway), isTrue);
+
+    // 끝난 뒤에는 더 이상 움직이지 않는다 — 계속 도는 애니메이션이 아니다.
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(painterIn(tester, exerciseChart).shouldRepaint(settled), isFalse);
+  });
+
+  testWidgets('영양 지표를 바꾸면 추이 그래프 애니메이션이 다시 재생된다', (WidgetTester tester) async {
+    await pumpHome(tester);
+    await tester.pumpAndSettle();
+
+    ChartReveal revealIn(Finder scope) => tester.widget<ChartReveal>(
+      find.descendant(of: scope, matching: find.byType(ChartReveal)).first,
+    );
+
+    final Object? beforeKey = revealIn(nutritionChart).replayKey;
+    expect(beforeKey, isNotNull, reason: '지표 전환을 재생 키로 넘기지 않고 있다');
+
+    await tester.tap(find.text('나트륨').first);
+    await tester.pump();
+
+    expect(revealIn(nutritionChart).replayKey, isNot(beforeKey));
+
+    // 새 지표의 선이 다시 그려지는 동안 painter 가 갱신된다.
+    final CustomPainter atStart = painterIn(tester, nutritionChart);
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(painterIn(tester, nutritionChart).shouldRepaint(atStart), isTrue);
+
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('애니메이션이 꺼진 환경에서는 첫 프레임부터 최종 상태로 그린다', (
+    WidgetTester tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(800, 1600));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          accountRepositoryProvider.overrideWithValue(
+            MockAccountRepository(
+              profile: const UserProfile(
+                id: 'member',
+                name: '테스트',
+                email: 'member@example.com',
+              ),
+            ),
+          ),
+          dashboardSummaryProvider.overrideWith((ref) async => summary),
+          memberCoachRepositoryProvider.overrideWithValue(
+            MockMemberCoachRepository(),
+          ),
+        ],
+        child: MaterialApp(
+          locale: const Locale('ko'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          builder: (BuildContext context, Widget? child) => MediaQuery(
+            data: MediaQuery.of(context).copyWith(disableAnimations: true),
+            child: child!,
+          ),
+          home: const Scaffold(body: DashboardContent()),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    final CustomPainter first = painterIn(tester, exerciseChart);
+    await tester.pump(const Duration(milliseconds: 300));
+
+    // 진행도가 처음부터 1 이라 다시 그릴 일이 없다.
+    expect(painterIn(tester, exerciseChart).shouldRepaint(first), isFalse);
+    expect(
+      find.descendant(
+        of: exerciseChart,
+        matching: find.byType(TweenAnimationBuilder<double>),
+      ),
+      findsNothing,
+    );
+  });
+}

--- a/frontend/flutter/test/features/diet/diet_progress_animation_test.dart
+++ b/frontend/flutter/test/features/diet/diet_progress_animation_test.dart
@@ -1,0 +1,96 @@
+/// 식단 영양 진행 바의 채워지는 모션 (#653).
+///
+/// 진행 바는 `ColoredBox` 를 감싼 `SizedBox` 의 폭/높이로 값을 표현하므로,
+/// 애니메이션이 도는 동안 그 크기가 실제로 커지는지 잰다.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
+import 'package:oncare/features/diet/presentation/pages/diet_record_page.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+import '../../helpers/fake_diet_repository.dart';
+
+void main() {
+  /// 진입 애니메이션이 도는 중을 봐야 하므로 `pumpAndSettle` 은 쓰지 않는다.
+  Future<void> pumpDiet(
+    WidgetTester tester, {
+    bool disableAnimations = false,
+  }) async {
+    await tester.binding.setSurfaceSize(const Size(800, 1800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          dietRepositoryProvider.overrideWithValue(FakeDietRepository()),
+        ],
+        child: MaterialApp(
+          locale: const Locale('ko'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          builder: (BuildContext context, Widget? child) => MediaQuery(
+            data: MediaQuery.of(
+              context,
+            ).copyWith(disableAnimations: disableAnimations),
+            child: child!,
+          ),
+          home: const DietRecordPage(),
+        ),
+      ),
+    );
+    // 저장소 future 는 가짜 시계가 흘러야 풀린다. 바가 붙는 프레임에서 멈추면
+    // 진행 바는 방금 mount 된 참이라 애니메이션은 t=0 이다.
+    for (int i = 0; i < 20; i++) {
+      await tester.pump(const Duration(milliseconds: 50));
+      if (find
+          .byKey(const Key('nutrition-macro-progress-탄수화물'))
+          .evaluate()
+          .isNotEmpty) {
+        return;
+      }
+    }
+    fail('영양 진행 바가 렌더되지 않았다');
+  }
+
+  /// 채워진 부분의 폭. 트랙(`Positioned.fill`)이 아니라 `SizedBox` 로 감싼
+  /// 마지막 `ColoredBox` 가 값이다.
+  double filledWidth(WidgetTester tester, String label) {
+    final Finder bar = find.byKey(Key('nutrition-macro-progress-$label'));
+    final Finder fill = find
+        .descendant(
+          of: bar,
+          matching: find.byWidgetPredicate(
+            (Widget w) => w is SizedBox && w.height == 6,
+          ),
+        )
+        .last;
+    return tester.getSize(fill).width;
+  }
+
+  testWidgets('영양 진행 바는 0에서 목표 비율까지 채워진다', (WidgetTester tester) async {
+    await pumpDiet(tester);
+
+    final double atStart = filledWidth(tester, '탄수화물');
+    await tester.pump(const Duration(milliseconds: 250));
+    final double midway = filledWidth(tester, '탄수화물');
+    await tester.pumpAndSettle();
+    final double settled = filledWidth(tester, '탄수화물');
+
+    expect(atStart, 0, reason: '첫 프레임부터 채워져 있다');
+    expect(midway, greaterThan(atStart), reason: '바가 채워지지 않았다');
+    expect(settled, greaterThan(midway), reason: '바가 끝까지 채워지지 않았다');
+  });
+
+  testWidgets('애니메이션이 꺼진 환경에서는 첫 프레임부터 다 채워져 있다', (WidgetTester tester) async {
+    await pumpDiet(tester, disableAnimations: true);
+
+    final double atStart = filledWidth(tester, '탄수화물');
+    expect(atStart, greaterThan(0));
+
+    await tester.pump(const Duration(milliseconds: 250));
+    expect(filledWidth(tester, '탄수화물'), atStart);
+  });
+}

--- a/frontend/flutter/test/features/exercise/exercise_chart_animation_test.dart
+++ b/frontend/flutter/test/features/exercise/exercise_chart_animation_test.dart
@@ -1,0 +1,189 @@
+/// 운동 기록 탭 그래프의 진입 애니메이션 (#653).
+///
+/// 오늘 = 도넛(원을 따라 그려짐), 이번 주/이번 달 = 스택 막대(바닥에서 자람).
+/// painter 를 직접 래스터화해 칠해진 픽셀이 늘어나는 것으로 "정말 그려지고
+/// 있는가"를 확인한다 — `shouldRepaint` 만으로는 방향을 알 수 없다.
+library;
+
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/design_system/charts/chart_reveal.dart';
+import 'package:oncare/features/account/data/repositories/mock_account_repository.dart';
+import 'package:oncare/features/account/domain/entities/user_profile.dart';
+import 'package:oncare/features/account/presentation/controllers/account_controller.dart';
+import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
+import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
+import 'package:oncare/features/exercise/presentation/pages/exercise_page.dart';
+import 'package:oncare/features/member_coach/data/repositories/mock_member_coach_repository.dart';
+import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+void main() {
+  // 요일마다 세 종류가 모두 있는 주 — 도넛에 세 조각, 막대에 세 층이 쌓인다.
+  const ExerciseWeek week = ExerciseWeek(
+    sessions: <ExerciseSession>[],
+    dailyMinutes: <double>[60, 45, 70, 30, 55, 40, 65],
+    dailyCalories: <double>[300, 220, 350, 150, 270, 200, 320],
+    cardioMinutes: <double>[30, 20, 35, 15, 25, 20, 30],
+    strengthMinutes: <double>[20, 15, 25, 10, 20, 12, 25],
+    stretchingMinutes: <double>[10, 10, 10, 5, 10, 8, 10],
+    dayLabels: <String>['월', '화', '수', '목', '금', '토', '일'],
+    totalMinutes: 365,
+    totalCalories: 1810,
+    streakDays: 7,
+    aiCoachMessage: '꾸준히 운동해 보세요.',
+  );
+
+  /// 진입 애니메이션이 도는 중을 봐야 하므로 `pumpAndSettle` 은 쓰지 않는다.
+  Future<void> pumpExercise(WidgetTester tester) async {
+    await tester.binding.setSurfaceSize(const Size(800, 1800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          appConfigProvider.overrideWithValue(
+            const AppConfig(
+              environment: Environment.dev,
+              apiBaseUrl: 'https://example.test',
+              useMockApi: true,
+            ),
+          ),
+          accountRepositoryProvider.overrideWithValue(
+            MockAccountRepository(
+              profile: const UserProfile(
+                id: 'member',
+                name: '테스트',
+                email: 'member@example.com',
+              ),
+            ),
+          ),
+          exerciseWeekProvider.overrideWith((ref) async => week),
+          memberCoachRepositoryProvider.overrideWithValue(
+            MockMemberCoachRepository(),
+          ),
+        ],
+        child: const MaterialApp(
+          locale: Locale('ko'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: ExercisePage(),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+  }
+
+  /// 기간 토글의 그래프 painter. 도넛과 스택 막대 모두 `ChartReveal` 바로 아래
+  /// 첫 `CustomPaint` 다.
+  CustomPainter chartPainter(WidgetTester tester) {
+    return tester
+        .widget<CustomPaint>(
+          find
+              .descendant(
+                of: find.byType(ChartReveal),
+                matching: find.byType(CustomPaint),
+              )
+              .first,
+        )
+        .painter!;
+  }
+
+  Future<int> inkOf(CustomPainter painter, Size size) async {
+    final ui.PictureRecorder recorder = ui.PictureRecorder();
+    painter.paint(Canvas(recorder), size);
+    final ui.Image image = await recorder.endRecording().toImage(
+      size.width.ceil(),
+      size.height.ceil(),
+    );
+    final ByteData pixels = (await image.toByteData())!;
+    image.dispose();
+    int ink = 0;
+    for (int i = 3; i < pixels.lengthInBytes; i += 4) {
+      if (pixels.getUint8(i) > 0) ink++;
+    }
+    return ink;
+  }
+
+  testWidgets('오늘 도넛은 원을 따라 점점 그려진다', (WidgetTester tester) async {
+    await pumpExercise(tester);
+    await tester.tap(find.text('오늘'));
+    await tester.pump();
+
+    const Size size = Size.square(116);
+    final CustomPainter atStart = chartPainter(tester);
+    await tester.pump(const Duration(milliseconds: 300));
+    final CustomPainter midway = chartPainter(tester);
+    await tester.pumpAndSettle();
+    final CustomPainter settled = chartPainter(tester);
+
+    final List<int> ink = (await tester.runAsync(() async {
+      return <int>[
+        await inkOf(atStart, size),
+        await inkOf(midway, size),
+        await inkOf(settled, size),
+      ];
+    }))!;
+
+    expect(ink[0], 0, reason: '첫 프레임부터 호가 그려져 있다');
+    expect(ink[1], greaterThan(ink[0]), reason: '호가 뻗어 나가지 않았다');
+    expect(ink[2], greaterThan(ink[1]), reason: '호가 한 바퀴를 채우지 못했다');
+  });
+
+  testWidgets('주간 스택 막대는 바닥에서 자라 오른다', (WidgetTester tester) async {
+    await pumpExercise(tester);
+
+    const Size size = Size(600, 150);
+    final CustomPainter atStart = chartPainter(tester);
+    await tester.pump(const Duration(milliseconds: 350));
+    final CustomPainter midway = chartPainter(tester);
+    await tester.pumpAndSettle();
+    final CustomPainter settled = chartPainter(tester);
+
+    final List<int> ink = (await tester.runAsync(() async {
+      return <int>[
+        await inkOf(atStart, size),
+        await inkOf(midway, size),
+        await inkOf(settled, size),
+      ];
+    }))!;
+
+    // 눈금선과 요일 라벨은 처음부터 그려지므로 0 은 아니고, 막대가 자라는
+    // 만큼만 늘어난다.
+    expect(ink[1], greaterThan(ink[0]), reason: '막대가 자라지 않았다');
+    expect(ink[2], greaterThan(ink[1]), reason: '막대가 끝까지 자라지 않았다');
+  });
+
+  testWidgets('이번 주 ↔ 이번 달 전환은 막대 애니메이션을 다시 재생한다', (WidgetTester tester) async {
+    await pumpExercise(tester);
+    await tester.pumpAndSettle();
+
+    ChartReveal reveal() =>
+        tester.widget<ChartReveal>(find.byType(ChartReveal).first);
+
+    final Object? weekly = reveal().replayKey;
+    expect(weekly, isNotNull, reason: '기간을 재생 키로 넘기지 않고 있다');
+
+    await tester.tap(find.text('이번 달'));
+    await tester.pump();
+    expect(reveal().replayKey, isNot(weekly));
+
+    const Size size = Size(600, 150);
+    final CustomPainter atStart = chartPainter(tester);
+    await tester.pump(const Duration(milliseconds: 350));
+    final CustomPainter midway = chartPainter(tester);
+
+    final List<int> ink = (await tester.runAsync(() async {
+      return <int>[await inkOf(atStart, size), await inkOf(midway, size)];
+    }))!;
+    expect(ink[1], greaterThan(ink[0]), reason: '월간 막대가 다시 자라지 않았다');
+
+    await tester.pumpAndSettle();
+  });
+}

--- a/frontend/flutter/test/features/exercise/exercise_chart_animation_test.dart
+++ b/frontend/flutter/test/features/exercise/exercise_chart_animation_test.dart
@@ -5,9 +5,6 @@
 /// 있는가"를 확인한다 — `shouldRepaint` 만으로는 방향을 알 수 없다.
 library;
 
-import 'dart:typed_data';
-import 'dart:ui' as ui;
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -23,6 +20,8 @@ import 'package:oncare/features/exercise/presentation/pages/exercise_page.dart';
 import 'package:oncare/features/member_coach/data/repositories/mock_member_coach_repository.dart';
 import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
+
+import '../../helpers/painter_ink.dart';
 
 void main() {
   // 요일마다 세 종류가 모두 있는 주 — 도넛에 세 조각, 막대에 세 층이 쌓인다.
@@ -95,22 +94,6 @@ void main() {
         .painter!;
   }
 
-  Future<int> inkOf(CustomPainter painter, Size size) async {
-    final ui.PictureRecorder recorder = ui.PictureRecorder();
-    painter.paint(Canvas(recorder), size);
-    final ui.Image image = await recorder.endRecording().toImage(
-      size.width.ceil(),
-      size.height.ceil(),
-    );
-    final ByteData pixels = (await image.toByteData())!;
-    image.dispose();
-    int ink = 0;
-    for (int i = 3; i < pixels.lengthInBytes; i += 4) {
-      if (pixels.getUint8(i) > 0) ink++;
-    }
-    return ink;
-  }
-
   testWidgets('오늘 도넛은 원을 따라 점점 그려진다', (WidgetTester tester) async {
     await pumpExercise(tester);
     await tester.tap(find.text('오늘'));
@@ -125,9 +108,9 @@ void main() {
 
     final List<int> ink = (await tester.runAsync(() async {
       return <int>[
-        await inkOf(atStart, size),
-        await inkOf(midway, size),
-        await inkOf(settled, size),
+        await painterInk(atStart, size),
+        await painterInk(midway, size),
+        await painterInk(settled, size),
       ];
     }))!;
 
@@ -148,9 +131,9 @@ void main() {
 
     final List<int> ink = (await tester.runAsync(() async {
       return <int>[
-        await inkOf(atStart, size),
-        await inkOf(midway, size),
-        await inkOf(settled, size),
+        await painterInk(atStart, size),
+        await painterInk(midway, size),
+        await painterInk(settled, size),
       ];
     }))!;
 
@@ -180,7 +163,10 @@ void main() {
     final CustomPainter midway = chartPainter(tester);
 
     final List<int> ink = (await tester.runAsync(() async {
-      return <int>[await inkOf(atStart, size), await inkOf(midway, size)];
+      return <int>[
+        await painterInk(atStart, size),
+        await painterInk(midway, size),
+      ];
     }))!;
     expect(ink[1], greaterThan(ink[0]), reason: '월간 막대가 다시 자라지 않았다');
 

--- a/frontend/flutter/test/helpers/painter_ink.dart
+++ b/frontend/flutter/test/helpers/painter_ink.dart
@@ -1,0 +1,29 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Rasterizes [painter] at [size] and counts the pixels it actually painted.
+///
+/// Chart entry animations live inside `CustomPaint`, so the widget tree says
+/// nothing about whether a bar grew or an arc swept. Comparing ink across
+/// frames does: more ink means more chart got drawn.
+///
+/// `Picture.toImage` is genuinely async, so this must run inside
+/// [WidgetTester.runAsync] — calling it in the fake-async zone hangs the test.
+Future<int> painterInk(CustomPainter painter, Size size) async {
+  final ui.PictureRecorder recorder = ui.PictureRecorder();
+  painter.paint(Canvas(recorder), size);
+  final ui.Image image = await recorder.endRecording().toImage(
+    size.width.ceil(),
+    size.height.ceil(),
+  );
+  final ByteData pixels = (await image.toByteData())!;
+  image.dispose();
+  int ink = 0;
+  for (int i = 3; i < pixels.lengthInBytes; i += 4) {
+    if (pixels.getUint8(i) > 0) ink++;
+  }
+  return ink;
+}

--- a/frontend/flutter_trainer/.gitignore
+++ b/frontend/flutter_trainer/.gitignore
@@ -47,3 +47,50 @@ app.*.map.json
 # drift web runtime (fetched by tool/fetch_drift_wasm.sh; CI downloads too)
 /web/sqlite3.wasm
 /web/drift_worker.js
+
+# Android related (사용자 앱 frontend/flutter/.gitignore 와 동일한 규칙)
+**/android/**/gradle-wrapper.jar
+.gradle/
+**/android/captures/
+**/android/gradlew
+**/android/gradlew.bat
+**/android/local.properties
+**/android/**/GeneratedPluginRegistrant.java
+**/android/key.properties
+*.jks
+
+# iOS/XCode related
+**/ios/**/*.mode1v3
+**/ios/**/*.mode2v3
+**/ios/**/*.moved-aside
+**/ios/**/*.pbxuser
+**/ios/**/*.perspectivev3
+**/ios/**/*sync/
+**/ios/**/.sconsign.dblite
+**/ios/**/.tags*
+**/ios/**/.vagrant/
+**/ios/**/DerivedData/
+**/ios/**/Icon?
+**/ios/**/Pods/
+**/ios/**/.symlinks/
+**/ios/**/profile
+**/ios/**/xcuserdata
+**/ios/.generated/
+**/ios/Flutter/App.framework
+**/ios/Flutter/Flutter.framework
+**/ios/Flutter/Flutter.podspec
+**/ios/Flutter/Generated.xcconfig
+**/ios/Flutter/ephemeral
+**/ios/Flutter/app.flx
+**/ios/Flutter/app.zip
+**/ios/Flutter/flutter_assets/
+**/ios/Flutter/flutter_export_environment.sh
+**/ios/ServiceDefinitions.json
+**/ios/Runner/GeneratedPluginRegistrant.*
+
+# macOS
+**/Flutter/ephemeral/
+**/Pods/
+**/macos/Flutter/GeneratedPluginRegistrant.swift
+**/macos/Flutter/ephemeral
+**/xcuserdata/


### PR DESCRIPTION
## Summary

* 사용자 앱 그래프 5종에 진입 애니메이션을 추가했습니다 — 막대는 바닥에서 자라 오르고, 도넛은 원을 따라 그려지고, 꺾은선은 왼쪽에서 오른쪽으로 이어지고, 진행 바는 채워집니다.
* 모션 상수(재생 시간·커브)를 `design_system/tokens/motion.dart` 한 곳으로 모으고, 0→1 진행값을 내려주는 공용 `ChartReveal` 위젯을 추가했습니다.
* 기간 토글(오늘/이번 주/이번 달)과 홈 영양 지표 전환 시 `replayKey`로 모션을 다시 재생해, 데이터가 바뀐 것을 눈으로 따라갈 수 있게 했습니다.
* 접근성 설정에서 애니메이션을 끈 경우(`MediaQuery.disableAnimations`)에는 tween 없이 최종 상태를 즉시 렌더합니다.

---

## Changes

### ✨ Features

* `design_system/tokens/motion.dart` — 그래프 모션 토큰(`chartDraw` 750ms / `chartGrow` 850ms / `meterFill` 600ms, `easeOutCubic`, 막대 stagger 비율)
* `design_system/charts/chart_reveal.dart` — 공용 `ChartReveal` 위젯 + 막대용 `chartStagger` 헬퍼

### 🎨 UI/UX

* 홈 주간 영양 추이: 선이 월요일에서 오늘 쪽으로 그려지고, 데이터 포인트·값 라벨이 선이 닿는 순간 페이드인
* 홈 주간 운동 막대: 요일 순서대로 바닥에서 자라 오르고 값 라벨이 함께 등장
* 운동 기록 오늘 도넛: 12시 방향부터 시계 방향으로 그려짐
* 운동 기록 주간/월간 스택 막대: 날짜 순서대로 자라 오름
* 식단 영양 진행 바(가로/세로): 0에서 목표 비율까지 채워지고, 날짜 이동·식단 추가로 값이 바뀌면 다시 채워짐

### 🔧 Improvements

* `_DonutPainter`: 세그먼트 각도가 gap보다 작을 때 음수 sweep으로 엉뚱한 점이 찍히던 경로를 정리
* `ChartReveal`: 비유한(non-finite) `replayKey`를 고정 sentinel로 접어, NaN 키가 매 프레임 tween을 재생성하는 것을 차단
* `chartStagger`: 반환값을 0..1로 clamp — painter가 `Color.withValues(alpha:)`에 그대로 넘기므로 오버슈트 커브에서 assert가 나지 않도록

---

## Commits

1. `502dcc65` feat(ui): animate user app chart entry

---

## Notes

* 그래프는 전부 `CustomPaint`라 위젯 트리만으로는 모양을 검증할 수 없습니다. painter를 `PictureRecorder`로 직접 래스터화해 **칠해진 픽셀 수가 늘어나는지** 재는 방식으로 "정말 자라 오르는가"를 못박았습니다 (도넛은 첫 프레임 ink가 정확히 0).
* `/review` 결과 공용 위젯에서 잠재 이슈 2건을 발견해 이 PR에서 함께 수정했습니다: (1) NaN `replayKey`가 매 프레임 애니메이션을 재시작시켜 진행 바가 0에 멈추는 경로, (2) `chartStagger`가 clamp 없이 커브 값을 반환해 오버슈트 커브 도입 시 debug assert로 죽는 경로. 둘 다 현재 호출부에서는 발현되지 않지만 함정 자체를 제거했습니다.
* 트레이너 앱(`frontend/flutter_trainer/`)과 `design_system/charts/`의 fl_chart 래퍼(디자인 카탈로그 전용)는 스코프에서 제외했습니다.
* 브라우저 프리뷰로 실제 화면 확인을 시도했으나 이 환경에서 Flutter web 캔버스가 합성되지 않아 스크린샷을 받지 못했습니다. 체감 속도는 실기기/에뮬레이터에서 한 번 확인 부탁드립니다.

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [ ] UI 확인
* [x] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 홈 탭 진입 → 주간 영양 추이 선이 왼쪽부터 그려지고, 주간 운동 막대가 요일 순으로 자라 오르는지 확인
2. 홈 영양 지표를 칼로리 → 나트륨 → 당류로 전환 → 전환할 때마다 선이 처음부터 다시 그려지는지 확인
3. 운동 탭 → "오늘" 선택 → 도넛이 12시 방향부터 원을 따라 그려지는지 확인
4. 운동 탭 → "이번 주" ↔ "이번 달" 전환 → 막대가 매번 바닥에서 다시 자라는지 확인
5. 식단 탭 진입 → 영양 진행 바가 0에서 채워지는지, 날짜를 옮기면 다시 채워지는지 확인
6. OS 접근성 설정에서 "동작 줄이기"를 켠 뒤 재진입 → 모션 없이 최종 상태로 바로 보이는지 확인

---

## Related Issues

Closes #653

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 대시보드, 식단, 운동 차트에 진입 애니메이션을 추가했습니다.
  * 영양 진행 막대가 목표 비율까지 자연스럽게 채워집니다.
  * 기간을 전환하면 관련 차트 애니메이션이 다시 재생됩니다.
  * 애니메이션을 줄이거나 비활성화한 환경에서는 최종 상태가 즉시 표시됩니다.

* **테스트**
  * 차트와 진행 막대의 시작·진행·완료 상태 및 재생 동작을 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->