### PR TITLE
feat(demo): 데모 식단·운동 기록을 최근 한 달로 확대

### DIFF
--- a/backend/API_CONTRACT.md
+++ b/backend/API_CONTRACT.md
@@ -64,11 +64,12 @@
 
 | Method | Path | 응답 핵심 필드 |
 |---|---|---|
-| GET | `/exercise/weeks/current` | `{ sessions[], daily_minutes[7], daily_calories[7], cardio_minutes[7], strength_minutes[7], stretching_minutes[7], day_labels[7], total_minutes, total_calories, streak_days, ai_coach_message }` |
+| GET | `/exercise/weeks/current` | 질의 `?week_start=YYYY-MM-DD`(생략 시 이번 주) → `{ sessions[], daily_minutes[7], daily_calories[7], cardio_minutes[7], strength_minutes[7], stretching_minutes[7], day_labels[7], total_minutes, total_calories, streak_days, ai_coach_message }` |
 | POST | `/exercise/sessions` | 입력 `{ type, minutes(>0), calories, intensity(light\|moderate\|high), day_label? }` → 생성된 `sessions[]` 항목 |
 | PUT | `/exercise/sessions/{id}` | 입력 동일(부분 갱신) → 갱신된 항목 |
 
 `sessions[]`: `{ id(str), day_label, type(cardio|strength|yoga|walking), minutes, calories, intensity(light|moderate|high), source(member|trainer_pt), date_label, time_label, items[str] }`
