### PR TITLE
feat(notification): 데모 알림도 눌러 관련 화면으로 가게

### DIFF
--- a/frontend/flutter/lib/features/notification/data/repositories/mock_notification_repository.dart
+++ b/frontend/flutter/lib/features/notification/data/repositories/mock_notification_repository.dart
@@ -6,6 +6,10 @@ import 'package:oncare/features/notification/domain/repositories/notification_re
 /// 실서비스(실로그인) 화면은 `/notifications` 백엔드를 읽지만, 데모 둘러보기는
 /// 기존과 동일하게 보이도록 이 하드코딩 목록을 유지한다. 컨트롤러가 목 모드에서
 /// 이 목록을 즉시 시드로 사용한다.
+///
+/// 각 알림은 실서버가 내려 주는 것과 같은 모양의 목적지(`action`)를 갖는다 —
+/// 없으면 데모에서는 눌러도 읽음 처리만 되어, 구현돼 있는 이동 기능이 없는 것처럼
+/// 보인다(#667). 목록의 생김새는 달라지지 않는다: `action` 은 그려지지 않는다.
 const List<AlertItem> demoAlerts = <AlertItem>[
   AlertItem(
     id: 'a1',
@@ -13,6 +17,7 @@ const List<AlertItem> demoAlerts = <AlertItem>[
     body: '점심 짬뽕으로 오늘 나트륨이 3,421mg까지 올랐어요. 물을 충분히 드세요.',
     timeAgo: '10분 전',
     category: AlertCategory.reminder,
+    action: AlertAction(label: '식단 보기', target: AlertTarget.diet),
   ),
   AlertItem(
     id: 'a2',
@@ -20,6 +25,7 @@ const List<AlertItem> demoAlerts = <AlertItem>[
     body: '오늘 18:00 김트레이너와 12회차 PT를 마쳤어요!',
     timeAgo: '1시간 전',
     category: AlertCategory.achievement,
+    action: AlertAction(label: '운동 기록 보기', target: AlertTarget.exercise),
   ),
   AlertItem(
     id: 'a3',
@@ -27,6 +33,7 @@ const List<AlertItem> demoAlerts = <AlertItem>[
     body: '마무리로 어깨 회전근개 스트레칭을 꼭 해주세요.',
     timeAgo: '2시간 전',
     category: AlertCategory.reminder,
+    action: AlertAction(label: '대화 보기', target: AlertTarget.coachChat),
   ),
   AlertItem(
     id: 'a4',
@@ -35,6 +42,8 @@ const List<AlertItem> demoAlerts = <AlertItem>[
     timeAgo: '어제',
     category: AlertCategory.system,
     read: true,
+    // 갈 곳을 일부러 주지 않는다. **목적지 없는 알림이 목록에서 사라지거나
+    // 엉뚱한 곳으로 가지 않는지**를 데모에서도 볼 수 있어야 한다.
   ),
 ];
 

--- a/frontend/flutter/test/features/notification/notification_controller_test.dart
+++ b/frontend/flutter/test/features/notification/notification_controller_test.dart
@@ -59,6 +59,44 @@ void main() {
     expect(state.unreadCount, greaterThan(0));
   });
 
+  test('데모 알림도 갈 곳을 갖는다', () {
+    // 목적지가 없으면 데모에서는 눌러도 읽음 처리만 된다 — 구현돼 있는 이동
+    // 기능이 데모에서만 없는 것처럼 보인다. (#667)
+    final container = _container();
+    addTearDown(container.dispose);
+    final List<AlertItem> items = container
+        .read(notificationControllerProvider)
+        .items;
+
+    expect(
+      items.where((AlertItem i) => i.action?.isNavigable ?? false),
+      isNotEmpty,
+    );
+    // 갈 곳 없는 알림도 목록에는 남는다 — 사라지거나 엉뚱한 곳으로 가지 않는다.
+    expect(items.where((AlertItem i) => i.action == null), isNotEmpty);
+  });
+
+  test('읽어도 갈 곳은 남는다', () {
+    // `copyWith` 가 action 을 흘리면, 한 번 읽은 알림은 다시 눌러도 이동하지
+    // 않는다 — 목록에는 그대로 있으니 원인을 찾기 어렵다.
+    final container = _container();
+    addTearDown(container.dispose);
+    final notifier = container.read(notificationControllerProvider.notifier);
+    final AlertItem target = container
+        .read(notificationControllerProvider)
+        .items
+        .firstWhere((AlertItem i) => i.action != null);
+
+    notifier.markRead(target.id);
+
+    final AlertItem after = container
+        .read(notificationControllerProvider)
+        .items
+        .firstWhere((AlertItem i) => i.id == target.id);
+    expect(after.read, isTrue);
+    expect(after.action?.target, target.action?.target);
+  });
+
   test('markRead toggles a single item', () {
     final container = _container();
     addTearDown(container.dispose);


### PR DESCRIPTION
Closes #667

#636 으로 알림을 눌러 관련 화면으로 갈 수 있게 됐는데, **데모 둘러보기에서는 그 동작이 전혀 드러나지 않았다.** 데모 알림 네 건 중 어느 것도 목적지를 갖고 있지 않아, 앱은 갈 곳이 없다고 판단하고 읽음 처리만 했다.

로그인 없이 둘러보는 사람에게는 눌러도 아무 반응이 없는 목록으로 보인다. 구현돼 있는 기능이 데모에서만 없는 것처럼 보이는 상태였다.

## Changes

데모 알림에 내용과 맞는 목적지를 붙였다. 실서버가 내려 주는 것과 같은 모양(`AlertAction`)이라 앱은 두 경로를 구분하지 않는다.

| 데모 알림 | 목적지 |
| --- | --- |
| 나트륨 섭취 주의 | 식단 |
| PT 수업 완료 | 운동 |
| 트레이너 피드백 도착 | 담당 트레이너 대화 |
| 서비스 점검 안내 | **없음** |

마지막 한 건은 일부러 비워 뒀다. 목적지 없는 알림이 **목록에서 사라지거나 엉뚱한 곳으로 가지 않는지**를 데모에서도 볼 수 있어야 한다. 서버가 앱이 모르는 종류를 새로 추가했을 때와 같은 상황이다.

## 데모 화면은 그대로다

- **목록의 생김새가 바뀌지 않는다.** `action` 은 그려지지 않는다 — 타일은 배지·시간·제목·본문만 그린다.
- 읽음 처리와 미읽음 배지 동작도 그대로다.
- 달라지는 것은 눌렀을 때 이동이 일어난다는 점 하나다.

## 확인한 것

`AlertItem.copyWith` 가 `action` 을 함께 옮기는지 확인했다. 흘렸다면 **한 번 읽은 알림은 다시 눌러도 이동하지 않는데 목록에는 그대로 남아** 원인을 찾기 어려웠을 것이다. 지금은 옮기고 있고, 회귀를 막는 테스트를 넣었다.

데모 코치(`김트레이너`)가 이미 있어 대화 이동도 그대로 동작한다.

## Tests

- 데모 알림이 갈 곳을 갖는지, 그리고 갈 곳 없는 알림도 목록에 남는지
- 읽은 뒤에도 목적지가 살아 있는지

알림 테스트 56건 통과, `flutter analyze` 무이슈.
