### PR TITLE
fix(ci): Flutter 버전을 고정하고 custom_lint 매달림을 끊는다

### DIFF
--- a/.github/workflows/aws-frontend-deploy.yml
+++ b/.github/workflows/aws-frontend-deploy.yml
@@ -33,6 +33,11 @@ jobs:
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: stable
+          # Flutter 를 고정한다. `channel: stable` 만 두면 새 stable 이 나온 순간
+          # 아무도 코드를 건드리지 않았는데 CI 가 깨진다 — 실제로 3.47.0 에서
+          # riverpod_lint 가 새 문법을 몰라 분석 도중 매달렸다(#659). 올릴 때는
+          # 의도적으로 올린다.
+          flutter-version: '3.44.9'
           cache: true
 
       - name: Check Flutter version

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,11 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
+          # Flutter 를 고정한다. `channel: stable` 만 두면 새 stable 이 나온 순간
+          # 아무도 코드를 건드리지 않았는데 CI 가 깨진다 — 실제로 3.47.0 에서
+          # riverpod_lint 가 새 문법을 몰라 분석 도중 매달렸다(#659). 올릴 때는
+          # 의도적으로 올린다.
+          flutter-version: '3.44.9'
           cache: true
 
       - name: Check Flutter version

--- a/.github/workflows/trainer-ci.yml
+++ b/.github/workflows/trainer-ci.yml
@@ -38,6 +38,11 @@ jobs:
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: stable
+          # Flutter 를 고정한다. `channel: stable` 만 두면 새 stable 이 나온 순간
+          # 아무도 코드를 건드리지 않았는데 CI 가 깨진다 — 실제로 3.47.0 에서
+          # riverpod_lint 가 새 문법을 몰라 분석 도중 매달렸다(#659). 올릴 때는
+          # 의도적으로 올린다.
+          flutter-version: '3.44.9'
           cache: true
 
       - name: Install dependencies
@@ -66,6 +71,11 @@ jobs:
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: stable
+          # Flutter 를 고정한다. `channel: stable` 만 두면 새 stable 이 나온 순간
+          # 아무도 코드를 건드리지 않았는데 CI 가 깨진다 — 실제로 3.47.0 에서
+          # riverpod_lint 가 새 문법을 몰라 분석 도중 매달렸다(#659). 올릴 때는
+          # 의도적으로 올린다.
+          flutter-version: '3.44.9'
           cache: true
 
       - name: Install dependencies

--- a/.github/workflows/user-app-ci.yml
+++ b/.github/workflows/user-app-ci.yml
@@ -39,6 +39,11 @@ jobs:
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: stable
+          # Flutter 를 고정한다. `channel: stable` 만 두면 새 stable 이 나온 순간
+          # 아무도 코드를 건드리지 않았는데 CI 가 깨진다 — 실제로 3.47.0 에서
+          # riverpod_lint 가 새 문법을 몰라 분석 도중 매달렸다(#659). 올릴 때는
+          # 의도적으로 올린다.
+          flutter-version: '3.44.9'
           cache: true
 
       - name: Install dependencies
@@ -52,6 +57,11 @@ jobs:
       # 여기서만 걸리므로 별도 단계로 돌린다 — 이 저장소의 analysis_options
       # 주석도 `dart run custom_lint` 를 안내한다.
       - name: Custom lint (riverpod_lint)
+        # 이 단계는 실패보다 **매달리는** 쪽으로 깨진 적이 있다 — 플러그인이 분석 중
+        # 예외를 던지고도 프로세스가 끝나지 않아, 러너가 죽을 때까지 붙잡혀 PR 이
+        # 전부 대기 상태가 됐다(#659). 정상 실행은 1분 남짓이라 여유를 두고도
+        # 매달림은 확실히 끊는다.
+        timeout-minutes: 10
         run: dart run custom_lint
 
       - name: Test


### PR DESCRIPTION
Closes #659

## Summary

사용자 앱 CI 의 `custom_lint` 단계가 **끝나지 않아** 열려 있는 PR 이 전부 병합 대기 상태가
됐다. 실패로 떨어지지도 않고 러너가 죽을 때까지 매달렸다 — 두 번 연속 같은 지점에서.

원인은 코드가 아니라 툴체인이다.

| | Flutter |
| --- | --- |
| 어제 성공한 실행 | **3.44.9** |
| 오늘 멈춘 실행 | **3.47.0** |

워크플로가 `channel: stable` 만 두고 버전을 고정하지 않아, 새 stable 이 나온 순간 아무도
코드를 건드리지 않았는데 깨졌다.

## 무엇이 터지나

```
Plugin avoid_build_context_in_providers threw while analyzing
  integration_test/app_smoke_test.dart:
Exception: Missing implementation of visitDotShorthandPropertyAccess
...
Terminate orphan process: pid (2955) (dart:custom_lin)
```

3.47 의 Dart 는 dot-shorthand 문법을 쓰는데, 잠긴 `analyzer 7.6.0` 에 그것을 다루는 visitor
가 없다. `riverpod_lint` 가 분석 도중 예외를 던지고 프로세스가 끝나지 않는다.

## 왜 올려서 해결하지 않았나

`riverpod_lint` 2.x 의 마지막인 **2.6.5 가 `analyzer ^7.0.0` 을 요구**한다. 새 analyzer 를
쓰는 `custom_lint 0.8.x`·`riverpod_lint 3.x` 는 **Riverpod 3 을 전제**하는데 이 저장소는
`flutter_riverpod ^2.6.1` 이다. 프레임워크 이전이 먼저라 지금은 올라갈 곳이 없다.

Riverpod 3 이전은 #659 에 후속 항목으로 남겼다.

## Changes

- 워크플로 **다섯 곳 모두** Flutter 를 3.44.9 로 고정한다. 사용자 앱 CI 만 고치면 배포와
  트레이너 CI 가 다음에 같은 방식으로 깨진다.
- `custom_lint` 단계에 `timeout-minutes: 10` 을 건다. 같은 일이 또 생겨도 러너가 붙잡히는
  대신 정해진 시간 안에 실패로 끝난다 — **매달리는 실패는 원인을 찾기까지 오래 걸린다**
  (이번에도 그래서 한참 걸렸다).

## Verification

- 워크플로 다섯 개 YAML 파싱 확인.
- 이 PR 의 CI 가 통과하는 것 자체가 검증이다 — 같은 `custom_lint` 단계를 지나야 한다.

## Notes

로컬에서는 재현되지 않았다. 내 로컬이 3.44.0 이라 CI 와 툴체인이 달랐고, 그 사실을 확인하지
않은 채 "로컬은 통과한다" 를 근거로 삼아 한동안 인프라 플레이크로 오판했다. 로컬 통과를
근거로 쓰려면 버전부터 맞춰 봐야 한다.
