### PR TITLE
feat(notification): 트레이너가 일정을 변경·취소하면 회원에게 알린다

### DIFF
--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -1246,6 +1246,67 @@ def register_program(
     return _schedule_out(session), True
 
 
+#: 회원이 약속을 지키려고 아는 값들. 이 넷 중 하나라도 달라지면 알린다.
+#: 메모(`note`)·프로그램은 트레이너의 준비물이라 빠져 있다 — 그것까지 알리면
+#: 알림함이 같은 일정으로 차고, 정작 시각이 바뀐 알림이 묻힌다.
+def _member_visible_slot(s: TrainerSchedule) -> tuple[str, str, str, int]:
+    return (s.date, s.time, s.type, s.duration_minutes)
+
+
+def _slot_body(slot: tuple[str, str, str, int]) -> str:
+    date, time, type_, _ = slot
+    return f"{date} {time} · {type_}"
+
+
+def _notify_schedule_changed(
+    db: Session,
+    *,
+    session: TrainerSchedule,
+    before_member_id: str | None,
+    before_slot: tuple[str, str, str, int],
+) -> None:
+    """바뀐 일정을 회원에게 알린다. **커밋하지 않는다.**
+
+    등록만 알리고 변경·취소를 알리지 않으면, 회원은 "새 일정이 등록되었어요" 를
+    믿고 이미 옮겨진 시간에 나간다. 취소 알림이 등록 알림보다 중요하다. (#664)
+    """
+    after_slot = _member_visible_slot(session)
+
+    if before_member_id == session.member_id:
+        if session.member_id is None or before_slot == after_slot:
+            return
+        notification_service.queue(
+            db,
+            member_id=session.member_id,
+            kind=notification_service.EXERCISE,
+            category=notification_service.MEMBER_SCHEDULE,
+            title="일정이 변경되었어요",
+            body=_slot_body(after_slot),
+        )
+        return
+
+    # 다른 회원에게 넘긴 일정. 넘겨받은 쪽만 알리면 원래 회원은 약속이 사라진
+    # 줄 모른 채 그 시간에 나간다 — 양쪽 모두 알린다.
+    if before_member_id is not None:
+        notification_service.queue(
+            db,
+            member_id=before_member_id,
+            kind=notification_service.EXERCISE,
+            category=notification_service.MEMBER_SCHEDULE,
+            title="일정이 취소되었어요",
+            body=_slot_body(before_slot),
+        )
+    if session.member_id is not None:
+        notification_service.queue(
+            db,
+            member_id=session.member_id,
+            kind=notification_service.EXERCISE,
+            category=notification_service.MEMBER_SCHEDULE,
+            title="새 일정이 등록되었어요",
+            body=_slot_body(after_slot),
+        )
+
+
 def update_session(
     db: Session, trainer_id: str, session_id: str, fields: dict
 ) -> ScheduleSessionOut | None:
@@ -1257,6 +1318,10 @@ def update_session(
     s = _get_owned_session(db, trainer_id, session_id)
     if s is None:
         return None
+    # 회원에게 알릴지 판단하려면 **바꾸기 전** 값을 들고 있어야 한다. 넘긴
+    # 일정의 취소 알림에는 옛 시각을 써야 회원이 어느 약속인지 안다.
+    before_member_id = s.member_id
+    before_slot = _member_visible_slot(s)
     # A reservation owns the booking coordinates and lifecycle, so changing
     # its time/member/type/duration through the general schedule API would
     # desynchronise the slot and remaining count. The trainer may still add
@@ -1284,6 +1349,12 @@ def update_session(
         s.note = fields["note"]
     if "program" in fields and fields["program"] is not None:
         s.program_json = _dump_program(fields["program"])
+    _notify_schedule_changed(
+        db,
+        session=s,
+        before_member_id=before_member_id,
+        before_slot=before_slot,
+    )
     db.commit()
     db.refresh(s)
     return _schedule_out(s)
@@ -1308,6 +1379,17 @@ def delete_session(db: Session, trainer_id: str, session_id: str) -> bool:
         derived = db.get(ExerciseSession, _derived_exercise_id(s.id))
         if derived is not None:
             db.delete(derived)
+    # 아직 오지 않은 약속만 알린다. 이미 끝난 PT 의 기록 정리까지 알리면 회원은
+    # 지난 일을 취소 통보로 받는다. (#664)
+    if s.member_id is not None and s.status != "완료":
+        notification_service.queue(
+            db,
+            member_id=s.member_id,
+            kind=notification_service.EXERCISE,
+            category=notification_service.MEMBER_SCHEDULE,
+            title="일정이 취소되었어요",
+            body=_slot_body(_member_visible_slot(s)),
+        )
     db.delete(s)
     db.commit()
     return True

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -1246,10 +1246,12 @@ def register_program(
     return _schedule_out(session), True
 
 
-#: 회원이 약속을 지키려고 아는 값들. 이 넷 중 하나라도 달라지면 알린다.
-#: 메모(`note`)·프로그램은 트레이너의 준비물이라 빠져 있다 — 그것까지 알리면
-#: 알림함이 같은 일정으로 차고, 정작 시각이 바뀐 알림이 묻힌다.
 def _member_visible_slot(s: TrainerSchedule) -> tuple[str, str, str, int]:
+    """회원이 약속을 지키려고 아는 값들. 이 넷 중 하나라도 달라지면 알린다.
+
+    메모(`note`)·프로그램은 트레이너의 준비물이라 빠져 있다 — 그것까지 알리면
+    알림함이 같은 일정으로 차고, 정작 시각이 바뀐 알림이 묻힌다. (#664)
+    """
     return (s.date, s.time, s.type, s.duration_minutes)
 
 

--- a/backend/tests/test_notification_hooks.py
+++ b/backend/tests/test_notification_hooks.py
@@ -267,6 +267,135 @@ def test_a_schedule_without_a_member_notifies_nobody(client, db_session):
     assert _titles(client, member_token) == []
 
 
+# --- 일정 변경·취소 (#664) ---------------------------------------------------
+
+
+def _schedule(client, trainer_token: str, member_id: str | None, **overrides):
+    """일정을 하나 만들고 그 id 를 준다."""
+    payload = {
+        "date": (clock.today() + timedelta(days=1)).isoformat(),
+        "time": "10:00",
+        "client_name": "알림 회원" if member_id else "신규 고객",
+        "member_id": member_id,
+        "type": "1:1 PT",
+        "duration_minutes": 50,
+        "note": "",
+        "program": [],
+    }
+    payload.update(overrides)
+    created = client.post(
+        "/v1/trainer/schedule", headers=_auth(trainer_token), json=payload
+    )
+    assert created.status_code == 201, created.text
+    return created.json()["id"]
+
+
+def test_moving_a_session_tells_the_member(client, db_session):
+    """시각이 바뀌면 알린다 — 등록만 알리면 회원은 옛 시간에 나간다."""
+    trainer_token, member_id, member_token, _ = _pair(client, db_session)
+    session_id = _schedule(client, trainer_token, member_id)
+
+    moved = client.put(
+        f"/v1/trainer/schedule/{session_id}",
+        headers=_auth(trainer_token),
+        json={"time": "15:00"},
+    )
+
+    assert moved.status_code == 200, moved.text
+    assert "일정이 변경되었어요" in _titles(client, member_token)
+
+
+def test_editing_only_the_note_tells_nobody(client, db_session):
+    """메모는 트레이너의 준비물이다. 알리면 알림함이 같은 일정으로 찬다."""
+    trainer_token, member_id, member_token, _ = _pair(client, db_session)
+    session_id = _schedule(client, trainer_token, member_id)
+    before = _titles(client, member_token)
+
+    edited = client.put(
+        f"/v1/trainer/schedule/{session_id}",
+        headers=_auth(trainer_token),
+        json={"note": "스쿼트 자세 확인"},
+    )
+
+    assert edited.status_code == 200, edited.text
+    assert _titles(client, member_token) == before
+
+
+def test_cancelling_a_session_tells_the_member(client, db_session):
+    trainer_token, member_id, member_token, _ = _pair(client, db_session)
+    session_id = _schedule(client, trainer_token, member_id)
+
+    removed = client.delete(
+        f"/v1/trainer/schedule/{session_id}", headers=_auth(trainer_token)
+    )
+
+    assert removed.status_code in (200, 204), removed.text
+    assert "일정이 취소되었어요" in _titles(client, member_token)
+
+
+def test_unassigning_a_member_tells_that_member(client, db_session):
+    """배정을 풀면 회원 쪽에서는 약속이 사라진다 — 취소와 같다."""
+    trainer_token, member_id, member_token, _ = _pair(client, db_session)
+    session_id = _schedule(client, trainer_token, member_id)
+
+    unassigned = client.put(
+        f"/v1/trainer/schedule/{session_id}",
+        headers=_auth(trainer_token),
+        json={"member_id": ""},
+    )
+
+    assert unassigned.status_code == 200, unassigned.text
+    assert "일정이 취소되었어요" in _titles(client, member_token)
+
+
+def test_assigning_an_empty_slot_tells_the_new_member(client, db_session):
+    """비어 있던 슬롯에 회원이 들어오면 그 회원에게는 새 일정이다."""
+    trainer_token, member_id, member_token, _ = _pair(client, db_session)
+    session_id = _schedule(client, trainer_token, None, type="상담")
+
+    assigned = client.put(
+        f"/v1/trainer/schedule/{session_id}",
+        headers=_auth(trainer_token),
+        json={"member_id": member_id},
+    )
+
+    assert assigned.status_code == 200, assigned.text
+    assert "새 일정이 등록되었어요" in _titles(client, member_token)
+
+
+def test_cancelling_an_empty_slot_tells_nobody(client, db_session):
+    trainer_token, _, member_token, _ = _pair(client, db_session)
+    session_id = _schedule(client, trainer_token, None, type="상담")
+
+    removed = client.delete(
+        f"/v1/trainer/schedule/{session_id}", headers=_auth(trainer_token)
+    )
+
+    assert removed.status_code in (200, 204), removed.text
+    assert _titles(client, member_token) == []
+
+
+def test_a_schedule_change_can_be_switched_off(client, db_session):
+    """운동 알림을 끄면 변경 알림도 오지 않는다 — 등록 알림과 같은 종류다."""
+    trainer_token, member_id, member_token, _ = _pair(client, db_session)
+    session_id = _schedule(client, trainer_token, member_id)
+    client.put(
+        "/v1/users/me/notification-settings",
+        headers=_auth(member_token),
+        json={"exercise_reminder": False},
+    )
+    before = _titles(client, member_token)
+
+    moved = client.put(
+        f"/v1/trainer/schedule/{session_id}",
+        headers=_auth(trainer_token),
+        json={"time": "16:00"},
+    )
+
+    assert moved.status_code == 200, moved.text
+    assert _titles(client, member_token) == before
+
+
 def test_a_settings_read_failure_still_delivers_the_message(
     client, db_session, monkeypatch
 ):


### PR DESCRIPTION
Closes #664

일정은 **등록만 알리고 있었다.** 그 일정을 옮기거나 취소해도 회원은 아무 것도 받지 못했다 — "새 일정이 등록되었어요" 를 믿고 이미 사라진 시간에 나가게 된다. 취소 알림이 등록 알림보다 중요하다.

## Summary

`update_session` · `delete_session` 두 곳에서 해당 회원에게 인앱 알림을 만든다. 기존 알림·화면·API 계약은 그대로 두고 **알림을 만드는 지점만 늘렸다.**

## 무엇이 바뀌었을 때 알리는가

핵심은 "언제 알리지 **않을지**" 였다. 전부 알리면 알림함이 같은 일정으로 차고, 정작 시각이 바뀐 알림이 묻힌다.

| 바뀐 것 | 알림 |
| --- | --- |
| 날짜·시각·종류·소요 시간 | 보낸다 |
| 메모(`note`)·프로그램 | 보내지 않는다 — 트레이너의 준비물이지 회원의 약속이 아니다 |

## 회원이 바뀌는 경우

`update_session` 은 일정을 다른 회원에게 넘길 수 있다. 넘겨받은 쪽만 알리면 **원래 회원은 약속이 사라진 줄 모른 채 그 시간에 나간다.** 그래서 양쪽 모두 알린다.

- 원래 회원 → "일정이 취소되었어요" (**옛** 시각으로 — 어느 약속인지 알아야 한다)
- 새 회원 → "새 일정이 등록되었어요"

배정을 푸는 것(`member_id` 를 비움)도 회원 쪽에서는 약속이 사라지는 일이라 취소로 알린다.

## Changes

- 회원이 배정되지 않은 슬롯은 알릴 대상이 없어 만들지 않는다. 등록 알림과 같은 규칙이다(#489).
- 이미 끝난(`완료`) 일정의 삭제는 알리지 않는다. 파생 기록 정리라, 알리면 회원이 지난 일을 취소 통보로 받는다.
- `kind` 는 등록 알림과 같은 `EXERCISE` — 회원이 운동 알림을 끄면 변경 알림도 함께 꺼진다.
- `category` 는 `MEMBER_SCHEDULE` — 알림을 누르면 일정 화면으로 가고 최신 값을 받는다(#636).

## 건드리지 않은 것

루틴 수정·철회는 그대로 뒀다. `update_routine` 은 **알림을 보내지 않기로 이미 정해 둔 결정**이 있다(#504) — 배정 알림 뒤에 정정 알림이 겹치면 회원 알림함이 같은 루틴으로 찬다. 철회도 같은 취지다.

예약에서 파생된 일정도 대상이 아니다. 이 경로는 수정·삭제가 이미 막혀 있다.

## Tests

일정 알림 훅 테스트에 7건을 더했다 — 시각 변경, 메모만 변경(알리지 않음), 취소, 배정 해제, 빈 슬롯에 배정, 빈 슬롯 취소(아무도 알리지 않음), 그리고 **운동 알림을 끄면 변경 알림도 오지 않는지**.

`test_notification_hooks` 24건, 트레이너·상담·배정 루틴 관련 101건 통과.
