### PR TITLE
feat(notification): 알림을 눌러 관련 화면으로 가고 최신 상태를 보게

### DIFF
--- a/backend/app/api/v1/notifications.py
+++ b/backend/app/api/v1/notifications.py
@@ -30,9 +30,23 @@ router = APIRouter(tags=["notifications"])
 
 # 알림 카테고리 → 바로가기 액션(프론트 라우트 힌트). system 은 액션 없음.
 _ACTION_BY_CATEGORY: dict[str, NotificationAction] = {
+    # 성격만 나타내던 기존 값들.
     "reminder": NotificationAction(label="기록하러 가기", target="dashboard"),
     "health_check": NotificationAction(label="일정 보기", target="schedule"),
     "achievement": NotificationAction(label="대시보드 보기", target="dashboard"),
+    # 트레이너가 한 일 — 예전에는 전부 `system` 으로 뭉쳐 갈 곳이 없었다(#636).
+    notification_service.MEMBER_COACH_CHAT: NotificationAction(
+        label="대화 보기", target="coach_chat"
+    ),
+    notification_service.MEMBER_ROUTINE: NotificationAction(
+        label="운동 보기", target="exercise"
+    ),
+    notification_service.MEMBER_SCHEDULE: NotificationAction(
+        label="일정 보기", target="schedule"
+    ),
+    notification_service.MEMBER_CONSULTATION: NotificationAction(
+        label="트레이너 보기", target="exercise"
+    ),
 }
 
 

--- a/backend/app/services/consultation_service.py
+++ b/backend/app/services/consultation_service.py
@@ -387,6 +387,13 @@ def _notify(db: Session, *, user_id: str, title: str, body: str) -> None:
 
     승인·거절은 회원이 앱을 열어 보기 전에는 알 수 없는 변화라 알림이 결과 전달의
     유일한 경로다. 푸시 발송은 이번 범위 밖이며 여기서는 행만 남긴다.
