### PR TITLE
feat(coaching): 배정 루틴 수행 기록과 트레이너 피드백 양방향 연결

### DIFF
--- a/backend/app/api/v1/exercise.py
+++ b/backend/app/api/v1/exercise.py
@@ -47,7 +47,7 @@ _ALLOWED_INTENSITIES = {"light", "moderate", "high"}
 
 
 def _reject_if_derived(row: ExerciseSession) -> None:
-    """트레이너 PT 완료로 파생된 기록은 회원이 고칠 수 없다. (#499)
+    """트레이너 PT/배정 루틴에서 파생된 기록은 회원이 고칠 수 없다. (#499, #638)
 
     404 가 아니라 409 다 — 기록은 분명히 존재하고 회원 것이며, 화면에도 보인다.
     없는 척하면 앱이 목록에서 사라진 줄 알고 잘못 갱신한다. 삭제하려면 트레이너가
@@ -56,7 +56,7 @@ def _reject_if_derived(row: ExerciseSession) -> None:
     if row.source != "member":
         raise HTTPException(
             status_code=409,
-            detail="트레이너가 완료 처리한 PT 기록은 수정하거나 삭제할 수 없습니다.",
+            detail="코칭에서 생성된 운동 기록은 수정하거나 삭제할 수 없습니다.",
         )
 
 

--- a/backend/app/api/v1/member_coach.py
+++ b/backend/app/api/v1/member_coach.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm import Session
 
 from app.api.deps import CurrentUser, RequireMember
 from app.db.session import get_db
+from app.schemas.exercise_api import AssignedRoutineCompleteRequest
 from app.schemas.trainer_api import (
     ChatMessageOut, ChatSendRequest, MemberCoachOut, RoutineOut, ScheduleSessionOut,
 )
@@ -82,6 +83,34 @@ def my_routines(
 ) -> list[RoutineOut]:
     """트레이너/AI가 나에게 배정한 루틴."""
     return trainer_service.build_member_routines(db, current_user.id)
+
+
+@router.post(
+    "/me/coach/routines/{routine_id}/complete",
+    response_model=RoutineOut,
+)
+def complete_my_routine(
+    routine_id: str,
+    payload: AssignedRoutineCompleteRequest,
+    member: RequireMember,
+    db: Annotated[Session, Depends(get_db)],
+) -> RoutineOut:
+    """나에게 배정된 루틴을 회원 운동 기록으로 한 번만 완료한다."""
+    if payload.intensity not in {"light", "moderate", "high"}:
+        raise HTTPException(status_code=400, detail="허용되지 않는 운동 강도입니다.")
+    trainer_id = _my_trainer_or_404(db, member.id)
+    try:
+        return trainer_service.complete_assigned_routine(
+            db,
+            trainer_id,
+            member.id,
+            routine_id,
+            minutes=payload.minutes,
+            intensity=payload.intensity,
+            member_note=payload.member_note,
+        )
+    except trainer_service.RoutineNotFound as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.get("/me/coach/sessions", response_model=list[ScheduleSessionOut])

--- a/backend/app/api/v1/trainer.py
+++ b/backend/app/api/v1/trainer.py
@@ -44,6 +44,7 @@ from app.schemas.trainer_api import (
     ClientCoachRequest, ClientDietEntryOut,
     MemberHealthProfileOut, MemberHealthProfileUpdate,
     ReportSendRequest, RoutineAssignRequest, RoutineOut, RoutineHistoryOut,
+    RoutineFeedbackRequest,
     RoutineOptionsOut, RoutineOptionsRequest, RoutineUpdateRequest,
     ScheduleCompleteRequest, ScheduleCreateRequest, ScheduleProgramRegisterOut,
     ScheduleProgramRegisterRequest, ScheduleSessionOut, ScheduleUpdateRequest,
@@ -351,6 +352,32 @@ def trainer_client_history(
     """담당 고객의 운동 완료 기록(최신순). 타 트레이너 기록/메모는 제외한다."""
     _require_client(db, trainer.id, member_id)
     return trainer_service.build_client_history(db, member_id, trainer.id)
+
+
+@router.put(
+    "/trainer/clients/{member_id}/history/{history_id}/feedback",
+    response_model=RoutineHistoryOut,
+)
+def trainer_update_routine_feedback(
+    member_id: str,
+    history_id: str,
+    payload: RoutineFeedbackRequest,
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> RoutineHistoryOut:
+    """담당 회원의 배정 루틴 수행 기록에 피드백을 남기거나 고친다."""
+    link = _require_client(db, trainer.id, member_id)
+    if not link.active:
+        raise HTTPException(status_code=404, detail="현재 담당 고객을 찾을 수 없습니다.")
+    feedback = payload.feedback.strip()
+    if not feedback:
+        raise HTTPException(status_code=400, detail="피드백 내용이 필요합니다.")
+    try:
+        return trainer_service.update_assigned_routine_feedback(
+            db, trainer.id, member_id, history_id, feedback
+        )
+    except trainer_service.RoutineNotFound as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.get(

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -199,11 +199,27 @@ class ExerciseSession(Base):
     intensity: Mapped[str] = mapped_column(
         String(20), default="moderate", server_default="moderate"
     )
-    #: 이 기록을 누가 만들었나. member=회원이 직접 남김, trainer_pt=트레이너가 PT
-    #: 세션을 완료 처리해 파생된 기록. 파생 기록은 근거가 트레이너에게 있어 회원이
-    #: 고칠 수 없고(#499), 화면에서도 수기 기록과 구분해 보여준다.
+    #: 이 기록을 누가 만들었나. member=회원 수기, trainer_pt=PT 완료 파생,
+    #: assigned_routine=배정 루틴 수행. 파생 기록은 일반 수기 기록처럼 회원이
+    #: 고치거나 지울 수 없다(#499, #638).
     source: Mapped[str] = mapped_column(
         String(20), default="member", server_default="member"
+    )
+    # 배정 루틴 수행이면 원본 id와 당시 내용을 함께 보존한다. 루틴이 나중에
+    # 수정·철회돼도 이미 끝낸 운동 기록은 당시 내용으로 남아야 한다(#638).
+    assigned_routine_id: Mapped[str | None] = mapped_column(
+        String(64), nullable=True, unique=True, index=True
+    )
+    assigned_trainer_id: Mapped[str | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    assigned_routine_name: Mapped[str] = mapped_column(
+        String(100), default="", server_default=""
+    )
+    member_note: Mapped[str] = mapped_column(Text, default="", server_default="")
+    trainer_feedback: Mapped[str] = mapped_column(Text, default="", server_default="")
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()

--- a/backend/app/schemas/exercise_api.py
+++ b/backend/app/schemas/exercise_api.py
@@ -1,5 +1,6 @@
 """운동 API 스키마 — 프론트 _exerciseCurrentWeek 계약 정렬."""
 from __future__ import annotations
+from datetime import datetime
 from pydantic import BaseModel, Field
 
 
@@ -13,10 +14,15 @@ class ExerciseSessionOut(BaseModel):
     date_label: str
     time_label: str
     items: list[str]
-    # 이 기록을 누가 만들었나. member=회원이 직접 남김, trainer_pt=트레이너가 PT
-    # 세션을 완료해 파생된 기록. 앱은 이 값으로 배지를 붙이고 수정·삭제를 감춘다.
+    # 기록 출처: member | trainer_pt | assigned_routine. 앱은 파생 기록을
+    # 수기 기록과 구분하고 수정·삭제를 감춘다.
     # 기본값이 있어야 이 필드를 모르는 기존 클라이언트가 깨지지 않는다. (#499)
     source: str = "member"
+    assigned_routine_id: str | None = None
+    assigned_routine_name: str = ""
+    member_note: str = ""
+    trainer_feedback: str = ""
+    completed_at: datetime | None = None
 
 
 class ExerciseWeekResponse(BaseModel):
@@ -42,3 +48,11 @@ class ExerciseSessionCreate(BaseModel):
     calories: int = Field(0, ge=0)
     intensity: str = "moderate"  # light|moderate|high
     day_label: str | None = None
+
+
+class AssignedRoutineCompleteRequest(BaseModel):
+    """회원이 배정 루틴을 실제 수행한 결과."""
+
+    minutes: int = Field(..., gt=0, le=600)
+    intensity: str = "moderate"
+    member_note: str = Field(default="", max_length=1000)

--- a/backend/app/schemas/trainer_api.py
+++ b/backend/app/schemas/trainer_api.py
@@ -142,12 +142,15 @@ class ClientDietEntryOut(BaseModel):
 
 class RoutineHistoryOut(BaseModel):
     """고객 운동기록 서브탭 항목 — 프론트 RoutineHistoryEntry 계약 정렬."""
+    id: str = ""
     date_label: str          # "7/12 (오늘)"
     label: str               # "PT 세션 · 트레이너 지도"
     completion_rate: int     # 0..100
     exercises: list[str]
     client_feedback: str
     trainer_note: str
+    assigned_routine_id: str | None = None
+    completed_at: _datetime | None = None
 
 
 # 채팅 sender 출력 허용값 — 뷰어 관점(_sender_out): 트레이너 앱은 trainer|client,
@@ -189,6 +192,12 @@ class RoutineOut(BaseModel):
     type: RoutineType
     reason: str
     source: RoutineSource
+    completed: bool = False
+    completed_at: _datetime | None = None
+    completed_minutes: int | None = None
+    completed_intensity: str | None = None
+    member_note: str = ""
+    trainer_feedback: str = ""
 
 
 class RoutineAssignRequest(BaseModel):
@@ -221,6 +230,10 @@ class RoutineUpdateRequest(PartialUpdate):
     minutes: int | None = Field(default=None, ge=0, le=600)
     type: RoutineType | None = None
     reason: str | None = Field(default=None, max_length=200)
+
+
+class RoutineFeedbackRequest(BaseModel):
+    feedback: str = Field(min_length=1, max_length=2000)
 
 
 RoutineIntensityPreference = Literal["low", "moderate", "high"]

--- a/backend/app/services/exercise_service.py
+++ b/backend/app/services/exercise_service.py
@@ -150,9 +150,18 @@ def build_current_week(rows: list) -> dict:
             "minutes": r.minutes, "calories": r.calories,
             "intensity": getattr(r, "intensity", "moderate") or "moderate",
             "source": getattr(r, "source", "member") or "member",
+            "assigned_routine_id": getattr(r, "assigned_routine_id", None),
+            "assigned_routine_name": getattr(r, "assigned_routine_name", "") or "",
+            "member_note": getattr(r, "member_note", "") or "",
+            "trainer_feedback": getattr(r, "trainer_feedback", "") or "",
+            "completed_at": getattr(r, "completed_at", None),
             "date_label": _date_label_for_day(r.day_label),
             "time_label": _default_time_label(r.type),
-            "items": _default_items(r.type),
+            "items": (
+                [getattr(r, "assigned_routine_name", "")]
+                if getattr(r, "assigned_routine_name", "")
+                else _default_items(r.type)
+            ),
         })
 
     # 최근 요일 먼저

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -293,21 +293,49 @@ def build_client_history(
         .limit(limit)
     ).all()
 
-    out: list[RoutineHistoryOut] = []
+    assigned_rows = db.scalars(
+        select(ExerciseSession).where(
+            ExerciseSession.user_id == member_id,
+            ExerciseSession.source == "assigned_routine",
+            ExerciseSession.assigned_trainer_id == trainer_id,
+        )
+        .order_by(ExerciseSession.completed_at.desc(), ExerciseSession.created_at.desc())
+        .limit(limit)
+    ).all()
+
+    dated: list[tuple[str, float, RoutineHistoryOut]] = []
     for r in rows:
         try:
             exercises = json.loads(r.exercises_json) if r.exercises_json else []
         except json.JSONDecodeError:
             exercises = []
-        out.append(RoutineHistoryOut(
+        dated.append((r.date, clock.to_seoul(r.created_at).timestamp(), RoutineHistoryOut(
+            id=r.id,
             date_label=history_date_label(r.date),
             label=r.kind_label,
             completion_rate=r.completion_rate,
             exercises=exercises,
             client_feedback=r.client_feedback,
             trainer_note=r.trainer_note,
-        ))
-    return out
+        )))
+    for r in assigned_rows:
+        completed_at = r.completed_at or r.created_at
+        day = clock.to_seoul(completed_at).date().isoformat()
+        dated.append((day, clock.to_seoul(completed_at).timestamp(), RoutineHistoryOut(
+            id=r.id,
+            date_label=history_date_label(day),
+            label=r.assigned_routine_name or "배정 루틴 수행",
+            completion_rate=100,
+            exercises=[
+                f"{r.assigned_routine_name or r.type} · {r.minutes}분 · {r.intensity}"
+            ],
+            client_feedback=r.member_note,
+            trainer_note=r.trainer_feedback,
+            assigned_routine_id=r.assigned_routine_id,
+            completed_at=completed_at,
+        )))
+    dated.sort(key=lambda item: (item[0], item[1]), reverse=True)
+    return [item[2] for item in dated[:limit]]
 
 
 # ---- 채팅 (트레이너↔회원, 양방향 공유 스레드) ----
@@ -596,13 +624,18 @@ def build_routines(db: Session, member_id: str, trainer_id: str) -> list[Routine
         .where(TrainerRoutine.trainer_id == trainer_id, TrainerRoutine.member_id == member_id)
         .order_by(TrainerRoutine.sort_order, TrainerRoutine.created_at)
     ).all()
-    return [
-        RoutineOut(
-            id=r.id, name=r.name, minutes=r.minutes, type=r.type,
-            reason=r.reason, source=r.source,
-        )
-        for r in rows
-    ]
+    routine_ids = [row.id for row in rows]
+    completed = {}
+    if routine_ids:
+        completed = {
+            row.assigned_routine_id: row
+            for row in db.scalars(
+                select(ExerciseSession).where(
+                    ExerciseSession.assigned_routine_id.in_(routine_ids)
+                )
+            ).all()
+        }
+    return [_routine_out(row, completed.get(row.id)) for row in rows]
 
 
 class RoutineNotFound(Exception):
@@ -649,10 +682,12 @@ def update_routine(
             setattr(routine, field, fields[field])
     db.commit()
     db.refresh(routine)
-    return RoutineOut(
-        id=routine.id, name=routine.name, minutes=routine.minutes,
-        type=routine.type, reason=routine.reason, source=routine.source,
+    completion = db.scalar(
+        select(ExerciseSession).where(
+            ExerciseSession.assigned_routine_id == routine.id
+        )
     )
+    return _routine_out(routine, completion)
 
 
 def delete_routine(
@@ -672,10 +707,130 @@ def delete_routine(
     db.commit()
 
 
-def _routine_out(rt: TrainerRoutine) -> RoutineOut:
+def _routine_out(
+    rt: TrainerRoutine, completion: ExerciseSession | None = None
+) -> RoutineOut:
     return RoutineOut(
         id=rt.id, name=rt.name, minutes=rt.minutes, type=rt.type,
         reason=rt.reason, source=rt.source,
+        completed=completion is not None,
+        completed_at=completion.completed_at if completion is not None else None,
+        completed_minutes=completion.minutes if completion is not None else None,
+        completed_intensity=completion.intensity if completion is not None else None,
+        member_note=completion.member_note if completion is not None else "",
+        trainer_feedback=(
+            completion.trainer_feedback if completion is not None else ""
+        ),
+    )
+
+
+_ROUTINE_EXERCISE_TYPES = {
+    "걷기": "walking",
+    "유산소": "cardio",
+    "근력": "strength",
+    "요가": "yoga",
+    "스트레칭": "stretching",
+    "기타": "other",
+}
+
+
+def complete_assigned_routine(
+    db: Session,
+    trainer_id: str,
+    member_id: str,
+    routine_id: str,
+    *,
+    minutes: int,
+    intensity: str,
+    member_note: str,
+) -> RoutineOut:
+    """배정 하나를 회원 운동 기록 한 건으로 완료한다.
+
+    `assigned_routine_id` unique 제약이 더블 탭·재전송을 같은 기록으로
+    모은다. 이름은 스냅샷이라 이후 배정 수정·철회에 흔들리지 않는다.
+    """
+    routine = _owned_routine(db, trainer_id, member_id, routine_id)
+    existing = db.scalar(
+        select(ExerciseSession).where(
+            ExerciseSession.assigned_routine_id == routine_id
+        )
+    )
+    if existing is not None:
+        return _routine_out(routine, existing)
+
+    completed_at = clock.now()
+    exercise_type = _ROUTINE_EXERCISE_TYPES.get(routine.type, "other")
+    row = ExerciseSession(
+        id=f"assigned-ex-{uuid.uuid4().hex[:12]}",
+        user_id=member_id,
+        week_start=exercise_service.monday_of_str(completed_at.date().isoformat()),
+        day_label=exercise_service.weekday_label_of(completed_at.date().isoformat()),
+        type=exercise_type,
+        minutes=minutes,
+        calories=exercise_service.estimate_calories(
+            exercise_type, minutes, intensity
+        ),
+        intensity=intensity,
+        source="assigned_routine",
+        assigned_routine_id=routine.id,
+        assigned_trainer_id=trainer_id,
+        assigned_routine_name=routine.name,
+        member_note=member_note.strip(),
+        completed_at=completed_at,
+    )
+    db.add(row)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        existing = db.scalar(
+            select(ExerciseSession).where(
+                ExerciseSession.assigned_routine_id == routine_id
+            )
+        )
+        if existing is None:
+            raise
+        return _routine_out(routine, existing)
+    db.refresh(row)
+    personal_ingest.refresh_exercise(db, member_id, session_id=row.id)
+    return _routine_out(routine, row)
+
+
+def update_assigned_routine_feedback(
+    db: Session,
+    trainer_id: str,
+    member_id: str,
+    history_id: str,
+    feedback: str,
+) -> RoutineHistoryOut:
+    """현재 담당 트레이너가 자신이 배정한 수행 기록에 피드백한다."""
+    row = db.scalar(
+        select(ExerciseSession).where(
+            ExerciseSession.id == history_id,
+            ExerciseSession.user_id == member_id,
+            ExerciseSession.source == "assigned_routine",
+            ExerciseSession.assigned_trainer_id == trainer_id,
+        )
+    )
+    if row is None:
+        raise RoutineNotFound("배정 루틴 수행 기록을 찾을 수 없습니다.")
+    row.trainer_feedback = feedback.strip()
+    db.commit()
+    db.refresh(row)
+    completed_at = row.completed_at or row.created_at
+    day = clock.to_seoul(completed_at).date().isoformat()
+    return RoutineHistoryOut(
+        id=row.id,
+        date_label=history_date_label(day),
+        label=row.assigned_routine_name or "배정 루틴 수행",
+        completion_rate=100,
+        exercises=[
+            f"{row.assigned_routine_name or row.type} · {row.minutes}분 · {row.intensity}"
+        ],
+        client_feedback=row.member_note,
+        trainer_note=row.trainer_feedback,
+        assigned_routine_id=row.assigned_routine_id,
+        completed_at=completed_at,
     )
 
 

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -321,19 +321,13 @@ def build_client_history(
     for r in assigned_rows:
         completed_at = r.completed_at or r.created_at
         day = clock.to_seoul(completed_at).date().isoformat()
-        dated.append((day, clock.to_seoul(completed_at).timestamp(), RoutineHistoryOut(
-            id=r.id,
-            date_label=history_date_label(day),
-            label=r.assigned_routine_name or "배정 루틴 수행",
-            completion_rate=100,
-            exercises=[
-                f"{r.assigned_routine_name or r.type} · {r.minutes}분 · {r.intensity}"
-            ],
-            client_feedback=r.member_note,
-            trainer_note=r.trainer_feedback,
-            assigned_routine_id=r.assigned_routine_id,
-            completed_at=completed_at,
-        )))
+        dated.append(
+            (
+                day,
+                clock.to_seoul(completed_at).timestamp(),
+                _assigned_history_out(r),
+            )
+        )
     dated.sort(key=lambda item: (item[0], item[1]), reverse=True)
     return [item[2] for item in dated[:limit]]
 
@@ -803,7 +797,11 @@ def update_assigned_routine_feedback(
     history_id: str,
     feedback: str,
 ) -> RoutineHistoryOut:
-    """현재 담당 트레이너가 자신이 배정한 수행 기록에 피드백한다."""
+    """활성 담당 관계가 확인된 트레이너가 자신이 배정한 기록에 피드백한다.
+
+    API 계층은 현재 활성 담당 관계를 먼저 확인하고, 여기서는 수행 스냅샷의
+    배정 트레이너까지 일치하는지 추가로 검증한다(#638).
+    """
     row = db.scalar(
         select(ExerciseSession).where(
             ExerciseSession.id == history_id,
@@ -817,6 +815,11 @@ def update_assigned_routine_feedback(
     row.trainer_feedback = feedback.strip()
     db.commit()
     db.refresh(row)
+    return _assigned_history_out(row)
+
+
+def _assigned_history_out(row: ExerciseSession) -> RoutineHistoryOut:
+    """배정 루틴 수행을 조회·수정 응답에서 공유하는 이력 계약으로 변환한다."""
     completed_at = row.completed_at or row.created_at
     day = clock.to_seoul(completed_at).date().isoformat()
     return RoutineHistoryOut(

--- a/backend/migrations/versions/0033_assigned_routine_completion.py
+++ b/backend/migrations/versions/0033_assigned_routine_completion.py
@@ -1,0 +1,81 @@
+"""Link assigned routines to member exercise completion and feedback.
+
+Revision ID: 0033_routine_completion
+Revises: 0032_member_weight
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0033_routine_completion"
+down_revision: str | Sequence[str] | None = "0032_member_weight"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "exercise_sessions",
+        sa.Column("assigned_routine_id", sa.String(length=64), nullable=True),
+    )
+    op.add_column(
+        "exercise_sessions",
+        sa.Column("assigned_trainer_id", sa.String(length=64), nullable=True),
+    )
+    op.add_column(
+        "exercise_sessions",
+        sa.Column(
+            "assigned_routine_name", sa.String(length=100),
+            nullable=False, server_default="",
+        ),
+    )
+    op.add_column(
+        "exercise_sessions",
+        sa.Column("member_note", sa.Text(), nullable=False, server_default=""),
+    )
+    op.add_column(
+        "exercise_sessions",
+        sa.Column("trainer_feedback", sa.Text(), nullable=False, server_default=""),
+    )
+    op.add_column(
+        "exercise_sessions",
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_exercise_sessions_assigned_trainer",
+        "exercise_sessions", "users", ["assigned_trainer_id"], ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index(
+        "ix_exercise_sessions_assigned_trainer_id",
+        "exercise_sessions", ["assigned_trainer_id"], unique=False,
+    )
+    op.create_index(
+        "ix_exercise_sessions_assigned_routine_id",
+        "exercise_sessions", ["assigned_routine_id"], unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_exercise_sessions_assigned_routine_id", table_name="exercise_sessions"
+    )
+    op.drop_index(
+        "ix_exercise_sessions_assigned_trainer_id", table_name="exercise_sessions"
+    )
+    op.drop_constraint(
+        "fk_exercise_sessions_assigned_trainer",
+        "exercise_sessions", type_="foreignkey",
+    )
+    for column in (
+        "completed_at",
+        "trainer_feedback",
+        "member_note",
+        "assigned_routine_name",
+        "assigned_trainer_id",
+        "assigned_routine_id",
+    ):
+        op.drop_column("exercise_sessions", column)

--- a/backend/tests/test_assigned_routine_completion.py
+++ b/backend/tests/test_assigned_routine_completion.py
@@ -144,6 +144,23 @@ def test_completion_feedback_and_history_share_one_record(client, assigned_routi
     ).status_code == 409
 
 
+@pytest.mark.parametrize("minutes", [0, -5, 601])
+def test_completion_rejects_out_of_range_minutes(
+    client, assigned_routine, minutes
+):
+    """앱을 거치지 않은 완료 요청도 서버의 1~600분 계약을 지킨다."""
+    _, routine = assigned_routine
+    member_headers = _headers(_login(client, "jisu@oncare.com"))
+
+    response = client.post(
+        f"/v1/me/coach/routines/{routine['id']}/complete",
+        headers=member_headers,
+        json={"minutes": minutes},
+    )
+
+    assert response.status_code == 422, response.text
+
+
 def test_snapshot_and_feedback_survive_routine_deletion(client, assigned_routine):
     trainer_token, routine = assigned_routine
     member_headers = _headers(_login(client, "jisu@oncare.com"))

--- a/backend/tests/test_assigned_routine_completion.py
+++ b/backend/tests/test_assigned_routine_completion.py
@@ -1,0 +1,248 @@
+"""배정 루틴 수행 기록과 트레이너 피드백의 양방향 연결. (#638) DB 필요."""
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+
+MEMBER_ID = "user-jisu"
+TRAINER_ID = "trainer-demo"
+
+
+def _headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _login(client, email: str) -> str:
+    response = client.post(
+        "/v1/auth/login",
+        data={"username": email, "password": "oncare123"},
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["access_token"]
+
+
+@pytest.fixture()
+def assigned_routine(client, db_session):
+    """독립적인 루틴을 하나 배정하고 파생 운동 기록까지 정리한다."""
+    from app.models.models import ExerciseSession, TrainerRoutine
+
+    trainer_token = _login(client, "trainer@oncare.com")
+    name = f"양방향 테스트 {uuid4().hex[:6]}"
+    created = client.post(
+        f"/v1/trainer/clients/{MEMBER_ID}/routines",
+        headers=_headers(trainer_token),
+        json={
+            "name": name,
+            "minutes": 30,
+            "type": "근력",
+            "reason": "완료 기록 연결 테스트",
+        },
+    )
+    assert created.status_code == 201, created.text
+    routine = created.json()
+    yield trainer_token, routine
+
+    db_session.rollback()
+    completion = db_session.query(ExerciseSession).filter_by(
+        assigned_routine_id=routine["id"]
+    ).one_or_none()
+    if completion is not None:
+        db_session.delete(completion)
+    stored_routine = db_session.get(TrainerRoutine, routine["id"])
+    if stored_routine is not None:
+        db_session.delete(stored_routine)
+    db_session.commit()
+
+
+def test_completion_feedback_and_history_share_one_record(client, assigned_routine):
+    trainer_token, routine = assigned_routine
+    member_token = _login(client, "jisu@oncare.com")
+    member_headers = _headers(member_token)
+    trainer_headers = _headers(trainer_token)
+
+    before = client.get(
+        "/v1/exercise/weeks/current", headers=member_headers
+    ).json()["total_minutes"]
+    completed = client.post(
+        f"/v1/me/coach/routines/{routine['id']}/complete",
+        headers=member_headers,
+        json={
+            "minutes": 37,
+            "intensity": "high",
+            "member_note": "마지막 세트가 힘들었어요.",
+        },
+    )
+    assert completed.status_code == 200, completed.text
+    assert completed.json()["completed"] is True
+    assert completed.json()["completed_minutes"] == 37
+    assert completed.json()["completed_intensity"] == "high"
+    completion_time = completed.json()["completed_at"]
+
+    # 더블 탭·재시도는 새 기록이나 새 값을 만들지 않는다.
+    retried = client.post(
+        f"/v1/me/coach/routines/{routine['id']}/complete",
+        headers=member_headers,
+        json={"minutes": 10, "intensity": "light", "member_note": "재시도"},
+    )
+    assert retried.status_code == 200, retried.text
+    assert retried.json()["completed_at"] == completion_time
+    assert retried.json()["member_note"] == "마지막 세트가 힘들었어요."
+
+    week = client.get("/v1/exercise/weeks/current", headers=member_headers).json()
+    assert week["total_minutes"] == before + 37
+    session = next(
+        row for row in week["sessions"]
+        if row["assigned_routine_id"] == routine["id"]
+    )
+    assert session["source"] == "assigned_routine"
+    assert session["assigned_routine_name"] == routine["name"]
+    assert session["member_note"] == "마지막 세트가 힘들었어요."
+
+    history = client.get(
+        f"/v1/trainer/clients/{MEMBER_ID}/history", headers=trainer_headers
+    ).json()
+    history_row = next(
+        row for row in history if row["assigned_routine_id"] == routine["id"]
+    )
+    assert history_row["id"] == session["id"]
+    assert history_row["client_feedback"] == "마지막 세트가 힘들었어요."
+
+    feedback = client.put(
+        f"/v1/trainer/clients/{MEMBER_ID}/history/{history_row['id']}/feedback",
+        headers=trainer_headers,
+        json={"feedback": "자세가 안정적이었어요. 다음엔 40분으로 늘려요."},
+    )
+    assert feedback.status_code == 200, feedback.text
+
+    member_routine = next(
+        row for row in client.get(
+            "/v1/me/coach/routines", headers=member_headers
+        ).json()
+        if row["id"] == routine["id"]
+    )
+    assert member_routine["completed"] is True
+    assert member_routine["trainer_feedback"].startswith("자세가 안정적")
+    refreshed_session = next(
+        row for row in client.get(
+            "/v1/exercise/weeks/current", headers=member_headers
+        ).json()["sessions"]
+        if row["id"] == session["id"]
+    )
+    assert refreshed_session["trainer_feedback"] == member_routine["trainer_feedback"]
+
+    # 파생 기록은 회원이 일반 수기 기록처럼 고치거나 지울 수 없다.
+    edit = client.put(
+        f"/v1/exercise/sessions/{session['id']}",
+        headers=member_headers,
+        json={"type": "strength", "minutes": 1, "calories": 1},
+    )
+    assert edit.status_code == 409
+    assert client.delete(
+        f"/v1/exercise/sessions/{session['id']}", headers=member_headers
+    ).status_code == 409
+
+
+def test_snapshot_and_feedback_survive_routine_deletion(client, assigned_routine):
+    trainer_token, routine = assigned_routine
+    member_headers = _headers(_login(client, "jisu@oncare.com"))
+    trainer_headers = _headers(trainer_token)
+
+    completed = client.post(
+        f"/v1/me/coach/routines/{routine['id']}/complete",
+        headers=member_headers,
+        json={"minutes": 30, "member_note": "완료"},
+    )
+    assert completed.status_code == 200, completed.text
+
+    changed = client.put(
+        f"/v1/trainer/clients/{MEMBER_ID}/routines/{routine['id']}",
+        headers=trainer_headers,
+        json={"name": "나중에 바꾼 이름"},
+    )
+    assert changed.status_code == 200, changed.text
+    deleted = client.delete(
+        f"/v1/trainer/clients/{MEMBER_ID}/routines/{routine['id']}",
+        headers=trainer_headers,
+    )
+    assert deleted.status_code == 200, deleted.text
+
+    history = client.get(
+        f"/v1/trainer/clients/{MEMBER_ID}/history", headers=trainer_headers
+    ).json()
+    row = next(item for item in history if item["assigned_routine_id"] == routine["id"])
+    assert row["label"] == routine["name"]
+
+    updated = client.put(
+        f"/v1/trainer/clients/{MEMBER_ID}/history/{row['id']}/feedback",
+        headers=trainer_headers,
+        json={"feedback": "삭제 후에도 남는 피드백"},
+    )
+    assert updated.status_code == 200, updated.text
+    sessions = client.get(
+        "/v1/exercise/weeks/current", headers=member_headers
+    ).json()["sessions"]
+    saved = next(item for item in sessions if item["assigned_routine_id"] == routine["id"])
+    assert saved["assigned_routine_name"] == routine["name"]
+    assert saved["trainer_feedback"] == "삭제 후에도 남는 피드백"
+
+
+def test_only_owner_can_complete_or_write_feedback(
+    client, db_session, assigned_routine
+):
+    from app.core.security import create_access_token
+    from app.models.models import TrainerClient, User
+
+    trainer_token, routine = assigned_routine
+    other_member = _login(client, "sungho@oncare.com")
+    denied_completion = client.post(
+        f"/v1/me/coach/routines/{routine['id']}/complete",
+        headers=_headers(other_member),
+        json={"minutes": 30},
+    )
+    assert denied_completion.status_code == 404
+
+    member_headers = _headers(_login(client, "jisu@oncare.com"))
+    completed = client.post(
+        f"/v1/me/coach/routines/{routine['id']}/complete",
+        headers=member_headers,
+        json={"minutes": 30},
+    ).json()
+    history = client.get(
+        f"/v1/trainer/clients/{MEMBER_ID}/history",
+        headers=_headers(trainer_token),
+    ).json()
+    history_id = next(
+        item["id"] for item in history
+        if item["assigned_routine_id"] == routine["id"]
+    )
+    assert completed["completed"] is True
+
+    other_trainer_id = f"trainer-{uuid4().hex[:10]}"
+    other_trainer = User(
+        id=other_trainer_id,
+        email=f"{other_trainer_id}@oncare.com",
+        name="다른 트레이너",
+        hashed_password="unused",
+        role="trainer",
+    )
+    link = TrainerClient(
+        id=f"tc-{uuid4().hex[:12]}",
+        trainer_id=other_trainer_id,
+        member_id=MEMBER_ID,
+        active=False,
+    )
+    db_session.add_all([other_trainer, link])
+    db_session.commit()
+    try:
+        denied_feedback = client.put(
+            f"/v1/trainer/clients/{MEMBER_ID}/history/{history_id}/feedback",
+            headers=_headers(create_access_token(other_trainer_id)),
+            json={"feedback": "보이면 안 됨"},
+        )
+        assert denied_feedback.status_code == 404
+    finally:
+        db_session.delete(link)
+        db_session.delete(other_trainer)
+        db_session.commit()

--- a/backend/tests/test_assigned_routine_completion.py
+++ b/backend/tests/test_assigned_routine_completion.py
@@ -227,13 +227,15 @@ def test_only_owner_can_complete_or_write_feedback(
         hashed_password="unused",
         role="trainer",
     )
+    db_session.add(other_trainer)
+    db_session.flush()  # TrainerClient.trainer_id FK 부모를 먼저 반영한다.
     link = TrainerClient(
         id=f"tc-{uuid4().hex[:12]}",
         trainer_id=other_trainer_id,
         member_id=MEMBER_ID,
         active=False,
     )
-    db_session.add_all([other_trainer, link])
+    db_session.add(link)
     db_session.commit()
     try:
         denied_feedback = client.put(

--- a/frontend/flutter/lib/features/exercise/domain/entities/exercise_week.dart
+++ b/frontend/flutter/lib/features/exercise/domain/entities/exercise_week.dart
@@ -39,7 +39,7 @@ ExerciseIntensity _exerciseIntensityFromString(String? s) => ExerciseIntensity
 /// 파생된 기록이다(#499, #638). 회원의 일반 수기 기록이 아니므로 편집하지 못한다.
 enum ExerciseSource { member, trainerPt, assignedRoutine }
 
-/// 서버 계약값(`member`|`trainer_pt`) → [ExerciseSource].
+/// 서버 계약값(`member`|`trainer_pt`|`assigned_routine`) → [ExerciseSource].
 ///
 /// 모르는 값과 누락은 [ExerciseSource.member] 로 떨어뜨린다. 이 필드를 모르는
 /// 예전 응답(그리고 데모/목 경로)에서 기록이 통째로 잠기면 안 된다.

--- a/frontend/flutter/lib/features/exercise/domain/entities/exercise_week.dart
+++ b/frontend/flutter/lib/features/exercise/domain/entities/exercise_week.dart
@@ -29,18 +29,15 @@ ExerciseType _exerciseTypeFromString(String s) => ExerciseType.values
 /// 가벼움 / 보통 / 높음 chips and the `_intensityFactor` multipliers.
 enum ExerciseIntensity { light, moderate, high }
 
-ExerciseIntensity _exerciseIntensityFromString(String? s) =>
-    ExerciseIntensity.values.firstWhere(
-      (i) => i.name == s,
-      orElse: () => ExerciseIntensity.moderate,
-    );
+ExerciseIntensity _exerciseIntensityFromString(String? s) => ExerciseIntensity
+    .values
+    .firstWhere((i) => i.name == s, orElse: () => ExerciseIntensity.moderate);
 
 /// 이 기록을 누가 만들었는가.
 ///
-/// [ExerciseSource.trainerPt] 는 트레이너가 PT 세션을 완료 처리해 서버가 파생시킨
-/// 기록이다(#499). 근거가 트레이너에게 있어 회원이 고칠 수 없고, 서버도 수정·삭제를
-/// 409 로 거절한다 — 화면에서 편집 동작을 감추는 것은 그 규칙을 앞당겨 보여주는 것뿐이다.
-enum ExerciseSource { member, trainerPt }
+/// [ExerciseSource.trainerPt]와 [ExerciseSource.assignedRoutine]은 코칭 흐름에서
+/// 파생된 기록이다(#499, #638). 회원의 일반 수기 기록이 아니므로 편집하지 못한다.
+enum ExerciseSource { member, trainerPt, assignedRoutine }
 
 /// 서버 계약값(`member`|`trainer_pt`) → [ExerciseSource].
 ///
@@ -48,6 +45,7 @@ enum ExerciseSource { member, trainerPt }
 /// 예전 응답(그리고 데모/목 경로)에서 기록이 통째로 잠기면 안 된다.
 ExerciseSource _exerciseSourceFromString(String? s) => switch (s) {
   'trainer_pt' => ExerciseSource.trainerPt,
+  'assigned_routine' => ExerciseSource.assignedRoutine,
   _ => ExerciseSource.member,
 };
 
@@ -63,6 +61,11 @@ class ExerciseSession {
     this.timeLabel,
     this.items = const <String>[],
     this.source = ExerciseSource.member,
+    this.assignedRoutineId,
+    this.assignedRoutineName = '',
+    this.memberNote = '',
+    this.trainerFeedback = '',
+    this.completedAt,
   });
 
   final String? id;
@@ -90,7 +93,13 @@ class ExerciseSession {
   /// 기록의 출처. 기본값은 회원이 직접 남긴 것.
   final ExerciseSource source;
 
-  /// 회원이 이 기록을 고칠 수 있는가. 트레이너가 완료 처리한 PT 기록은 불가.
+  final String? assignedRoutineId;
+  final String assignedRoutineName;
+  final String memberNote;
+  final String trainerFeedback;
+  final DateTime? completedAt;
+
+  /// 회원이 직접 남긴 일반 기록만 편집할 수 있다.
   bool get isEditable => source == ExerciseSource.member;
 
   factory ExerciseSession.fromJson(Map<String, Object?> json) =>
@@ -107,6 +116,11 @@ class ExerciseSession {
             .cast<String>()
             .toList(),
         source: _exerciseSourceFromString(json['source'] as String?),
+        assignedRoutineId: json['assigned_routine_id'] as String?,
+        assignedRoutineName: json['assigned_routine_name'] as String? ?? '',
+        memberNote: json['member_note'] as String? ?? '',
+        trainerFeedback: json['trainer_feedback'] as String? ?? '',
+        completedAt: DateTime.tryParse(json['completed_at'] as String? ?? ''),
       );
 }
 

--- a/frontend/flutter/lib/features/member_coach/data/dtos/member_coach_dtos.dart
+++ b/frontend/flutter/lib/features/member_coach/data/dtos/member_coach_dtos.dart
@@ -23,6 +23,14 @@ CoachRoutine coachRoutineFromJson(Map<String, Object?> json) {
     type: _str(json['type']),
     reason: _str(json['reason']),
     source: _str(json['source']),
+    completed: json['completed'] == true,
+    completedAt: DateTime.tryParse(_str(json['completed_at'])),
+    completedMinutes: json['completed_minutes'] is num
+        ? (json['completed_minutes']! as num).toInt()
+        : null,
+    completedIntensity: json['completed_intensity'] as String?,
+    memberNote: _str(json['member_note']),
+    trainerFeedback: _str(json['trainer_feedback']),
   );
 }
 

--- a/frontend/flutter/lib/features/member_coach/data/repositories/dio_member_coach_repository.dart
+++ b/frontend/flutter/lib/features/member_coach/data/repositories/dio_member_coach_repository.dart
@@ -40,6 +40,32 @@ class DioMemberCoachRepository implements MemberCoachRepository {
       _getList('/me/coach/routines', coachRoutineFromJson);
 
   @override
+  Future<CoachRoutine> completeRoutine(
+    String routineId, {
+    required int minutes,
+    String intensity = 'moderate',
+    String memberNote = '',
+  }) async {
+    try {
+      final Response<Map<String, Object?>> response = await _dio.post(
+        '/me/coach/routines/$routineId/complete',
+        data: <String, Object?>{
+          'minutes': minutes,
+          'intensity': intensity,
+          'member_note': memberNote.trim(),
+        },
+      );
+      final Map<String, Object?>? data = response.data;
+      if (data == null) {
+        throw const FormatException('Missing completed routine.');
+      }
+      return coachRoutineFromJson(data);
+    } on DioException catch (e) {
+      throw AppError.fromDio(e);
+    }
+  }
+
+  @override
   Future<List<CoachSession>> fetchSessions() =>
       _getList('/me/coach/sessions', coachSessionFromJson);
 

--- a/frontend/flutter/lib/features/member_coach/data/repositories/mock_member_coach_repository.dart
+++ b/frontend/flutter/lib/features/member_coach/data/repositories/mock_member_coach_repository.dart
@@ -183,6 +183,36 @@ class MockMemberCoachRepository implements MemberCoachRepository {
   Future<List<CoachRoutine>> fetchRoutines() async =>
       List<CoachRoutine>.unmodifiable(_routines);
 
+  @override
+  Future<CoachRoutine> completeRoutine(
+    String routineId, {
+    required int minutes,
+    String intensity = 'moderate',
+    String memberNote = '',
+  }) async {
+    final int index = _routines.indexWhere(
+      (CoachRoutine routine) => routine.id == routineId,
+    );
+    if (index < 0) throw StateError('Routine not found.');
+    final CoachRoutine current = _routines[index];
+    if (current.completed) return current;
+    final CoachRoutine completed = CoachRoutine(
+      id: current.id,
+      name: current.name,
+      minutes: current.minutes,
+      type: current.type,
+      reason: current.reason,
+      source: current.source,
+      completed: true,
+      completedAt: DateTime.now(),
+      completedMinutes: minutes,
+      completedIntensity: intensity,
+      memberNote: memberNote.trim(),
+    );
+    _routines[index] = completed;
+    return completed;
+  }
+
   /// 데모에는 트레이너가 잡은 일정이 없다. (#490)
   ///
   /// 시드로 만들어 넣지 않는 이유: 데모 홈에 없던 카드가 생겨 화면이 지금과

--- a/frontend/flutter/lib/features/member_coach/data/repositories/mock_member_coach_repository.dart
+++ b/frontend/flutter/lib/features/member_coach/data/repositories/mock_member_coach_repository.dart
@@ -196,13 +196,7 @@ class MockMemberCoachRepository implements MemberCoachRepository {
     if (index < 0) throw StateError('Routine not found.');
     final CoachRoutine current = _routines[index];
     if (current.completed) return current;
-    final CoachRoutine completed = CoachRoutine(
-      id: current.id,
-      name: current.name,
-      minutes: current.minutes,
-      type: current.type,
-      reason: current.reason,
-      source: current.source,
+    final CoachRoutine completed = current.copyWith(
       completed: true,
       completedAt: DateTime.now(),
       completedMinutes: minutes,

--- a/frontend/flutter/lib/features/member_coach/domain/entities/member_coach.dart
+++ b/frontend/flutter/lib/features/member_coach/domain/entities/member_coach.dart
@@ -30,6 +30,12 @@ class CoachRoutine {
     required this.type,
     required this.reason,
     required this.source,
+    this.completed = false,
+    this.completedAt,
+    this.completedMinutes,
+    this.completedIntensity,
+    this.memberNote = '',
+    this.trainerFeedback = '',
   });
 
   final String id;
@@ -40,6 +46,12 @@ class CoachRoutine {
 
   /// `ai` (AI-suggested) or `trainer` (hand-assigned).
   final String source;
+  final bool completed;
+  final DateTime? completedAt;
+  final int? completedMinutes;
+  final String? completedIntensity;
+  final String memberNote;
+  final String trainerFeedback;
 
   bool get isTrainerRecommended => source == 'trainer';
   bool get isAiRecommended => source == 'ai';

--- a/frontend/flutter/lib/features/member_coach/domain/entities/member_coach.dart
+++ b/frontend/flutter/lib/features/member_coach/domain/entities/member_coach.dart
@@ -55,6 +55,28 @@ class CoachRoutine {
 
   bool get isTrainerRecommended => source == 'trainer';
   bool get isAiRecommended => source == 'ai';
+
+  CoachRoutine copyWith({
+    bool? completed,
+    DateTime? completedAt,
+    int? completedMinutes,
+    String? completedIntensity,
+    String? memberNote,
+    String? trainerFeedback,
+  }) => CoachRoutine(
+    id: id,
+    name: name,
+    minutes: minutes,
+    type: type,
+    reason: reason,
+    source: source,
+    completed: completed ?? this.completed,
+    completedAt: completedAt ?? this.completedAt,
+    completedMinutes: completedMinutes ?? this.completedMinutes,
+    completedIntensity: completedIntensity ?? this.completedIntensity,
+    memberNote: memberNote ?? this.memberNote,
+    trainerFeedback: trainerFeedback ?? this.trainerFeedback,
+  );
 }
 
 /// A PT session the coach booked for the member — `/me/coach/sessions`.

--- a/frontend/flutter/lib/features/member_coach/domain/repositories/member_coach_repository.dart
+++ b/frontend/flutter/lib/features/member_coach/domain/repositories/member_coach_repository.dart
@@ -14,6 +14,14 @@ abstract interface class MemberCoachRepository {
   /// Routines the coach has assigned (newest first).
   Future<List<CoachRoutine>> fetchRoutines();
 
+  /// Records an assigned routine once in the member's exercise history.
+  Future<CoachRoutine> completeRoutine(
+    String routineId, {
+    required int minutes,
+    String intensity = 'moderate',
+    String memberNote = '',
+  });
+
   /// PT sessions the coach booked. The trainer owns the schedule — the
   /// member reads it only. (#490)
   Future<List<CoachSession>> fetchSessions();

--- a/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_card.dart
+++ b/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_card.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:oncare/app/router/routes.dart';
+import 'package:oncare/core/errors/app_error.dart';
 import 'package:oncare/design_system/figma/figma_kit.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
@@ -231,6 +232,7 @@ class _RecommendedExerciseRowState
           .completeRoutine(
             routine.id,
             minutes: input.minutes,
+            intensity: input.intensity,
             memberNote: input.note,
           );
       ref.invalidate(coachRoutinesProvider);
@@ -240,11 +242,20 @@ class _RecommendedExerciseRowState
           context,
         ).showSnackBar(const SnackBar(content: Text('운동 기록에 반영했어요')));
       }
-    } catch (_) {
+    } catch (error, stackTrace) {
+      debugPrint('completeRoutine failed: $error\n$stackTrace');
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('완료 기록에 실패했어요. 다시 시도해 주세요')),
-        );
+        if (error is NotFoundError) {
+          ref.invalidate(coachRoutinesProvider);
+        }
+        final String message = switch (error) {
+          NotFoundError() => '이 루틴은 더 이상 없어요. 목록을 새로 불러와 주세요',
+          NetworkError() => '네트워크 연결을 확인하고 다시 시도해 주세요',
+          _ => '완료 기록에 실패했어요.',
+        };
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(message)));
       }
     } finally {
       if (mounted) setState(() => _saving = false);
@@ -366,9 +377,14 @@ class _RecommendedExerciseRowState
 }
 
 class _RoutineCompletionInput {
-  const _RoutineCompletionInput({required this.minutes, required this.note});
+  const _RoutineCompletionInput({
+    required this.minutes,
+    required this.intensity,
+    required this.note,
+  });
 
   final int minutes;
+  final String intensity;
   final String note;
 }
 
@@ -386,6 +402,7 @@ class _RoutineCompletionDialogState extends State<_RoutineCompletionDialog> {
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   late final TextEditingController _minutesController;
   final TextEditingController _noteController = TextEditingController();
+  String _intensity = 'moderate';
 
   @override
   void initState() {
@@ -424,6 +441,21 @@ class _RoutineCompletionDialogState extends State<_RoutineCompletionDialog> {
               },
             ),
             const SizedBox(height: 12),
+            const Align(alignment: Alignment.centerLeft, child: Text('수행 강도')),
+            const SizedBox(height: 6),
+            SegmentedButton<String>(
+              key: const Key('routineCompletionIntensity'),
+              segments: const <ButtonSegment<String>>[
+                ButtonSegment<String>(value: 'light', label: Text('가벼움')),
+                ButtonSegment<String>(value: 'moderate', label: Text('보통')),
+                ButtonSegment<String>(value: 'high', label: Text('높음')),
+              ],
+              selected: <String>{_intensity},
+              onSelectionChanged: (Set<String> selected) {
+                setState(() => _intensity = selected.single);
+              },
+            ),
+            const SizedBox(height: 12),
             TextFormField(
               key: const Key('routineCompletionNote'),
               controller: _noteController,
@@ -449,6 +481,7 @@ class _RoutineCompletionDialogState extends State<_RoutineCompletionDialog> {
             Navigator.of(context).pop(
               _RoutineCompletionInput(
                 minutes: int.parse(_minutesController.text),
+                intensity: _intensity,
                 note: _noteController.text,
               ),
             );

--- a/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_card.dart
+++ b/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_card.dart
@@ -199,57 +199,263 @@ class AiRecommendedExerciseCard extends ConsumerWidget {
   }
 }
 
-class _RecommendedExerciseRow extends StatelessWidget {
+class _RecommendedExerciseRow extends ConsumerStatefulWidget {
   const _RecommendedExerciseRow({required this.routine});
 
   final CoachRoutine routine;
 
   @override
+  ConsumerState<_RecommendedExerciseRow> createState() =>
+      _RecommendedExerciseRowState();
+}
+
+class _RecommendedExerciseRowState
+    extends ConsumerState<_RecommendedExerciseRow> {
+  bool _saving = false;
+
+  Future<void> _complete() async {
+    final CoachRoutine routine = widget.routine;
+    final _RoutineCompletionInput? input =
+        await showDialog<_RoutineCompletionInput>(
+          context: context,
+          builder: (_) => _RoutineCompletionDialog(
+            initialMinutes: routine.minutes > 0 ? routine.minutes : 1,
+          ),
+        );
+    if (input == null || !mounted) return;
+
+    setState(() => _saving = true);
+    try {
+      await ref
+          .read(memberCoachRepositoryProvider)
+          .completeRoutine(
+            routine.id,
+            minutes: input.minutes,
+            memberNote: input.note,
+          );
+      ref.invalidate(coachRoutinesProvider);
+      ref.invalidate(exerciseWeekProvider);
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('운동 기록에 반영했어요')));
+      }
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('완료 기록에 실패했어요. 다시 시도해 주세요')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final CoachRoutine routine = widget.routine;
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
       decoration: BoxDecoration(
         color: FigmaColors.statBg,
         borderRadius: BorderRadius.circular(12),
       ),
-      child: Row(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Text(
-                  routine.name,
-                  style: const TextStyle(
-                    fontSize: 14,
-                    fontWeight: FontWeight.w700,
-                    color: FigmaColors.ink,
-                  ),
+          Row(
+            children: <Widget>[
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      routine.name,
+                      style: const TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w700,
+                        color: FigmaColors.ink,
+                      ),
+                    ),
+                    if (routine.reason.isNotEmpty) ...<Widget>[
+                      const SizedBox(height: 2),
+                      Text(
+                        routine.reason,
+                        style: const TextStyle(
+                          fontSize: 12.5,
+                          color: AppColors.foreground,
+                        ),
+                      ),
+                    ],
+                  ],
                 ),
-                if (routine.reason.isNotEmpty) ...<Widget>[
-                  const SizedBox(height: 2),
+              ),
+              const SizedBox(width: 8),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: <Widget>[
                   Text(
-                    routine.reason,
+                    '${routine.type} · '
+                    '${routine.completedMinutes ?? routine.minutes}분',
                     style: const TextStyle(
                       fontSize: 12.5,
-                      color: AppColors.foreground,
+                      fontWeight: FontWeight.w700,
+                      color: FigmaColors.primary,
                     ),
                   ),
+                  const SizedBox(height: 4),
+                  if (routine.completed)
+                    const Row(
+                      children: <Widget>[
+                        Icon(Icons.check_circle, size: 16, color: Colors.green),
+                        SizedBox(width: 4),
+                        Text('수행 완료'),
+                      ],
+                    )
+                  else
+                    SizedBox(
+                      height: 30,
+                      child: OutlinedButton(
+                        key: Key('completeRoutine-${routine.id}'),
+                        onPressed: _saving ? null : _complete,
+                        style: OutlinedButton.styleFrom(
+                          padding: const EdgeInsets.symmetric(horizontal: 10),
+                        ),
+                        child: _saving
+                            ? const SizedBox.square(
+                                dimension: 14,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
+                              )
+                            : const Text('수행 완료'),
+                      ),
+                    ),
                 ],
-              ],
-            ),
+              ),
+            ],
           ),
-          const SizedBox(width: 8),
-          Text(
-            '${routine.type} · ${routine.minutes}분',
-            style: const TextStyle(
-              fontSize: 12.5,
-              fontWeight: FontWeight.w700,
-              color: FigmaColors.primary,
+          if (routine.memberNote.isNotEmpty) ...<Widget>[
+            const SizedBox(height: 8),
+            Text('내 메모: ${routine.memberNote}'),
+          ],
+          if (routine.trainerFeedback.isNotEmpty) ...<Widget>[
+            const SizedBox(height: 8),
+            Container(
+              key: Key('routineFeedback-${routine.id}'),
+              width: double.infinity,
+              padding: const EdgeInsets.all(10),
+              decoration: BoxDecoration(
+                color: FigmaColors.softBlue,
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: Text(
+                '트레이너 피드백: ${routine.trainerFeedback}',
+                style: const TextStyle(
+                  fontSize: 12.5,
+                  height: 1.4,
+                  color: FigmaColors.ink,
+                ),
+              ),
             ),
-          ),
+          ],
         ],
       ),
+    );
+  }
+}
+
+class _RoutineCompletionInput {
+  const _RoutineCompletionInput({required this.minutes, required this.note});
+
+  final int minutes;
+  final String note;
+}
+
+class _RoutineCompletionDialog extends StatefulWidget {
+  const _RoutineCompletionDialog({required this.initialMinutes});
+
+  final int initialMinutes;
+
+  @override
+  State<_RoutineCompletionDialog> createState() =>
+      _RoutineCompletionDialogState();
+}
+
+class _RoutineCompletionDialogState extends State<_RoutineCompletionDialog> {
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  late final TextEditingController _minutesController;
+  final TextEditingController _noteController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _minutesController = TextEditingController(
+      text: '${widget.initialMinutes}',
+    );
+  }
+
+  @override
+  void dispose() {
+    _minutesController.dispose();
+    _noteController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('루틴 수행 완료'),
+      content: Form(
+        key: _formKey,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            TextFormField(
+              key: const Key('routineCompletionMinutes'),
+              controller: _minutesController,
+              keyboardType: TextInputType.number,
+              decoration: const InputDecoration(labelText: '실제 수행 시간(분)'),
+              validator: (String? value) {
+                final int? minutes = int.tryParse(value ?? '');
+                return minutes == null || minutes < 1 || minutes > 600
+                    ? '1~600분 사이로 입력해 주세요'
+                    : null;
+              },
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              key: const Key('routineCompletionNote'),
+              controller: _noteController,
+              maxLength: 1000,
+              maxLines: 3,
+              decoration: const InputDecoration(
+                labelText: '메모(선택)',
+                hintText: '힘들었던 점이나 몸 상태를 남겨 보세요',
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('취소'),
+        ),
+        FilledButton(
+          key: const Key('confirmRoutineCompletion'),
+          onPressed: () {
+            if (!(_formKey.currentState?.validate() ?? false)) return;
+            Navigator.of(context).pop(
+              _RoutineCompletionInput(
+                minutes: int.parse(_minutesController.text),
+                note: _noteController.text,
+              ),
+            );
+          },
+          child: const Text('완료 기록'),
+        ),
+      ],
     );
   }
 }

--- a/frontend/flutter/test/features/exercise/exercise_health_goals_test.dart
+++ b/frontend/flutter/test/features/exercise/exercise_health_goals_test.dart
@@ -74,6 +74,13 @@ class _SessionMemberCoachRepository implements MemberCoachRepository {
   @override
   Future<List<CoachRoutine>> fetchRoutines() async => const <CoachRoutine>[];
   @override
+  Future<CoachRoutine> completeRoutine(
+    String routineId, {
+    required int minutes,
+    String intensity = 'moderate',
+    String memberNote = '',
+  }) async => throw UnsupportedError('not used');
+  @override
   Future<List<CoachSession>> fetchSessions() async => sessions;
   @override
   Future<List<CoachMessage>> fetchChat() async => const <CoachMessage>[];

--- a/frontend/flutter/test/features/member_coach/dio_member_coach_repository_test.dart
+++ b/frontend/flutter/test/features/member_coach/dio_member_coach_repository_test.dart
@@ -79,6 +79,42 @@ void main() {
     expect(routines.single.name, '저강도 유산소');
   });
 
+  test(
+    'completeRoutine posts the result and returns completion state',
+    () async {
+      when(
+        () => dio.post<Map<String, Object?>>(
+          '/me/coach/routines/r1/complete',
+          data: <String, Object?>{
+            'minutes': 35,
+            'intensity': 'moderate',
+            'member_note': '마지막 세트가 힘들었어요',
+          },
+        ),
+      ).thenAnswer(
+        (_) async => _ok<Map<String, Object?>>(<String, Object?>{
+          'id': 'r1',
+          'name': '코어 운동',
+          'minutes': 30,
+          'type': '근력',
+          'reason': '',
+          'source': 'trainer',
+          'completed': true,
+          'member_note': '마지막 세트가 힘들었어요',
+        }, '/me/coach/routines/r1/complete'),
+      );
+
+      final CoachRoutine completed = await repo.completeRoutine(
+        'r1',
+        minutes: 35,
+        memberNote: '  마지막 세트가 힘들었어요  ',
+      );
+
+      expect(completed.completed, isTrue);
+      expect(completed.memberNote, '마지막 세트가 힘들었어요');
+    },
+  );
+
   test('fetchChat parses and sorts the thread oldest first', () async {
     when(() => dio.get<List<dynamic>>('/me/coach/chat')).thenAnswer(
       (_) async => Response<List<dynamic>>(

--- a/frontend/flutter/test/features/member_coach/member_coach_dtos_test.dart
+++ b/frontend/flutter/test/features/member_coach/member_coach_dtos_test.dart
@@ -28,9 +28,21 @@ void main() {
       'type': '유산소',
       'reason': '혈압 안정',
       'source': 'ai',
+      'completed': true,
+      'completed_at': '2026-08-13T10:00:00Z',
+      'completed_minutes': 25,
+      'completed_intensity': 'high',
+      'member_note': '힘들었어요',
+      'trainer_feedback': '잘했어요',
     });
     expect(r.minutes, 20);
     expect(r.source, 'ai');
+    expect(r.completed, isTrue);
+    expect(r.completedAt, DateTime.utc(2026, 8, 13, 10));
+    expect(r.completedMinutes, 25);
+    expect(r.completedIntensity, 'high');
+    expect(r.memberNote, '힘들었어요');
+    expect(r.trainerFeedback, '잘했어요');
   });
 
   group('coachMessageFromJson (member viewpoint)', () {

--- a/frontend/flutter/test/features/member_coach/recommended_exercise_cards_test.dart
+++ b/frontend/flutter/test/features/member_coach/recommended_exercise_cards_test.dart
@@ -168,6 +168,52 @@ void main() {
     );
   });
 
+  testWidgets('배정 루틴 완료를 기록하고 완료 상태를 갱신한다', (WidgetTester tester) async {
+    final MockMemberCoachRepository repository = MockMemberCoachRepository();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          memberCoachRepositoryProvider.overrideWithValue(repository),
+          myTrainerProvider.overrideWith((ref) async => _assignedTrainer),
+        ],
+        child: const MaterialApp(home: Scaffold(body: CoachCard())),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('completeRoutine-seed-r2')));
+    await tester.pumpAndSettle();
+    expect(find.text('루틴 수행 완료'), findsOneWidget);
+    await tester.enterText(
+      find.byKey(const Key('routineCompletionNote')),
+      '허리는 편안했어요',
+    );
+    await tester.tap(find.byKey(const Key('confirmRoutineCompletion')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('운동 기록에 반영했어요'), findsOneWidget);
+    expect(find.text('내 메모: 허리는 편안했어요'), findsOneWidget);
+    expect(find.byKey(const Key('completeRoutine-seed-r2')), findsNothing);
+  });
+
+  testWidgets('완료한 루틴에 트레이너 피드백을 표시한다', (WidgetTester tester) async {
+    await pumpRecommendationCards(tester, const <CoachRoutine>[
+      CoachRoutine(
+        id: 'done',
+        name: '완료 루틴',
+        minutes: 20,
+        type: '근력',
+        reason: '',
+        source: 'trainer',
+        completed: true,
+        trainerFeedback: '자세가 좋았어요',
+      ),
+    ]);
+
+    expect(find.text('트레이너 피드백: 자세가 좋았어요'), findsOneWidget);
+    expect(find.byKey(const Key('routineFeedback-done')), findsOneWidget);
+  });
+
   testWidgets('각 출처의 추천 운동이 없으면 안내 문구를 표시한다', (WidgetTester tester) async {
     await pumpRecommendationCards(tester, const <CoachRoutine>[]);
 

--- a/frontend/flutter/test/features/member_coach/recommended_exercise_cards_test.dart
+++ b/frontend/flutter/test/features/member_coach/recommended_exercise_cards_test.dart
@@ -188,12 +188,16 @@ void main() {
       find.byKey(const Key('routineCompletionNote')),
       '허리는 편안했어요',
     );
+    await tester.tap(find.text('높음'));
     await tester.tap(find.byKey(const Key('confirmRoutineCompletion')));
     await tester.pumpAndSettle();
 
+    final CoachRoutine completed = (await repository.fetchRoutines())
+        .firstWhere((CoachRoutine routine) => routine.id == 'seed-r2');
     expect(find.text('운동 기록에 반영했어요'), findsOneWidget);
     expect(find.text('내 메모: 허리는 편안했어요'), findsOneWidget);
     expect(find.byKey(const Key('completeRoutine-seed-r2')), findsNothing);
+    expect(completed.completedIntensity, 'high');
   });
 
   testWidgets('완료한 루틴에 트레이너 피드백을 표시한다', (WidgetTester tester) async {

--- a/frontend/flutter_trainer/lib/features/clients/data/dtos/client_dtos.dart
+++ b/frontend/flutter_trainer/lib/features/clients/data/dtos/client_dtos.dart
@@ -45,12 +45,15 @@ ClientDietEntry clientDietEntryFromJson(Map<String, Object?> json) {
 /// `GET /v1/trainer/clients/{id}/history` element → [RoutineHistoryEntry].
 RoutineHistoryEntry routineHistoryEntryFromJson(Map<String, Object?> json) {
   return RoutineHistoryEntry(
+    id: _str(json['id']),
     dateLabel: _str(json['date_label']),
     label: _str(json['label']),
     completionRate: _int(json['completion_rate']),
     exercises: _strList(json['exercises']),
     clientFeedback: _str(json['client_feedback']),
     trainerNote: _str(json['trainer_note']),
+    assignedRoutineId: _nullableStr(json['assigned_routine_id']),
+    completedAt: DateTime.tryParse(_str(json['completed_at'])),
   );
 }
 
@@ -90,6 +93,8 @@ List<TrainerClient> prioritizeClients(
 }
 
 String _str(Object? v) => v is String ? v : '';
+
+String? _nullableStr(Object? v) => v is String && v.isNotEmpty ? v : null;
 
 int _int(Object? v) => v is num ? v.toInt() : 0;
 

--- a/frontend/flutter_trainer/lib/features/clients/data/repositories/dio_client_repository.dart
+++ b/frontend/flutter_trainer/lib/features/clients/data/repositories/dio_client_repository.dart
@@ -101,6 +101,28 @@ class DioClientRepository implements ClientRepository, ClientDataRefresher {
   );
 
   @override
+  Future<RoutineHistoryEntry> updateHistoryFeedback(
+    String clientId,
+    String historyId,
+    String feedback,
+  ) async {
+    final String path =
+        '/trainer/clients/${Uri.encodeComponent(clientId)}/history/'
+        '${Uri.encodeComponent(historyId)}/feedback';
+    try {
+      final Response<Map<String, Object?>> response = await _dio.put(
+        path,
+        data: <String, Object?>{'feedback': feedback.trim()},
+      );
+      final Map<String, Object?>? data = response.data;
+      if (data == null) throw const FormatException('Missing history row.');
+      return routineHistoryEntryFromJson(data);
+    } on DioException catch (error) {
+      throw AppError.fromDio(error);
+    }
+  }
+
+  @override
   Future<MemberHealthProfile> fetchHealthProfile(String clientId) async {
     try {
       final response = await _dio.get<Map<String, Object?>>(

--- a/frontend/flutter_trainer/lib/features/clients/domain/entities/routine_history_entry.dart
+++ b/frontend/flutter_trainer/lib/features/clients/domain/entities/routine_history_entry.dart
@@ -4,13 +4,19 @@
 class RoutineHistoryEntry {
   /// Creates a history entry.
   const RoutineHistoryEntry({
+    this.id = '',
     required this.dateLabel,
     required this.label,
     required this.completionRate,
     required this.exercises,
     required this.clientFeedback,
     required this.trainerNote,
+    this.assignedRoutineId,
+    this.completedAt,
   });
+
+  /// Stable history id used when editing feedback.
+  final String id;
 
   /// Display date (e.g. "7/12 (오늘)").
   final String dateLabel;
@@ -29,4 +35,8 @@ class RoutineHistoryEntry {
 
   /// Trainer's note (may be empty — the note box is hidden then).
   final String trainerNote;
+
+  /// Present only when this history row came from an assigned routine.
+  final String? assignedRoutineId;
+  final DateTime? completedAt;
 }

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/workout_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/workout_view.dart
@@ -106,7 +106,7 @@ class WorkoutView extends ConsumerWidget {
                 icon: Icons.fitness_center_outlined,
               ),
             for (final entry in entries) ...<Widget>[
-              _HistoryCard(entry: entry),
+              _HistoryCard(clientId: client.id, entry: entry),
               const SizedBox(height: AppSpacing.md),
             ],
           ],
@@ -534,14 +534,46 @@ class _LegendDot extends StatelessWidget {
 
 /// A single workout record: date/kind, completion donut, exercise lines
 /// (skipped ones struck through), client feedback, trainer note.
-class _HistoryCard extends StatelessWidget {
-  const _HistoryCard({required this.entry});
+class _HistoryCard extends ConsumerStatefulWidget {
+  const _HistoryCard({required this.clientId, required this.entry});
 
+  final String clientId;
   final RoutineHistoryEntry entry;
+
+  @override
+  ConsumerState<_HistoryCard> createState() => _HistoryCardState();
+}
+
+class _HistoryCardState extends ConsumerState<_HistoryCard> {
+  bool _saving = false;
+
+  Future<void> _editFeedback() async {
+    final AppLocalizations l = AppLocalizations.of(context);
+    final String? feedback = await showDialog<String>(
+      context: context,
+      builder: (_) => _FeedbackDialog(initialValue: widget.entry.trainerNote),
+    );
+    if (feedback == null || !mounted) return;
+
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    setState(() => _saving = true);
+    try {
+      await ref
+          .read(clientRepositoryProvider)
+          .updateHistoryFeedback(widget.clientId, widget.entry.id, feedback);
+      ref.invalidate(clientHistoryProvider(widget.clientId));
+      messenger.showSnackBar(SnackBar(content: Text(l.routineFeedbackSaved)));
+    } catch (_) {
+      messenger.showSnackBar(SnackBar(content: Text(l.routineFeedbackFailed)));
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     final AppLocalizations l = AppLocalizations.of(context);
+    final RoutineHistoryEntry entry = widget.entry;
     return Container(
       padding: const EdgeInsets.all(AppSpacing.lg),
       decoration: BoxDecoration(
@@ -599,8 +631,76 @@ class _HistoryCard extends StatelessWidget {
               color: AppColors.warning,
             ),
           ],
+          if (entry.assignedRoutineId != null) ...<Widget>[
+            const SizedBox(height: AppSpacing.sm),
+            Align(
+              alignment: Alignment.centerRight,
+              child: ActionButton(
+                key: ValueKey<String>('routine-feedback-${entry.id}'),
+                label: entry.trainerNote.isEmpty
+                    ? l.routineFeedbackWrite
+                    : l.routineFeedbackEdit,
+                onPressed: _saving ? null : _editFeedback,
+              ),
+            ),
+          ],
         ],
       ),
+    );
+  }
+}
+
+class _FeedbackDialog extends StatefulWidget {
+  const _FeedbackDialog({required this.initialValue});
+
+  final String initialValue;
+
+  @override
+  State<_FeedbackDialog> createState() => _FeedbackDialogState();
+}
+
+class _FeedbackDialogState extends State<_FeedbackDialog> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialValue);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations l = AppLocalizations.of(context);
+    return AlertDialog(
+      title: Text(l.routineFeedbackTitle),
+      content: TextField(
+        key: const ValueKey<String>('routine-feedback-input'),
+        controller: _controller,
+        autofocus: true,
+        maxLength: 2000,
+        maxLines: 5,
+        decoration: InputDecoration(hintText: l.routineFeedbackHint),
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(l.actionCancel),
+        ),
+        FilledButton(
+          key: const ValueKey<String>('routine-feedback-save'),
+          onPressed: () {
+            final String text = _controller.text.trim();
+            if (text.isNotEmpty) Navigator.of(context).pop(text);
+          },
+          child: Text(l.actionSave),
+        ),
+      ],
     );
   }
 }

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/workout_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/workout_view.dart
@@ -3,7 +3,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:oncare_trainer/app/router/routes.dart';
+import 'package:oncare_trainer/core/errors/app_error.dart';
 import 'package:oncare_trainer/core/utils/date_format.dart';
+import 'package:oncare_trainer/core/utils/server_message.dart';
 import 'package:oncare_trainer/features/dashboard/domain/dashboard_summary.dart'
     show elapsedWeekdays, weekdayCount, weekdayLabels;
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
@@ -563,8 +565,18 @@ class _HistoryCardState extends ConsumerState<_HistoryCard> {
           .updateHistoryFeedback(widget.clientId, widget.entry.id, feedback);
       ref.invalidate(clientHistoryProvider(widget.clientId));
       messenger.showSnackBar(SnackBar(content: Text(l.routineFeedbackSaved)));
-    } catch (_) {
-      messenger.showSnackBar(SnackBar(content: Text(l.routineFeedbackFailed)));
+    } catch (error) {
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            serverDetailOr(
+              l,
+              error is AppError ? error.message : null,
+              l.routineFeedbackFailed,
+            ),
+          ),
+        ),
+      );
     } finally {
       if (mounted) setState(() => _saving = false);
     }

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
@@ -3475,6 +3475,42 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Nothing recorded this week'**
   String get searchDetailNoRecord;
+
+  /// No description provided for @routineFeedbackTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Workout feedback'**
+  String get routineFeedbackTitle;
+
+  /// No description provided for @routineFeedbackHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Write coaching feedback for the member'**
+  String get routineFeedbackHint;
+
+  /// No description provided for @routineFeedbackWrite.
+  ///
+  /// In en, this message translates to:
+  /// **'Write feedback'**
+  String get routineFeedbackWrite;
+
+  /// No description provided for @routineFeedbackEdit.
+  ///
+  /// In en, this message translates to:
+  /// **'Edit feedback'**
+  String get routineFeedbackEdit;
+
+  /// No description provided for @routineFeedbackSaved.
+  ///
+  /// In en, this message translates to:
+  /// **'Feedback saved'**
+  String get routineFeedbackSaved;
+
+  /// No description provided for @routineFeedbackFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not save feedback. Please try again'**
+  String get routineFeedbackFailed;
 }
 
 class _AppLocalizationsDelegate

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
@@ -1925,4 +1925,23 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get searchDetailNoRecord => 'Nothing recorded this week';
+
+  @override
+  String get routineFeedbackTitle => 'Workout feedback';
+
+  @override
+  String get routineFeedbackHint => 'Write coaching feedback for the member';
+
+  @override
+  String get routineFeedbackWrite => 'Write feedback';
+
+  @override
+  String get routineFeedbackEdit => 'Edit feedback';
+
+  @override
+  String get routineFeedbackSaved => 'Feedback saved';
+
+  @override
+  String get routineFeedbackFailed =>
+      'Could not save feedback. Please try again';
 }

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
@@ -1869,4 +1869,22 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get searchDetailNoRecord => '이번 주 기록 없음';
+
+  @override
+  String get routineFeedbackTitle => '수행 피드백';
+
+  @override
+  String get routineFeedbackHint => '회원에게 전할 코칭 피드백을 입력해 주세요';
+
+  @override
+  String get routineFeedbackWrite => '피드백 작성';
+
+  @override
+  String get routineFeedbackEdit => '피드백 수정';
+
+  @override
+  String get routineFeedbackSaved => '피드백을 저장했어요';
+
+  @override
+  String get routineFeedbackFailed => '피드백을 저장하지 못했어요. 다시 시도해 주세요';
 }

--- a/frontend/flutter_trainer/lib/l10n/app_en.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_en.arb
@@ -1293,5 +1293,11 @@
       }
     }
   },