+`week_start`: 그 주의 월요일. 월요일이 아닌 날짜를 줘도 그 날이 속한 주로 맞춘다. 형식이 깨지면 422. 회원 앱이 지난 날짜를 골랐을 때 그 주를 받는다. (#671)
 `intensity`: 생략 시 `moderate`. 수정 시트가 저장된 강도로 복원되고 칼로리 추정 배수(0.85/1.0/1.2)의 근거가 된다.
 `source`: 생략 시 `member`. `trainer_pt` 는 트레이너가 PT 세션을 완료 처리해 서버가 파생시킨 기록(id 는 `sched-ex-{session_id}`)으로, 근거가 트레이너에게 있어 **회원의 PUT/DELETE 는 409** 로 거절된다. 지우려면 트레이너가 그 세션을 삭제해야 하고 그러면 이 기록도 함께 사라진다. (#499)
 `day_labels`: `["월","화","수","목","금","토","일"]`

--- a/backend/app/api/v1/exercise.py
+++ b/backend/app/api/v1/exercise.py
@@ -7,9 +7,10 @@
 from __future__ import annotations
 
 import uuid
+from datetime import date
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -64,8 +65,24 @@ def _reject_if_derived(row: ExerciseSession) -> None:
 def current_week(
     current_user: CurrentUser,
     db: Annotated[Session, Depends(get_db)],
+    week_start: Annotated[str | None, Query(description="조회할 주의 월요일 YYYY-MM-DD")] = None,
 ) -> ExerciseWeekResponse:
-    week_start = monday_of_this_week_str()
+    """한 주의 운동 집계. `week_start` 없이 부르면 이번 주다.
+
+    회원 앱이 지난 날짜를 고르면 그 주를 받아 하루치를 보여준다. 이 파라미터가
+    없을 때는 조회 경로가 이번 주 하나뿐이라 지난 기록을 볼 방법이 없었다.
+    월요일이 아닌 날짜를 줘도 그 날이 속한 주로 맞춘다.
+    """
+    if week_start is None:
+        week_start = monday_of_this_week_str()
+    else:
+        try:
+            date.fromisoformat(week_start)
+        except ValueError:
+            raise HTTPException(
+                status_code=422, detail="week_start 는 YYYY-MM-DD 형식이어야 합니다."
+            ) from None
+        week_start = monday_of_str(week_start)
     rows = db.scalars(
         select(ExerciseSession)
         .where(ExerciseSession.user_id == current_user.id)

--- a/backend/app/api/v1/exercise.py
+++ b/backend/app/api/v1/exercise.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import date
+from datetime import datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -76,8 +76,11 @@ def current_week(
     if week_start is None:
         week_start = monday_of_this_week_str()
     else:
+        # strptime 으로 엄격하게 본다. date.fromisoformat 은 3.11 부터
+        # `20260810` 같은 기본 형식도 받아, 앱의 로컬 목업(엄격한 YYYY-MM-DD)과
+        # 받아들이는 값의 집합이 갈린다.
         try:
-            date.fromisoformat(week_start)
+            datetime.strptime(week_start, "%Y-%m-%d")
         except ValueError:
             raise HTTPException(
                 status_code=422, detail="week_start 는 YYYY-MM-DD 형식이어야 합니다."

--- a/backend/tests/test_exercise.py
+++ b/backend/tests/test_exercise.py
@@ -158,3 +158,72 @@ def test_update_session_rejects_bad_type(client):
         headers=h,
     )
     assert r.status_code == 400
+
+
+def test_week_start_query_returns_that_week(client):
+    """`week_start` 로 지난 주를 조회한다 (#671).
+
+    앱이 지난 날짜를 고르면 그 주를 받아 하루치를 그린다. 파라미터가 없던 때는
+    조회가 이번 주 하나뿐이라 지난 기록을 볼 방법이 없었다.
+    """
+    from datetime import date, timedelta
+
+    from app.services.exercise_service import monday_of_this_week_str
+
+    h = _login(client)
+    client.post(
+        "/v1/exercise/sessions",
+        json={"type": "cardio", "minutes": 30, "calories": 200, "day_label": "월"},
+        headers=h,
+    )
+
+    this_monday = date.fromisoformat(monday_of_this_week_str())
+    last_monday = this_monday - timedelta(days=7)
+
+    # 지난 주에는 기록이 없다 — 이번 주 값이 새어 나오면 안 된다.
+    past = client.get(
+        "/v1/exercise/weeks/current",
+        params={"week_start": last_monday.isoformat()},
+        headers=h,
+    )
+    assert past.status_code == 200, past.text
+    assert past.json()["total_minutes"] == 0
+
+    # 이번 주를 명시해도 파라미터 없이 부른 것과 같다.
+    current = client.get(
+        "/v1/exercise/weeks/current",
+        params={"week_start": this_monday.isoformat()},
+        headers=h,
+    )
+    assert current.json()["total_minutes"] == 30
+
+
+def test_week_start_accepts_any_day_of_that_week(client):
+    """월요일이 아닌 날짜를 줘도 그 날이 속한 주로 맞춘다."""
+    from datetime import date, timedelta
+
+    from app.services.exercise_service import monday_of_this_week_str
+
+    h = _login(client)
+    client.post(
+        "/v1/exercise/sessions",
+        json={"type": "cardio", "minutes": 25, "calories": 150, "day_label": "월"},
+        headers=h,
+    )
+
+    thursday = date.fromisoformat(monday_of_this_week_str()) + timedelta(days=3)
+    r = client.get(
+        "/v1/exercise/weeks/current",
+        params={"week_start": thursday.isoformat()},
+        headers=h,
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["total_minutes"] == 25
+
+
+def test_week_start_rejects_malformed_date(client):
+    h = _login(client)
+    r = client.get(
+        "/v1/exercise/weeks/current", params={"week_start": "2026-13-99"}, headers=h
+    )
+    assert r.status_code == 422

--- a/backend/tests/test_exercise.py
+++ b/backend/tests/test_exercise.py
@@ -227,3 +227,24 @@ def test_week_start_rejects_malformed_date(client):
         "/v1/exercise/weeks/current", params={"week_start": "2026-13-99"}, headers=h
     )
     assert r.status_code == 422
+
+
+def test_week_start_rejects_non_iso_basic_format(client):
+    """`20260810` 같은 기본 형식은 받지 않는다.
+
+    date.fromisoformat 은 3.11 부터 이 형식도 받지만, 앱의 로컬 목업은 엄격한
+    YYYY-MM-DD 만 받는다. 두 구현이 같은 요청에 다르게 답하면 안 된다.
+    """
+    h = _login(client)
+    r = client.get(
+        "/v1/exercise/weeks/current", params={"week_start": "20260810"}, headers=h
+    )
+    assert r.status_code == 422
+
+
+def test_week_start_rejects_empty_string(client):
+    h = _login(client)
+    r = client.get(
+        "/v1/exercise/weeks/current", params={"week_start": ""}, headers=h
+    )
+    assert r.status_code == 422

--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -261,7 +261,7 @@ class LocalApiInterceptor extends Interceptor {
       'minutes': minutes,
       'calories': calories,
       'intensity': intensity,
-      'date_label': _dateLabelForDayLabel(dayLabel),
+      'date_label': _dateLabelForDayLabel(dayLabel, _mondayOfThisWeekString()),
       'time_label': _defaultTimeLabel(type),
       'items': _defaultItems(type),
     });
@@ -813,8 +813,20 @@ class LocalApiInterceptor extends Interceptor {
     '일',
   ];
 
+  /// GET /exercise/weeks/current[?week_start=YYYY-MM-DD]
+  ///
+  /// `week_start` 없이 부르면 이번 주다(예전 동작 그대로). 운동 탭이 주를 뒤로
+  /// 넘길 때 그 주의 월요일을 실어 보낸다(#671) — 그 전에는 조회 경로가 이번
+  /// 주 하나뿐이라 지난주를 받아올 방법이 없었다.
   Future<Response<Object?>> _exerciseCurrentWeek(RequestOptions options) async {
-    final weekStart = _mondayOfThisWeekString();
+    final Object? requested = options.queryParameters['week_start'];
+    final String? requestedWeek = requested is String && requested.isNotEmpty
+        ? requested
+        : null;
+    if (requestedWeek != null && !_isDateString(requestedWeek)) {
+      return _badRequest(options, 'week_start must be YYYY-MM-DD');
+    }
+    final weekStart = requestedWeek ?? _mondayOfThisWeekString();
     final rows = await (_db.select(
       _db.exerciseSessions,
     )..where((t) => t.weekStart.equals(weekStart))).get();
@@ -868,7 +880,7 @@ class LocalApiInterceptor extends Interceptor {
         // Date/time labels are synthesized here so the React-style
         // session list ("오늘", "어제", "MM월 DD일") works without
         // a schema migration on the drift `exerciseSessions` table.
-        'date_label': _dateLabelForDayLabel(r.dayLabel),
+        'date_label': _dateLabelForDayLabel(r.dayLabel, weekStart),
         'time_label': _defaultTimeLabel(r.type),
         'items': _defaultItems(r.type),
       });
@@ -933,20 +945,21 @@ class LocalApiInterceptor extends Interceptor {
     return best;
   }
 
-  /// "오늘 / 어제 / N요일 / MM월 DD일" for a given weekday label.
-  String _dateLabelForDayLabel(String dayLabel) {
-    final now = DateTime.now();
-    final todayIdx = now.weekday - 1; // 0=Mon
+  /// "오늘 / 어제 / MM월 DD일" for a weekday label inside [weekStart]'s week.
+  ///
+  /// 요일만으로는 어느 주인지 알 수 없어 지난주 기록에도 '오늘'이 붙던 문제가
+  /// 있었다. 주의 월요일에서 실제 날짜를 되짚어 오늘과 견준다.
+  String _dateLabelForDayLabel(String dayLabel, String weekStart) {
     final dayIdx = _weekdayLabels.indexOf(dayLabel);
-    if (dayIdx < 0) return dayLabel;
-    final delta = todayIdx - dayIdx;
+    final monday = DateTime.tryParse(weekStart);
+    if (dayIdx < 0 || monday == null) return dayLabel;
+    final date = monday.add(Duration(days: dayIdx));
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final delta = today.difference(DateTime(date.year, date.month, date.day)).inDays;
     if (delta == 0) return '오늘';
     if (delta == 1) return '어제';
-    if (delta > 1 && delta <= 6) {
-      final date = now.subtract(Duration(days: delta));
-      return '${date.month}월 ${date.day}일';
-    }
-    return '$dayLabel요일';
+    return '${date.month}월 ${date.day}일';
   }
 
   String _defaultTimeLabel(String type) => switch (type) {
@@ -1013,7 +1026,7 @@ class LocalApiInterceptor extends Interceptor {
       'minutes': minutes,
       'calories': calories,
       'intensity': intensity,
-      'date_label': _dateLabelForDayLabel(dayLabel),
+      'date_label': _dateLabelForDayLabel(dayLabel, _mondayOfThisWeekString()),
       'time_label': _defaultTimeLabel(type),
       'items': _defaultItems(type),
     });

--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -819,14 +819,23 @@ class LocalApiInterceptor extends Interceptor {
   /// 넘길 때 그 주의 월요일을 실어 보낸다(#671) — 그 전에는 조회 경로가 이번
   /// 주 하나뿐이라 지난주를 받아올 방법이 없었다.
   Future<Response<Object?>> _exerciseCurrentWeek(RequestOptions options) async {
-    final Object? requested = options.queryParameters['week_start'];
-    final String? requestedWeek = requested is String && requested.isNotEmpty
-        ? requested
-        : null;
-    if (requestedWeek != null && !_isDateString(requestedWeek)) {
-      return _badRequest(options, 'week_start must be YYYY-MM-DD');
+    // 파라미터가 **있으면** 그 값을 그대로 검사한다. 빈 문자열도 "잘못된 값"이다
+    // — 서버(FastAPI)가 그렇게 답하므로 여기서 조용히 이번 주로 흘려보내면 두
+    //   구현이 갈린다.
+    final bool hasWeekStart = options.queryParameters.containsKey('week_start');
+    final String weekStart;
+    if (hasWeekStart) {
+      final Object? requested = options.queryParameters['week_start'];
+      final String raw = requested is String ? requested : '';
+      if (!_isDateString(raw)) {
+        return _unprocessable(options, 'week_start must be YYYY-MM-DD');
+      }
+      // 월요일이 아닌 날짜를 줘도 그 날이 속한 주로 맞춘다 — 서버의
+      // `monday_of_str` 과 같은 규칙(backend/API_CONTRACT.md).
+      weekStart = _mondayOfString(raw);
+    } else {
+      weekStart = _mondayOfThisWeekString();
     }
-    final weekStart = requestedWeek ?? _mondayOfThisWeekString();
     final rows = await (_db.select(
       _db.exerciseSessions,
     )..where((t) => t.weekStart.equals(weekStart))).get();
@@ -953,7 +962,8 @@ class LocalApiInterceptor extends Interceptor {
     final dayIdx = _weekdayLabels.indexOf(dayLabel);
     final monday = DateTime.tryParse(weekStart);
     if (dayIdx < 0 || monday == null) return dayLabel;
-    final date = monday.add(Duration(days: dayIdx));
+    // Duration 이 아니라 날짜 성분으로 더한다(서머타임 안전).
+    final date = DateTime(monday.year, monday.month, monday.day + dayIdx);
     final now = DateTime.now();
     final today = DateTime(now.year, now.month, now.day);
     final delta = today.difference(DateTime(date.year, date.month, date.day)).inDays;
@@ -1598,9 +1608,16 @@ class LocalApiInterceptor extends Interceptor {
     return '${d.inDays}일 전';
   }
 
-  String _mondayOfThisWeekString() {
-    final now = DateTime.now();
-    final monday = DateTime(now.year, now.month, now.day - (now.weekday - 1));
+  String _mondayOfThisWeekString() => _mondayOf(DateTime.now());
+
+  /// `YYYY-MM-DD` 가 속한 주의 월요일. FastAPI `monday_of_str` 과 같은 규칙이다.
+  /// 형식은 호출 전에 검사한다([_isDateString]).
+  String _mondayOfString(String date) => _mondayOf(DateTime.parse(date));
+
+  String _mondayOf(DateTime d) {
+    // 날짜 성분으로 뺀다 — Duration 으로 빼면 서머타임이 있는 지역에서 하루가
+    // 24시간이 아닌 날에 어긋난다.
+    final monday = DateTime(d.year, d.month, d.day - (d.weekday - 1));
     return '${monday.year.toString().padLeft(4, '0')}-'
         '${monday.month.toString().padLeft(2, '0')}-'
         '${monday.day.toString().padLeft(2, '0')}';
@@ -1635,6 +1652,16 @@ class LocalApiInterceptor extends Interceptor {
       requestOptions: options,
       statusCode: 400,
       data: <String, Object?>{'code': 'bad_request', 'message': message},
+    );
+  }
+
+  /// 형식이 잘못된 값. FastAPI 의 검증 실패와 같은 422 를 쓴다 — 두 구현이
+  /// 같은 요청에 다른 상태 코드를 주면 클라이언트가 갈린다.
+  Response<Object?> _unprocessable(RequestOptions options, String message) {
+    return Response<Object?>(
+      requestOptions: options,
+      statusCode: 422,
+      data: <String, Object?>{'code': 'unprocessable', 'message': message},
     );
   }
 

--- a/frontend/flutter/lib/core/storage/seed_data.dart
+++ b/frontend/flutter/lib/core/storage/seed_data.dart
@@ -14,9 +14,20 @@ import 'package:oncare/core/storage/app_database.dart';
 /// 키를 날짜마다 만들면 지난 날짜 키가 계속 쌓인다. 한 키를 통째로 덮어쓰면 그 문제가 없다.
 const String kDietDayMessagesKey = 'diet_day_messages';
 
+/// 큐레이션 사흘(오늘·어제·그제) **앞으로** 더 채우는 과거 일수.
+///
+/// 데모에서 날짜를 옮기면 대부분 "기록이 없어요"만 나오던 문제(#671)를 없앤다.
+/// 주간 스트립은 오늘 앞뒤 3일을 보여주고 주 단위로 뒤로 넘어갈 수 있으므로,
+/// 한 달치를 채워 두면 지난주로 넘겨도 기록이 이어진다.
+const int kDemoDietHistoryDays = 30;
+
+/// 현재 주 **앞으로** 시드하는 지난 주 수. 운동은 주 단위(`weekStart`)로
+/// 조회하므로 날짜가 아니라 주로 센다.
+const int kDemoExerciseHistoryWeeks = 4;
+
 /// Date-aware idempotent seeder. Runs at bootstrap.
 ///
-/// **Flag format (v4+).** `AppKeyValues['seeded_v14']` stores the
+/// **Flag format (v4+).** `AppKeyValues['seeded_v15']` stores the
 /// *date string* the seed last ran with (`YYYY-MM-DD`). Behaviour:
 ///
 /// - `null` (first ever boot, or upgrading from v1/v2) — wipe any
@@ -47,7 +58,7 @@ Future<void> seedIfEmpty(AppDatabase db) async {
   final twoDaysAgo = _fmtDate(now.subtract(const Duration(days: 2)));
   final weekStart = _fmtDate(_mondayOfThisWeek(now));
 
-  final seedDate = await db.readValue('seeded_v14');
+  final seedDate = await db.readValue('seeded_v15');
   if (seedDate == today) {
     // Already seeded for today — leave both seed rows and user rows
     // untouched.
@@ -86,6 +97,9 @@ Future<void> seedIfEmpty(AppDatabase db) async {
   // v14: 끼니별 AI 코멘트·사진이 행으로 내려오고 하루 코치 문구가 추가됐다.
   // 플래그를 올리지 않으면 오늘 이미 시드된 설치가 빈 코멘트를 그대로 들고 있게 된다.
   await db.deleteValue('seeded_v13');
+  // v15: 과거 한 달치 식단·지난 4주 운동이 추가됐다(#671). 올리지 않으면 오늘
+  // 이미 시드된 설치가 사흘치 그대로 남아 날짜를 옮겨도 여전히 비어 보인다.
+  await db.deleteValue('seeded_v14');
   // Also clear the curated KV advice so re-seed state is fully reset: this
   // version re-writes it below, but if a later seed drops or renames the key
   // an existing install would otherwise keep the stale text forever.
@@ -348,6 +362,9 @@ Future<void> seedIfEmpty(AppDatabase db) async {
           aiComment: const Value('연어의 지방과 현미밥의 복합 탄수화물 조합이 좋아요.'),
           photoAsset: const Value('assets/images/diet-salmon-brown-rice.jpeg'),
         ),
+        // 큐레이션 사흘 앞으로 한 달치를 더 채운다 — 날짜를 옮겨도 기록이
+        // 이어지도록(#671).
+        ..._historyDietEntries(now),
       ]);
     });
 
@@ -491,6 +508,8 @@ Future<void> seedIfEmpty(AppDatabase db) async {
           minutes: 20,
           calories: 60,
         ),
+        // 지난 주들 — 운동 탭에서 주를 뒤로 넘겨도 기록이 이어지도록(#671).
+        ..._historyExerciseSessions(now),
       ]);
     });
 
@@ -553,7 +572,6 @@ Future<void> seedIfEmpty(AppDatabase db) async {
     });
 
     // ---- Notifications ----
-    final now = DateTime.now();
     await db.batch((Batch b) {
       b.insertAll(db.notificationItems, <NotificationItemsCompanion>[
         NotificationItemsCompanion.insert(
@@ -599,7 +617,437 @@ Future<void> seedIfEmpty(AppDatabase db) async {
     }),
   );
 
-  await db.putValue('seeded_v14', today);
+  await db.putValue('seeded_v15', today);
+}
+
+// ─────────────────────────────────────────────── 과거 기록 (데모 히스토리) ──
+
+/// 한 가지 음식. 화면이 읽는 키(`sodium_mg` 등)와 같은 이름을 쓴다.
+class _SeedFood {
+  const _SeedFood(
+    this.name, {
+    required this.calories,
+    required this.sodiumMg,
+    required this.sugarG,
+    required this.carbsG,
+    required this.proteinG,
+    required this.fatG,
+  });
+
+  final String name;
+  final int calories;
+  final int sodiumMg;
+  final double sugarG;
+  final double carbsG;
+  final double proteinG;
+  final double fatG;
+
+  Map<String, Object?> toJson() => <String, Object?>{
+    'name': name,
+    'calories': calories,
+    'sodium_mg': sodiumMg,
+    'sugar_g': sugarG,
+    'carbs_g': carbsG,
+    'protein_g': proteinG,
+    'fat_g': fatG,
+  };
+}
+
+/// 한 끼니 템플릿. 날짜만 갈아 끼우면 그날의 기록이 된다.
+class _SeedMeal {
+  const _SeedMeal({
+    required this.slug,
+    required this.mealType,
+    required this.timeLabel,
+    required this.foods,
+    required this.aiComment,
+    this.photoAsset = '',
+  });
+
+  final String slug;
+  final String mealType;
+  final String timeLabel;
+  final List<_SeedFood> foods;
+  final String aiComment;
+  final String photoAsset;
+
+  int get totalCalories =>
+      foods.fold<int>(0, (int a, _SeedFood f) => a + f.calories);
+  int get totalSodium =>
+      foods.fold<int>(0, (int a, _SeedFood f) => a + f.sodiumMg);
+  double get totalSugar =>
+      foods.fold<double>(0, (double a, _SeedFood f) => a + f.sugarG);
+
+  DietEntriesCompanion companion(String date) => DietEntriesCompanion.insert(
+    id: 'seed-diet-$date-$slug',
+    date: date,
+    mealType: mealType,
+    timeLabel: timeLabel,
+    foodsJson: jsonEncode(<Map<String, Object?>>[
+      for (final _SeedFood f in foods) f.toJson(),
+    ]),
+    totalCalories: totalCalories,
+    sodiumMg: Value(totalSodium),
+    sugarG: Value(totalSugar),
+    aiComment: Value(aiComment),
+    photoAsset: Value(photoAsset),
+  );
+}
+
+const List<_SeedMeal> _historyBreakfasts = <_SeedMeal>[
+  _SeedMeal(
+    slug: 'breakfast',
+    mealType: 'breakfast',
+    timeLabel: '08:05',
+    photoAsset: 'assets/images/diet-oatmeal-banana.jpeg',
+    aiComment: '오트밀로 식이섬유를 챙긴 아침이에요.',
+    foods: <_SeedFood>[
+      _SeedFood(
+        '오트밀',
+        calories: 250,
+        sodiumMg: 100,
+        sugarG: 6,
+        carbsG: 42,
+        proteinG: 10,
+        fatG: 6,
+      ),
+      _SeedFood(
+        '바나나',
+        calories: 105,
+        sodiumMg: 1,
+        sugarG: 14,
+        carbsG: 27,
+        proteinG: 1.3,
+        fatG: 0.4,
+      ),
+    ],
+  ),
+  _SeedMeal(
+    slug: 'breakfast',
+    mealType: 'breakfast',
+    timeLabel: '08:30',
+    photoAsset: 'assets/images/diet-greek-yogurt-nuts.jpeg',
+    aiComment: '단백질과 불포화지방을 고르게 섭취했어요.',
+    foods: <_SeedFood>[
+      _SeedFood(
+        '그릭 요거트',
+        calories: 170,
+        sodiumMg: 75,
+        sugarG: 7,
+        carbsG: 8,
+        proteinG: 18,
+        fatG: 8,
+      ),
+      _SeedFood(
+        '견과류',
+        calories: 150,
+        sodiumMg: 5,
+        sugarG: 2,
+        carbsG: 6,
+        proteinG: 5,
+        fatG: 13,
+      ),
+    ],
+  ),
+  _SeedMeal(
+    slug: 'breakfast',
+    mealType: 'breakfast',
+    timeLabel: '07:50',
+    photoAsset: 'assets/images/breakfast-scrambled-egg-strawberry.jpg',
+    aiComment: '달걀 단백질에 과일로 비타민을 더했어요.',
+    foods: <_SeedFood>[
+      _SeedFood(
+        '스크램블 에그',
+        calories: 185,
+        sodiumMg: 220,
+        sugarG: 0.8,
+        carbsG: 2,
+        proteinG: 13,
+        fatG: 14,
+      ),
+      _SeedFood(
+        '딸기',
+        calories: 32,
+        sodiumMg: 1,
+        sugarG: 5.5,
+        carbsG: 8,
+        proteinG: 0.5,
+        fatG: 0.5,
+      ),
+    ],
+  ),
+];
+
+const List<_SeedMeal> _historyLunches = <_SeedMeal>[
+  _SeedMeal(
+    slug: 'lunch',
+    mealType: 'lunch',
+    timeLabel: '12:30',
+    photoAsset: 'assets/images/diet-chicken-salad.jpg',
+    aiComment: '닭가슴살과 채소로 단백질·식이섬유를 챙겼어요.',
+    foods: <_SeedFood>[
+      _SeedFood(
+        '닭가슴살 샐러드',
+        calories: 315,
+        sodiumMg: 395,
+        sugarG: 10,
+        carbsG: 19,
+        proteinG: 34,
+        fatG: 11.1,
+      ),
+    ],
+  ),
+  _SeedMeal(
+    slug: 'lunch',
+    mealType: 'lunch',
+    timeLabel: '12:20',
+    photoAsset: 'assets/images/diet-vegetable-bibimbap.jpg',
+    aiComment: '야채가 풍부해요. 고추장을 줄이면 나트륨이 더 좋아져요.',
+    foods: <_SeedFood>[
+      _SeedFood(
+        '야채비빔밥',
+        calories: 610,
+        sodiumMg: 900,
+        sugarG: 12,
+        carbsG: 92,
+        proteinG: 20,
+        fatG: 16,
+      ),
+    ],
+  ),
+  _SeedMeal(
+    slug: 'lunch',
+    mealType: 'lunch',
+    timeLabel: '12:50',
+    photoAsset: 'assets/images/lunch-jjamppong.jpg',
+    aiComment: '국물 나트륨이 높은 날이에요. 국물은 남기는 편이 좋아요.',
+    foods: <_SeedFood>[
+      _SeedFood(
+        '짬뽕',
+        calories: 750,
+        sodiumMg: 3200,
+        sugarG: 8.5,
+        carbsG: 107,
+        proteinG: 29,
+        fatG: 22.5,
+      ),
+    ],
+  ),
+  _SeedMeal(
+    slug: 'lunch',
+    mealType: 'lunch',
+    timeLabel: '12:10',
+    photoAsset: 'assets/images/diet-doenjang-rice.jpeg',
+    aiComment: '집밥 한 상이에요. 찌개 국물만 조금 남겨 보세요.',
+    foods: <_SeedFood>[
+      _SeedFood(
+        '된장찌개',
+        calories: 300,
+        sodiumMg: 1300,
+        sugarG: 5,
+        carbsG: 18,
+        proteinG: 24,
+        fatG: 15,
+      ),
+      _SeedFood(
+        '밥',
+        calories: 310,
+        sodiumMg: 5,
+        sugarG: 0.7,
+        carbsG: 67,
+        proteinG: 6,
+        fatG: 2.5,
+      ),
+    ],
+  ),
+];
+
+const List<_SeedMeal> _historyDinners = <_SeedMeal>[
+  _SeedMeal(
+    slug: 'dinner',
+    mealType: 'dinner',
+    timeLabel: '18:40',
+    photoAsset: 'assets/images/diet-salmon-brown-rice.jpeg',
+    aiComment: '연어의 지방과 현미밥의 복합 탄수화물 조합이 좋아요.',
+    foods: <_SeedFood>[
+      _SeedFood(
+        '연어구이',
+        calories: 395,
+        sodiumMg: 505,
+        sugarG: 9,
+        carbsG: 19,
+        proteinG: 35,
+        fatG: 19,
+      ),
+      _SeedFood(
+        '현미밥',
+        calories: 280,
+        sodiumMg: 5,
+        sugarG: 0,
+        carbsG: 58,
+        proteinG: 6,
+        fatG: 2,
+      ),
+    ],
+  ),
+  _SeedMeal(
+    slug: 'dinner',
+    mealType: 'dinner',
+    timeLabel: '19:10',
+    photoAsset: 'assets/images/diet-doenjang-rice.jpeg',
+    aiComment: '포만감은 좋지만 국물 나트륨이 높은 편이에요.',
+    foods: <_SeedFood>[
+      _SeedFood(
+        '된장찌개',
+        calories: 300,
+        sodiumMg: 1300,
+        sugarG: 5,
+        carbsG: 18,
+        proteinG: 24,
+        fatG: 15,
+      ),
+      _SeedFood(
+        '밥',
+        calories: 310,
+        sodiumMg: 5,
+        sugarG: 0.7,
+        carbsG: 67,
+        proteinG: 6,
+        fatG: 2.5,
+      ),
+    ],
+  ),
+  _SeedMeal(
+    slug: 'dinner',
+    mealType: 'dinner',
+    timeLabel: '18:20',
+    photoAsset: 'assets/images/diet-chicken-salad.jpg',
+    aiComment: '가볍게 마무리한 저녁이에요.',
+    foods: <_SeedFood>[
+      _SeedFood(
+        '닭가슴살 샐러드',
+        calories: 315,
+        sodiumMg: 395,
+        sugarG: 10,
+        carbsG: 19,
+        proteinG: 34,
+        fatG: 11.1,
+      ),
+      _SeedFood(
+        '고구마',
+        calories: 130,
+        sodiumMg: 20,
+        sugarG: 6.5,
+        carbsG: 30,
+        proteinG: 2,
+        fatG: 0.2,
+      ),
+    ],
+  ),
+];
+
+const _SeedMeal _historySnack = _SeedMeal(
+  slug: 'snack',
+  mealType: 'snack',
+  timeLabel: '15:40',
+  photoAsset: 'assets/images/snack-coffee-nuts.jpg',
+  aiComment: '당류가 낮고 건강한 지방을 채운 간식이에요.',
+  foods: <_SeedFood>[
+    _SeedFood(
+      '아이스 아메리카노',
+      calories: 10,
+      sodiumMg: 5,
+      sugarG: 0,
+      carbsG: 2,
+      proteinG: 0.5,
+      fatG: 0,
+    ),
+    _SeedFood(
+      '견과류 한 봉',
+      calories: 90,
+      sodiumMg: 2,
+      sugarG: 3,
+      carbsG: 1,
+      proteinG: 2,
+      fatG: 8,
+    ),
+  ],
+);
+
+/// 큐레이션 사흘 앞의 과거 식단. `offset` 은 오늘로부터의 일수(3 부터).
+///
+/// 날짜마다 조합을 돌려 값이 달라지게 한다 — 모든 날이 같으면 주간·월간 추이가
+/// 직선이 되어 기간 뷰가 아무것도 말해 주지 않는다. 7일마다 한 번은 저녁을
+/// 비우고(늦은 저녁 미기록), 11일마다 한 번은 하루를 통째로 비운다 — "기록이
+/// 없는 날"도 데모에 남아 있어야 그 빈 화면이 맞게 동작하는지 볼 수 있다.
+List<DietEntriesCompanion> _historyDietEntries(DateTime now) {
+  final entries = <DietEntriesCompanion>[];
+  for (int offset = 3; offset < 3 + kDemoDietHistoryDays; offset++) {
+    if (offset % 11 == 0) continue;
+    final String date = _fmtDate(now.subtract(Duration(days: offset)));
+    entries.add(
+      _historyBreakfasts[offset % _historyBreakfasts.length].companion(date),
+    );
+    entries.add(
+      _historyLunches[offset % _historyLunches.length].companion(date),
+    );
+    if (offset % 7 != 6) {
+      entries.add(
+        _historyDinners[offset % _historyDinners.length].companion(date),
+      );
+    }
+    if (offset % 3 == 0) entries.add(_historySnack.companion(date));
+  }
+  return entries;
+}
+
+/// 한 주의 운동 세션 한 벌. `minutes` 는 요일별 유산소·근력·스트레칭 분이다.
+const List<(String day, int cardio, int strength, int stretching)>
+_historyWeekPattern =
+    <(String, int, int, int)>[
+      ('월', 30, 10, 5),
+      ('화', 40, 0, 10),
+      ('수', 0, 0, 0),
+      ('목', 35, 20, 5),
+      ('금', 45, 0, 10),
+      ('토', 25, 30, 15),
+      ('일', 20, 0, 10),
+    ];
+
+/// 지난 주들의 운동 세션. 주마다 강도를 조금씩 달리해(`scale`) 주간 비교가
+/// 의미를 갖게 한다. 이번 주는 큐레이션 값을 쓰므로 `weeksAgo` 는 1 부터다.
+List<ExerciseSessionsCompanion> _historyExerciseSessions(DateTime now) {
+  final sessions = <ExerciseSessionsCompanion>[];
+  final DateTime thisMonday = _mondayOfThisWeek(now);
+  for (int weeksAgo = 1; weeksAgo <= kDemoExerciseHistoryWeeks; weeksAgo++) {
+    final String weekStart = _fmtDate(
+      thisMonday.subtract(Duration(days: 7 * weeksAgo)),
+    );
+    // 오래된 주일수록 조금 적게 — 데모에서 "요즘 늘고 있다"로 읽힌다.
+    final double scale = 1 - (weeksAgo * 0.12);
+    for (final (String day, int cardio, int strength, int stretching)
+        in _historyWeekPattern) {
+      void add(String type, int minutes, int caloriesPerMin) {
+        final int scaled = (minutes * scale).round();
+        if (scaled <= 0) return;
+        sessions.add(
+          ExerciseSessionsCompanion.insert(
+            id: 'seed-ex-$weekStart-$day-$type',
+            weekStart: weekStart,
+            dayLabel: day,
+            type: type,
+            minutes: scaled,
+            calories: scaled * caloriesPerMin,
+          ),
+        );
+      }
+
+      add('cardio', cardio, 7);
+      add('strength', strength, 5);
+      add('stretching', stretching, 3);
+    }
+  }
+  return sessions;
 }
 
 String _fmtDate(DateTime d) =>

--- a/frontend/flutter/lib/features/exercise/data/repositories/dio_exercise_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/dio_exercise_repository.dart
@@ -16,6 +16,20 @@ class DioExerciseRepository implements ExerciseRepository {
   }
 
   @override
+  Future<ExerciseWeek> fetchWeek(DateTime weekStart) async {
+    final res = await _dio.get<Map<String, Object?>>(
+      '/exercise/weeks/current',
+      queryParameters: <String, Object?>{'week_start': _dateString(weekStart)},
+    );
+    return ExerciseWeek.fromJson(res.data!);
+  }
+
+  static String _dateString(DateTime d) =>
+      '${d.year.toString().padLeft(4, '0')}-'
+      '${d.month.toString().padLeft(2, '0')}-'
+      '${d.day.toString().padLeft(2, '0')}';
+
+  @override
   Future<ExerciseSession> addSession({
     required ExerciseType type,
     required int minutes,

--- a/frontend/flutter/lib/features/exercise/data/repositories/mock_exercise_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/mock_exercise_repository.dart
@@ -173,7 +173,12 @@ class MockExerciseRepository implements ExerciseRepository {
     final DateTime monday = _today.subtract(
       Duration(days: _todayIdx + 7 * weeksAgo),
     );
-    final DateTime date = monday.add(Duration(days: dayIdx));
+    // Duration 이 아니라 날짜 성분으로 더한다(서머타임 안전).
+    final DateTime date = DateTime(
+      monday.year,
+      monday.month,
+      monday.day + dayIdx,
+    );
     return '${date.month}월 ${date.day}일';
   }
 

--- a/frontend/flutter/lib/features/exercise/data/repositories/mock_exercise_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/mock_exercise_repository.dart
@@ -16,7 +16,8 @@ class MockExerciseRepository implements ExerciseRepository {
   /// [today] defaults to the real date; tests inject a fixed date so the
   /// date-relative seed stays deterministic.
   MockExerciseRepository({DateTime? today})
-    : _todayIdx = (today ?? DateTime.now()).weekday - 1 {
+    : _today = _dateOnly(today ?? DateTime.now()),
+      _todayIdx = (today ?? DateTime.now()).weekday - 1 {
     _sessions.addAll(_seed(_todayIdx));
     _totalCalories = _sessions.fold<int>(
       0,
@@ -26,6 +27,11 @@ class MockExerciseRepository implements ExerciseRepository {
 
   /// Today's weekday index (0 = Mon … 6 = Sun).
   final int _todayIdx;
+
+  /// 자정으로 자른 오늘. 지난 주 조회가 몇 주 전인지 세는 기준이다.
+  final DateTime _today;
+
+  static DateTime _dateOnly(DateTime d) => DateTime(d.year, d.month, d.day);
 
   static const List<String> _dayLabels = <String>[
     '월',
@@ -103,6 +109,75 @@ class MockExerciseRepository implements ExerciseRepository {
   }
 
   @override
+  Future<ExerciseWeek> fetchWeek(DateTime weekStart) async {
+    await Future<void>.delayed(const Duration(milliseconds: 150));
+    final int weeksAgo = _weeksAgo(weekStart);
+    // 이번 주(또는 미래)는 CRUD 가 반영된 살아 있는 주다.
+    if (weeksAgo <= 0) return _buildWeek();
+    return _pastWeek(weeksAgo);
+  }
+
+  /// [weekStart] 가 이번 주에서 몇 주 전인지. 이번 주면 0.
+  int _weeksAgo(DateTime weekStart) {
+    final DateTime thisMonday = _today.subtract(Duration(days: _todayIdx));
+    final int days = thisMonday.difference(_dateOnly(weekStart)).inDays;
+    return days <= 0 ? 0 : (days / 7).round();
+  }
+
+  /// 지난 주의 기록. 주마다 조금씩 다른 값이라야 주간 비교가 뜻을 갖는다 —
+  /// 오래된 주일수록 조금 적게(요즘 늘고 있다), 그리고 주마다 쉬는 날이 하루씩
+  /// 밀린다. 인메모리 CRUD 는 이번 주에만 적용되므로 여기서는 파생값만 만든다.
+  ExerciseWeek _pastWeek(int weeksAgo) {
+    const List<(ExerciseType, int, int)> dayPlan = <(ExerciseType, int, int)>[
+      (ExerciseType.cardio, 35, 260),
+      (ExerciseType.strength, 15, 105),
+      (ExerciseType.stretching, 10, 40),
+    ];
+    final double scale = (1 - weeksAgo * 0.1).clamp(0.4, 1.0);
+    final int restDay = weeksAgo % 7; // 주마다 쉬는 요일이 하나씩 밀린다.
+    final List<ExerciseSession> sessions = <ExerciseSession>[];
+    for (int i = 0; i < _dayLabels.length; i++) {
+      if (i == restDay) continue;
+      int k = 0;
+      for (final (ExerciseType type, int min, int kcal) in dayPlan) {
+        // 요일마다 종목 구성이 조금씩 달라지도록 한 종목씩 건너뛴다.
+        if ((i + k) % 3 == 2) {
+          k++;
+          continue;
+        }
+        final int minutes = (min * scale).round();
+        if (minutes <= 0) {
+          k++;
+          continue;
+        }
+        sessions.add(
+          ExerciseSession(
+            id: 'past-$weeksAgo-$i-${k++}',
+            dayLabel: _dayLabels[i],
+            dateLabel: _dateLabel(weeksAgo, i),
+            type: type,
+            minutes: minutes,
+            calories: (kcal * scale).round(),
+          ),
+        );
+      }
+    }
+    return _weekFrom(
+      sessions,
+      aiCoachMessage: '지난 기록이에요. 이번 주와 견줘 보면 흐름이 보여요.',
+    );
+  }
+
+  /// 지난 주 어느 요일의 "M월 D일" 라벨.
+  String _dateLabel(int weeksAgo, int dayIdx) {
+    final DateTime monday = _today.subtract(
+      Duration(days: _todayIdx + 7 * weeksAgo),
+    );
+    final DateTime date = monday.add(Duration(days: dayIdx));
+    return '${date.month}월 ${date.day}일';
+  }
+
+  @override
   Future<ExerciseSession> addSession({
     required ExerciseType type,
     required int minutes,
@@ -169,7 +244,21 @@ class MockExerciseRepository implements ExerciseRepository {
   /// 요일별 시간·칼로리·유형별 시간·총분·연속일을 [_sessions]에서 계산한다.
   /// daily/dailyCal 은 그 날 모든 세션의 합이고, 유형별 버킷 합도 같은 세션에서
   /// 나오므로 `daily[i] == cardio[i] + strength[i] + stretching[i]` 가 성립한다.
-  ExerciseWeek _buildWeek() {
+  ExerciseWeek _buildWeek() => _weekFrom(
+    _sessions,
+    // 이번 주 총 칼로리만 CRUD 델타로 따로 유지된다(세션 합과 어긋날 수 있는
+    // 시드 헤드라인이라 그대로 넘긴다).
+    totalCalories: _totalCalories,
+    aiCoachMessage: _aiCoachMessage,
+  );
+
+  /// [sessions] 에서 한 주의 파생값을 만든다. 이번 주와 지난 주가 같은 규칙을
+  /// 쓰므로 두 화면의 수치 정의가 어긋나지 않는다.
+  ExerciseWeek _weekFrom(
+    List<ExerciseSession> sessions, {
+    int? totalCalories,
+    required String aiCoachMessage,
+  }) {
     final int n = _dayLabels.length;
     final List<double> daily = List<double>.filled(n, 0);
     final List<double> dailyCal = List<double>.filled(n, 0);
@@ -178,7 +267,7 @@ class MockExerciseRepository implements ExerciseRepository {
     final List<double> stretching = List<double>.filled(n, 0);
     int totalMinutes = 0;
 
-    for (final ExerciseSession s in _sessions) {
+    for (final ExerciseSession s in sessions) {
       final int i = _dayLabels.indexOf(s.dayLabel);
       if (i >= 0) {
         daily[i] += s.minutes;
@@ -196,10 +285,12 @@ class MockExerciseRepository implements ExerciseRepository {
       stretchingMinutes: stretching,
       dayLabels: List<String>.of(_dayLabels),
       totalMinutes: totalMinutes,
-      totalCalories: _totalCalories,
+      totalCalories:
+          totalCalories ??
+          sessions.fold<int>(0, (int a, ExerciseSession s) => a + s.calories),
       streakDays: longestActiveStreak(daily),
-      aiCoachMessage: _aiCoachMessage,
-      sessions: List<ExerciseSession>.of(_sessions),
+      aiCoachMessage: aiCoachMessage,
+      sessions: List<ExerciseSession>.of(sessions),
     );
   }
 

--- a/frontend/flutter/lib/features/exercise/domain/repositories/exercise_repository.dart
+++ b/frontend/flutter/lib/features/exercise/domain/repositories/exercise_repository.dart
@@ -3,6 +3,12 @@ import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
 abstract class ExerciseRepository {
   Future<ExerciseWeek> fetchThisWeek();
 
+  /// 한 주의 기록. [weekStart] 는 그 주의 **월요일**이다.
+  ///
+  /// 조회가 이번 주 하나뿐이라 운동 탭에서 지난 날짜를 골라도 보여줄 것이
+  /// 없었다(#671). 이번 주를 넘겨 부르면 [fetchThisWeek] 과 같은 결과다.
+  Future<ExerciseWeek> fetchWeek(DateTime weekStart);
+
   /// Persist a new workout session (POST /exercise/sessions) and return
   /// the created session as the server materialised it.
   Future<ExerciseSession> addSession({

--- a/frontend/flutter/lib/features/exercise/presentation/controllers/exercise_controller.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/controllers/exercise_controller.dart
@@ -35,6 +35,22 @@ final exerciseWeekProvider = FutureProvider<ExerciseWeek>((ref) {
   return ref.watch(exerciseRepositoryProvider).fetchThisWeek();
 }, name: 'exerciseWeek');
 
+/// 그 주의 월요일. 주 단위 조회의 키다.
+DateTime mondayOfWeek(DateTime date) {
+  final DateTime d = DateTime(date.year, date.month, date.day);
+  return d.subtract(Duration(days: d.weekday - 1));
+}
+
+/// 지난 주 운동 기록. 이번 주는 [exerciseWeekViewProvider] 가 담당하므로 여기서
+/// 다루지 않는다 — 오늘 체크한 AI 추천 운동이 더해진 값과 두 벌이 되면 같은 주가
+/// 화면마다 다른 수치를 갖게 된다(#671).
+final exercisePastWeekProvider = FutureProvider.family<ExerciseWeek, DateTime>((
+  ref,
+  DateTime weekStart,
+) {
+  return ref.watch(exerciseRepositoryProvider).fetchWeek(weekStart);
+}, name: 'exercisePastWeek');
+
 /// Today's activity delta for one AI recommendation. Shared so the exercise
 /// tab's check and the home "주간 추이" chart read the same numbers.
 class AiRoutineDelta {

--- a/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
@@ -247,7 +247,10 @@ class _RecordTabState extends ConsumerState<_RecordTab> {
           ),
           const SizedBox(height: 8),
           if (!atToday)
-            const _ExerciseOtherDay()
+            // 고른 날짜가 이번 주면 이미 받아 둔 주간 데이터에서, 지난 주면 그
+            // 주를 따로 받아 그날의 기록을 그린다. 예전에는 데이터를 보지도 않고
+            // "기록이 없어요"만 그려, 시드가 있는 날조차 비어 보였다(#671).
+            _ExerciseSelectedDay(thisWeek: week, date: _selected)
           else ...<Widget>[
             // 1) 이번 주 운동 요약
             Padding(
@@ -476,10 +479,208 @@ class _Arrow extends StatelessWidget {
   }
 }
 
-/// Shown when a non-today date is selected in the 운동 주간 달력 — mirrors the
-/// 식단 탭's empty state (same copy, 식단→운동).
-class _ExerciseOtherDay extends StatelessWidget {
-  const _ExerciseOtherDay();
+/// 운동 주간 달력에서 오늘이 아닌 날짜를 골랐을 때 그 날의 기록.
+///
+/// 고른 날짜가 이번 주면 이미 받아 둔 [thisWeek] 에서 그대로 읽고(추가 요청
+/// 없음), 지난 주면 그 주를 따로 받는다. 정말 기록이 없는 날에만 빈 문구를
+/// 남긴다.
+class _ExerciseSelectedDay extends ConsumerWidget {
+  const _ExerciseSelectedDay({required this.thisWeek, required this.date});
+
+  final ExerciseWeek thisWeek;
+  final DateTime date;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final DateTime weekStart = mondayOfWeek(date);
+    final DateTime thisMonday = mondayOfWeek(DateTime.now());
+    if (weekStart == thisMonday) {
+      return _ExerciseDayDetail(week: thisWeek, date: date);
+    }
+    return ref
+        .watch(exercisePastWeekProvider(weekStart))
+        .when(
+          loading: () => const Padding(
+            padding: EdgeInsets.symmetric(vertical: 48),
+            child: Center(
+              child: SizedBox(
+                width: 24,
+                height: 24,
+                child: CircularProgressIndicator(strokeWidth: 3),
+              ),
+            ),
+          ),
+          error: (Object e, StackTrace _) => const _ExerciseDayEmpty(),
+          data: (ExerciseWeek week) =>
+              _ExerciseDayDetail(week: week, date: date),
+        );
+  }
+}
+
+/// 하루치 운동 요약 — 시간·소모 칼로리·유형별 시간과 그날의 세션 목록.
+class _ExerciseDayDetail extends StatelessWidget {
+  const _ExerciseDayDetail({required this.week, required this.date});
+
+  final ExerciseWeek week;
+  final DateTime date;
+
+  double _at(List<double> series, int i) =>
+      i >= 0 && i < series.length ? series[i] : 0;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations l = AppLocalizations.of(context);
+    final int i = date.weekday - 1; // 0 = 월
+    final double minutes = _at(week.dailyMinutes, i);
+    if (minutes <= 0) return const _ExerciseDayEmpty();
+
+    final double calories = _at(week.dailyCalories, i);
+    final String dayLabel = i < week.dayLabels.length ? week.dayLabels[i] : '';
+    final List<ExerciseSession> sessions = week.sessions
+        .where((ExerciseSession s) => s.dayLabel == dayLabel)
+        .toList();
+    final List<(String, double)> breakdown = <(String, double)>[
+      (l.exTypeCardio, _at(week.cardioMinutes, i)),
+      (l.exTypeStrength, _at(week.strengthMinutes, i)),
+      (l.exTypeStretching, _at(week.stretchingMinutes, i)),
+    ].where(((String, double) e) => e.$2 > 0).toList();
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            '${date.month}월 ${date.day}일 ${l.pageExerciseTitle}',
+            style: const TextStyle(
+              fontSize: 15,
+              fontWeight: FontWeight.w700,
+              color: FigmaColors.ink,
+            ),
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: <Widget>[
+              Expanded(
+                child: _StatCard(
+                  label: l.exStatTime,
+                  value: '${minutes.round()}',
+                  unit: l.unitMinutes,
+                  accent: true,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: _StatCard(
+                  label: l.exStatCalories,
+                  value: NumberFormat('#,###').format(calories.round()),
+                  unit: l.unitKcal,
+                  accent: true,
+                ),
+              ),
+            ],
+          ),
+          if (breakdown.isNotEmpty) ...<Widget>[
+            const SizedBox(height: 14),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(14),
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(16),
+                boxShadow: kCardShadow,
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  for (final (String label, double m) in breakdown)
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 4),
+                      child: Row(
+                        children: <Widget>[
+                          Text(
+                            label,
+                            style: const TextStyle(
+                              fontSize: 13,
+                              fontWeight: FontWeight.w600,
+                              color: AppColors.foreground,
+                            ),
+                          ),
+                          const Spacer(),
+                          Text(
+                            '${m.round()}${l.unitMinutes}',
+                            style: const TextStyle(
+                              fontSize: 13.5,
+                              fontWeight: FontWeight.w800,
+                              color: FigmaColors.primary,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ],
+          if (sessions.isNotEmpty) ...<Widget>[
+            const SizedBox(height: 14),
+            for (final ExerciseSession s in sessions)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 14,
+                    vertical: 12,
+                  ),
+                  decoration: BoxDecoration(
+                    color: FigmaColors.softBlue,
+                    borderRadius: BorderRadius.circular(14),
+                  ),
+                  child: Row(
+                    children: <Widget>[
+                      Expanded(
+                        child: Text(
+                          _exerciseTypeLabel(l, s.type),
+                          style: const TextStyle(
+                            fontSize: 13.5,
+                            fontWeight: FontWeight.w700,
+                            color: FigmaColors.ink,
+                          ),
+                        ),
+                      ),
+                      Text(
+                        '${s.minutes}${l.unitMinutes} · '
+                        '${NumberFormat('#,###').format(s.calories)} ${l.unitKcal}',
+                        style: const TextStyle(
+                          fontSize: 12.5,
+                          fontWeight: FontWeight.w600,
+                          color: AppColors.mutedForeground,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+/// 운동 유형 → 화면 라벨. 유형별 분해 카드와 같은 문구를 쓴다.
+String _exerciseTypeLabel(AppLocalizations l, ExerciseType type) =>
+    switch (type) {
+      ExerciseType.cardio || ExerciseType.walking => l.exTypeCardio,
+      ExerciseType.strength => l.exTypeStrength,
+      ExerciseType.stretching || ExerciseType.yoga => l.exTypeStretching,
+      ExerciseType.other => l.exTypeCardio,
+    };
+
+/// 정말로 기록이 없는 날 — 식단 탭과 같은 문구를 공유하고 섹션 이름만 바꿔 낀다.
+class _ExerciseDayEmpty extends StatelessWidget {
+  const _ExerciseDayEmpty();
 
   @override
   Widget build(BuildContext context) {
@@ -488,7 +689,6 @@ class _ExerciseOtherDay extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 48),
       child: Center(
         child: Text(
-          // 식단 탭과 같은 문구를 공유하고 섹션 이름만 바꿔 끼운다.
           l.otherDateEmpty(l.pageExerciseTitle),
           textAlign: TextAlign.center,
           style: const TextStyle(

--- a/frontend/flutter/test/core/network/local_api_interceptor_exercise_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_exercise_test.dart
@@ -275,12 +275,64 @@ void main() {
     );
   });
 
-  test('week_start 형식이 깨지면 400 이다', () async {
+  test('week_start 로 월요일이 아닌 날을 줘도 그 주로 맞춘다 (#671)', () async {
+    // 서버(FastAPI)가 monday_of_str 로 맞추므로 목업도 같아야 한다.
+    final DateTime lastMonday = DateTime.parse(
+      _currentMonday(),
+    ).subtract(const Duration(days: 7));
+    String fmt(DateTime d) =>
+        '${d.year.toString().padLeft(4, '0')}-'
+        '${d.month.toString().padLeft(2, '0')}-'
+        '${d.day.toString().padLeft(2, '0')}';
+    final String lastWeek = fmt(lastMonday);
+    await db
+        .into(db.exerciseSessions)
+        .insert(
+          ExerciseSessionsCompanion.insert(
+            id: 'ex-last-wed',
+            weekStart: lastWeek,
+            dayLabel: '수',
+            type: 'cardio',
+            minutes: 35,
+            calories: 240,
+          ),
+        );
+
+    // 그 주의 목요일을 넘긴다.
+    final res = await dio.get<Map<String, Object?>>(
+      '/exercise/weeks/current',
+      queryParameters: <String, Object?>{
+        'week_start': fmt(lastMonday.add(const Duration(days: 3))),
+      },
+    );
+    expect(res.data!['total_minutes'], 35);
+  });
+
+  test('week_start 형식이 깨지면 422 다 (서버와 같은 코드)', () async {
     final res = await dio.get<Map<String, Object?>>(
       '/exercise/weeks/current',
       queryParameters: <String, Object?>{'week_start': 'not-a-date'},
       options: Options(validateStatus: (int? s) => true),
     );
-    expect(res.statusCode, 400);
+    expect(res.statusCode, 422);
+  });
+
+  test('week_start 가 빈 문자열이어도 조용히 이번 주로 넘어가지 않는다', () async {
+    // FastAPI 는 빈 값에 422 를 준다. 목업이 이번 주를 돌려주면 두 구현이 갈린다.
+    final res = await dio.get<Map<String, Object?>>(
+      '/exercise/weeks/current',
+      queryParameters: <String, Object?>{'week_start': ''},
+      options: Options(validateStatus: (int? s) => true),
+    );
+    expect(res.statusCode, 422);
+  });
+
+  test('ISO 기본 형식(20260810)은 받지 않는다', () async {
+    final res = await dio.get<Map<String, Object?>>(
+      '/exercise/weeks/current',
+      queryParameters: <String, Object?>{'week_start': '20260810'},
+      options: Options(validateStatus: (int? s) => true),
+    );
+    expect(res.statusCode, 422);
   });
 }

--- a/frontend/flutter/test/core/network/local_api_interceptor_exercise_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_exercise_test.dart
@@ -204,4 +204,83 @@ void main() {
     );
     expect(res.statusCode, 400);
   });
+
+  test('week_start 로 지난 주를 조회한다 (#671)', () async {
+    // 지난 주 월요일에 세션 하나. 이번 주 시드와 섞이면 안 된다.
+    final DateTime lastMonday = DateTime.parse(
+      _currentMonday(),
+    ).subtract(const Duration(days: 7));
+    final String lastWeek =
+        '${lastMonday.year.toString().padLeft(4, '0')}-'
+        '${lastMonday.month.toString().padLeft(2, '0')}-'
+        '${lastMonday.day.toString().padLeft(2, '0')}';
+    await db
+        .into(db.exerciseSessions)
+        .insert(
+          ExerciseSessionsCompanion.insert(
+            id: 'ex-last-mon',
+            weekStart: lastWeek,
+            dayLabel: '월',
+            type: 'cardio',
+            minutes: 20,
+            calories: 140,
+          ),
+        );
+
+    final res = await dio.get<Map<String, Object?>>(
+      '/exercise/weeks/current',
+      queryParameters: <String, Object?>{'week_start': lastWeek},
+    );
+    expect(res.data!['total_minutes'], 20);
+    expect((res.data!['sessions']! as List<Object?>).length, 1);
+
+    // 파라미터가 없으면 예전 그대로 이번 주다.
+    final current = await dio.get<Map<String, Object?>>(
+      '/exercise/weeks/current',
+    );
+    expect(current.data!['total_minutes'], isNot(20));
+  });
+
+  test('지난 주 세션의 date_label 은 오늘/어제로 잘못 붙지 않는다 (#671)', () async {
+    final DateTime lastMonday = DateTime.parse(
+      _currentMonday(),
+    ).subtract(const Duration(days: 7));
+    final String lastWeek =
+        '${lastMonday.year.toString().padLeft(4, '0')}-'
+        '${lastMonday.month.toString().padLeft(2, '0')}-'
+        '${lastMonday.day.toString().padLeft(2, '0')}';
+    await db
+        .into(db.exerciseSessions)
+        .insert(
+          ExerciseSessionsCompanion.insert(
+            id: 'ex-last-tue',
+            weekStart: lastWeek,
+            dayLabel: '화',
+            type: 'cardio',
+            minutes: 30,
+            calories: 200,
+          ),
+        );
+
+    final res = await dio.get<Map<String, Object?>>(
+      '/exercise/weeks/current',
+      queryParameters: <String, Object?>{'week_start': lastWeek},
+    );
+    final sessions = (res.data!['sessions']! as List<Object?>)
+        .cast<Map<String, Object?>>();
+    final DateTime lastTuesday = lastMonday.add(const Duration(days: 1));
+    expect(
+      sessions.single['date_label'],
+      '${lastTuesday.month}월 ${lastTuesday.day}일',
+    );
+  });
+
+  test('week_start 형식이 깨지면 400 이다', () async {
+    final res = await dio.get<Map<String, Object?>>(
+      '/exercise/weeks/current',
+      queryParameters: <String, Object?>{'week_start': 'not-a-date'},
+      options: Options(validateStatus: (int? s) => true),
+    );
+    expect(res.statusCode, 400);
+  });
 }

--- a/frontend/flutter/test/core/storage/seed_data_test.dart
+++ b/frontend/flutter/test/core/storage/seed_data_test.dart
@@ -45,7 +45,15 @@ void main() {
       expect(diet.where((r) => r.date == today).length, 3);
       expect(diet.where((r) => r.date == _daysAgoString(1)).length, 3);
       expect(diet.where((r) => r.date == _daysAgoString(2)).length, 3);
-      expect(diet.where((r) => r.date == _daysAgoString(3)), isEmpty);
+      // 큐레이션 사흘 앞으로도 기록이 이어진다 — 날짜를 옮기면 대부분
+      // 비어 있던 데모 문제(#671).
+      expect(diet.where((r) => r.date == _daysAgoString(3)), isNotEmpty);
+      expect(diet.where((r) => r.date == _daysAgoString(30)), isNotEmpty);
+      expect(
+        diet.where((r) => r.date == _daysAgoString(kDemoDietHistoryDays + 5)),
+        isEmpty,
+        reason: '히스토리는 한 달치까지만 채운다',
+      );
       final salmonDinner = diet.firstWhere(
         (row) => row.id == 'seed-diet-two-days-ago-dinner',
       );
@@ -75,7 +83,21 @@ void main() {
             .toSet(),
         <String>{'breakfast', 'lunch', 'snack'},
       );
-      expect(diet.where((row) => row.mealType == 'snack').length, 1);
+      // 큐레이션 사흘 중 간식은 오늘 하루뿐이다(과거 히스토리는 별도).
+      expect(
+        diet
+            .where(
+              (row) =>
+                  row.mealType == 'snack' &&
+                  <String>[
+                    today,
+                    _daysAgoString(1),
+                    _daysAgoString(2),
+                  ].contains(row.date),
+            )
+            .length,
+        1,
+      );
       // Schedule seeds a couple of events on today (for the dashboard's
       // "오늘의 일정") plus a few spread across the current month (for the
       // calendar). All stay within the current month so the date-slide
@@ -98,7 +120,65 @@ void main() {
         reason: 'exercise sessions for the current week must be seeded',
       );
 
-      expect(await db.readValue('seeded_v14'), today);
+      expect(await db.readValue('seeded_v15'), today);
+    });
+
+    test('과거 식단은 날짜마다 값이 달라 추이가 직선이 되지 않는다', () async {
+      await seedIfEmpty(db);
+      final diet = await db.select(db.dietEntries).get();
+
+      final Map<String, int> caloriesByDate = <String, int>{};
+      for (int offset = 3; offset < 3 + kDemoDietHistoryDays; offset++) {
+        final String date = _daysAgoString(offset);
+        final int kcal = diet
+            .where((r) => r.date == date)
+            .fold<int>(0, (int sum, r) => sum + r.totalCalories);
+        if (kcal > 0) caloriesByDate[date] = kcal;
+      }
+
+      expect(caloriesByDate.length, greaterThan(20));
+      expect(
+        caloriesByDate.values.toSet().length,
+        greaterThan(3),
+        reason: '모든 날이 같은 칼로리면 주간·월간 추이가 직선이 된다',
+      );
+      // 기록이 통째로 없는 날도 남겨 둔다 — 빈 화면이 맞게 동작하는지 데모에서
+      // 볼 수 있어야 한다.
+      expect(
+        caloriesByDate.length,
+        lessThan(kDemoDietHistoryDays),
+        reason: '기록 없는 날이 최소 하나는 남아야 한다',
+      );
+    });
+
+    test('지난 주 운동 세션도 시드된다', () async {
+      await seedIfEmpty(db);
+      final exercise = await db.select(db.exerciseSessions).get();
+
+      final DateTime now = DateTime.now();
+      final DateTime thisMonday = DateTime(
+        now.year,
+        now.month,
+        now.day - (now.weekday - 1),
+      );
+      final Set<String> weekStarts = exercise
+          .map((r) => r.weekStart)
+          .toSet();
+
+      for (int weeksAgo = 0; weeksAgo <= kDemoExerciseHistoryWeeks; weeksAgo++) {
+        final DateTime monday = thisMonday.subtract(
+          Duration(days: 7 * weeksAgo),
+        );
+        final String key =
+            '${monday.year.toString().padLeft(4, '0')}-'
+            '${monday.month.toString().padLeft(2, '0')}-'
+            '${monday.day.toString().padLeft(2, '0')}';
+        expect(
+          weekStarts,
+          contains(key),
+          reason: '$weeksAgo주 전 운동 기록이 있어야 한다',
+        );
+      }
     });
 
     test('same-day re-run is a no-op (does not duplicate rows)', () async {
@@ -164,7 +244,7 @@ void main() {
     test('stale flag (different date) re-seeds with today', () async {
       // Pretend the seed last ran a week ago.
       await seedIfEmpty(db);
-      await db.putValue('seeded_v14', '2020-01-01');
+      await db.putValue('seeded_v15', '2020-01-01');
 
       await seedIfEmpty(db);
 
@@ -172,7 +252,7 @@ void main() {
       final diet = await db.select(db.dietEntries).get();
       expect(diet, isNotEmpty);
       expect(diet.where((r) => r.date == today).length, 3);
-      expect(await db.readValue('seeded_v14'), today);
+      expect(await db.readValue('seeded_v15'), today);
     });
 
     test('legacy seeded_v2=true flag is migrated and cleared', () async {
@@ -199,7 +279,7 @@ void main() {
 
       // Legacy flag cleared, current flag set to today.
       expect(await db.readValue('seeded_v2'), isNull);
-      expect(await db.readValue('seeded_v14'), _todayString());
+      expect(await db.readValue('seeded_v15'), _todayString());
 
       // Stale seed-prefixed row was wiped and replaced with today's
       // seed batch.
@@ -229,7 +309,7 @@ void main() {
 
       await seedIfEmpty(db);
       // Force a re-seed by ageing the flag.
-      await db.putValue('seeded_v14', '2020-01-01');
+      await db.putValue('seeded_v15', '2020-01-01');
       await seedIfEmpty(db);
 
       final diet = await db.select(db.dietEntries).get();

--- a/frontend/flutter/test/features/exercise/exercise_selected_day_test.dart
+++ b/frontend/flutter/test/features/exercise/exercise_selected_day_test.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/features/account/data/repositories/mock_account_repository.dart';
+import 'package:oncare/features/account/presentation/controllers/account_controller.dart';
+import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
+import 'package:oncare/features/exercise/domain/repositories/exercise_repository.dart';
+import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
+import 'package:oncare/features/exercise/presentation/pages/exercise_page.dart';
+import 'package:oncare/features/member_coach/data/repositories/mock_member_coach_repository.dart';
+import 'package:oncare/features/member_coach/domain/repositories/member_coach_repository.dart';
+import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+const List<String> _dayLabels = <String>['월', '화', '수', '목', '금', '토', '일'];
+
+/// 요일마다 [minutes] 분씩 채운 주. 0 을 주면 기록이 없는 주가 된다.
+ExerciseWeek _week(double minutes) {
+  final List<double> daily = List<double>.filled(7, minutes);
+  return ExerciseWeek(
+    sessions: <ExerciseSession>[
+      if (minutes > 0)
+        for (final String d in _dayLabels)
+          ExerciseSession(
+            id: 'x-$d',
+            dayLabel: d,
+            type: ExerciseType.cardio,
+            minutes: minutes.round(),
+            calories: minutes.round() * 7,
+          ),
+    ],
+    dailyMinutes: daily,
+    dailyCalories: List<double>.filled(7, minutes * 7),
+    cardioMinutes: daily,
+    strengthMinutes: List<double>.filled(7, 0),
+    stretchingMinutes: List<double>.filled(7, 0),
+    dayLabels: _dayLabels,
+    totalMinutes: (minutes * 7).round(),
+    totalCalories: (minutes * 49).round(),
+    streakDays: minutes > 0 ? 7 : 0,
+    aiCoachMessage: '',
+  );
+}
+
+/// 모든 주가 같은 값인 저장소. 어느 날짜를 골라도 기록이 있다.
+class _FixedWeekRepository implements ExerciseRepository {
+  _FixedWeekRepository(this.minutes);
+  final double minutes;
+
+  @override
+  Future<ExerciseWeek> fetchThisWeek() async => _week(minutes);
+
+  @override
+  Future<ExerciseWeek> fetchWeek(DateTime weekStart) async => _week(minutes);
+
+  @override
+  Future<ExerciseSession> addSession({
+    required ExerciseType type,
+    required int minutes,
+    required int calories,
+    required String dayLabel,
+    ExerciseIntensity intensity = ExerciseIntensity.moderate,
+  }) async => throw UnimplementedError();
+
+  @override
+  Future<void> deleteSession(String id) async => throw UnimplementedError();
+
+  @override
+  Future<ExerciseSession> updateSession({
+    required String id,
+    required ExerciseType type,
+    required int minutes,
+    required int calories,
+    required String dayLabel,
+    ExerciseIntensity intensity = ExerciseIntensity.moderate,
+  }) async => throw UnimplementedError();
+}
+
+Widget _app(ExerciseRepository repo) {
+  return ProviderScope(
+    overrides: <Override>[
+      // 데모 설정 — _PtLogCard 등 하위 카드가 실서버 provider 를 타지 않는다.
+      appConfigProvider.overrideWithValue(
+        const AppConfig(
+          environment: Environment.dev,
+          apiBaseUrl: 'https://example.test',
+          useMockApi: true,
+        ),
+      ),
+      exerciseRepositoryProvider.overrideWithValue(repo),
+      accountRepositoryProvider.overrideWithValue(MockAccountRepository()),
+      memberCoachRepositoryProvider.overrideWithValue(
+        MockMemberCoachRepository() as MemberCoachRepository,
+      ),
+    ],
+    child: const MaterialApp(
+      locale: Locale('ko'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: ExercisePage(),
+    ),
+  );
+}
+
+/// 오늘이 아니면서 **이번 주 안에** 있고 주간 스트립(오늘 ±3일)에 보이는 날짜.
+DateTime _otherDayThisWeek() {
+  final DateTime now = DateTime.now();
+  final DateTime today = DateTime(now.year, now.month, now.day);
+  // 월요일이면 어제가 지난 주로 넘어가므로 내일을 고른다. 그 밖에는 어제.
+  return today.weekday == DateTime.monday
+      ? today.add(const Duration(days: 1))
+      : today.subtract(const Duration(days: 1));
+}
+
+void main() {
+  testWidgets('오늘이 아닌 날에 기록이 있으면 빈 문구 대신 그날 요약을 그린다 (#671)', (
+    WidgetTester tester,
+  ) async {
+    tester.view.physicalSize = const Size(500, 1600);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(_app(_FixedWeekRepository(40)));
+    await tester.pumpAndSettle();
+
+    final AppLocalizations l = AppLocalizations.of(
+      tester.element(find.byType(ExercisePage)),
+    );
+    final DateTime target = _otherDayThisWeek();
+
+    await tester.tap(find.text('${target.day}').first);
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text(l.otherDateEmpty(l.pageExerciseTitle)),
+      findsNothing,
+      reason: '기록이 있는 날인데 빈 문구가 나오면 안 된다',
+    );
+    expect(
+      find.text('${target.month}월 ${target.day}일 ${l.pageExerciseTitle}'),
+      findsOneWidget,
+    );
+    // 유형별 분해에 그날의 유산소 40분이 보인다.
+    expect(find.text('40${l.unitMinutes}'), findsWidgets);
+  });
+
+  testWidgets('정말 기록이 없는 날에는 빈 문구가 그대로 나온다', (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(500, 1600);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(_app(_FixedWeekRepository(0)));
+    await tester.pumpAndSettle();
+
+    final AppLocalizations l = AppLocalizations.of(
+      tester.element(find.byType(ExercisePage)),
+    );
+    final DateTime target = _otherDayThisWeek();
+
+    await tester.tap(find.text('${target.day}').first);
+    await tester.pumpAndSettle();
+
+    expect(find.text(l.otherDateEmpty(l.pageExerciseTitle)), findsOneWidget);
+  });
+}

--- a/frontend/flutter/test/features/exercise/exercise_selected_day_test.dart
+++ b/frontend/flutter/test/features/exercise/exercise_selected_day_test.dart
@@ -78,6 +78,29 @@ class _FixedWeekRepository implements ExerciseRepository {
   }) async => throw UnimplementedError();
 }
 
+/// 이번 주와 지난 주가 서로 다른 값인 저장소. 지난 주 조회 경로(`fetchWeek`)를
+/// 실제로 지났는지 수치로 구분하기 위한 대역.
+class _TwoWeekRepository extends _FixedWeekRepository {
+  _TwoWeekRepository({
+    required double thisWeek,
+    required this.pastWeekMinutes,
+    this.failPastWeek = false,
+  }) : super(thisWeek);
+
+  final double pastWeekMinutes;
+  final bool failPastWeek;
+
+  /// 지난 주를 실제로 받아 갔는지. 이번 주 값이 재활용되면 false 로 남는다.
+  bool fetchedPastWeek = false;
+
+  @override
+  Future<ExerciseWeek> fetchWeek(DateTime weekStart) async {
+    fetchedPastWeek = true;
+    if (failPastWeek) throw StateError('past week lookup failed');
+    return _week(pastWeekMinutes);
+  }
+}
+
 Widget _app(ExerciseRepository repo) {
   return ProviderScope(
     overrides: <Override>[
@@ -159,6 +182,83 @@ void main() {
     );
     final DateTime target = _otherDayThisWeek();
 
+    await tester.tap(find.text('${target.day}').first);
+    await tester.pumpAndSettle();
+
+    expect(find.text(l.otherDateEmpty(l.pageExerciseTitle)), findsOneWidget);
+  });
+
+  testWidgets('지난 주로 넘겨 고른 날은 그 주를 따로 받아 그린다 (#671)', (
+    WidgetTester tester,
+  ) async {
+    tester.view.physicalSize = const Size(500, 1600);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    // 이번 주 40분 / 지난 주 12분 — 이번 주 값이 재사용되면 12분이 안 나온다.
+    final _TwoWeekRepository repo = _TwoWeekRepository(
+      thisWeek: 40,
+      pastWeekMinutes: 12,
+    );
+    await tester.pumpWidget(_app(repo));
+    await tester.pumpAndSettle();
+
+    final AppLocalizations l = AppLocalizations.of(
+      tester.element(find.byType(ExercisePage)),
+    );
+
+    // 주간 스트립의 왼쪽 화살표로 한 주 뒤로 간다.
+    await tester.tap(find.byIcon(Icons.chevron_left).first);
+    await tester.pumpAndSettle();
+
+    // 지난 주로 옮긴 스트립의 가운데 날짜(= 오늘 -7일)를 고른다.
+    final DateTime now = DateTime.now();
+    final DateTime target = DateTime(
+      now.year,
+      now.month,
+      now.day,
+    ).subtract(const Duration(days: 7));
+    await tester.tap(find.text('${target.day}').first);
+    await tester.pumpAndSettle();
+
+    expect(
+      repo.fetchedPastWeek,
+      isTrue,
+      reason: '지난 주는 fetchWeek 으로 따로 받아야 한다',
+    );
+    expect(
+      find.text('${target.month}월 ${target.day}일 ${l.pageExerciseTitle}'),
+      findsOneWidget,
+    );
+    expect(find.text('12${l.unitMinutes}'), findsWidgets);
+    expect(find.text(l.otherDateEmpty(l.pageExerciseTitle)), findsNothing);
+  });
+
+  testWidgets('지난 주 조회가 실패하면 빈 문구로 내려앉는다', (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(500, 1600);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    final _TwoWeekRepository repo = _TwoWeekRepository(
+      thisWeek: 40,
+      pastWeekMinutes: 12,
+      failPastWeek: true,
+    );
+    await tester.pumpWidget(_app(repo));
+    await tester.pumpAndSettle();
+
+    final AppLocalizations l = AppLocalizations.of(
+      tester.element(find.byType(ExercisePage)),
+    );
+
+    await tester.tap(find.byIcon(Icons.chevron_left).first);
+    await tester.pumpAndSettle();
+    final DateTime now = DateTime.now();
+    final DateTime target = DateTime(
+      now.year,
+      now.month,
+      now.day,
+    ).subtract(const Duration(days: 7));
     await tester.tap(find.text('${target.day}').first);
     await tester.pumpAndSettle();
 

--- a/frontend/flutter/test/features/exercise/mock_exercise_repository_test.dart
+++ b/frontend/flutter/test/features/exercise/mock_exercise_repository_test.dart
@@ -119,4 +119,53 @@ void main() {
       expect(after.dailyMinutes[4], 80);
     });
   });
+
+  group('fetchWeek 로 지난 주를 조회한다 (#671)', () {
+    test('이번 주 월요일을 주면 fetchThisWeek 과 같다', () async {
+      final MockExerciseRepository r = repo();
+      // 2024-01-05 는 금요일 → 그 주 월요일은 2024-01-01.
+      final ExerciseWeek week = await r.fetchWeek(DateTime(2024));
+      final ExerciseWeek current = await r.fetchThisWeek();
+      expect(week.dailyMinutes, current.dailyMinutes);
+      expect(week.totalMinutes, current.totalMinutes);
+    });
+
+    test('지난 주는 값이 있고, 이번 주와 다르다', () async {
+      final MockExerciseRepository r = repo();
+      final ExerciseWeek last = await r.fetchWeek(DateTime(2023, 12, 25));
+      final ExerciseWeek current = await r.fetchThisWeek();
+
+      expect(last.totalMinutes, greaterThan(0));
+      expect(last.sessions, isNotEmpty);
+      expect(
+        last.dailyMinutes,
+        isNot(current.dailyMinutes),
+        reason: '지난 주가 이번 주 복사본이면 주간 비교가 뜻이 없다',
+      );
+      // 하루 합 = 유형별 합 (이번 주와 같은 규칙).
+      for (int i = 0; i < last.dailyMinutes.length; i++) {
+        expect(
+          last.dailyMinutes[i],
+          closeTo(
+            last.cardioMinutes[i] +
+                last.strengthMinutes[i] +
+                last.stretchingMinutes[i],
+            0.001,
+          ),
+        );
+      }
+      // 지난 주 세션에는 '오늘' 라벨이 붙지 않는다.
+      expect(
+        last.sessions.every((ExerciseSession s) => s.dateLabel != '오늘'),
+        isTrue,
+      );
+    });
+
+    test('오래된 주일수록 운동량이 줄어든다', () async {
+      final MockExerciseRepository r = repo();
+      final ExerciseWeek oneWeekAgo = await r.fetchWeek(DateTime(2023, 12, 25));
+      final ExerciseWeek fourWeeksAgo = await r.fetchWeek(DateTime(2023, 12, 4));
+      expect(fourWeeksAgo.totalMinutes, lessThan(oneWeekAgo.totalMinutes));
+    });
+  });
 }


### PR DESCRIPTION
## Summary

* 데모에서 날짜를 옮기면 대부분 "선택한 날짜에 기록된 …이 없어요"만 나왔다. 둘러보는 사람에게는 앱에 데이터가 하루치밖에 없는 것으로 보였다.
* **식단**은 시드가 사흘(오늘·어제·그제)뿐이었다 — 주간 스트립이 보여주는 앞뒤 3일 중 넷은 언제나 비어 있었다.
* **운동**은 데이터가 있는데도 화면이 감췄다. 오늘이 아니면 데이터를 보지도 않고 빈 문구를 그려, 시드에 월~토 세션이 다 있는데도 어제를 누르면 "기록이 없어요"가 나왔다.
* 조회 경로가 `GET /exercise/weeks/current` 하나뿐이라 지난주는 받아올 방법 자체가 없어, `week_start` 질의 파라미터를 더했다.

---

## Changes

### ✨ Features

* `GET /exercise/weeks/current?week_start=YYYY-MM-DD` — FastAPI·로컬 인터셉터·Dio/Mock 저장소 모두. 생략하면 이번 주(예전 동작 그대로). 월요일이 아닌 날짜를 줘도 그 날이 속한 주로 맞춘다.
* 운동 탭에서 오늘이 아닌 날짜를 고르면 **그날의 요약**(운동 시간·소모 칼로리·유형별 분해·그날의 세션)을 그린다.

### 🔧 Improvements

* 식단 시드를 최근 한 달로 넓혔다. 사진·AI 코멘트가 붙은 큐레이션 사흘은 문안 그대로 두고, 그 앞을 회전 조합(아침 3종 × 점심 4종 × 저녁 3종)으로 채운다.
* 지난 4주치 운동 세션을 시드한다. 오래된 주일수록 조금 적게 — 데모에서 "요즘 늘고 있다"로 읽힌다.
* 시드 플래그 `seeded_v14` → `seeded_v15`. 올리지 않으면 오늘 이미 시드된 설치가 사흘치 그대로 남아 날짜를 옮겨도 여전히 비어 보인다.

### 🐛 Fixes

* 지난 주 세션에 '오늘'·'어제' 라벨이 붙던 문제. 요일 라벨만으로는 어느 주인지 알 수 없어, 주의 월요일에서 실제 날짜를 되짚어 오늘과 견준다.

### 📝 Docs

* `backend/API_CONTRACT.md` 에 `week_start` 계약 명시.

---

## Commits

1. `11ab5743` feat(demo): 데모 식단·운동 기록을 최근 한 달로 확대

2. `4dc771ef` fix(exercise): week_start 계약을 서버와 목업에서 일치시킨다

---

## Notes

* **"기록이 없어요"를 없애지 않았다.** 7일마다 저녁 한 끼, 11일마다 하루를 일부러 비워 뒀다 — 정말 기록이 없는 날의 빈 화면이 맞게 동작하는지 데모에서도 볼 수 있어야 한다.
* 날짜마다 값이 달라야 주간·월간 추이가 직선이 되지 않는다. 시드 테스트가 이 성질을 직접 확인한다.
* 데모(`useMockApi`)의 운동 탭은 drift 시드가 아니라 `MockExerciseRepository` 를 읽는다. 그래서 목 저장소도 지난 주를 만들 수 있게 했고, 이번 주와 지난 주가 **같은 파생 규칙**(`_weekFrom`)을 쓰도록 묶었다 — 두 화면의 수치 정의가 어긋나지 않는다.
* `ExerciseRepository` 에 `fetchWeek` 를 더했다. 구현체는 Dio·Mock 둘뿐이라 둘 다 갱신했다.

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 앱을 새로 켠다(시드 플래그가 올라가 재시드된다).
2. 식단 탭에서 날짜를 앞으로 옮기며 기록이 이어지는지 본다. 주 화살표로 지난주까지 넘겨 본다.
3. 운동 탭에서 어제를 누른다 → 빈 문구가 아니라 그날의 시간·칼로리·유형별 분해가 나온다.
4. 운동 탭에서 지난주로 넘겨 아무 날이나 누른다 → 그 주의 기록이 나온다.
5. 기록을 비워 둔 날을 누르면 "기록이 없어요"가 그대로 나오는지 확인한다.

```bash
flutter test test/core/storage/seed_data_test.dart test/core/network/local_api_interceptor_exercise_test.dart test/features/exercise
```

```bash
cd backend && python -m pytest tests/test_exercise.py -q
```

---

## Related Issues

Closes #671

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인



