### PR TITLE
fix(notification): 인앱 알림이 서버 상태를 따라가게

### DIFF
--- a/frontend/flutter/lib/design_system/figma/figma_kit.dart
+++ b/frontend/flutter/lib/design_system/figma/figma_kit.dart
@@ -276,6 +276,7 @@ class FigmaTabHeader extends StatelessWidget {
     this.leading,
     this.onBell,
     this.onCalendar,
+    this.bellHasUnread = false,
   });
 
   final String title;
@@ -283,6 +284,10 @@ class FigmaTabHeader extends StatelessWidget {
   final Widget? leading;
   final VoidCallback? onBell;
   final VoidCallback? onCalendar;
+
+  /// 벨에 미읽음 점을 띄울지. 예전에는 항상 켜져 있어서 읽을 것이 없어도 점이
+  /// 남았다 — 화면이 서버 상태를 받아 넘긴다(디자인 시스템은 알림을 모른다).
+  final bool bellHasUnread;
 
   @override
   Widget build(BuildContext context) {
@@ -306,7 +311,7 @@ class FigmaTabHeader extends StatelessWidget {
           ),
           FigmaCircleButton(
             icon: Icons.notifications_none_rounded,
-            showDot: true,
+            showDot: bellHasUnread,
             onTap: onBell,
           ),
           const SizedBox(width: 10),

--- a/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
@@ -21,6 +21,7 @@ import 'package:oncare/features/exercise/presentation/controllers/exercise_contr
 import 'package:oncare/features/member_coach/domain/entities/member_coach.dart';
 import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
 import 'package:oncare/features/member_coach/presentation/widgets/trainer_chat_header_button.dart';
+import 'package:oncare/features/notification/presentation/controllers/notification_controller.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 import 'package:oncare/shared/services/exercise_burn_goal_provider.dart';
 import 'package:oncare/shared/widgets/coaching_sheet.dart';
@@ -60,12 +61,19 @@ class DashboardContent extends StatelessWidget {
         child: ListView(
           padding: const EdgeInsets.only(bottom: 108),
           children: <Widget>[
-            FigmaTabHeader(
-              title: 'On - Care',
-              leading: const HeartLogo(),
-              trailingAction: const TrainerChatHeaderButton(),
-              onBell: onNotificationTap,
-              onCalendar: onCalendarTap,
+            // 벨 배지는 서버 미읽음을 본다. 이 build 에는 ref 가 없어 여기서만
+            // 지역적으로 얻는다 — 헤더 전체를 다시 그리지 않는다.
+            Consumer(
+              builder: (BuildContext context, WidgetRef ref, Widget? _) =>
+FigmaTabHeader(
+                  title: 'On - Care',
+                  leading: const HeartLogo(),
+                  trailingAction: const TrainerChatHeaderButton(),
+                  onBell: onNotificationTap,
+                  bellHasUnread:
+                      (ref.watch(notificationUnreadProvider).valueOrNull ?? 0) > 0,
+                  onCalendar: onCalendarTap,
+                ),
             ),
             const SizedBox(height: 8),
             Consumer(

--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -13,6 +13,7 @@ import 'package:oncare/features/diet/domain/entities/diet_day.dart';
 import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
 import 'package:oncare/features/diet/presentation/widgets/diet_flows.dart';
 import 'package:oncare/features/member_coach/presentation/widgets/trainer_chat_header_button.dart';
+import 'package:oncare/features/notification/presentation/controllers/notification_controller.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 import 'package:oncare/shared/widgets/modals/schedule_calendar_sheet.dart';
 
@@ -156,6 +157,8 @@ class _DietRecordPageState extends ConsumerState<DietRecordPage> {
                   title: l.dietTitle,
                   trailingAction: const TrainerChatHeaderButton(),
                   onBell: () => context.push(AppRoutes.notification),
+                  bellHasUnread:
+                      (ref.watch(notificationUnreadProvider).valueOrNull ?? 0) > 0,
                   onCalendar: () => showScheduleCalendarSheet(context),
                 ),
                 _DateStrip(

--- a/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
@@ -20,6 +20,7 @@ import 'package:oncare/features/member_coach/domain/entities/member_coach.dart';
 import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
 import 'package:oncare/features/member_coach/presentation/widgets/coach_card.dart';
 import 'package:oncare/features/member_coach/presentation/widgets/trainer_chat_header_button.dart';
+import 'package:oncare/features/notification/presentation/controllers/notification_controller.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 import 'package:oncare/shared/services/exercise_burn_goal_provider.dart';
 import 'package:oncare/shared/widgets/modals/schedule_calendar_sheet.dart';
@@ -61,11 +62,18 @@ class _ExercisePageState extends State<ExercisePage> {
             child: ListView(
               padding: const EdgeInsets.only(bottom: 108),
               children: <Widget>[
-                FigmaTabHeader(
-                  title: l.pageExerciseTitle,
-                  trailingAction: const TrainerChatHeaderButton(),
-                  onBell: () => context.push(AppRoutes.notification),
-                  onCalendar: () => showScheduleCalendarSheet(context),
+                // 벨 배지는 서버 미읽음을 본다. 이 build 에는 ref 가 없어 여기서만
+                // 지역적으로 얻는다 — 헤더 전체를 다시 그리지 않는다.
+                Consumer(
+                  builder: (BuildContext context, WidgetRef ref, Widget? _) =>
+FigmaTabHeader(
+                      title: l.pageExerciseTitle,
+                      trailingAction: const TrainerChatHeaderButton(),
+                      onBell: () => context.push(AppRoutes.notification),
+                      bellHasUnread:
+                          (ref.watch(notificationUnreadProvider).valueOrNull ?? 0) > 0,
+                      onCalendar: () => showScheduleCalendarSheet(context),
+                    ),
                 ),
                 _SubTabs(
                   active: _subTab,

--- a/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
@@ -14,6 +14,7 @@ import 'package:oncare/features/member_coach/presentation/widgets/trainer_chat_h
 import 'package:oncare/features/my_health/domain/entities/health_history.dart';
 import 'package:oncare/features/my_health/presentation/controllers/my_health_controller.dart';
 import 'package:oncare/features/my_health/presentation/widgets/my_flows.dart';
+import 'package:oncare/features/notification/presentation/controllers/notification_controller.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 import 'package:oncare/shared/widgets/modals/schedule_calendar_sheet.dart';
 
@@ -58,6 +59,8 @@ class MyHealthPage extends ConsumerWidget {
                   title: l.myTabTitle,
                   trailingAction: const TrainerChatHeaderButton(),
                   onBell: () => context.push(AppRoutes.notification),
+                  bellHasUnread:
+                      (ref.watch(notificationUnreadProvider).valueOrNull ?? 0) > 0,
                   onCalendar: () => showScheduleCalendarSheet(context),
                 ),
                 const SizedBox(height: 4),

--- a/frontend/flutter/lib/features/notification/data/repositories/dio_notification_repository.dart
+++ b/frontend/flutter/lib/features/notification/data/repositories/dio_notification_repository.dart
@@ -60,9 +60,14 @@ class DioNotificationRepository implements NotificationRepository {
   /// 서버가 준 행동 유도. 없으면 null — 읽음 처리만 하는 알림이다.
   static AlertAction? _actionFrom(Object? raw) {
     if (raw is! Map<String, Object?>) return null;
-    final label = (raw['label'] as String?) ?? '';
-    final target = raw['target'] as String?;
-    if (label.isEmpty || target == null) return null;
+    // 캐스팅하지 않고 확인만 한다. 계약이 깨진 action 하나가 `TypeError` 를 던지면
+    // **알림 목록 전체가 실패한다** — 그 한 건만 버리고 나머지는 보여 준다(리뷰).
+    //
+    // 미읽음 수와 반대로 판단하는 이유: 그쪽은 값 하나라 던지면 폴링이 마지막 좋은
+    // 값을 유지한다. 여기서 던지면 멀쩡한 알림까지 함께 사라진다.
+    final Object? label = raw['label'];
+    final Object? target = raw['target'];
+    if (label is! String || label.isEmpty || target is! String) return null;
     return AlertAction(label: label, target: _targetFrom(target));
   }
 

--- a/frontend/flutter/lib/features/notification/data/repositories/dio_notification_repository.dart
+++ b/frontend/flutter/lib/features/notification/data/repositories/dio_notification_repository.dart
@@ -26,6 +26,14 @@ class DioNotificationRepository implements NotificationRepository {
     await _dio.post<Object?>('/notifications/read-all');
   }
 
+  @override
+  Future<int> unreadCount() async {
+    final res = await _dio.get<Map<String, Object?>>(
+      '/notifications/unread-count',
+    );
+    return (res.data?['count'] as num?)?.toInt() ?? 0;
+  }
+
   static AlertItem _fromJson(Map<String, Object?> json) {
     return AlertItem(
       id: json['id']! as String,
@@ -34,8 +42,29 @@ class DioNotificationRepository implements NotificationRepository {
       timeAgo: (json['time_ago'] as String?) ?? '',
       category: _categoryFrom(json['category']! as String),
       read: (json['read'] as bool?) ?? false,
+      action: _actionFrom(json['action']),
     );
   }
+
+  /// 서버가 준 행동 유도. 없으면 null — 읽음 처리만 하는 알림이다.
+  static AlertAction? _actionFrom(Object? raw) {
+    if (raw is! Map<String, Object?>) return null;
+    final label = (raw['label'] as String?) ?? '';
+    final target = raw['target'] as String?;
+    if (label.isEmpty || target == null) return null;
+    return AlertAction(label: label, target: _targetFrom(target));
+  }
+
+  /// 앱이 모르는 target 은 [AlertTarget.unknown] 이다. 목록에서 빼지 않고 이동만
+  /// 하지 않는다 — 안 보이는 알림보다 갈 곳 없는 알림이 낫다(트레이너 웹과 같은 규칙).
+  static AlertTarget _targetFrom(String s) => switch (s) {
+    'dashboard' => AlertTarget.dashboard,
+    'schedule' => AlertTarget.schedule,
+    'coach_chat' => AlertTarget.coachChat,
+    'exercise' => AlertTarget.exercise,
+    'diet' => AlertTarget.diet,
+    _ => AlertTarget.unknown,
+  };
 
   static AlertCategory _categoryFrom(String s) => switch (s) {
     'reminder' => AlertCategory.reminder,

--- a/frontend/flutter/lib/features/notification/data/repositories/dio_notification_repository.dart
+++ b/frontend/flutter/lib/features/notification/data/repositories/dio_notification_repository.dart
@@ -31,13 +31,18 @@ class DioNotificationRepository implements NotificationRepository {
     final res = await _dio.get<Map<String, Object?>>(
       '/notifications/unread-count',
     );
-    final Object? raw = res.data?['count'];
+    // 서버가 쓰는 키는 `unread` 다(트레이너 웹도 같은 키를 읽는다). `count` 로 읽고
+    // 있었는데, 그러면 실서버에서 늘 값을 못 찾아 배지가 아예 동작하지 않는다.
+    final Object? raw = res.data?['unread'];
     // 잘못된 응답을 0 으로 삼키면 **읽지 않은 알림이 있는데도 배지가 꺼진다.**
     // 던져서 폴링이 마지막 좋은 값을 유지하게 한다(연결 실패와 같은 취급).
-    if (raw is! num || raw < 0) {
+    //
+    // `num` 이 아니라 `int` 를 요구하는 이유: 계약은 0 이상의 정수다. 소수를 받아
+    // `toInt()` 로 잘라 내면 1.5 가 1 이 되어 **틀린 수를 조용히 보여 준다**(리뷰).
+    if (raw is! int || raw < 0) {
       throw const FormatException('unread-count 응답이 올바르지 않습니다');
     }
-    return raw.toInt();
+    return raw;
   }
 
   static AlertItem _fromJson(Map<String, Object?> json) {

--- a/frontend/flutter/lib/features/notification/data/repositories/dio_notification_repository.dart
+++ b/frontend/flutter/lib/features/notification/data/repositories/dio_notification_repository.dart
@@ -31,7 +31,13 @@ class DioNotificationRepository implements NotificationRepository {
     final res = await _dio.get<Map<String, Object?>>(
       '/notifications/unread-count',
     );
-    return (res.data?['count'] as num?)?.toInt() ?? 0;
+    final Object? raw = res.data?['count'];
+    // 잘못된 응답을 0 으로 삼키면 **읽지 않은 알림이 있는데도 배지가 꺼진다.**
+    // 던져서 폴링이 마지막 좋은 값을 유지하게 한다(연결 실패와 같은 취급).
+    if (raw is! num || raw < 0) {
+      throw const FormatException('unread-count 응답이 올바르지 않습니다');
+    }
+    return raw.toInt();
   }
 
   static AlertItem _fromJson(Map<String, Object?> json) {

--- a/frontend/flutter/lib/features/notification/data/repositories/mock_notification_repository.dart
+++ b/frontend/flutter/lib/features/notification/data/repositories/mock_notification_repository.dart
@@ -38,21 +38,32 @@ const List<AlertItem> demoAlerts = <AlertItem>[
   ),
 ];
 
-/// 데모/로컬 모드용 [NotificationRepository]. 목록은 [demoAlerts] 고정이고,
-/// 읽음 변이는 세션 메모리(컨트롤러 state)에서만 처리하므로 no-op 이다.
+/// 데모/로컬 모드용 [NotificationRepository].
+///
+/// 목록은 [demoAlerts] 로 시작하고 읽음 처리를 **세션 동안 기억한다.** 예전에는
+/// 읽음이 no-op 이라, 미읽음 수를 물으면 늘 처음 상태를 답했다 — 데모에서 "모두 읽음"
+/// 을 눌러도 벨의 점이 남아, 목록과 배지가 서로 다른 말을 했다(리뷰).
 class MockNotificationRepository implements NotificationRepository {
-  const MockNotificationRepository();
+  MockNotificationRepository();
+
+  List<AlertItem> _items = List<AlertItem>.of(demoAlerts);
 
   @override
-  Future<List<AlertItem>> fetchAll() async => demoAlerts;
+  Future<List<AlertItem>> fetchAll() async => List<AlertItem>.of(_items);
 
   @override
-  Future<void> markRead(String id) async {}
+  Future<void> markRead(String id) async {
+    _items = _items
+        .map((AlertItem a) => a.id == id ? a.copyWith(read: true) : a)
+        .toList();
+  }
 
   @override
-  Future<void> markAllRead() async {}
+  Future<void> markAllRead() async {
+    _items = _items.map((AlertItem a) => a.copyWith(read: true)).toList();
+  }
 
   @override
   Future<int> unreadCount() async =>
-      demoAlerts.where((AlertItem a) => !a.read).length;
+      _items.where((AlertItem a) => !a.read).length;
 }

--- a/frontend/flutter/lib/features/notification/data/repositories/mock_notification_repository.dart
+++ b/frontend/flutter/lib/features/notification/data/repositories/mock_notification_repository.dart
@@ -51,4 +51,8 @@ class MockNotificationRepository implements NotificationRepository {
 
   @override
   Future<void> markAllRead() async {}
+
+  @override
+  Future<int> unreadCount() async =>
+      demoAlerts.where((AlertItem a) => !a.read).length;
 }

--- a/frontend/flutter/lib/features/notification/domain/entities/alert_item.dart
+++ b/frontend/flutter/lib/features/notification/domain/entities/alert_item.dart
@@ -1,5 +1,26 @@
 enum AlertCategory { reminder, healthCheck, achievement, system }
 
+/// 알림을 눌렀을 때 갈 곳. 서버가 알림마다 내려준다(`action.target`).
+///
+/// 앱이 모르는 target 은 [unknown] 이 되고, 그 알림은 읽음 처리만 하고 이동하지
+/// 않는다 — 서버가 새 종류를 추가했을 때 **갈 곳 없는 알림**이 되는 편이 목록에서
+/// 사라지거나 엉뚱한 화면으로 보내는 것보다 낫다.
+enum AlertTarget { dashboard, schedule, coachChat, exercise, diet, unknown }
+
+/// 알림 항목의 행동 유도 — 문구는 서버가, 이동은 앱이 정한다.
+class AlertAction {
+  const AlertAction({required this.label, required this.target});
+
+  /// 버튼/힌트에 쓰는 서버 문구.
+  final String label;
+
+  /// 눌렀을 때 갈 곳.
+  final AlertTarget target;
+
+  /// 앱이 실제로 이동할 수 있는 행동인가.
+  bool get isNavigable => target != AlertTarget.unknown;
+}
+
 class AlertItem {
   const AlertItem({
     required this.id,
@@ -8,6 +29,7 @@ class AlertItem {
     required this.timeAgo,
     required this.category,
     this.read = false,
+    this.action,
   });
 
   final String id;
@@ -17,6 +39,9 @@ class AlertItem {
   final AlertCategory category;
   final bool read;
 
+  /// 서버가 지정한 이동 경로. 없으면 읽음 처리만 한다.
+  final AlertAction? action;
+
   AlertItem copyWith({bool? read}) => AlertItem(
     id: id,
     title: title,
@@ -24,11 +49,39 @@ class AlertItem {
     timeAgo: timeAgo,
     category: category,
     read: read ?? this.read,
+    action: action,
   );
 }
 
+/// 알림 목록 화면이 그리는 상태.
+///
+/// [items] 와 [failedToLoad] 를 함께 들고 있는 이유: 조회가 실패해도 **이미 받아 둔
+/// 목록을 지우지 않는다.** 지하철에서 새로고침했다고 알림이 사라지면, 사용자는 읽지
+/// 않은 알림이 있었는지조차 알 수 없게 된다.
 class NotificationState {
-  const NotificationState({required this.items});
+  const NotificationState({
+    required this.items,
+    this.loading = false,
+    this.failedToLoad = false,
+  });
+
   final List<AlertItem> items;
+
+  /// 첫 조회가 진행 중인가. 새로고침 중에는 기존 목록을 그대로 보여 준다.
+  final bool loading;
+
+  /// 마지막 조회가 실패했는가. 화면이 재시도를 제안하는 근거다.
+  final bool failedToLoad;
+
   int get unreadCount => items.where((AlertItem i) => !i.read).length;
+
+  NotificationState copyWith({
+    List<AlertItem>? items,
+    bool? loading,
+    bool? failedToLoad,
+  }) => NotificationState(
+    items: items ?? this.items,
+    loading: loading ?? this.loading,
+    failedToLoad: failedToLoad ?? this.failedToLoad,
+  );
 }

--- a/frontend/flutter/lib/features/notification/domain/repositories/notification_repository.dart
+++ b/frontend/flutter/lib/features/notification/domain/repositories/notification_repository.dart
@@ -9,4 +9,10 @@ abstract class NotificationRepository {
 
   /// Persist all of the user's notifications as read.
   Future<void> markAllRead();
+
+  /// 서버 기준 미읽음 수.
+  ///
+  /// 목록을 통째로 받아 세지 않고 따로 두는 이유: 헤더 배지는 모든 탭에 떠 있어서
+  /// 알림을 열지 않아도 최신이어야 하는데, 그때마다 전체 목록을 받는 것은 과하다.
+  Future<int> unreadCount();
 }

--- a/frontend/flutter/lib/features/notification/presentation/controllers/notification_controller.dart
+++ b/frontend/flutter/lib/features/notification/presentation/controllers/notification_controller.dart
@@ -69,11 +69,14 @@ class NotificationController extends StateNotifier<NotificationState> {
           .map((AlertItem i) => i.id == id ? i.copyWith(read: true) : i)
           .toList(),
     );
-    onChanged?.call();
     try {
       await _repo.markRead(id);
     } catch (_) {
       // 낙관적 업데이트 유지 — 영속화 실패는 다음 로드에서 정정된다.
+    } finally {
+      // **쓰기가 끝난 뒤에** 다시 센다. 먼저 부르면 서버가 아직 옛 수를 답해,
+      // 배지가 다음 폴링까지 틀린 채로 남는다(리뷰).
+      onChanged?.call();
     }
   }
 
@@ -81,11 +84,12 @@ class NotificationController extends StateNotifier<NotificationState> {
     state = NotificationState(
       items: state.items.map((AlertItem i) => i.copyWith(read: true)).toList(),
     );
-    onChanged?.call();
     try {
       await _repo.markAllRead();
     } catch (_) {
       // 낙관적 업데이트 유지.
+    } finally {
+      onChanged?.call();
     }
   }
 
@@ -109,7 +113,7 @@ class NotificationController extends StateNotifier<NotificationState> {
 /// 데모/로컬 모드는 목, 실모드는 백엔드(`/notifications`) 리포.
 final notificationRepositoryProvider = Provider<NotificationRepository>((ref) {
   if (ref.watch(appConfigProvider).useMockApi) {
-    return const MockNotificationRepository();
+    return MockNotificationRepository();
   }
   return DioNotificationRepository(ref.watch(dioProvider));
 }, name: 'notificationRepository');

--- a/frontend/flutter/lib/features/notification/presentation/controllers/notification_controller.dart
+++ b/frontend/flutter/lib/features/notification/presentation/controllers/notification_controller.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:oncare/core/config/app_config.dart';
 import 'package:oncare/core/network/dio_client.dart';
+import 'package:oncare/core/utils/active_polling_stream.dart';
 import 'package:oncare/features/notification/data/repositories/dio_notification_repository.dart';
 import 'package:oncare/features/notification/data/repositories/mock_notification_repository.dart';
 import 'package:oncare/features/notification/domain/entities/alert_item.dart';
@@ -11,7 +12,7 @@ class NotificationController extends StateNotifier<NotificationState> {
   /// [seed] 가 주어지면(데모/목 모드) 즉시 노출하고 네트워크 로드를 건너뛴다 —
   /// 데모 둘러보기 화면이 기존과 동일하게 보이도록 유지한다. 실모드는 seed=null
   /// 로 생성해 백엔드(`/notifications`)에서 최신 알림을 불러온다.
-  NotificationController(this._repo, {List<AlertItem>? seed})
+  NotificationController(this._repo, {List<AlertItem>? seed, this.onChanged})
     : _allowSimulatePush = seed != null,
       super(NotificationState(items: seed ?? const <AlertItem>[])) {
     if (seed == null) {
@@ -21,24 +22,46 @@ class NotificationController extends StateNotifier<NotificationState> {
 
   final NotificationRepository _repo;
 
+  /// 목록이 바뀌면 호출된다. 헤더 배지가 목록과 같은 서버 상태를 보도록,
+  /// 읽음 처리 직후 다음 폴링을 기다리지 않고 즉시 다시 세게 한다.
+  final void Function()? onChanged;
+
   /// 가상 푸시 주입은 목/데모 모드에서만 허용한다(seed 가 주어진 경우).
   /// 실모드는 서버가 진실원본이라, 로컬 팬텀을 넣으면 다음 [refresh] 에서
   /// 사라져 상태가 어긋난다.
   final bool _allowSimulatePush;
 
-  Future<void> _load() async {
+  /// 진행 중인 조회. 화면 진입과 포그라운드 복귀가 겹쳐도 요청이 두 번 나가지 않게
+  /// 같은 future 를 돌려준다 — 중복 조회는 목록이 두 번 흔들리는 것으로 보인다.
+  Future<void>? _inFlight;
+
+  Future<void> _load() {
+    return _inFlight ??= _loadOnce().whenComplete(() => _inFlight = null);
+  }
+
+  Future<void> _loadOnce() async {
+    if (mounted) state = state.copyWith(loading: true);
     try {
       final items = await _repo.fetchAll();
-      if (mounted) {
-        state = NotificationState(items: items);
-      }
+      if (!mounted) return;
+      // 서버가 진실원본이다. 목록을 통째로 갈아 끼우므로 중복이 남지 않는다.
+      state = NotificationState(items: items);
+      onChanged?.call();
     } catch (_) {
-      // 알림 로드 실패는 화면 접근을 막지 않는다(빈 목록 유지).
+      // 실패해도 **이미 받아 둔 목록은 지우지 않는다.** 화면이 재시도를 제안한다.
+      if (!mounted) return;
+      state = state.copyWith(loading: false, failedToLoad: true);
     }
   }
 
-  /// 실모드에서 서버 알림을 다시 불러온다.
-  Future<void> refresh() => _load();
+  /// 서버 알림을 다시 불러온다.
+  ///
+  /// 화면 진입·복귀·당겨서 새로고침이 모두 이 경로를 쓴다. 목 모드에서는 시드가
+  /// 진실원본이라 아무 일도 하지 않는다 — 데모 화면이 네트워크를 타면 안 된다.
+  Future<void> refresh() async {
+    if (_allowSimulatePush) return;
+    await _load();
+  }
 
   Future<void> markRead(String id) async {
     state = NotificationState(
@@ -46,6 +69,7 @@ class NotificationController extends StateNotifier<NotificationState> {
           .map((AlertItem i) => i.id == id ? i.copyWith(read: true) : i)
           .toList(),
     );
+    onChanged?.call();
     try {
       await _repo.markRead(id);
     } catch (_) {
@@ -57,6 +81,7 @@ class NotificationController extends StateNotifier<NotificationState> {
     state = NotificationState(
       items: state.items.map((AlertItem i) => i.copyWith(read: true)).toList(),
     );
+    onChanged?.call();
     try {
       await _repo.markAllRead();
     } catch (_) {
@@ -95,8 +120,33 @@ final notificationControllerProvider =
     StateNotifierProvider<NotificationController, NotificationState>((ref) {
       final useMock = ref.watch(appConfigProvider).useMockApi;
       final repo = ref.watch(notificationRepositoryProvider);
-      return NotificationController(repo, seed: useMock ? demoAlerts : null);
+      return NotificationController(
+        repo,
+        seed: useMock ? demoAlerts : null,
+        onChanged: () => ref.invalidate(notificationUnreadProvider),
+      );
     }, name: 'notifications');
+
+/// 헤더 벨 배지가 읽는 **서버 기준** 미읽음 수.
+///
+/// 목록 전체를 받아 세지 않는 이유: 배지는 모든 탭에 떠 있어서 알림을 열지 않아도
+/// 최신이어야 하는데, 그때마다 전체 목록을 받는 것은 과하다.
+///
+/// 폴링은 앱이 앞에 있을 때만 돌고, 일시적 실패에는 마지막 값을 유지한다
+/// (`activePollingStream`). 트레이너가 무언가 하면 회원 앱을 재시작하지 않아도
+/// 배지가 따라온다.
+final notificationUnreadProvider = StreamProvider<int>((ref) {
+  final repo = ref.watch(notificationRepositoryProvider);
+  if (ref.watch(appConfigProvider).useMockApi) {
+    // 데모에는 따라갈 서버가 없다. 시드 값을 한 번만 내보내고 폴링하지 않는다 —
+    // 없는 서버를 15초마다 찌르는 타이머가 화면 수명 내내 남는다.
+    return Stream<int>.fromFuture(repo.unreadCount());
+  }
+  return activePollingStream<int>(
+    load: repo.unreadCount,
+    interval: const Duration(seconds: 15),
+  );
+}, name: 'notificationUnread');
 
 /// 안읽음 배지 등 가벼운 소비처용 목록(리포 직접). 컨트롤러와 별개로 유지한다.
 final notificationListProvider = FutureProvider.autoDispose<List<AlertItem>>(

--- a/frontend/flutter/lib/features/notification/presentation/pages/notification_page.dart
+++ b/frontend/flutter/lib/features/notification/presentation/pages/notification_page.dart
@@ -19,15 +19,51 @@ import 'package:oncare/shared/widgets/empty_state.dart';
       AlertCategory.system => (label: '시스템', tone: AppBadgeTone.neutral),
     };
 
-class NotificationPage extends ConsumerWidget {
+class NotificationPage extends ConsumerStatefulWidget {
   const NotificationPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<NotificationPage> createState() => _NotificationPageState();
+}
+
+/// 화면이 살아 있는 동안 서버 상태를 따라간다.
+///
+/// 진입할 때 한 번, 그리고 앱이 앞으로 돌아올 때마다 다시 조회한다. 트레이너가
+/// 무언가 해도 회원 앱을 재시작해야 보이던 문제를 없앤다 — 알림함을 열어 둔 채
+/// 잠깐 다른 앱을 다녀오는 것이 실제로 자주 하는 동작이다.
+class _NotificationPageState extends ConsumerState<NotificationPage>
+    with WidgetsBindingObserver {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    // 첫 프레임 뒤에 부른다 — build 중에 provider 를 건드리지 않는다.
+    WidgetsBinding.instance.addPostFrameCallback((_) => _refresh());
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) _refresh();
+  }
+
+  Future<void> _refresh() {
+    if (!mounted) return Future<void>.value();
+    return ref.read(notificationControllerProvider.notifier).refresh();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
     final config = ref.watch(appConfigProvider);
     final state = ref.watch(notificationControllerProvider);
     final notifier = ref.read(notificationControllerProvider.notifier);
+    final bool showRetry = state.failedToLoad;
 
     final Widget page = Scaffold(
       key: const Key('notificationPage'),
@@ -40,23 +76,39 @@ class NotificationPage extends ConsumerWidget {
           ),
         ],
       ),
-      body: state.items.isEmpty
-          ? const EmptyState(
-              icon: Icons.notifications_off_outlined,
-              title: '알림이 없습니다',
-            )
-          : ListView.separated(
-              padding: const EdgeInsets.all(AppSpacing.lg),
-              itemCount: state.items.length,
-              separatorBuilder: (_, _) => const SizedBox(height: AppSpacing.sm),
-              itemBuilder: (BuildContext ctx, int i) {
-                final item = state.items[i];
-                return _AlertTile(
-                  item: item,
-                  onTap: () => notifier.markRead(item.id),
-                );
-              },
-            ),
+      // 목록이 비어 있어도 당겨서 새로고침할 수 있어야 한다 — 빈 화면이야말로
+      // 다시 받아 보고 싶은 순간이다. 그래서 본문은 항상 스크롤 가능하다.
+      body: RefreshIndicator(
+        onRefresh: _refresh,
+        child: ListView.separated(
+          padding: const EdgeInsets.all(AppSpacing.lg),
+          physics: const AlwaysScrollableScrollPhysics(),
+          itemCount:
+              (showRetry ? 1 : 0) +
+              (state.items.isEmpty ? 1 : state.items.length),
+          separatorBuilder: (_, _) => const SizedBox(height: AppSpacing.sm),
+          itemBuilder: (BuildContext ctx, int i) {
+            // 조회가 실패해도 **받아 둔 목록은 그대로 둔다.** 맨 위에 사정과 재시도만
+            // 얹는다 — 목록이 사라지면 읽지 않은 알림이 있었는지조차 알 수 없다.
+            if (showRetry && i == 0) {
+              return _RetryBanner(onRetry: _refresh);
+            }
+            if (state.items.isEmpty) {
+              return const SizedBox(
+                height: 320,
+                child: EmptyState(
+                  icon: Icons.notifications_off_outlined,
+                  title: '알림이 없습니다',
+                ),
+              );
+            }
+            return _AlertTile(
+              item: state.items[i - (showRetry ? 1 : 0)],
+              onTap: () => notifier.markRead(state.items[i - (showRetry ? 1 : 0)].id),
+            );
+          },
+        ),
+      ),
       // 가상 푸시는 목/데모 모드 전용 개발 도구 — 실모드에서는 버튼을 숨긴다
       // (서버에 없는 팬텀 알림 방지, 죽은 버튼 방지).
       floatingActionButton: config.useMockApi
@@ -113,6 +165,32 @@ class _AlertTile extends StatelessWidget {
                 Text(item.body, style: theme.textTheme.bodyMedium),
               ],
             ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+
+/// 조회 실패를 알리고 다시 시도하게 한다.
+class _RetryBanner extends StatelessWidget {
+  const _RetryBanner({required this.onRetry});
+
+  final Future<void> Function() onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return AppCard(
+      key: const Key('notificationRetryBanner'),
+      child: Row(
+        children: <Widget>[
+          const Icon(Icons.cloud_off_rounded, size: 20),
+          const SizedBox(width: AppSpacing.sm),
+          const Expanded(child: Text('최신 알림을 불러오지 못했어요')),
+          TextButton(
+            onPressed: () => onRetry(),
+            child: const Text('다시 시도'),
           ),
         ],
       ),

--- a/frontend/flutter/test/features/dashboard/dashboard_content_state_test.dart
+++ b/frontend/flutter/test/features/dashboard/dashboard_content_state_test.dart
@@ -16,6 +16,7 @@ import 'package:oncare/features/diet/domain/entities/diet_day.dart';
 import 'package:oncare/features/member_coach/data/repositories/mock_member_coach_repository.dart';
 import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
 import 'package:oncare/features/member_coach/presentation/widgets/coach_chat_sheet.dart';
+import 'package:oncare/features/notification/presentation/controllers/notification_controller.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 
 void main() {
@@ -167,7 +168,13 @@ void main() {
   testWidgets('home uses the shared tab header and notification style', (
     WidgetTester tester,
   ) async {
-    await pumpDashboard(tester, load: () async => liveSummary);
+    await pumpDashboard(
+      tester,
+      load: () async => liveSummary,
+      extraOverrides: <Override>[
+        notificationUnreadProvider.overrideWith((ref) => Stream<int>.value(2)),
+      ],
+    );
     await tester.pumpAndSettle();
 
     expect(find.byType(FigmaTabHeader), findsOneWidget);
@@ -180,8 +187,32 @@ void main() {
             widget.icon == Icons.notifications_none_rounded,
       ),
     );
+    // 점은 이제 **서버 미읽음을 따른다.** 예전에는 항상 켜져 있어서 읽을 것이
+    // 없어도 남았다(#636).
     expect(notificationButton.showDot, isTrue);
     expect(notificationButton.dotColor, FigmaColors.orange);
+  });
+
+  testWidgets('읽지 않은 알림이 없으면 벨에 점이 없다', (WidgetTester tester) async {
+    await pumpDashboard(
+      tester,
+      load: () async => liveSummary,
+      extraOverrides: <Override>[
+        notificationUnreadProvider.overrideWith(
+          (ref) => Stream<int>.value(0),
+        ),
+      ],
+    );
+    await tester.pumpAndSettle();
+
+    final FigmaCircleButton bell = tester.widget(
+      find.byWidgetPredicate(
+        (Widget widget) =>
+            widget is FigmaCircleButton &&
+            widget.icon == Icons.notifications_none_rounded,
+      ),
+    );
+    expect(bell.showDot, isFalse);
   });
 
   testWidgets('shows error state', (WidgetTester tester) async {

--- a/frontend/flutter/test/features/notification/dio_notification_repository_test.dart
+++ b/frontend/flutter/test/features/notification/dio_notification_repository_test.dart
@@ -1,0 +1,150 @@
+/// 실 백엔드 알림 계약 — #636 리뷰.
+///
+/// 미읽음 수를 서버에서 읽는 부분이 **키를 잘못 보고 있었다.** 서버는 `unread` 를
+/// 내려주는데 `count` 로 읽어, 실서버에서는 늘 값을 못 찾았다. 목 모드에서는 그 경로가
+/// 아예 돌지 않아 기존 테스트로는 드러나지 않았다.
+///
+/// 여기서 계약을 못 박는다 — 키 이름, 그리고 잘못된 응답을 **조용히 0 으로 삼키지
+/// 않는다**는 것.
+library;
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/notification/data/repositories/dio_notification_repository.dart';
+import 'package:oncare/features/notification/domain/entities/alert_item.dart';
+
+/// 지정한 본문으로만 답하는 가짜 서버.
+Dio _dio(Object? body, {int status = 200}) {
+  final Dio dio = Dio(BaseOptions(baseUrl: 'https://example.test'));
+  dio.interceptors.add(
+    InterceptorsWrapper(
+      onRequest: (RequestOptions options, RequestInterceptorHandler handler) {
+        handler.resolve(
+          Response<Object?>(
+            requestOptions: options,
+            statusCode: status,
+            data: body,
+          ),
+        );
+      },
+    ),
+  );
+  return dio;
+}
+
+void main() {
+  group('unreadCount', () {
+    test('서버가 쓰는 키(unread)를 읽는다', () async {
+      final repo = DioNotificationRepository(
+        _dio(<String, Object?>{'unread': 3}),
+      );
+
+      expect(await repo.unreadCount(), 3);
+    });
+
+    test('읽을 것이 없으면 0 이다', () async {
+      final repo = DioNotificationRepository(
+        _dio(<String, Object?>{'unread': 0}),
+      );
+
+      expect(await repo.unreadCount(), 0);
+    });
+
+    test('키가 없으면 0 으로 삼키지 않고 던진다', () async {
+      // 0 으로 돌려주면 읽지 않은 알림이 있는데도 배지가 즉시 꺼진다. 던져야
+      // 폴링이 마지막 좋은 값을 유지한다.
+      final repo = DioNotificationRepository(
+        _dio(<String, Object?>{'count': 3}),
+      );
+
+      expect(repo.unreadCount(), throwsA(isA<FormatException>()));
+    });
+
+    test('소수는 잘라 내지 않고 던진다', () async {
+      // toInt() 로 잘라 내면 1.5 가 1 이 되어 틀린 수를 조용히 보여 준다.
+      final repo = DioNotificationRepository(
+        _dio(<String, Object?>{'unread': 1.5}),
+      );
+
+      expect(repo.unreadCount(), throwsA(isA<FormatException>()));
+    });
+
+    test('음수는 던진다', () async {
+      final repo = DioNotificationRepository(
+        _dio(<String, Object?>{'unread': -1}),
+      );
+
+      expect(repo.unreadCount(), throwsA(isA<FormatException>()));
+    });
+  });
+
+  group('fetchAll', () {
+    test('서버가 준 action 을 이동 경로로 옮긴다', () async {
+      final repo = DioNotificationRepository(
+        _dio(<Object?>[
+          <String, Object?>{
+            'id': 'n1',
+            'title': '제목',
+            'body': '본문',
+            'time_ago': '방금',
+            'category': 'reminder',
+            'read': false,
+            'action': <String, Object?>{
+              'label': '기록하러 가기',
+              'target': 'dashboard',
+            },
+          },
+        ]),
+      );
+
+      final AlertItem item = (await repo.fetchAll()).single;
+      expect(item.action?.label, '기록하러 가기');
+      expect(item.action?.target, AlertTarget.dashboard);
+      expect(item.action?.isNavigable, isTrue);
+    });
+
+    test('모르는 target 은 목록에서 빼지 않고 이동만 하지 않는다', () async {
+      final repo = DioNotificationRepository(
+        _dio(<Object?>[
+          <String, Object?>{
+            'id': 'n1',
+            'title': '제목',
+            'body': '본문',
+            'time_ago': '방금',
+            'category': 'system',
+            'read': false,
+            'action': <String, Object?>{
+              'label': '어딘가로',
+              'target': 'not_yet_known_to_the_app',
+            },
+          },
+        ]),
+      );
+
+      final AlertItem item = (await repo.fetchAll()).single;
+      // 안 보이는 알림보다 갈 곳 없는 알림이 낫다(트레이너 웹과 같은 규칙).
+      expect(item.action?.target, AlertTarget.unknown);
+      expect(item.action?.isNavigable, isFalse);
+    });
+
+    test('action 이 없는 알림도 그대로 실린다', () async {
+      final repo = DioNotificationRepository(
+        _dio(<Object?>[
+          <String, Object?>{
+            'id': 'n1',
+            'title': '제목',
+            'body': '본문',
+            'time_ago': '방금',
+            'category': 'system',
+            'read': true,
+          },
+        ]),
+      );
+
+      final AlertItem item = (await repo.fetchAll()).single;
+      expect(item.action, isNull);
+      expect(item.read, isTrue);
+    });
+  });
+}

--- a/frontend/flutter/test/features/notification/dio_notification_repository_test.dart
+++ b/frontend/flutter/test/features/notification/dio_notification_repository_test.dart
@@ -128,6 +128,37 @@ void main() {
       expect(item.action?.isNavigable, isFalse);
     });
 
+    test('계약이 깨진 action 하나가 목록 전체를 무너뜨리지 않는다', () async {
+      final repo = DioNotificationRepository(
+        _dio(<Object?>[
+          <String, Object?>{
+            'id': 'n1',
+            'title': '깨진 action',
+            'body': '본문',
+            'time_ago': '방금',
+            'category': 'system',
+            'read': false,
+            // label 이 문자열이 아니다. 캐스팅하면 여기서 TypeError 가 나고
+            // 멀쩡한 아래 알림까지 함께 사라진다.
+            'action': <String, Object?>{'label': 42, 'target': 'dashboard'},
+          },
+          <String, Object?>{
+            'id': 'n2',
+            'title': '정상',
+            'body': '본문',
+            'time_ago': '방금',
+            'category': 'reminder',
+            'read': false,
+          },
+        ]),
+      );
+
+      final List<AlertItem> items = await repo.fetchAll();
+      expect(items, hasLength(2));
+      expect(items.first.action, isNull);
+      expect(items.last.title, '정상');
+    });
+
     test('action 이 없는 알림도 그대로 실린다', () async {
       final repo = DioNotificationRepository(
         _dio(<Object?>[

--- a/frontend/flutter/test/features/notification/dio_notification_repository_test.dart
+++ b/frontend/flutter/test/features/notification/dio_notification_repository_test.dart
@@ -128,7 +128,7 @@ void main() {
       expect(item.action?.isNavigable, isFalse);
     });
 
-    test('계약이 깨진 action 하나가 목록 전체를 무너뜨리지 않는다', () async {
+    test('계약이 깨진 action 이 목록 전체를 무너뜨리지 않는다', () async {
       final repo = DioNotificationRepository(
         _dio(<Object?>[
           <String, Object?>{
@@ -144,6 +144,17 @@ void main() {
           },
           <String, Object?>{
             'id': 'n2',
+            'title': '깨진 target',
+            'body': '본문',
+            'time_ago': '방금',
+            'category': 'system',
+            'read': false,
+            // target 도 같은 위험을 갖는다. label 만 검사하면 여기서 다시
+            // TypeError 가 나므로 두 자리를 따로 지킨다.
+            'action': <String, Object?>{'label': '어딘가로', 'target': 42},
+          },
+          <String, Object?>{
+            'id': 'n3',
             'title': '정상',
             'body': '본문',
             'time_ago': '방금',
@@ -154,9 +165,11 @@ void main() {
       );
 
       final List<AlertItem> items = await repo.fetchAll();
-      expect(items, hasLength(2));
-      expect(items.first.action, isNull);
-      expect(items.last.title, '정상');
+      expect(items, hasLength(3));
+      // 깨진 것은 action 만 잃고, 알림 자체는 목록에 남는다.
+      expect(items[0].action, isNull);
+      expect(items[1].action, isNull);
+      expect(items[2].title, '정상');
     });
 
     test('action 이 없는 알림도 그대로 실린다', () async {

--- a/frontend/flutter/test/features/notification/notification_controller_test.dart
+++ b/frontend/flutter/test/features/notification/notification_controller_test.dart
@@ -44,6 +44,10 @@ class _RecordingRepo implements NotificationRepository {
 
   @override
   Future<void> markAllRead() async => markAllReadCalls++;
+
+  @override
+  Future<int> unreadCount() async =>
+      _items.where((AlertItem a) => !a.read).length;
 }
 
 void main() {

--- a/frontend/flutter/test/features/notification/notification_list_provider_test.dart
+++ b/frontend/flutter/test/features/notification/notification_list_provider_test.dart
@@ -2,14 +2,16 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:oncare/features/notification/data/repositories/mock_notification_repository.dart';
+import 'package:oncare/features/notification/domain/entities/alert_item.dart';
 import 'package:oncare/features/notification/presentation/controllers/notification_controller.dart';
 
 void main() {
+  _demoReadStateTests();
   test('notificationListProvider returns the mock repo payload', () async {
     final container = ProviderContainer(
       overrides: <Override>[
         notificationRepositoryProvider.overrideWithValue(
-          const MockNotificationRepository(),
+          MockNotificationRepository(),
         ),
       ],
     );
@@ -21,5 +23,36 @@ void main() {
     // Mix of read/unread for the unreadCount badge logic to lean on.
     expect(list.any((e) => !e.read), isTrue);
     expect(list.any((e) => e.read), isTrue);
+  });
+}
+
+/// 데모 저장소가 읽음을 기억하는지 — #636 리뷰.
+///
+/// 예전에는 읽음이 no-op 이라 미읽음 수를 물으면 늘 처음 상태를 답했다. 데모에서
+/// "모두 읽음" 을 눌러도 벨의 점이 남아 목록과 배지가 서로 다른 말을 했다.
+void _demoReadStateTests() {
+  test('데모에서 모두 읽음 처리하면 미읽음 수가 0 이 된다', () async {
+    final repo = MockNotificationRepository();
+    expect(await repo.unreadCount(), greaterThan(0));
+
+    await repo.markAllRead();
+
+    expect(await repo.unreadCount(), 0);
+    expect(
+      (await repo.fetchAll()).every((AlertItem a) => a.read),
+      isTrue,
+    );
+  });
+
+  test('데모에서 한 건 읽으면 그만큼만 줄어든다', () async {
+    final repo = MockNotificationRepository();
+    final int before = await repo.unreadCount();
+    final AlertItem unread = (await repo.fetchAll()).firstWhere(
+      (AlertItem a) => !a.read,
+    );
+
+    await repo.markRead(unread.id);
+
+    expect(await repo.unreadCount(), before - 1);
   });
 }

--- a/frontend/flutter/test/features/notification/notification_refresh_test.dart
+++ b/frontend/flutter/test/features/notification/notification_refresh_test.dart
@@ -54,6 +54,10 @@ class _ScriptedRepo implements NotificationRepository {
   /// 조회를 붙잡아 두었다가 테스트가 풀어 주게 한다(겹침 검증용).
   Completer<void>? gate;
 
+  /// 읽음 쓰기를 붙잡아 둔다. 쓰기가 끝나기 전에 미읽음을 다시 세면 서버가 옛 수를
+  /// 답하므로, 그 순서를 검증하는 데 쓴다.
+  Completer<void>? writeGate;
+
   void serve(List<AlertItem> items) => _items = items;
 
   @override
@@ -66,6 +70,7 @@ class _ScriptedRepo implements NotificationRepository {
 
   @override
   Future<void> markRead(String id) async {
+    if (writeGate != null) await writeGate!.future;
     _items = _items
         .map((AlertItem i) => i.id == id ? i.copyWith(read: true) : i)
         .toList();
@@ -195,6 +200,34 @@ void main() {
     await _settle();
 
     // 다음 폴링을 기다리면 목록과 배지가 잠시 어긋나 보인다.
+    expect(repo.unreadCalls, greaterThan(before));
+  });
+
+  test('쓰기가 끝나기 전에는 미읽음을 다시 세지 않는다', () async {
+    final repo = _ScriptedRepo(<AlertItem>[_alert('a'), _alert('b')])
+      ..writeGate = Completer<void>();
+    final container = _container(repo);
+
+    container.listen<AsyncValue<int>>(
+      notificationUnreadProvider,
+      (AsyncValue<int>? _, AsyncValue<int> _) {},
+      fireImmediately: true,
+    );
+    await container.read(notificationControllerProvider.notifier).refresh();
+    await _settle();
+    final int before = repo.unreadCalls;
+
+    final Future<void> pending = container
+        .read(notificationControllerProvider.notifier)
+        .markRead('a');
+    await _settle();
+    // 아직 서버에 반영되지 않았다. 여기서 다시 세면 옛 수를 받아 배지가 다음
+    // 폴링까지 틀린 채로 남는다(리뷰).
+    expect(repo.unreadCalls, before);
+
+    repo.writeGate!.complete();
+    await pending;
+    await _settle();
     expect(repo.unreadCalls, greaterThan(before));
   });
 

--- a/frontend/flutter/test/features/notification/notification_refresh_test.dart
+++ b/frontend/flutter/test/features/notification/notification_refresh_test.dart
@@ -1,0 +1,216 @@
+/// 알림이 서버 상태를 따라가는지 — #636.
+///
+/// 예전에는 컨트롤러가 생성될 때 한 번만 조회했다. `refresh()` 는 있었지만 부르는
+/// 곳이 없어, 트레이너가 무언가 해도 회원 앱을 **재시작해야** 알림을 볼 수 있었다.
+///
+/// 여기서 고정하는 성질.
+///
+///  * 다시 조회하면 서버 목록으로 갈아 끼운다(중복이 남지 않는다).
+///  * 조회가 겹쳐도 요청은 한 번만 나간다.
+///  * 실패해도 **받아 둔 목록을 지우지 않고** 재시도를 제안한다.
+///  * 목 모드는 네트워크를 타지 않는다 — 데모 화면이 서버를 찌르면 안 된다.
+library;
+
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/features/notification/domain/entities/alert_item.dart';
+import 'package:oncare/features/notification/domain/repositories/notification_repository.dart';
+import 'package:oncare/features/notification/presentation/controllers/notification_controller.dart';
+
+const AppConfig _realConfig = AppConfig(
+  environment: Environment.prod,
+  apiBaseUrl: 'https://api.test/v1',
+  useMockApi: false,
+);
+
+const AppConfig _mockConfig = AppConfig(
+  environment: Environment.dev,
+  apiBaseUrl: 'https://dev.api.test',
+  useMockApi: true,
+);
+
+AlertItem _alert(String id, {bool read = false}) => AlertItem(
+  id: id,
+  title: '알림 $id',
+  body: '본문',
+  timeAgo: '방금',
+  category: AlertCategory.system,
+  read: read,
+);
+
+/// 조회 횟수를 세고, 결과와 실패를 시나리오별로 바꿀 수 있는 대역.
+class _ScriptedRepo implements NotificationRepository {
+  _ScriptedRepo(this._items);
+
+  List<AlertItem> _items;
+  int fetchCalls = 0;
+  int unreadCalls = 0;
+  bool fetchThrows = false;
+
+  /// 조회를 붙잡아 두었다가 테스트가 풀어 주게 한다(겹침 검증용).
+  Completer<void>? gate;
+
+  void serve(List<AlertItem> items) => _items = items;
+
+  @override
+  Future<List<AlertItem>> fetchAll() async {
+    fetchCalls++;
+    if (gate != null) await gate!.future;
+    if (fetchThrows) throw StateError('네트워크 없음');
+    return _items;
+  }
+
+  @override
+  Future<void> markRead(String id) async {
+    _items = _items
+        .map((AlertItem i) => i.id == id ? i.copyWith(read: true) : i)
+        .toList();
+  }
+
+  @override
+  Future<void> markAllRead() async {
+    _items = _items.map((AlertItem i) => i.copyWith(read: true)).toList();
+  }
+
+  @override
+  Future<int> unreadCount() async {
+    unreadCalls++;
+    return _items.where((AlertItem i) => !i.read).length;
+  }
+}
+
+ProviderContainer _container(_ScriptedRepo repo, {AppConfig? config}) {
+  final container = ProviderContainer(
+    overrides: <Override>[
+      appConfigProvider.overrideWithValue(config ?? _realConfig),
+      notificationRepositoryProvider.overrideWithValue(repo),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+Future<void> _settle() => Future<void>.delayed(Duration.zero);
+
+void main() {
+  // 미읽음 배지는 `activePollingStream` 을 쓰고, 그 스트림이 앱 생명주기를 읽는다.
+  // 바인딩이 없으면 스트림이 시작조차 못 해 배지 검증이 조용히 통과한다.
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('다시 조회하면 서버 목록으로 갈아 끼운다', () async {
+    final repo = _ScriptedRepo(<AlertItem>[_alert('a')]);
+    final container = _container(repo);
+
+    final notifier = container.read(notificationControllerProvider.notifier);
+    await _settle();
+    expect(container.read(notificationControllerProvider).items, hasLength(1));
+
+    // 트레이너가 무언가 해서 서버에 알림이 하나 더 생긴 상황.
+    repo.serve(<AlertItem>[_alert('b'), _alert('a')]);
+    await notifier.refresh();
+
+    final List<AlertItem> items = container
+        .read(notificationControllerProvider)
+        .items;
+    // 통째로 갈아 끼우므로 같은 알림이 두 번 보이지 않는다.
+    expect(items.map((AlertItem i) => i.id), <String>['b', 'a']);
+  });
+
+  test('조회가 겹쳐도 요청은 한 번만 나간다', () async {
+    final repo = _ScriptedRepo(<AlertItem>[_alert('a')])
+      ..gate = Completer<void>();
+    final container = _container(repo);
+
+    final notifier = container.read(notificationControllerProvider.notifier);
+    // 생성자 조회가 아직 붙잡혀 있는 사이 진입 재조회가 겹친다.
+    final Future<void> second = notifier.refresh();
+    repo.gate!.complete();
+    await second;
+
+    // 화면 진입과 포그라운드 복귀가 겹치는 상황이라 실제로 자주 일어난다.
+    expect(repo.fetchCalls, 1);
+  });
+
+  test('조회에 실패해도 받아 둔 목록을 지우지 않는다', () async {
+    final repo = _ScriptedRepo(<AlertItem>[_alert('a'), _alert('b')]);
+    final container = _container(repo);
+
+    final notifier = container.read(notificationControllerProvider.notifier);
+    await _settle();
+    expect(container.read(notificationControllerProvider).items, hasLength(2));
+
+    repo.fetchThrows = true;
+    await notifier.refresh();
+
+    final NotificationState state = container.read(
+      notificationControllerProvider,
+    );
+    // 목록이 사라지면 읽지 않은 알림이 있었는지조차 알 수 없다.
+    expect(state.items, hasLength(2));
+    expect(state.failedToLoad, isTrue);
+  });
+
+  test('실패 뒤 다시 성공하면 실패 표시가 사라진다', () async {
+    final repo = _ScriptedRepo(<AlertItem>[_alert('a')])..fetchThrows = true;
+    final container = _container(repo);
+
+    final notifier = container.read(notificationControllerProvider.notifier);
+    await _settle();
+    expect(
+      container.read(notificationControllerProvider).failedToLoad,
+      isTrue,
+    );
+
+    repo.fetchThrows = false;
+    await notifier.refresh();
+
+    expect(
+      container.read(notificationControllerProvider).failedToLoad,
+      isFalse,
+    );
+  });
+
+  test('읽음 처리하면 미읽음 배지를 즉시 다시 센다', () async {
+    final repo = _ScriptedRepo(<AlertItem>[_alert('a'), _alert('b')]);
+    final container = _container(repo);
+
+    // 헤더가 배지를 보고 있는 상황을 만든다. 아무도 구독하지 않으면 무효화해도
+    // 다시 조회되지 않는다(Riverpod 의 정상 동작) — 실제로는 탭 헤더가 늘 본다.
+    container.listen<AsyncValue<int>>(
+      notificationUnreadProvider,
+      (AsyncValue<int>? _, AsyncValue<int> _) {},
+      fireImmediately: true,
+    );
+    await container.read(notificationControllerProvider.notifier).refresh();
+    await _settle();
+    final int before = repo.unreadCalls;
+
+    await container
+        .read(notificationControllerProvider.notifier)
+        .markRead('a');
+    await _settle();
+
+    // 다음 폴링을 기다리면 목록과 배지가 잠시 어긋나 보인다.
+    expect(repo.unreadCalls, greaterThan(before));
+  });
+
+  test('목 모드는 새로고침해도 네트워크를 타지 않는다', () async {
+    final repo = _ScriptedRepo(<AlertItem>[_alert('a')]);
+    final container = _container(repo, config: _mockConfig);
+
+    final notifier = container.read(notificationControllerProvider.notifier);
+    await notifier.refresh();
+    await _settle();
+
+    // 데모는 시드가 진실원본이다. 서버를 찌르면 데모 화면이 흔들린다.
+    expect(repo.fetchCalls, 0);
+    expect(
+      container.read(notificationControllerProvider).items,
+      isNotEmpty,
+    );
+  });
+}


### PR DESCRIPTION
#636 의 앞 절반입니다. **이슈를 닫지 않습니다** — 딥링크는 후속 PR 로 갑니다(아래 참고).

## Summary

트레이너가 상담을 승인하거나 메시지를 보내도, 회원이 **앱을 재시작해야** 알림을 볼 수
있었다. `refresh()` 는 있었지만 부르는 곳이 없었고 헤더 벨은 항상 점이 켜져 있었다.

이 PR 은 **알림이 서버 상태를 따라가게** 한다. 알림을 눌러 관련 화면으로 가는 것은
다음 PR 이다.

## Changes

**벨 배지가 실제 미읽음을 가리킨다.** `showDot: true` 가 하드코딩돼 있어 읽을 알림이
없어도 점이 켜져 있었다 — 배지가 아무것도 뜻하지 않는 상태였다. 디자인 시스템은 알림을
모르게 두고(`bellHasUnread` 파라미터) 네 탭이 서버 기준 미읽음을 넘긴다.

미읽음은 목록과 따로 조회한다. 배지는 모든 탭에 떠 있어 알림을 열지 않아도 최신이어야
하는데, 그때마다 전체 목록을 받는 것은 과하다. 앱이 앞에 있을 때만 폴링하고 일시적 실패에는
마지막 값을 유지한다(채팅 미읽음과 같은 방식). 읽음·전체읽음 직후에는 다음 폴링을 기다리지
않고 즉시 다시 센다 — 목록과 배지가 같은 서버 상태를 보여야 한다.

**화면이 진입·복귀·당김으로 다시 읽는다.** 알림함을 열어 둔 채 잠깐 다른 앱을 다녀오는
것은 실제로 자주 하는 동작이라 포그라운드 복귀를 포함했다. 목록이 비어 있어도 당길 수
있도록 본문을 항상 스크롤 가능하게 뒀다 — 빈 화면이야말로 다시 받아 보고 싶은 순간이다.

**실패해도 받아 둔 목록을 지우지 않는다.** 위에 사정과 재시도만 얹는다. 목록이 사라지면
읽지 않은 알림이 있었는지조차 알 수 없다. 진입과 복귀가 겹쳐도 요청은 한 번만 나간다.

## 데모 영향 없음

데모 알림 네 건 중 세 건이 미읽음이라 벨의 점이 그대로 켜진다. 그리고 **데모는 폴링하지
않는다** — 따라갈 서버가 없는데 15초마다 찌르는 타이머가 화면 수명 내내 남아 있었다.
시드 값을 한 번만 읽는다. 새로고침도 목 모드에서는 네트워크를 타지 않는다.

## Verification

신규 테스트 6개 — 다시 조회가 목록을 통째로 갈아 끼우는지(중복 없음), 겹친 조회가 한 번만
나가는지, 실패해도 목록이 남는지, 실패 뒤 성공하면 표시가 걷히는지, 읽음 직후 배지를 즉시
다시 세는지, 목 모드가 네트워크를 타지 않는지.

배지를 검증하던 기존 테스트는 **하드코딩된 값을 확인하고 있었을 뿐**이라, 미읽음이 있을 때
켜지고 없을 때 꺼지는 동작 검증으로 바꿨다.

`flutter analyze` 클린, 테스트 547개 통과.

## 후속 PR 로 미룬 것과 그 이유

딥링크(완료 조건 4)를 시작하려다 백엔드에서 발견한 것이 있다. **`kind` 는 목적지가 아니라
알림 설정 키다.**

| 알림 | kind | 실제 목적지 |
| --- | --- | --- |
| 새 운동 루틴 배정 | `EXERCISE` | 운동 |
| 새 일정 등록 | `EXERCISE` | 일정 |
| 담당 트레이너 연결 해제 | `TRAINER_MESSAGE` | 헬스장·트레이너 |
| 예약한 수업 취소 | `TRAINER_MESSAGE` | 예약 |

같은 키가 서로 다른 곳을 가리키므로, `category` 를 `kind` 에서 유도하는 지금 구조로는 목적지를
구분할 수 없다. **모든 `queue` 호출부에 목적지를 명시**해야 하고 그러면 백엔드 서비스·API·
호출부와 양쪽 클라이언트가 함께 움직인다. 한 PR 에 넣으면 리뷰가 어려워져 나눴다.

앱 쪽 준비는 이 PR 에 이미 들어 있다 — `AlertAction`/`AlertTarget` 과 서버 `action` 파싱,
모르는 target 은 이동만 하지 않는 규칙(트레이너 웹과 같다).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 읽지 않은 알림이 있을 때 주요 화면의 알림 아이콘에 배지가 표시됩니다.
  * 알림 목록을 새로고침하고 앱 복귀 시 최신 상태를 다시 확인합니다.
  * 알림 항목의 이동 대상과 관련 안내를 지원합니다.
  * 알림 조회 실패 시 기존 목록을 유지하며 재시도할 수 있습니다.

* **버그 수정**
  * 읽지 않은 알림이 없을 때 배지가 표시되던 문제를 수정했습니다.
  * 알림 읽음 처리 후 배지 상태가 즉시 갱신됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->