-  "searchDetailNoRecord": "Nothing recorded this week"
+  "searchDetailNoRecord": "Nothing recorded this week",
+  "routineFeedbackTitle": "Workout feedback",
+  "routineFeedbackHint": "Write coaching feedback for the member",
+  "routineFeedbackWrite": "Write feedback",
+  "routineFeedbackEdit": "Edit feedback",
+  "routineFeedbackSaved": "Feedback saved",
+  "routineFeedbackFailed": "Could not save feedback. Please try again"
 }

--- a/frontend/flutter_trainer/lib/l10n/app_ko.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_ko.arb
@@ -565,5 +565,11 @@
   "searchDetailLastRoutine": "마지막 루틴 {when}",
   "searchDetailNoRoutine": "보낸 루틴 없음",
   "searchDetailCompletion": "이번 주 이행률 {percent}%",
-  "searchDetailNoRecord": "이번 주 기록 없음"
+  "searchDetailNoRecord": "이번 주 기록 없음",
+  "routineFeedbackTitle": "수행 피드백",
+  "routineFeedbackHint": "회원에게 전할 코칭 피드백을 입력해 주세요",
+  "routineFeedbackWrite": "피드백 작성",
+  "routineFeedbackEdit": "피드백 수정",
+  "routineFeedbackSaved": "피드백을 저장했어요",
+  "routineFeedbackFailed": "피드백을 저장하지 못했어요. 다시 시도해 주세요"
 }

