### PR TITLE
fix(schedule): 월 달력이 마지막 주까지 보이도록 수정

### DIFF
--- a/frontend/flutter/lib/shared/widgets/modals/schedule_calendar_sheet.dart
+++ b/frontend/flutter/lib/shared/widgets/modals/schedule_calendar_sheet.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -53,6 +55,11 @@ class _CalendarBodyState extends ConsumerState<_CalendarBody> {
     widget.initialDate.year,
     widget.initialDate.month,
   );
+
+  /// 한 주 칸의 최소 높이. 남은 높이를 주 수로 나눈 값이 이보다 작아지면 —
+  /// 세로가 짧은 기기나 6주짜리 달 — 칸을 더 줄이는 대신 그리드를 스크롤한다.
+  /// 날짜 숫자와 일정 칩 한 줄이 들어가는 최소치다.
+  static const double _minRowHeight = 56;
 
   static const List<String> _weekdays = <String>[
     '일',
@@ -165,74 +172,109 @@ class _CalendarBodyState extends ConsumerState<_CalendarBody> {
                 skipLoadingOnRefresh: true,
                 data: (List<ScheduleEvent> events) {
                   final byDay = _groupByDay(events);
-                  return GridView.builder(
-                    physics: const NeverScrollableScrollPhysics(),
-                    gridDelegate:
-                        const SliverGridDelegateWithFixedCrossAxisCount(
-                          crossAxisCount: 7,
-                          childAspectRatio: 0.72,
-                        ),
-                    itemCount: days.length,
-                    itemBuilder: (BuildContext _, int i) {
-                      final day = days[i];
-                      if (day == null) {
-                        return const DecoratedBox(
-                          decoration: BoxDecoration(
-                            border: Border(
-                              right: BorderSide(color: AppColors.border),
-                              bottom: BorderSide(color: AppColors.border),
+                  return LayoutBuilder(
+                    builder: (BuildContext _, BoxConstraints constraints) {
+                      // 칸 높이를 남은 세로 공간에서 정한다. 가로폭에서 고정
+                      // 비율로 잡으면 6주짜리 달의 마지막 주가 남은 높이를
+                      // 넘겨 잘렸다 — 스크롤도 꺼져 있어 8월이 22일에서
+                      // 끝나 보이던 원인이다(#669).
+                      final int rows = (days.length / 7).ceil();
+                      final double rowHeight = math.max(
+                        _minRowHeight,
+                        constraints.maxHeight / math.max(rows, 1),
+                      );
+                      return GridView.builder(
+                        // 최소 높이에 걸려 다 담기지 않는 경우에만 스크롤이
+                        // 생긴다. 어떤 경우에도 잘라내지 않는다.
+                        physics: const ClampingScrollPhysics(),
+                        padding: EdgeInsets.zero,
+                        gridDelegate:
+                            SliverGridDelegateWithFixedCrossAxisCount(
+                              crossAxisCount: 7,
+                              mainAxisExtent: rowHeight,
                             ),
-                          ),
-                        );
-                      }
-                      final isToday =
-                          day.year == today.year &&
-                          day.month == today.month &&
-                          day.day == today.day;
-                      final dayEvents =
-                          byDay[day.day] ?? const <ScheduleEvent>[];
-                      return Container(
-                        decoration: BoxDecoration(
-                          color: isToday
-                              ? AppColors.primary.withValues(alpha: 0.05)
-                              : null,
-                          border: const Border(
-                            right: BorderSide(color: AppColors.border),
-                            bottom: BorderSide(color: AppColors.border),
-                          ),
-                        ),
-                        padding: const EdgeInsets.all(4),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: <Widget>[
-                            Text(
-                              '${day.day}',
-                              style: theme.textTheme.bodySmall?.copyWith(
-                                fontWeight: FontWeight.w700,
-                                color: isToday ? AppColors.primary : null,
-                              ),
-                            ),
-                            const SizedBox(height: 2),
-                            for (final ScheduleEvent e in dayEvents)
-                              Container(
-                                margin: const EdgeInsets.only(bottom: 2),
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 4,
-                                  vertical: 2,
-                                ),
-                                decoration: BoxDecoration(
-                                  color: scheduleCategoryColor(e.category),
-                                  borderRadius: BorderRadius.circular(4),
-                                ),
-                                child: Text(
-                                  '${e.time} ${e.title}'.trim(),
-                                  style: const TextStyle(fontSize: 9),
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
+                        itemCount: days.length,
+                        itemBuilder: (BuildContext _, int i) {
+                          final day = days[i];
+                          if (day == null) {
+                            return const DecoratedBox(
+                              decoration: BoxDecoration(
+                                border: Border(
+                                  right: BorderSide(color: AppColors.border),
+                                  bottom: BorderSide(color: AppColors.border),
                                 ),
                               ),
-                          ],
-                        ),
+                            );
+                          }
+                          final isToday =
+                              day.year == today.year &&
+                              day.month == today.month &&
+                              day.day == today.day;
+                          final dayEvents =
+                              byDay[day.day] ?? const <ScheduleEvent>[];
+                          return Container(
+                            key: Key('calendar-day-${day.day}'),
+                            decoration: BoxDecoration(
+                              color: isToday
+                                  ? AppColors.primary.withValues(alpha: 0.05)
+                                  : null,
+                              border: const Border(
+                                right: BorderSide(color: AppColors.border),
+                                bottom: BorderSide(color: AppColors.border),
+                              ),
+                            ),
+                            padding: const EdgeInsets.all(4),
+                            // 칸 높이는 남은 공간에서 정해지므로 일정이 여럿인
+                            // 날은 칩이 칸을 넘길 수 있다. 넘치는 칩은 잘라내되
+                            // (clip) 레이아웃 경고 없이 날짜 숫자는 항상 남긴다.
+                            clipBehavior: Clip.hardEdge,
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: <Widget>[
+                                Text(
+                                  '${day.day}',
+                                  style: theme.textTheme.bodySmall?.copyWith(
+                                    fontWeight: FontWeight.w700,
+                                    color: isToday ? AppColors.primary : null,
+                                  ),
+                                ),
+                                const SizedBox(height: 2),
+                                Expanded(
+                                  child: ListView(
+                                    padding: EdgeInsets.zero,
+                                    physics:
+                                        const NeverScrollableScrollPhysics(),
+                                    children: <Widget>[
+                                      for (final ScheduleEvent e in dayEvents)
+                                        Container(
+                                          margin: const EdgeInsets.only(
+                                            bottom: 2,
+                                          ),
+                                          padding: const EdgeInsets.symmetric(
+                                            horizontal: 4,
+                                            vertical: 2,
+                                          ),
+                                          decoration: BoxDecoration(
+                                            color: scheduleCategoryColor(
+                                              e.category,
+                                            ),
+                                            borderRadius:
+                                                BorderRadius.circular(4),
+                                          ),
+                                          child: Text(
+                                            '${e.time} ${e.title}'.trim(),
+                                            style: const TextStyle(fontSize: 9),
+                                            maxLines: 1,
+                                            overflow: TextOverflow.ellipsis,
+                                          ),
+                                        ),
+                                    ],
+                                  ),
+                                ),
+                              ],
+                            ),
+                          );
+                        },
                       );
                     },
                   );
@@ -248,21 +290,29 @@ class _CalendarBodyState extends ConsumerState<_CalendarBody> {
                 ),
               ),
             ),
-            const SizedBox(height: AppSpacing.md),
+            // 시스템 내비게이션 바 인셋만큼 더 띄운다 — 인셋이 있는 기기에서
+            // 마지막 주가 내비게이션 바 뒤로 들어가 보이지 않던 문제(#669).
+            SizedBox(
+              height: AppSpacing.md + MediaQuery.viewPaddingOf(context).bottom,
+            ),
           ],
         ),
       ),
     );
   }
 