+
+    category 를 `system` 이 아니라 상담 결과로 밝히는 이유: 앱이 이 값으로 갈 곳을
+    정한다. `system` 은 목적지가 없어, 승인 알림을 눌러도 담당 트레이너 화면으로
+    갈 수 없었다(#636).
+
+    수신 설정을 보지 않는 것은 의도다 — 내가 보낸 요청의 처리 결과는 끌 수 있는
+    알림이 아니다. 그래서 `notification_service.queue` 가 아니라 여기서 직접 만든다.
     """
     db.add(
         Notification(
@@ -394,7 +401,7 @@ def _notify(db: Session, *, user_id: str, title: str, body: str) -> None:
             user_id=user_id,
             title=title,
             body=body,
-            category="system",
+            category=notification_service.MEMBER_CONSULTATION,
             read=False,
         )
     )

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -40,8 +40,15 @@ DEFAULTS: dict[str, bool] = {
     WEEKLY_REPORT: False,
 }
 
-#: 알림 종류 → 목록에 실릴 category. 앱은 이 값으로 이동 경로를 고른다
-#: (`notifications._ACTION_BY_CATEGORY`).
+#: 알림 종류 → 목록에 실릴 기본 category.
+#:
+#: **`kind` 는 목적지가 아니라 알림 수신 설정 키다.** 같은 키로 서로 다른 곳을
+#: 가리키는 알림이 나간다 — 루틴 배정과 일정 등록이 둘 다 `EXERCISE` 이고, 연결
+#: 해제와 예약 취소가 둘 다 `TRAINER_MESSAGE` 다. 그래서 여기서 유도한 값만으로는
+#: 앱이 갈 곳을 정할 수 없다(#636).
+#:
+#: 호출부가 `queue(category=...)` 로 목적지를 밝히면 그 값이 우선한다. 이 표는
+#: 밝히지 않은 호출부를 위한 기본값이다.
 _CATEGORY: dict[str, str] = {
     TRAINER_MESSAGE: "system",
     EXERCISE: "reminder",
@@ -142,6 +149,7 @@ def queue(
     kind: str,
     title: str,
     body: str = "",
+    category: str | None = None,
 ) -> Notification | None:
     """알림을 세션에 **추가만** 한다(커밋하지 않는다). 꺼져 있으면 None.
 
@@ -152,6 +160,10 @@ def queue(
     별도 실패 모드를 만들지 않는다는 뜻이기도 하다 — 여기서 하는 일은 `db.add`
     뿐이라 원래 요청을 새로 실패시킬 여지가 없다. 외부 발송(푸시)은 이 함수
     바깥의 일이다(#474).
+
+    [category] 는 **회원이 이 알림을 누르면 갈 곳**이다. `kind` 로는 정할 수 없어
+    호출부가 밝힌다([_CATEGORY] 참고). 앱이 모르는 값을 받으면 목록에는 싣고 이동만
+    하지 않으므로, 새 값을 더해도 기존 앱이 깨지지 않는다.
     """
     if not wants(db, member_id, kind):
         return None
@@ -160,7 +172,7 @@ def queue(
         user_id=member_id,
         title=title,
         body=body,
-        category=_CATEGORY.get(kind, "system"),
+        category=category or _CATEGORY.get(kind, "system"),
         read=False,
     )
     db.add(notification)
@@ -177,6 +189,16 @@ def unread_count(db: Session, member_id: str) -> int:
     ).all()
     return len(rows)
 
+
+#: 회원 알림의 목적지. `Notification.category` 에 그대로 저장되고, 앱이 이 값에
+#: 붙은 action 을 보고 이동한다(`notifications._ACTION_BY_CATEGORY`).
+#:
+#: 기존 값(reminder·health_check·achievement·system)은 "성격" 에 가깝고 목적지를
+#: 구분하지 못했다. 트레이너가 한 일은 모두 `system` 으로 뭉쳐 갈 곳이 없었다(#636).
+MEMBER_COACH_CHAT = "coach_chat"
+MEMBER_ROUTINE = "routine"
+MEMBER_SCHEDULE = "member_schedule"
+MEMBER_CONSULTATION = "consultation_result"
 
 #: 트레이너 알림의 종류. `Notification.category` 에 그대로 저장되고, 트레이너 앱이
 #: 이 값으로 어디로 이동할지 정한다. 회원 알림의 category 집합

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -473,6 +473,8 @@ def send_message(
                 else f"{trainer_name or '트레이너'} 트레이너의 메시지"
             ),
             body=text,
+            # 리포트도 대화 스레드로 도착한다 — 별도 리포트 함이 없다.
+            category=notification_service.MEMBER_COACH_CHAT,
         )
     db.commit()
     db.refresh(msg)
@@ -572,6 +574,8 @@ def delete_trainer_account(db: Session, trainer: User) -> None:
             db,
             member_id=member_id,
             kind=notification_service.TRAINER_MESSAGE,
+            # 새 트레이너를 찾는 화면으로 보낸다.
+            category=notification_service.MEMBER_CONSULTATION,
             title="담당 트레이너 연결이 해제되었어요",
             body=f"{trainer_name} 트레이너가 서비스를 떠났습니다. 새 트레이너를 찾아보세요.",
         )
@@ -581,6 +585,7 @@ def delete_trainer_account(db: Session, trainer: User) -> None:
             db,
             member_id=member_id,
             kind=notification_service.TRAINER_MESSAGE,
+            category=notification_service.MEMBER_SCHEDULE,
             title="예약한 수업이 취소되었어요",
             body=f"{trainer_name} 트레이너가 서비스를 떠나 예약이 취소되었습니다.",
         )
@@ -750,6 +755,7 @@ def assign_routine(
         db,
         member_id=member_id,
         kind=notification_service.EXERCISE,
+        category=notification_service.MEMBER_ROUTINE,
         title="새 운동 루틴이 배정되었어요",
         body=f"{name} · {minutes}분",
     )
@@ -1012,6 +1018,7 @@ def create_session(
             db,
             member_id=member_id,
             kind=notification_service.EXERCISE,
+            category=notification_service.MEMBER_SCHEDULE,
             title="새 일정이 등록되었어요",
             body=f"{date} {time} · {type_}",
         )

--- a/frontend/flutter/lib/features/notification/presentation/alert_navigation.dart
+++ b/frontend/flutter/lib/features/notification/presentation/alert_navigation.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:oncare/app/router/routes.dart';
+import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
+import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
+import 'package:oncare/features/member_coach/presentation/widgets/coach_chat_sheet.dart';
+import 'package:oncare/features/notification/domain/entities/alert_item.dart';
+import 'package:oncare/features/schedule/presentation/controllers/schedule_controller.dart';
+
+/// 알림을 눌렀을 때 관련 화면으로 보내고, **그 화면이 읽는 값을 다시 받게 한다.**
+///
+/// 이동만 하면 방금 알림이 알려 준 변화가 화면에 없을 수 있다 — 트레이너가 배정한
+/// 루틴을 보러 갔는데 앱이 들고 있던 옛 목록이 그대로면, 알림이 거짓말을 한 것처럼
+/// 보인다. 그래서 이동 직전에 그 화면의 provider 를 무효화한다.
+///
+/// 서버가 준 target 을 앱이 모르면 아무 데도 가지 않는다. 목록에서 빼거나 엉뚱한
+/// 화면으로 보내는 것보다, 읽음 처리만 하고 제자리에 두는 편이 낫다.
+Future<void> openAlertTarget(
+  BuildContext context,
+  WidgetRef ref,
+  AlertItem item,
+) async {
+  final AlertAction? action = item.action;
+  if (action == null || !action.isNavigable) return;
+
+  switch (action.target) {
+    case AlertTarget.coachChat:
+      // 대화는 코치 정보를 알아야 열 수 있다. 아직 못 받았으면 이동하지 않는다 —
+      // 이름 없는 빈 대화창을 여느니 알림 목록에 남는 편이 낫다.
+      ref
+        ..invalidate(coachChatProvider)
+        ..invalidate(coachUnreadProvider);
+      final String? name = ref.read(memberCoachProvider).valueOrNull?.name;
+      if (name == null || !context.mounted) return;
+      await openTrainerChatPage(context, trainerName: name);
+    case AlertTarget.exercise:
+      ref
+        ..invalidate(exerciseWeekProvider)
+        ..invalidate(coachRoutinesProvider);
+      if (!context.mounted) return;
+      context.go(AppRoutes.exercise);
+    case AlertTarget.schedule:
+      ref
+        ..invalidate(scheduleEventsProvider)
+        ..invalidate(scheduleMonthProvider)
+        ..invalidate(coachSessionsProvider);
+      if (!context.mounted) return;
+      context.go(AppRoutes.dashboard);
+    case AlertTarget.dashboard:
+      if (!context.mounted) return;
+      context.go(AppRoutes.dashboard);
+    case AlertTarget.diet:
+      if (!context.mounted) return;
+      context.go(AppRoutes.diet);
+    case AlertTarget.unknown:
+      return;
+  }
+}

--- a/frontend/flutter/lib/features/notification/presentation/alert_navigation.dart
+++ b/frontend/flutter/lib/features/notification/presentation/alert_navigation.dart
@@ -27,12 +27,20 @@ Future<void> openAlertTarget(
 
   switch (action.target) {
     case AlertTarget.coachChat:
-      // 대화는 코치 정보를 알아야 열 수 있다. 아직 못 받았으면 이동하지 않는다 —
-      // 이름 없는 빈 대화창을 여느니 알림 목록에 남는 편이 낫다.
       ref
         ..invalidate(coachChatProvider)
         ..invalidate(coachUnreadProvider);
-      final String? name = ref.read(memberCoachProvider).valueOrNull?.name;
+      // 대화는 코치 정보를 알아야 열 수 있다. 들고 있는 값을 그냥 읽으면 안 된다 —
+      // 아직 로딩 중이거나, 트레이너가 붙기 전에 받아 둔 `null` 이 남아 있으면
+      // 눌러도 아무 일이 없다. 코치가 보낸 알림인데 코치를 모른다고 답하는 꼴이다.
+      // 그래서 새로 받아 온 뒤에 판단한다.
+      String? name;
+      try {
+        name = (await ref.refresh(memberCoachProvider.future))?.name;
+      } on Exception {
+        // 못 받으면 이동하지 않는다. 이름 없는 빈 대화창을 여느니 제자리가 낫다.
+        return;
+      }
       if (name == null || !context.mounted) return;
       await openTrainerChatPage(context, trainerName: name);
     case AlertTarget.exercise:

--- a/frontend/flutter/lib/features/notification/presentation/pages/notification_page.dart
+++ b/frontend/flutter/lib/features/notification/presentation/pages/notification_page.dart
@@ -7,6 +7,7 @@ import 'package:oncare/design_system/atoms/app_card.dart';
 import 'package:oncare/design_system/theme/app_theme.dart';
 import 'package:oncare/design_system/tokens/spacing.dart';
 import 'package:oncare/features/notification/domain/entities/alert_item.dart';
+import 'package:oncare/features/notification/presentation/alert_navigation.dart';
 import 'package:oncare/features/notification/presentation/controllers/notification_controller.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 import 'package:oncare/shared/widgets/empty_state.dart';
@@ -102,9 +103,15 @@ class _NotificationPageState extends ConsumerState<NotificationPage>
                 ),
               );
             }
+            final AlertItem item = state.items[i - (showRetry ? 1 : 0)];
             return _AlertTile(
-              item: state.items[i - (showRetry ? 1 : 0)],
-              onTap: () => notifier.markRead(state.items[i - (showRetry ? 1 : 0)].id),
+              item: item,
+              // 읽음 처리를 기다리지 않고 이동한다 — 서버 왕복 동안 화면이 멈춰
+              // 있으면 누른 것이 먹지 않은 것처럼 보인다.
+              onTap: () {
+                notifier.markRead(item.id);
+                openAlertTarget(context, ref, item);
+              },
             );
           },
         ),

--- a/frontend/flutter/test/features/notification/alert_navigation_test.dart
+++ b/frontend/flutter/test/features/notification/alert_navigation_test.dart
@@ -5,9 +5,21 @@
 /// 보인다 — 그래서 대상 화면이 읽는 값을 함께 무효화한다.
 library;
 
-import 'package:flutter_test/flutter_test.dart';
+import 'dart:async';
 
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:oncare/app/router/routes.dart';
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/features/member_coach/domain/entities/member_coach.dart';
+import 'package:oncare/features/member_coach/domain/repositories/member_coach_repository.dart';
+import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
 import 'package:oncare/features/notification/domain/entities/alert_item.dart';
+import 'package:oncare/features/notification/presentation/alert_navigation.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
 
 AlertItem _alert({AlertAction? action}) => AlertItem(
   id: 'n1',
@@ -17,6 +29,73 @@ AlertItem _alert({AlertAction? action}) => AlertItem(
   category: AlertCategory.system,
   action: action,
 );
+
+const AppConfig _config = AppConfig(
+  environment: Environment.dev,
+  apiBaseUrl: 'https://dev.api.test',
+  useMockApi: true,
+);
+
+const MemberCoach _coach = MemberCoach(
+  trainerId: 't1',
+  name: '김트레이너',
+  specialty: '체형 교정',
+  career: '5년',
+  intro: '반갑습니다',
+  gymName: '신촌점',
+  goal: '체중 감량',
+);
+
+/// 코치 정보를 **언제** 주는지 통제하려고 둔 가짜다. 화면이 들고 있던 값을 그냥
+/// 읽는지, 새로 받아 오는지가 이 PR 의 쟁점이라 호출 횟수도 센다.
+class _FakeCoachRepository implements MemberCoachRepository {
+  _FakeCoachRepository({this.coach, this.throws = false});
+
+  MemberCoach? coach;
+  bool throws;
+  int fetchCoachCalls = 0;
+  int unreadCalls = 0;
+
+  @override
+  Future<MemberCoach?> fetchCoach() async {
+    fetchCoachCalls++;
+    if (throws) throw Exception('네트워크 실패');
+    return coach;
+  }
+
+  @override
+  Future<int> unreadCount() async {
+    unreadCalls++;
+    return 0;
+  }
+
+  @override
+  Stream<List<CoachMessage>> watchChat() =>
+      Stream<List<CoachMessage>>.value(const <CoachMessage>[]);
+
+  @override
+  Future<List<CoachMessage>> fetchChat() async => const <CoachMessage>[];
+
+  @override
+  Future<List<CoachRoutine>> fetchRoutines() async => const <CoachRoutine>[];
+
+  @override
+  Future<List<CoachSession>> fetchSessions() async => const <CoachSession>[];
+
+  @override
+  Future<CoachRoutine> completeRoutine(
+    String routineId, {
+    required int minutes,
+    String intensity = 'moderate',
+    String memberNote = '',
+  }) async => throw UnimplementedError();
+
+  @override
+  Future<void> markRead() async {}
+
+  @override
+  Future<void> sendMessage(String text) async {}
+}
 
 void main() {
   group('AlertAction', () {
@@ -42,6 +121,136 @@ void main() {
 
     test('action 이 없는 알림도 정상이다', () {
       expect(_alert().action, isNull);
+    });
+  });
+
+  group('openAlertTarget', () {
+    late BuildContext ctx;
+    late WidgetRef wref;
+
+    /// 진입 화면(`/home`)이 살아 있는 채로 각 목적지를 확인한다. 목적지 화면은
+    /// 이름표만 둔다 — 여기서 볼 것은 "어디로 갔는가" 뿐이다.
+    Future<void> pumpApp(
+      WidgetTester tester,
+      _FakeCoachRepository repo,
+    ) async {
+      final GoRouter router = GoRouter(
+        initialLocation: '/home',
+        routes: <RouteBase>[
+          GoRoute(
+            path: '/home',
+            builder: (_, _) => Consumer(
+              builder: (BuildContext c, WidgetRef r, _) {
+                ctx = c;
+                wref = r;
+                // 무효화가 정말 다시 읽는지 보려면 누군가 듣고 있어야 한다.
+                r.watch(coachUnreadProvider);
+                return const Text('home');
+              },
+            ),
+          ),
+          GoRoute(path: AppRoutes.dashboard, builder: (_, _) => const Text('대시보드')),
+          GoRoute(path: AppRoutes.diet, builder: (_, _) => const Text('식단')),
+          GoRoute(path: AppRoutes.exercise, builder: (_, _) => const Text('운동')),
+        ],
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: <Override>[
+            appConfigProvider.overrideWithValue(_config),
+            memberCoachRepositoryProvider.overrideWithValue(repo),
+          ],
+          child: MaterialApp.router(
+            routerConfig: router,
+            // 대화 화면이 현지화 문자열을 읽는다 — 없으면 이동은 했는데 화면이
+            // 못 그려져, 이동 실패처럼 보인다.
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    /// 알림 화면과 **같은 방식으로** 부른다 — 기다리지 않는다. 대화 화면을 여는
+    /// 경로는 `Navigator.push` 를 돌려주는데 그 Future 는 사용자가 창을 닫아야
+    /// 끝나므로, 기다리면 이 함수는 영영 돌아오지 않는다.
+    Future<void> tap(WidgetTester tester, AlertTarget target) async {
+      unawaited(
+        openAlertTarget(
+          ctx,
+          wref,
+          _alert(action: AlertAction(label: '보기', target: target)),
+        ),
+      );
+      await tester.pump(); // 코치 정보를 새로 받는 구간
+      await tester.pump(); // 이동 반영
+      await tester.pump(const Duration(milliseconds: 400)); // 화면 전환
+    }
+
+    testWidgets('아는 목적지는 그 화면으로 보낸다', (WidgetTester tester) async {
+      for (final (AlertTarget target, String label) in <(AlertTarget, String)>[
+        (AlertTarget.dashboard, '대시보드'),
+        (AlertTarget.diet, '식단'),
+        (AlertTarget.exercise, '운동'),
+        // 일정은 아직 전용 화면이 없어 대시보드로 보낸다.
+        (AlertTarget.schedule, '대시보드'),
+      ]) {
+        await pumpApp(tester, _FakeCoachRepository());
+        await tap(tester, target);
+
+        expect(find.text(label), findsOneWidget, reason: '$target');
+      }
+    });
+
+    testWidgets('모르는 목적지는 아무 데도 가지 않는다', (WidgetTester tester) async {
+      await pumpApp(tester, _FakeCoachRepository());
+      await tap(tester, AlertTarget.unknown);
+
+      expect(find.text('home'), findsOneWidget);
+    });
+
+    testWidgets('action 이 없으면 아무 데도 가지 않는다', (WidgetTester tester) async {
+      await pumpApp(tester, _FakeCoachRepository());
+      await openAlertTarget(ctx, wref, _alert());
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(find.text('home'), findsOneWidget);
+    });
+
+    testWidgets('코치가 늦게 붙어도 대화를 연다', (WidgetTester tester) async {
+      // 트레이너가 붙기 전에 받아 둔 `null` 이 남아 있는 상황. 들고 있는 값을 그냥
+      // 읽으면 코치가 보낸 알림인데 코치를 모른다고 답하게 된다.
+      final _FakeCoachRepository repo = _FakeCoachRepository();
+      await pumpApp(tester, repo);
+      expect(wref.read(memberCoachProvider).valueOrNull, isNull);
+
+      repo.coach = _coach;
+      await tap(tester, AlertTarget.coachChat);
+
+      expect(find.text('김트레이너'), findsWidgets);
+    });
+
+    testWidgets('코치를 못 받으면 대화를 열지 않는다', (WidgetTester tester) async {
+      final _FakeCoachRepository repo = _FakeCoachRepository(throws: true);
+      await pumpApp(tester, repo);
+      await tap(tester, AlertTarget.coachChat);
+
+      // 이름 없는 빈 대화창을 여느니 알림 목록에 남는 편이 낫다.
+      expect(find.text('home'), findsOneWidget);
+    });
+
+    testWidgets('대화로 갈 때 읽지 않은 수를 다시 읽는다', (WidgetTester tester) async {
+      // 알림이 알려 준 변화가 화면에 없으면 알림이 거짓말을 한 것처럼 보인다.
+      final _FakeCoachRepository repo = _FakeCoachRepository(coach: _coach);
+      await pumpApp(tester, repo);
+      final int before = repo.unreadCalls;
+
+      await tap(tester, AlertTarget.coachChat);
+
+      expect(repo.unreadCalls, greaterThan(before));
     });
   });
 

--- a/frontend/flutter/test/features/notification/alert_navigation_test.dart
+++ b/frontend/flutter/test/features/notification/alert_navigation_test.dart
@@ -1,0 +1,65 @@
+/// 알림을 눌렀을 때 어디로 가고 무엇을 다시 받는지 — #636.
+///
+/// 이동만 하면 방금 알림이 알려 준 변화가 화면에 없을 수 있다. 트레이너가 배정한
+/// 루틴을 보러 갔는데 앱이 들고 있던 옛 목록이 그대로면 알림이 거짓말을 한 것처럼
+/// 보인다 — 그래서 대상 화면이 읽는 값을 함께 무효화한다.
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/notification/domain/entities/alert_item.dart';
+
+AlertItem _alert({AlertAction? action}) => AlertItem(
+  id: 'n1',
+  title: '제목',
+  body: '본문',
+  timeAgo: '방금',
+  category: AlertCategory.system,
+  action: action,
+);
+
+void main() {
+  group('AlertAction', () {
+    test('앱이 아는 target 은 이동할 수 있다', () {
+      const AlertAction action = AlertAction(
+        label: '대화 보기',
+        target: AlertTarget.coachChat,
+      );
+
+      expect(action.isNavigable, isTrue);
+    });
+
+    test('모르는 target 은 이동하지 않는다', () {
+      // 서버가 새 종류를 추가했는데 앱이 모르는 경우. 목록에서 빼거나 엉뚱한 화면으로
+      // 보내는 것보다, 읽음 처리만 하고 제자리에 두는 편이 낫다.
+      const AlertAction action = AlertAction(
+        label: '어딘가로',
+        target: AlertTarget.unknown,
+      );
+
+      expect(action.isNavigable, isFalse);
+    });
+
+    test('action 이 없는 알림도 정상이다', () {
+      expect(_alert().action, isNull);
+    });
+  });
+
+  group('AlertTarget', () {
+    test('서버가 쓰는 목적지를 모두 안다', () {
+      // 서버 `_ACTION_BY_CATEGORY` 가 내려주는 target 집합과 맞춘다. 한쪽만 늘어나면
+      // 알림은 오는데 갈 곳이 없어진다.
+      expect(
+        AlertTarget.values.toSet(),
+        containsAll(<AlertTarget>[
+          AlertTarget.dashboard,
+          AlertTarget.schedule,
+          AlertTarget.coachChat,
+          AlertTarget.exercise,
+          AlertTarget.diet,
+          AlertTarget.unknown,
+        ]),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #636

#658 의 뒤 절반입니다. 그 PR 이 "알림이 서버를 따라가게" 했다면, 이 PR 은 **"알림을 눌러
갈 수 있게"** 합니다.

## Summary

트레이너가 한 일은 회원 알림에서 모두 `system` 으로 뭉쳐 **갈 곳이 없었다.** 알림을 눌러도
읽음 처리만 되고, 무엇이 바뀌었는지는 사용자가 직접 화면을 찾아가야 했다.

## 근본 원인 — `kind` 는 목적지가 아니다

`kind` 는 **알림 수신 설정 키**다. 그래서 같은 키로 서로 다른 곳을 가리키는 알림이 나간다.

| 알림 | kind | 실제 목적지 |
| --- | --- | --- |
| 새 운동 루틴이 배정되었어요 | `EXERCISE` | 운동 |
| 새 일정이 등록되었어요 | `EXERCISE` | 일정 |
| 담당 트레이너 연결이 해제되었어요 | `TRAINER_MESSAGE` | 헬스장·트레이너 |
| 예약한 수업이 취소되었어요 | `TRAINER_MESSAGE` | 예약 |

여기서 category 를 유도하는 한 목적지를 구분할 수 없다. 그래서 `queue(category=...)` 로
**호출부가 목적지를 밝히게** 했다. 밝히지 않으면 예전 표를 그대로 쓰므로 기존 호출부는
손대지 않아도 된다.

## Changes

- 회원 알림을 만드는 다섯 곳이 각자 갈 곳을 지정한다.
- 상담 승인·거절도 목적지를 밝힌다. 이 알림은 `notification_service.queue` 가 아니라 상담
  서비스가 직접 행을 만들고 category 가 `system` 이었다 — **수신 설정으로 끌 수 없는
  알림**이라 그 구조는 그대로 두고 목적지만 밝혔다(내가 보낸 요청의 처리 결과는 끌 수 있는
  알림이 아니다).
- 서버 action 표에 새 목적지를 더한다. 앱이 모르는 값을 받으면 목록에는 싣고 이동만 하지
  않으므로, 값을 더해도 기존 앱이 깨지지 않는다.
- 앱은 이동하면서 **그 화면이 읽는 값을 함께 무효화한다.** 이동만 하면 방금 알림이 알려 준
  변화가 화면에 없을 수 있고, 그러면 알림이 거짓말을 한 것처럼 보인다.
- 읽음 처리를 기다리지 않고 이동한다. 서버 왕복 동안 화면이 멈춰 있으면 누른 것이 먹지 않은
  것처럼 보인다.

## Verification

- 사용자 앱 563개, 트레이너 웹 526개 통과. `flutter analyze` 클린.
- 백엔드 762개 통과. 실패 3개(RAG·코치 관련)와 스케줄 시드 1개는 **이 변경을 걷어내고 돌려도
  똑같이 실패**하는 것을 확인했다 — 로컬 환경·기존 문제이며 이 PR 과 무관하다.

## Notes

작업 중 이슈 본문의 서술 하나를 정정했다. "상담 승인·거절이 회원 알림을 만들지 않는다" 고
볼 뻔했으나, 상담 서비스의 지역 헬퍼(`_notify`)가 만들고 있었다. 실제 문제는 그 category 가
`system` 이라 갈 곳이 없던 것이고 그 부분만 고쳤다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 알림 항목을 탭하면 읽음 처리 후 관련 화면으로 바로 이동합니다.
  * 코치 채팅, 운동 루틴, 일정, 상담 결과 등 알림 유형별 이동 경로를 지원합니다.
  * 이동이 불가능하거나 알 수 없는 알림은 안전하게 처리됩니다.

* **버그 수정**
  * 상담 결과, 루틴 배정, 일정 변경 등 알림이 올바른 카테고리와 연결되도록 개선했습니다.
  * 알림 유형에 따라 정확한 목적지 화면이 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->