--- a/frontend/flutter_trainer/lib/shared/services/client_repository.dart
+++ b/frontend/flutter_trainer/lib/shared/services/client_repository.dart
@@ -41,6 +41,11 @@ abstract interface class ClientRepository {
 
   Stream<List<ClientDietEntry>> watchDiet(String clientId);
   Stream<List<RoutineHistoryEntry>> watchHistory(String clientId);
+  Future<RoutineHistoryEntry> updateHistoryFeedback(
+    String clientId,
+    String historyId,
+    String feedback,
+  );
   Future<MemberHealthProfile> fetchHealthProfile(String clientId);
   Future<MemberHealthProfile> updateHealthProfile(
     String clientId,
@@ -63,6 +68,15 @@ class DriftClientRepository implements ClientRepository {
   const DriftClientRepository(this._db);
 
   final AppDatabase _db;
+
+  @override
+  Future<RoutineHistoryEntry> updateHistoryFeedback(
+    String clientId,
+    String historyId,
+    String feedback,
+  ) => throw UnsupportedError(
+    'Assigned-routine feedback is available from the backend only.',
+  );
 
   @override
   bool get supportsRosterMutations => true;

--- a/frontend/flutter_trainer/test/features/clients/client_detail_workout_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_workout_test.dart
@@ -43,6 +43,47 @@ class _HistoryFailsOnceRepository extends DriftClientRepository {
   }
 }
 
+class _FeedbackRepository extends DriftClientRepository {
+  _FeedbackRepository(super.db)
+    : entry = const RoutineHistoryEntry(
+        id: 'assigned-ex-r1',
+        dateLabel: '8/13 (오늘)',
+        label: '코어 운동',
+        completionRate: 100,
+        exercises: <String>['코어 운동 · 30분'],
+        clientFeedback: '마지막 세트가 힘들었어요',
+        trainerNote: '',
+        assignedRoutineId: 'r1',
+      );
+
+  RoutineHistoryEntry entry;
+  int updateCalls = 0;
+
+  @override
+  Stream<List<RoutineHistoryEntry>> watchHistory(String clientId) =>
+      Stream<List<RoutineHistoryEntry>>.value(<RoutineHistoryEntry>[entry]);
+
+  @override
+  Future<RoutineHistoryEntry> updateHistoryFeedback(
+    String clientId,
+    String historyId,
+    String feedback,
+  ) async {
+    updateCalls += 1;
+    entry = RoutineHistoryEntry(
+      id: entry.id,
+      dateLabel: entry.dateLabel,
+      label: entry.label,
+      completionRate: entry.completionRate,
+      exercises: entry.exercises,
+      clientFeedback: entry.clientFeedback,
+      trainerNote: feedback,
+      assignedRoutineId: entry.assignedRoutineId,
+    );
+    return entry;
+  }
+}
+
 class _AssignedFailsOnceRepository extends MockTrainerRoutineRepository {
   int watchAssignedCalls = 0;
 
@@ -161,6 +202,42 @@ void main() {
         ),
       );
     }
+
+    testWidgets('배정 루틴 수행 기록에 피드백을 작성하고 수정한다', (tester) async {
+      late _FeedbackRepository repository;
+      await pumpTrainerApp(
+        tester,
+        token: 'demo-trainer-token',
+        at: AppRoutes.clientDetail('seed-client-1', section: 'workout'),
+        extraOverrides: <Override>[
+          clientRepositoryProvider.overrideWith((ref) {
+            repository = _FeedbackRepository(ref.watch(appDatabaseProvider));
+            return repository;
+          }),
+        ],
+      );
+
+      final Finder feedbackButton = find.byKey(
+        const ValueKey<String>('routine-feedback-assigned-ex-r1'),
+      );
+      await tester.scrollUntilVisible(feedbackButton, 150);
+      await tester.ensureVisible(feedbackButton);
+      await settle(tester);
+      await tester.tap(feedbackButton);
+      await settle(tester);
+      await tester.enterText(
+        find.byKey(const ValueKey<String>('routine-feedback-input')),
+        '자세가 안정적이었어요',
+      );
+      await tester.tap(
+        find.byKey(const ValueKey<String>('routine-feedback-save')),
+      );
+      await settle(tester);
+
+      expect(repository.updateCalls, 1);
+      expect(find.text('자세가 안정적이었어요'), findsOneWidget);
+      expect(find.text('피드백 수정'), findsOneWidget);
+    });
 
     testWidgets('김민수 averages only the weekdays that have happened', (
       tester,

--- a/frontend/flutter_trainer/test/features/clients/client_dtos_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_dtos_test.dart
@@ -99,17 +99,23 @@ void main() {
 
     test('maps a history entry with exercises list', () {
       final h = routineHistoryEntryFromJson(<String, Object?>{
+        'id': 'assigned-ex-r1',
         'date_label': '7/12 (오늘)',
         'label': 'PT 세션',
         'completion_rate': 80,
         'exercises': <Object?>['스쿼트 3세트', '✗ 런지'],
         'client_feedback': '무릎이 조금 아팠어요',
         'trainer_note': '강도 조절',
+        'assigned_routine_id': 'r1',
+        'completed_at': '2026-08-13T10:00:00Z',
       });
       expect(h.dateLabel, '7/12 (오늘)');
       expect(h.completionRate, 80);
       expect(h.exercises, <String>['스쿼트 3세트', '✗ 런지']);
       expect(h.trainerNote, '강도 조절');
+      expect(h.id, 'assigned-ex-r1');
+      expect(h.assignedRoutineId, 'r1');
+      expect(h.completedAt, DateTime.utc(2026, 8, 13, 10));
     });
   });
 

--- a/frontend/flutter_trainer/test/features/clients/client_repository_provider_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_repository_provider_test.dart
@@ -59,6 +59,12 @@ class _StreamingClientRepository implements ClientRepository {
   Stream<List<RoutineHistoryEntry>> watchHistory(String clientId) =>
       const Stream<List<RoutineHistoryEntry>>.empty();
   @override
+  Future<RoutineHistoryEntry> updateHistoryFeedback(
+    String clientId,
+    String historyId,
+    String feedback,
+  ) async => throw UnsupportedError('not used');
+  @override
   Future<MemberHealthProfile> fetchHealthProfile(String clientId) async =>
       MemberHealthProfile(memberId: clientId, memberName: '회원');
   @override

--- a/frontend/flutter_trainer/test/features/clients/dio_client_repository_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/dio_client_repository_test.dart
@@ -84,6 +84,44 @@ void main() {
     expect(meals.single.meal, '점심');
   });
 
+  test(
+    'updateHistoryFeedback writes and parses the shared history row',
+    () async {
+      const String path =
+          '/trainer/clients/member%2F1/history/assigned-ex-r1/feedback';
+      when(
+        () => dio.put<Map<String, Object?>>(
+          path,
+          data: <String, Object?>{'feedback': '자세가 좋았어요'},
+        ),
+      ).thenAnswer(
+        (_) async => Response<Map<String, Object?>>(
+          requestOptions: RequestOptions(path: path),
+          statusCode: 200,
+          data: <String, Object?>{
+            'id': 'assigned-ex-r1',
+            'date_label': '8/13 (오늘)',
+            'label': '코어 운동',
+            'completion_rate': 100,
+            'exercises': <Object?>['코어 운동 · 30분'],
+            'client_feedback': '힘들었어요',
+            'trainer_note': '자세가 좋았어요',
+            'assigned_routine_id': 'r1',
+          },
+        ),
+      );
+
+      final updated = await repo.updateHistoryFeedback(
+        'member/1',
+        'assigned-ex-r1',
+        '  자세가 좋았어요  ',
+      );
+
+      expect(updated.id, 'assigned-ex-r1');
+      expect(updated.trainerNote, '자세가 좋았어요');
+    },
+  );
+
   test('a refresh failure keeps the last successful client data', () async {
     const String path = '/trainer/clients/m1/diet';
     var calls = 0;

--- a/frontend/flutter_trainer/test/features/coaching/coaching_page_test.dart
+++ b/frontend/flutter_trainer/test/features/coaching/coaching_page_test.dart
@@ -150,6 +150,13 @@ class _FixedClientRepository implements ClientRepository {
       Stream.value(const <RoutineHistoryEntry>[]);
 
   @override
+  Future<RoutineHistoryEntry> updateHistoryFeedback(
+    String clientId,
+    String historyId,
+    String feedback,
+  ) async => throw UnsupportedError('not used');
+
+  @override
   Future<MemberHealthProfile> fetchHealthProfile(String clientId) async =>
       MemberHealthProfile(memberId: clientId, memberName: '회원');
 


### PR DESCRIPTION
## Summary

* 트레이너가 배정한 루틴을 회원이 완료 처리하면 하나의 운동 세션으로 저장하고 주간 집계에 반영합니다.
* 같은 수행 기록을 트레이너 고객 이력에서 조회하고 피드백을 작성·수정할 수 있게 연결합니다.
* 완료·피드백 상태를 회원 앱에 다시 노출하며, 중복 완료와 권한 없는 접근을 차단합니다.

---

## Changes

### ✨ Features

* 배정 루틴 완료 API와 트레이너 피드백 수정 API 추가
* 배정 루틴 식별자·스냅샷·완료 시각·회원 메모·트레이너 피드백 영속화
* 회원 앱 완료 입력 UI 및 피드백 표시 추가
* 트레이너 웹 수행 이력·피드백 작성/수정 UI 추가

### 🔧 Improvements

* 배정 루틴 완료를 기존 `ExerciseSession` 주간 집계와 통합
* 배정 ID unique 제약으로 중복 완료·네트워크 재시도 멱등성 보장
* 담당 트레이너 관계와 회원 소유권 검증, 배정 원본 수정·철회 후에도 수행 스냅샷 보존
* 배정 루틴에서 파생된 운동 세션의 일반 수정·삭제 차단

### 🎨 UI/UX

* 회원 루틴 카드에 완료 입력 다이얼로그와 수행/피드백 상태 표시
* 트레이너 고객 운동 기록에 배정 루틴 메모와 피드백 편집 동선 추가
* 트레이너 웹 영문·국문 현지화 문구 추가

### 📝 Docs

* 별도 문서 변경 없음

### 🐛 Fixes

* 별도 버그 수정 없음

---

## Commits

1. `3f7b79f5` feat(coaching): 배정 루틴 수행과 피드백을 연결한다
2. `64c9217b` test(coaching): 트레이너 FK 생성 순서를 보장한다
3. `e0395d34` fix(coaching): 리뷰 피드백을 반영한다

---

## Notes

* 새 테이블 대신 기존 `exercise_sessions`에 배정 루틴 연결·스냅샷 필드를 추가합니다.
* 마이그레이션 head는 `0033_routine_completion` 단일 상태입니다.
* 열린 PR은 없어 코드 변경 충돌 범위가 없습니다.
* 열린 #636과는 “피드백 이벤트”에서 접점이 있습니다. 이 PR은 피드백 저장·표시까지만 담당하며, 인앱 알림 갱신·배지·딥링크는 #636 범위로 남깁니다.
* `flutter analyze`는 분해형 한글이 포함된 로컬 경로에서 analysis server가 `FormatException: Unterminated string`으로 종료되어 완료하지 못했습니다. 전체 테스트와 웹 빌드로 컴파일을 검증했습니다.
* 백엔드 신규 통합 테스트 3건은 로컬 PostgreSQL이 없어 skip되며 CI의 PostgreSQL 환경에서 실행됩니다.

---

## Screenshots (Optional)

| Before | After |
| ------ | ----- |
| 첨부 없음 | 첨부 없음 |

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 트레이너가 회원에게 루틴을 배정하고 회원 앱에서 시간·강도·메모를 입력해 완료합니다.
2. 회원 주간 운동 집계와 트레이너 고객 운동 기록에 동일 수행이 한 번만 반영되는지 확인합니다.
3. 트레이너가 피드백을 작성·수정하고 회원 앱 재조회 후 같은 루틴에 표시되는지 확인합니다.
4. 중복 완료, 다른 회원 기록 접근, 비담당 트레이너 피드백이 차단되는지 확인합니다.

### Automated Checks

* 회원 Flutter 전체 테스트: 562 passed
* 트레이너 Flutter 전체 테스트: 528 passed
* 트레이너 Flutter web build: 성공
* 변경 백엔드 Python syntax/Ruff: 통과
* Alembic heads: `0033_routine_completion (head)`
* 백엔드 신규 테스트: 3 skipped (로컬 PostgreSQL 미구성)
* `git diff --check`: 통과

---

## Related Issues

Closes #638

* Related: #636 — 루틴 피드백 인앱 알림·배지·딥링크 후속 범위
* 기존 완료 기반: #499, #504, #581, #589

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 회원이 배정받은 운동 루틴을 실제 운동 시간·강도·메모와 함께 완료 처리할 수 있습니다.
  - 완료 상태, 수행 시간, 완료 시각, 회원 메모가 운동 기록과 루틴에 표시됩니다.
  - 트레이너가 회원의 배정 루틴 수행 기록에 피드백을 작성하거나 수정할 수 있습니다.
  - 회원과 트레이너 화면에서 운동 기록과 피드백이 서로 연동됩니다.

- **버그 수정**
  - 동일한 루틴의 중복 완료 처리를 방지합니다.
  - 코칭으로 생성된 운동 기록은 회원이 수정하거나 삭제할 수 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->