+  /// 그 달의 그리드 칸. 앞쪽은 1일의 요일까지 비우고, 뒤쪽도 마지막 주가 7칸이
+  /// 되도록 채운다 — 채우지 않으면 마지막 주의 테두리가 중간에서 끊긴다.
   static List<DateTime?> _daysInGrid(DateTime month) {
     final first = DateTime(month.year, month.month);
     final lastDay = DateTime(month.year, month.month + 1, 0);
     final leading = first.weekday % 7; // Sunday-first
+    final trailing = (7 - (leading + lastDay.day) % 7) % 7;
     return <DateTime?>[
       for (int i = 0; i < leading; i++) null,
       for (int d = 1; d <= lastDay.day; d++)
         DateTime(month.year, month.month, d),
+      for (int i = 0; i < trailing; i++) null,
     ];
   }
 }

--- a/frontend/flutter/lib/shared/widgets/modals/schedule_calendar_sheet.dart
+++ b/frontend/flutter/lib/shared/widgets/modals/schedule_calendar_sheet.dart
@@ -178,10 +178,12 @@ class _CalendarBodyState extends ConsumerState<_CalendarBody> {
                       // 비율로 잡으면 6주짜리 달의 마지막 주가 남은 높이를
                       // 넘겨 잘렸다 — 스크롤도 꺼져 있어 8월이 22일에서
                       // 끝나 보이던 원인이다(#669).
-                      final int rows = (days.length / 7).ceil();
+                      // _daysInGrid 가 앞뒤를 채워 항상 7의 배수를 돌려주므로
+                      // 나누어떨어진다.
+                      final int rows = days.length ~/ 7;
                       final double rowHeight = math.max(
                         _minRowHeight,
-                        constraints.maxHeight / math.max(rows, 1),
+                        constraints.maxHeight / rows,
                       );
                       return GridView.builder(
                         // 최소 높이에 걸려 다 담기지 않는 경우에만 스크롤이
@@ -224,10 +226,6 @@ class _CalendarBodyState extends ConsumerState<_CalendarBody> {
                               ),
                             ),
                             padding: const EdgeInsets.all(4),
-                            // 칸 높이는 남은 공간에서 정해지므로 일정이 여럿인
-                            // 날은 칩이 칸을 넘길 수 있다. 넘치는 칩은 잘라내되
-                            // (clip) 레이아웃 경고 없이 날짜 숫자는 항상 남긴다.
-                            clipBehavior: Clip.hardEdge,
                             child: Column(
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: <Widget>[
@@ -239,36 +237,55 @@ class _CalendarBodyState extends ConsumerState<_CalendarBody> {
                                   ),
                                 ),
                                 const SizedBox(height: 2),
+                                // 칸 높이는 남은 공간에서 정해지므로 일정이
+                                // 여럿인 날은 칩이 칸을 넘길 수 있다. 넘치는
+                                // 만큼은 ClipRect 가 잘라내고, OverflowBox 가
+                                // Column 에 무한 높이를 줘 오버플로 경고 없이
+                                // 그린다. 날짜 숫자는 언제나 남는다.
+                                //
+                                // 칸마다 ListView 를 두면 한 달에 스크롤 뷰가
+                                // 35~42개 생긴다 — 자르기만 하는 데 치르는
+                                // 값으로는 너무 비싸다.
                                 Expanded(
-                                  child: ListView(
-                                    padding: EdgeInsets.zero,
-                                    physics:
-                                        const NeverScrollableScrollPhysics(),
-                                    children: <Widget>[
-                                      for (final ScheduleEvent e in dayEvents)
-                                        Container(
-                                          margin: const EdgeInsets.only(
-                                            bottom: 2,
-                                          ),
-                                          padding: const EdgeInsets.symmetric(
-                                            horizontal: 4,
-                                            vertical: 2,
-                                          ),
-                                          decoration: BoxDecoration(
-                                            color: scheduleCategoryColor(
-                                              e.category,
+                                  child: ClipRect(
+                                    child: OverflowBox(
+                                      alignment: Alignment.topLeft,
+                                      maxHeight: double.infinity,
+                                      child: Column(
+                                        mainAxisSize: MainAxisSize.min,
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.start,
+                                        children: <Widget>[
+                                          for (final ScheduleEvent e
+                                              in dayEvents)
+                                            Container(
+                                              margin: const EdgeInsets.only(
+                                                bottom: 2,
+                                              ),
+                                              padding:
+                                                  const EdgeInsets.symmetric(
+                                                    horizontal: 4,
+                                                    vertical: 2,
+                                                  ),
+                                              decoration: BoxDecoration(
+                                                color: scheduleCategoryColor(
+                                                  e.category,
+                                                ),
+                                                borderRadius:
+                                                    BorderRadius.circular(4),
+                                              ),
+                                              child: Text(
+                                                '${e.time} ${e.title}'.trim(),
+                                                style: const TextStyle(
+                                                  fontSize: 9,
+                                                ),
+                                                maxLines: 1,
+                                                overflow: TextOverflow.ellipsis,
+                                              ),
                                             ),
-                                            borderRadius:
-                                                BorderRadius.circular(4),
-                                          ),
-                                          child: Text(
-                                            '${e.time} ${e.title}'.trim(),
-                                            style: const TextStyle(fontSize: 9),
-                                            maxLines: 1,
-                                            overflow: TextOverflow.ellipsis,
-                                          ),
-                                        ),
-                                    ],
+                                        ],
+                                      ),
+                                    ),
                                   ),
                                 ),
                               ],

--- a/frontend/flutter/test/shared/widgets/schedule_calendar_sheet_test.dart
+++ b/frontend/flutter/test/shared/widgets/schedule_calendar_sheet_test.dart
@@ -8,16 +8,19 @@ import 'package:oncare/features/schedule/presentation/controllers/schedule_contr
 import 'package:oncare/gen/l10n/app_localizations.dart';
 import 'package:oncare/shared/widgets/modals/schedule_calendar_sheet.dart';
 
-/// 일정 없는 달력만 본다 — 이 테스트가 확인하는 것은 **몇 칸이 그려지는가**이지
-/// 칸 안의 일정이 아니다.
+/// 지정한 일정만 돌려주는 대역. 기본값은 빈 달 — 칸 수를 보는 테스트는
+/// 칸 안의 일정에 좌우되지 않아야 한다.
 class _EmptyScheduleRepository implements ScheduleRepository {
+  _EmptyScheduleRepository([this.events = const <ScheduleEvent>[]]);
+
+  final List<ScheduleEvent> events;
+
   @override
   Future<List<ScheduleEvent>> fetchByDate(String date) async =>
       const <ScheduleEvent>[];
 
   @override
-  Future<List<ScheduleEvent>> fetchByMonth(String month) async =>
-      const <ScheduleEvent>[];
+  Future<List<ScheduleEvent>> fetchByMonth(String month) async => events;
 
   @override
   Future<ScheduleEvent> createEvent({
@@ -31,10 +34,15 @@ class _EmptyScheduleRepository implements ScheduleRepository {
 }
 
 /// 시트를 띄우는 버튼 하나짜리 화면.
-Widget _app({required DateTime initialDate}) {
+Widget _app({
+  required DateTime initialDate,
+  List<ScheduleEvent> events = const <ScheduleEvent>[],
+}) {
   return ProviderScope(
     overrides: <Override>[
-      scheduleRepositoryProvider.overrideWithValue(_EmptyScheduleRepository()),
+      scheduleRepositoryProvider.overrideWithValue(
+        _EmptyScheduleRepository(events),
+      ),
     ],
     child: MaterialApp(
       locale: const Locale('ko'),
@@ -53,11 +61,28 @@ Widget _app({required DateTime initialDate}) {
   );
 }
 
-Future<void> _openSheet(WidgetTester tester, DateTime initialDate) async {
-  await tester.pumpWidget(_app(initialDate: initialDate));
+Future<void> _openSheet(
+  WidgetTester tester,
+  DateTime initialDate, {
+  List<ScheduleEvent> events = const <ScheduleEvent>[],
+}) async {
+  await tester.pumpWidget(_app(initialDate: initialDate, events: events));
   await tester.tap(find.text('열기'));
   await tester.pumpAndSettle();
 }
+
+/// 달력 그리드가 그린 칸 수(선행 공백 + 날짜 + 후행 채움).
+int _gridCellCount(WidgetTester tester) {
+  final GridView grid = tester.widget<GridView>(find.byType(GridView));
+  return (grid.childrenDelegate as SliverChildBuilderDelegate).childCount!;
+}
+
+/// 달력 그리드 **자신의** Scrollable. 화면에 다른 스크롤 뷰가 있어도 이것을
+/// 집도록 GridView 밑에서 찾는다 — 엉뚱한 Scrollable 위에서 스크롤을 시험하면
+/// 아무것도 검증하지 못한다.
+Finder _calendarScrollable() => find
+    .descendant(of: find.byType(GridView), matching: find.byType(Scrollable))
+    .first;
 
 void main() {
   // 2026-08 은 1일이 토요일이라 6주 그리드가 되는 달이다 — 선행 공백 6칸 +
@@ -77,23 +102,42 @@ void main() {
     expect(find.byKey(const Key('calendar-day-22')), findsOneWidget);
     // 예전 구현이 잘라 먹던 마지막 주.
     expect(find.byKey(const Key('calendar-day-31')), findsOneWidget);
+    // 6주 × 7칸. 날짜 키만 보면 후행 채움 칸이 사라져도 통과하므로 칸 수까지
+    // 못박는다 — 마지막 주 테두리가 닫히는 근거다.
+    expect(_gridCellCount(tester), 42);
   });
 
   testWidgets('세로가 짧으면 잘라내지 않고 스크롤해서 말일에 닿는다', (
     WidgetTester tester,
   ) async {
-    tester.view.physicalSize = const Size(400, 640);
+    // 이 높이라야 6주 그리드가 남은 공간을 넘어 실제로 스크롤이 생긴다.
+    // 640 에서는 다 들어가 버려 스크롤 경로를 전혀 지나지 않는다.
+    tester.view.physicalSize = const Size(400, 500);
     tester.view.devicePixelRatio = 1;
     addTearDown(tester.view.reset);
 
     await _openSheet(tester, august2026);
 
+    final ScrollableState grid = tester.state(_calendarScrollable());
+    expect(
+      grid.position.maxScrollExtent,
+      greaterThan(0),
+      reason: '잘라내는 대신 스크롤이 생겨야 한다',
+    );
+    // 스크롤하기 전에는 말일에 닿지 못한다 — 이 전제가 깨지면 아래 스크롤
+    // 검증이 아무것도 확인하지 않게 된다.
+    expect(find.byKey(const Key('calendar-day-31')), findsNothing);
+
     await tester.scrollUntilVisible(
       find.byKey(const Key('calendar-day-31')),
-      120,
-      scrollable: find.byType(Scrollable).last,
+      80,
+      scrollable: _calendarScrollable(),
     );
+
+    expect(grid.position.pixels, greaterThan(0));
     expect(find.byKey(const Key('calendar-day-31')), findsOneWidget);
+    // 스크롤해도 칸 수는 그대로다(잘라낸 것이 아니라 밀려나 있을 뿐).
+    expect(_gridCellCount(tester), 42);
   });
 
   testWidgets('말일이 토요일이 아닌 달도 마지막 주가 7칸으로 닫힌다', (
@@ -106,10 +150,51 @@ void main() {
     // 2026-09: 1일 화요일 → 선행 2칸 + 30일 = 32칸, 후행 채움 3칸 = 35칸(5주).
     await _openSheet(tester, DateTime(2026, 9, 10));
 
-    final GridView grid = tester.widget<GridView>(find.byType(GridView));
-    final SliverChildBuilderDelegate delegate =
-        grid.childrenDelegate as SliverChildBuilderDelegate;
-    expect(delegate.childCount, 35);
+    expect(_gridCellCount(tester), 35);
     expect(find.byKey(const Key('calendar-day-30')), findsOneWidget);
+  });
+
+  testWidgets('주가 딱 맞아떨어지는 달은 빈 줄을 덧붙이지 않는다', (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(900, 1600);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    // 2026-02: 1일 일요일 + 28일 → 선행 0칸·후행 0칸으로 정확히 4주.
+    // 후행 계산의 바깥 `% 7` 이 빠지면 여기서 빈 한 줄이 더 붙는다.
+    await _openSheet(tester, DateTime(2026, 2, 10));
+
+    expect(_gridCellCount(tester), 28);
+    expect(find.byKey(const Key('calendar-day-28')), findsOneWidget);
+  });
+
+  testWidgets('일정이 칸을 넘쳐도 오버플로 없이 날짜 숫자는 남는다', (WidgetTester tester) async {
+    // 좁고 낮은 화면 + 한 날짜에 일정 6건 = 칸 높이를 확실히 넘긴다.
+    tester.view.physicalSize = const Size(400, 500);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await _openSheet(
+      tester,
+      august2026,
+      events: <ScheduleEvent>[
+        for (int i = 0; i < 6; i++)
+          ScheduleEvent(
+            id: 'e$i',
+            date: '2026-08-03',
+            time: '0$i:00',
+            title: '일정 $i',
+            category: ScheduleCategory.exercise,
+          ),
+      ],
+    );
+
+    expect(
+      tester.takeException(),
+      isNull,
+      reason: '칩이 칸을 넘쳐도 오버플로 예외가 나면 안 된다',
+    );
+    expect(find.byKey(const Key('calendar-day-3')), findsOneWidget);
+    // 칸 안에서 잘리더라도 첫 칩은 그려진다.
+    expect(find.text('00:00 일정 0'), findsOneWidget);
   });
 }

--- a/frontend/flutter/test/shared/widgets/schedule_calendar_sheet_test.dart
+++ b/frontend/flutter/test/shared/widgets/schedule_calendar_sheet_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/schedule/domain/entities/schedule_event.dart';
+import 'package:oncare/features/schedule/domain/repositories/schedule_repository.dart';
+import 'package:oncare/features/schedule/presentation/controllers/schedule_controller.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+import 'package:oncare/shared/widgets/modals/schedule_calendar_sheet.dart';
+
+/// 일정 없는 달력만 본다 — 이 테스트가 확인하는 것은 **몇 칸이 그려지는가**이지
+/// 칸 안의 일정이 아니다.
+class _EmptyScheduleRepository implements ScheduleRepository {
+  @override
+  Future<List<ScheduleEvent>> fetchByDate(String date) async =>
+      const <ScheduleEvent>[];
+
+  @override
+  Future<List<ScheduleEvent>> fetchByMonth(String month) async =>
+      const <ScheduleEvent>[];
+
+  @override
+  Future<ScheduleEvent> createEvent({
+    required String date,
+    required String title,
+    String time = '',
+    ScheduleCategory category = ScheduleCategory.other,
+  }) async {
+    throw UnimplementedError();
+  }
+}
+
+/// 시트를 띄우는 버튼 하나짜리 화면.
+Widget _app({required DateTime initialDate}) {
+  return ProviderScope(
+    overrides: <Override>[
+      scheduleRepositoryProvider.overrideWithValue(_EmptyScheduleRepository()),
+    ],
+    child: MaterialApp(
+      locale: const Locale('ko'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: Builder(
+          builder: (BuildContext context) => TextButton(
+            onPressed: () =>
+                showScheduleCalendarSheet(context, initialDate: initialDate),
+            child: const Text('열기'),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+Future<void> _openSheet(WidgetTester tester, DateTime initialDate) async {
+  await tester.pumpWidget(_app(initialDate: initialDate));
+  await tester.tap(find.text('열기'));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  // 2026-08 은 1일이 토요일이라 6주 그리드가 되는 달이다 — 선행 공백 6칸 +
+  // 31일 = 37칸. 잘림 회귀(#669)가 가장 먼저 드러나는 모양.
+  final DateTime august2026 = DateTime(2026, 8, 15);
+
+  testWidgets('세로가 넉넉하면 6주짜리 달의 말일까지 한 화면에 그린다', (
+    WidgetTester tester,
+  ) async {
+    tester.view.physicalSize = const Size(900, 1600);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await _openSheet(tester, august2026);
+
+    expect(find.byKey(const Key('calendar-day-1')), findsOneWidget);
+    expect(find.byKey(const Key('calendar-day-22')), findsOneWidget);
+    // 예전 구현이 잘라 먹던 마지막 주.
+    expect(find.byKey(const Key('calendar-day-31')), findsOneWidget);
+  });
+
+  testWidgets('세로가 짧으면 잘라내지 않고 스크롤해서 말일에 닿는다', (
+    WidgetTester tester,
+  ) async {
+    tester.view.physicalSize = const Size(400, 640);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await _openSheet(tester, august2026);
+
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('calendar-day-31')),
+      120,
+      scrollable: find.byType(Scrollable).last,
+    );
+    expect(find.byKey(const Key('calendar-day-31')), findsOneWidget);
+  });
+
+  testWidgets('말일이 토요일이 아닌 달도 마지막 주가 7칸으로 닫힌다', (
+    WidgetTester tester,
+  ) async {
+    tester.view.physicalSize = const Size(900, 1600);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    // 2026-09: 1일 화요일 → 선행 2칸 + 30일 = 32칸, 후행 채움 3칸 = 35칸(5주).
+    await _openSheet(tester, DateTime(2026, 9, 10));
+
+    final GridView grid = tester.widget<GridView>(find.byType(GridView));
+    final SliverChildBuilderDelegate delegate =
+        grid.childrenDelegate as SliverChildBuilderDelegate;
+    expect(delegate.childCount, 35);
+    expect(find.byKey(const Key('calendar-day-30')), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

* 사용자 앱 헤더의 달력 시트가 한 달을 끝까지 그리지 못했다. 8월(31일)을 열면 22일 언저리에서 잘리고 마지막 두 주가 사라졌다.
* 스크롤도 되지 않아 사용자에게는 "달력이 고장 났다"로 읽혔다.
* 셀 높이를 가로폭이 아니라 **남은 세로 공간**에서 정하고, 모자라면 잘라내지 말고 스크롤하게 고쳤다.

---

## Changes

### 🐛 Fixes

* 셀 높이를 `남은 높이 ÷ 주 수` 로 계산한다(`mainAxisExtent`). 예전에는 `childAspectRatio: 0.72` 로 **가로폭**에서 정해져 남은 세로 공간과 무관했고, 6주짜리 달에서는 필요한 높이가 남은 높이를 넘겼다.
* `NeverScrollableScrollPhysics` → `ClampingScrollPhysics`. 최소 행 높이(56)에 걸려 다 담기지 않는 경우에만 스크롤이 생기고, **어떤 경우에도 잘라내지 않는다.**
* 마지막 주의 남는 칸을 채워 그리드 테두리를 닫는다(예전에는 테두리가 중간에서 끊겼다).
* 시트 하단에 시스템 내비게이션 바 인셋(`viewPadding.bottom`)을 반영한다.

### 🎨 UI/UX

* 일정이 여럿인 날의 칩은 칸 안에서만 그려진다(`Expanded` + `clipBehavior`) — 날짜 숫자는 언제나 남는다.

---

## Commits

1. `bc03bc54` fix(schedule): 월 달력이 마지막 주까지 보이도록 수정

2. `bfd96e73` fix(schedule): 리뷰 피드백을 반영한다

---

## Notes

* 이 시트는 홈·식단·운동·MY 네 탭의 헤더 달력 버튼이 모두 여는 화면이다.
* 6주 그리드가 되는 달(1일이 금·토요일)에서 가장 잘 드러난다. 테스트는 2026-08(1일 토요일 → 선행 6칸 + 31일 = 37칸)을 쓴다.
* 셀에 `Key('calendar-day-N')` 를 붙였다 — 테스트가 "몇 일까지 그려졌는가"를 직접 확인할 수 있어야 이 회귀를 다시 잡는다.

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 앱 실행 → 아무 탭에서나 헤더의 달력 아이콘을 누른다.
2. 8월(또는 1일이 토요일인 달)로 옮겨 **31일까지 모두 보이는지** 확인한다.
3. 세로가 짧은 기기(또는 창)에서 열어 잘리지 않고 스크롤되는지 확인한다.
4. 마지막 주가 내비게이션 바에 가리지 않는지 확인한다.

새로 추가한 자동 검증:

```bash
flutter test test/shared/widgets/schedule_calendar_sheet_test.dart
```

---

## Related Issues

Closes #669

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 화면 높이에 맞춰 달력 그리드가 유연하게 배치됩니다.
  * 공간이 부족한 화면에서는 세로 스크롤로 달력의 마지막 날짜까지 확인할 수 있습니다.
  * 하단 내비게이션 바에 마지막 행이 가려지지 않도록 여백이 적용됩니다.
  * 일정이 많은 날짜의 내용은 셀 영역 안에서 깔끔하게 표시됩니다.

* **테스트**
  * 다양한 화면 높이와 5주·6주 달력에서 날짜 표시 및 스크롤 동작을 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


