### PR TITLE
test(member): add real-API E2E for member↔trainer reservation and cancellation

### DIFF
--- a/backend/app/db/seed_member_data.py
+++ b/backend/app/db/seed_member_data.py
@@ -485,11 +485,24 @@ def _seed_chat(db: Session, member_id: str) -> None:
     thread = _CHAT.get(member_id)
     if not thread:
         return
-    # 스레드가 최근으로 보이도록 base 를 몇 시간 전으로 두고, 메시지마다 그
+    # 스레드가 최근으로 보이도록 base 를 하루 안쪽 과거로 두고, 메시지마다 그
     # 메시지의 days_ago 만큼 더 과거로 민다. 같은 날 안에서는 2분 간격이다.
     # days_ago 가 뒤로 갈수록 작아지므로 시각은 계속 증가한다 — 스레드 정렬은
     # (created_at, id) 이라 이 단조성이 대화 순서를 보장한다.
-    base = datetime.now(timezone.utc) - timedelta(hours=2)
+    #
+    # **시각을 정오로 고정한다.** 예전에는 `now - 2시간` 을 그대로 썼는데, 시드가
+    # 자정 근처(UTC 01:30~02:00)에 돌면 base 가 23:5x 가 되어 `+ i*2분` 이 자정을
+    # 넘었다. 그러면 같은 days_ago 묶음이 이틀로 쪼개져 **사흘치 대화가 나흘**이 되고,
+    # 날짜로 묶는 화면(하루치 AI 분석 안내)도 함께 어긋난다. CI 가 그 시간대에 걸리면
+    # `test_demo_thread_spans_three_days` 가 아무 변경 없이 실패했다.
+    #
+    # 묶음 안의 최대 간격이 34분이라 정오 기준이면 어떤 시각에 시드해도 자정을 넘지
+    # 않는다. 오늘 정오가 아직 오지 않았으면 하루 뒤로 물러 미래 시각을 만들지 않는다.
+    now = datetime.now(timezone.utc)
+    span = timedelta(minutes=(len(thread) - 1) * 2)
+    base = now.replace(hour=12, minute=0, second=0, microsecond=0)
+    if base + span > now:
+        base -= timedelta(days=1)
     keep: set[str] = set()
     for i, (sender, text, days_ago) in enumerate(thread):
         cid = f"seed-chat-{member_id}-{i}"

--- a/docs/local_fullstack.md
+++ b/docs/local_fullstack.md
@@ -124,6 +124,74 @@ Flutter 3.44의 `integration_test` WebDriver 채널은 브라우저 스크린샷
 검증합니다. Chrome 프로세스 자체의 reload 이벤트까지 자동화해야 한다면 Flutter 공식
 드라이버가 reload 명령을 지원할 때 별도 시나리오로 추가해야 합니다.
 
+## 회원↔트레이너 예약·취소 E2E (#637)
+
+트레이너가 연 자리를 회원이 예약하고, 그 예약이 트레이너 일정으로 파생됐다가, 회원이 취소하면
+좌석과 일정이 함께 돌아오는 **양방향 흐름 전체**를 실 API로 검증합니다. 위 백엔드만 떠 있으면
+됩니다 — ChromeDriver도 브라우저도 필요 없습니다.
+
+```bash
+bash tool/run_reservation_e2e.sh
+```
+
+### 왜 브라우저가 없는가
+
+회원 앱의 배포 타깃은 iOS/Android지 웹이 아닙니다. 그래서 이 스위트는 브라우저 대신
+`IntegrationTestWidgetsFlutterBinding`(LiveBinding)을 `flutter test`로 돌립니다. 실제 위젯
+트리와 실제 HTTP가 그대로 동작하고, 트레이너 웹 스위트(ChromeDriver)보다 빠릅니다.
+`flutter test` 기본 바인딩은 FakeAsync라 실 네트워크 응답이 영원히 오지 않으므로,
+LiveBinding이 아니면 이 방식은 성립하지 않습니다.
+
+VM에는 구현이 없는 플러그인 세 개(`shared_preferences`, `flutter_secure_storage`,
+`path_provider`)는 하네스가 setUp에서 채웁니다.
+
+### 단계 구성
+
+두 앱은 **서로 다른 Dart 패키지**라 한 프로세스에 함께 띄울 수 없습니다. 그래서 한 시나리오를
+단계로 쪼개 번갈아 실행하고, 단계 사이의 상태는 **서버 DB**와 **상태 파일(id만)** 로 넘깁니다.
+잔여 좌석처럼 검증 대상인 값은 상태 파일에 담지 않습니다 — 담으면 서버가 아니라 앞 단계의
+기억을 검증하게 됩니다.
+
+| 순서 | 단계 | 앱 | 확인하는 것 |
+| --- | --- | --- | --- |
+| 1 | `create-slot` | 트레이너 웹 | UI로 연 슬롯의 정원·잔여 좌석이 서버와 일치 |
+| 2 | `reserve` | 회원 앱 | 슬롯 노출 · 예약 · 좌석 감소 · 재시작·재로그인 후 유지 |
+| 3 | `verify-schedule` | 트레이너 웹 | 그 예약이 만든 일정이 트레이너 화면에 표시 |
+| 4 | `cancel` | 회원 앱 | 취소 · 좌석 복구 · 재예약 가능 |
+| 5 | `verify-schedule-removed` | 트레이너 웹 | 일정 제거 · 좌석이 정원까지 복구 |
+| 6 | `edge-cases` | 회원 앱 | 중복·권한 없는 회원·동시 요청이 초과 예약을 못 만듦 |
+| 7 | `cleanup` | 트레이너 웹 | 이번 실행이 연 슬롯을 닫음 |
+
+실패하면 러너가 **어느 단계에서 멈췄는지와 상태 파일 경로**를 남깁니다. 그 단계만 따로 다시
+돌릴 수도 있습니다.
+
+```bash
+cd frontend/flutter
+flutter test test_e2e/reservation_member_test.dart \
+  --dart-define=USE_MOCK_API=false \
+  --dart-define=API_BASE_URL=http://localhost:8000/v1 \
+  --dart-define=E2E_PHASE=reserve \
+  --dart-define=E2E_STATE_FILE=/tmp/oncare_e2e.json
+```
+
+### 반복 실행과 남는 데이터
+
+매 실행은 **새 슬롯**을 엽니다. 앞선 실행이 중간에 죽어 예약이 남아 있어도 다음 실행은 그것을
+건드리지 않습니다. 슬롯 삭제 API는 없고 닫기만 가능하므로(`DELETE /trainer/reservation-slots/{id}`
+는 `is_closed`를 켭니다), 실행마다 **닫힌 슬롯이 하나씩 남습니다.** 닫힌 자리는 회원 조회에
+나오지 않아 다음 실행과 간섭하지 않습니다.
+
+### 테스트가 고정하는 계약
+
+- 트레이너는 `trainer@oncare.com`, 회원은 `minsu@oncare.com`(`user-demo`), 권한 밖 회원은
+  `jisu@oncare.com`이며 모두 기본 `DEMO_LOGIN_PASSWORD=oncare123`을 씁니다.
+- `USE_MOCK_API=false`가 아니거나 앱과 검증용 API 클라이언트의 `API_BASE_URL`이 다르면
+  **즉시 실패합니다.** 목업으로 새면서 초록불이 뜨는 것을 막습니다.
+- 화면 이동과 예약·취소는 사이드바·탭·버튼만 씁니다. 다만 "화면에 보였다"와 "서버에
+  저장됐다"는 다른 주장이므로, 각 단계는 UI와 서버 응답을 **둘 다** 확인합니다.
+- 슬롯 시각은 시트 기본값 10:00을 그대로 쓰고 날짜만 하루 뒤로 잡습니다 — `showTimePicker`
+  다이얼을 흉내 내는 쪽이 깨질 거리가 더 많습니다.
+
 ### 시드 기록과 AI 코치
 
 시드된 식단·운동·대화는 기동할 때 **개인 RAG 문서로도 적재**됩니다(#604). 그래서 데모

--- a/frontend/flutter/lib/app/router/main_shell.dart
+++ b/frontend/flutter/lib/app/router/main_shell.dart
@@ -150,6 +150,7 @@ class _MainShellState extends ConsumerState<MainShell>
                         ),
                         const SizedBox(width: 64),
                         _Destination(
+                          key: const ValueKey<String>('nav-exercise'),
                           icon: Icons.fitness_center_outlined,
                           activeIcon: Icons.fitness_center,
                           label: l.navExercise,
@@ -198,6 +199,7 @@ class _MainShellState extends ConsumerState<MainShell>
 
 class _Destination extends StatelessWidget {
   const _Destination({
+    super.key,
     required this.icon,
     required this.activeIcon,
     required this.label,

--- a/frontend/flutter/lib/features/auth/presentation/pages/sign_in_page.dart
+++ b/frontend/flutter/lib/features/auth/presentation/pages/sign_in_page.dart
@@ -129,6 +129,7 @@ class _SignInPageState extends ConsumerState<SignInPage> {
                       const SizedBox(height: AppSpacing.xxl),
 
                       AuthField(
+                        key: const ValueKey<String>('member-login-email'),
                         controller: _email,
                         hint: l.authEmailHint,
                         icon: Icons.mail_outline,
@@ -136,6 +137,7 @@ class _SignInPageState extends ConsumerState<SignInPage> {
                       ),
                       const SizedBox(height: AppSpacing.md),
                       AuthField(
+                        key: const ValueKey<String>('member-login-password'),
                         controller: _password,
                         hint: l.authPasswordHint,
                         icon: Icons.lock_outline,
@@ -154,6 +156,7 @@ class _SignInPageState extends ConsumerState<SignInPage> {
 
                       // 로그인 버튼(그라데이션)
                       AuthGradientButton(
+                        key: const ValueKey<String>('member-login-submit'),
                         loading: _loading,
                         label: l.authSignInAction,
                         onTap: _login,

--- a/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
@@ -128,6 +128,7 @@ class _SubTabs extends StatelessWidget {
     final bool on = active == i;
     return Expanded(
       child: GestureDetector(
+        key: ValueKey<String>('exercise-subtab-$i'),
         onTap: () => onChanged(i),
         behavior: HitTestBehavior.opaque,
         child: Container(

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/gym_tab.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/gym_tab.dart
@@ -687,10 +687,12 @@ class _ReservationPanelState extends ConsumerState<_ReservationPanel> {
         content: Text(l.exCancelConfirmBody(label)),
         actions: <Widget>[
           TextButton(
+            key: const ValueKey<String>('cancel-dialog-keep'),
             onPressed: () => Navigator.of(ctx).pop(false),
             child: Text(l.exCancelKeep),
           ),
           TextButton(
+            key: const ValueKey<String>('cancel-dialog-confirm'),
             onPressed: () => Navigator.of(ctx).pop(true),
             child: Text(l.exCancelReservation),
           ),
@@ -815,6 +817,7 @@ class _ReservationPanelState extends ConsumerState<_ReservationPanel> {
                     children: <Widget>[
                       for (final TrainerSlot slot in slots)
                         _SlotChip(
+                          key: ValueKey<String>('slot-chip-${slot.id}'),
                           label: _when(context, l, slot.startsAt),
                           sub: slot.isFull
                               ? l.exSlotFull
@@ -833,6 +836,7 @@ class _ReservationPanelState extends ConsumerState<_ReservationPanel> {
                     SizedBox(
                       width: double.infinity,
                       child: FilledButton(
+                        key: const ValueKey<String>('reserve-confirm'),
                         onPressed: busy ? null : () => _reserve(l, picked),
                         style: FilledButton.styleFrom(
                           backgroundColor: FigmaColors.primary,
@@ -1304,6 +1308,7 @@ class _TagChip extends StatelessWidget {
 
 class _SlotChip extends StatelessWidget {
   const _SlotChip({
+    super.key,
     required this.label,
     required this.sub,
     required this.selected,

--- a/frontend/flutter/test_e2e/reservation_member_test.dart
+++ b/frontend/flutter/test_e2e/reservation_member_test.dart
@@ -1,0 +1,227 @@
+/// 예약·취소 실 API E2E — 회원 앱 단계 (#637).
+///
+/// 트레이너 웹 단계와 번갈아 실행된다. 순서와 실행 방법은
+/// `scripts/run_reservation_e2e.sh` 와 `docs/local_fullstack.md` 참고.
+///
+///  1. (트레이너) `create-slot`
+///  2. `reserve`     — 회원이 그 자리를 보고 예약한다. 재시작·재로그인 뒤에도 유지.
+///  3. (트레이너) `verify-schedule`
+///  4. `cancel`      — 회원이 취소한다. 좌석이 돌아오고 다시 고를 수 있다.
+///  5. (트레이너) `verify-schedule-removed`
+///  6. `edge-cases`  — 중복·마감·과거·정원 경쟁이 초과 예약을 만들지 않는지.
+library;
+
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'support/e2e_harness.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(installPluginFakes);
+
+  testWidgets('회원 단계: $e2ePhase', (WidgetTester tester) async {
+    final E2eApi api = await E2eApi.login(memberEmail);
+    final E2eState state = E2eState.read();
+
+    switch (e2ePhase) {
+      case 'reserve':
+        final String slotId = state.require('slotId');
+        final int capacity = state.requireInt('slotCapacity');
+
+        // 트레이너가 만든 자리가 담당 회원에게 실제로 보이는가.
+        final Map<String, dynamic>? before = await api.slotById(slotId);
+        expect(
+          before,
+          isNotNull,
+          reason: '트레이너가 연 슬롯이 회원 조회에 나오지 않습니다.',
+        );
+        expect(before!['remaining'], capacity);
+
+        await bootSignedOut(tester);
+        await loginAsMember(tester);
+        await openGymTab(tester);
+
+        await pumpUntil(
+          tester,
+          find.byKey(ValueKey<String>('slot-chip-$slotId')),
+          step: '담당 트레이너의 슬롯이 회원 화면에 표시',
+        );
+        final Finder confirm = await selectSlotForReserve(tester, slotId);
+        await tester.ensureVisible(confirm);
+        await tester.pump();
+        await tester.tap(confirm);
+
+        // 서버에 예약이 남고 좌석이 하나 줄었는가. 화면 문구가 아니라 서버가 근거다.
+        Map<String, dynamic>? reservation;
+        final DateTime deadline = DateTime.now().add(
+          const Duration(seconds: 20),
+        );
+        while (reservation == null && DateTime.now().isBefore(deadline)) {
+          await tester.pump(const Duration(milliseconds: 200));
+          reservation = await api.reservationForSlot(slotId);
+        }
+        expect(reservation, isNotNull, reason: '예약 UI 가 서버에 예약을 만들지 못했습니다.');
+
+        final Map<String, dynamic>? afterReserve = await api.slotById(slotId);
+        expect(
+          afterReserve!['remaining'],
+          capacity - 1,
+          reason: '예약 후 잔여 좌석이 줄지 않았습니다.',
+        );
+
+        final String reservationId = reservation!['id'] as String;
+        // '내 예약' 에 나타나야 취소를 걸 수 있다.
+        await pumpUntil(
+          tester,
+          find.byKey(ValueKey<String>('cancel-reservation-$reservationId')),
+          step: '내 예약 목록에 방금 잡은 자리 표시',
+        );
+
+        // 재시작 + 재로그인 후에도 같은 서버 상태를 보는가.
+        await bootSignedOut(tester);
+        await loginAsMember(tester);
+        await openGymTab(tester);
+        await pumpUntil(
+          tester,
+          find.byKey(ValueKey<String>('cancel-reservation-$reservationId')),
+          step: '재로그인 후 내 예약 유지',
+        );
+        expect(
+          (await api.slotById(slotId))!['remaining'],
+          capacity - 1,
+          reason: '재로그인 후 잔여 좌석이 서버와 어긋납니다.',
+        );
+
+        E2eState.merge(<String, Object?>{'reservationId': reservationId});
+
+      case 'cancel':
+        final String slotId = state.require('slotId');
+        final int capacity = state.requireInt('slotCapacity');
+        final String reservationId = state.require('reservationId');
+
+        await bootSignedOut(tester);
+        await loginAsMember(tester);
+        await openGymTab(tester);
+
+        final Finder cancel = find.byKey(
+          ValueKey<String>('cancel-reservation-$reservationId'),
+        );
+        await pumpUntil(tester, cancel, step: '취소 버튼');
+        await tester.ensureVisible(cancel);
+        await tester.pump();
+        await tester.tap(cancel);
+        await tester.pump();
+
+        // 되돌릴 수 없는 동작이라 앱이 확인을 한 번 받는다. 그 확인을 눌러야 진행된다.
+        // 문구가 아니라 키로 찾는다 — 이 스위트는 로케일 기본값이 무엇이든 돌아야 한다.
+        final Finder confirmCancel = find.byKey(
+          const ValueKey<String>('cancel-dialog-confirm'),
+        );
+        await pumpUntil(tester, confirmCancel, step: '취소 확인 다이얼로그');
+        await tester.tap(confirmCancel);
+
+        await pumpUntilAbsent(tester, cancel, step: '취소한 예약이 목록에서 사라짐');
+
+        expect(
+          await api.reservationForSlot(slotId),
+          isNull,
+          reason: '취소했는데 서버에 예약이 남아 있습니다.',
+        );
+        expect(
+          (await api.slotById(slotId))!['remaining'],
+          capacity,
+          reason: '취소 후 좌석이 복구되지 않았습니다.',
+        );
+
+        // 좌석이 돌아왔으니 다시 고를 수 있어야 한다 — 취소가 자리를 죽이면 안 된다.
+        await selectSlotForReserve(tester, slotId);
+
+      case 'edge-cases':
+        // 여기는 화면이 아니라 계약을 본다. 초과 예약은 UI 를 거치지 않는 요청에서도
+        // 막혀야 하고, 동시 요청은 UI 로는 재현할 수 없다.
+        //
+        // 주의: `jisu@oncare.com` 도 이 트레이너의 **담당 회원**이다(시드). 그래서 이
+        // 계정의 예약은 거절되는 것이 아니라 두 번째 좌석을 정상적으로 가져간다.
+        final String slotId = state.require('slotId');
+        final int capacity = state.requireInt('slotCapacity');
+        expect(capacity, 2, reason: '이 단계는 정원 2 를 전제로 합니다.');
+
+        final E2eApi other = await E2eApi.login(otherMemberEmail);
+
+        // 1) 같은 회원이 같은 자리를 두 번 잡으면 좌석이 두 번 빠진다.
+        expect((await api.reserveRaw(slotId)).statusCode, 201);
+        expect(
+          (await api.reserveRaw(slotId)).statusCode,
+          409,
+          reason: '같은 슬롯을 두 번 예약할 수 있으면 좌석이 두 번 빠집니다.',
+        );
+        expect((await api.slotById(slotId))!['remaining'], capacity - 1);
+
+        // 2) 정원까지는 다른 담당 회원이 채울 수 있고, 그 다음은 막혀야 한다.
+        expect((await other.reserveRaw(slotId)).statusCode, 201);
+        expect((await api.slotById(slotId))!['remaining'], 0);
+        expect(
+          (await other.reserveRaw(slotId)).statusCode,
+          409,
+          reason: '정원이 찬 자리에 예약이 더 들어갔습니다.',
+        );
+
+        // 3) 마지막 좌석 경쟁. 정원 1 짜리 자리에서만 정직하게 재현된다 — 정원 2 에서는
+        //    한쪽이 첫 좌석을 채우는 순간 다른 요청이 '중복' 으로 걸려 경쟁이 아니게 된다.
+        final E2eApi trainer = await E2eApi.login(trainerEmail);
+        final Map<String, dynamic> raceSlot = await trainer.createSlotAsTrainer(
+          startsAt: DateTime.now().add(const Duration(days: 2)),
+          capacity: 1,
+        );
+        final String raceSlotId = raceSlot['id'] as String;
+
+        final List<Response<Object?>> raced =
+            await Future.wait<Response<Object?>>(<Future<Response<Object?>>>[
+              api.reserveRaw(raceSlotId),
+              other.reserveRaw(raceSlotId),
+            ]);
+        expect(
+          raced.where((Response<Object?> r) => r.statusCode == 201).length,
+          1,
+          reason: '마지막 한 자리에 동시 요청이 들어왔는데 성공이 하나가 아닙니다.',
+        );
+        expect(
+          (await api.slotById(raceSlotId))!['remaining'],
+          0,
+          reason: '경쟁 후 잔여 좌석이 0 이 아닙니다.',
+        );
+
+        // 4) 정리 — 이 단계가 만든 예약을 모두 되돌리고 경쟁용 슬롯을 닫는다.
+        for (final E2eApi client in <E2eApi>[api, other]) {
+          for (final String id in <String>[slotId, raceSlotId]) {
+            final Map<String, dynamic>? row = await client.reservationForSlot(
+              id,
+            );
+            if (row != null) {
+              expect((await client.cancelRaw(row['id'] as String)).statusCode, 200);
+            }
+          }
+        }
+        expect(
+          (await api.slotById(slotId))!['remaining'],
+          capacity,
+          reason: '정리 후 좌석이 정원까지 복구되지 않았습니다.',
+        );
+        await trainer.closeSlotAsTrainer(raceSlotId);
+
+        // 5) 없는(이미 취소된) 예약의 취소는 존재조차 드러내지 않는다.
+        expect(
+          (await api.cancelRaw('res-does-not-exist')).statusCode,
+          404,
+          reason: '없는 예약의 취소가 404 가 아닙니다.',
+        );
+
+      default:
+        fail('알 수 없는 E2E_PHASE: "$e2ePhase"');
+    }
+  });
+}

--- a/frontend/flutter/test_e2e/support/e2e_harness.dart
+++ b/frontend/flutter/test_e2e/support/e2e_harness.dart
@@ -1,0 +1,349 @@
+/// 실 API E2E 공통 하네스 (회원 앱) — #637.
+///
+/// 트레이너 웹 쪽 `frontend/flutter_trainer/test_e2e/support/e2e_harness.dart` 와
+/// 짝이다. 두 앱은 서로 다른 Dart 패키지라 한 프로세스에 함께 띄울 수 없어, 한
+/// 시나리오를 단계로 쪼개 번갈아 실행한다.
+///
+/// ## 왜 `test_e2e/` 이고 `integration_test/` 가 아닌가
+///
+/// `flutter test integration_test/...` 는 실기기·브라우저 러너를 요구한다. 이 스위트는
+/// 브라우저 없이 실 백엔드를 검증하므로 그 러너가 필요 없다. 대신
+/// `IntegrationTestWidgetsFlutterBinding`(LiveBinding)을 써서 실제 위젯 트리와 실제
+/// HTTP 를 얻는다 — `flutter test` 기본 바인딩은 FakeAsync 라 실 네트워크 응답이
+/// 영원히 오지 않는다.
+///
+/// `test/` 밖에 둔 이유는 CI 다. `user-app-ci.yml` 의 `flutter test` 는 인자 없이 돌아
+/// `test/` 만 훑는다. 백엔드가 없는 CI 에서 이 스위트가 딸려 돌면 무조건 깨진다.
+library;
+
+// `test_e2e/` 는 분석기가 테스트 디렉터리로 인정하는 경로(`test/`)가 아니다. 그래서
+// 테스트에서만 쓰라고 표시된 플러그인 페이크 진입점이 경고로 잡힌다 — 이 파일은
+// 테스트 전용이고 앱 코드에서 import 되지 않으므로 그 경고만 끈다.
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oncare/app/bootstrap.dart';
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/features/auth/presentation/pages/sign_in_page.dart';
+import 'package:oncare/features/dashboard/presentation/pages/dashboard_page.dart';
+import 'package:oncare/features/exercise/presentation/pages/exercise_page.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const String memberEmail = 'minsu@oncare.com';
+const String otherMemberEmail = 'jisu@oncare.com';
+/// 픽스처 전용. 정원 1 짜리 경쟁용 슬롯을 여는 데만 쓴다.
+const String trainerEmail = 'trainer@oncare.com';
+const String trainerId = 'trainer-demo';
+const String demoPassword = 'oncare123';
+
+const String apiBaseUrl = String.fromEnvironment('API_BASE_URL');
+const String e2ePhase = String.fromEnvironment('E2E_PHASE');
+const String e2eStateFile = String.fromEnvironment('E2E_STATE_FILE');
+
+/// 단계 사이로 넘기는 값. **화면에서 읽을 수 없는 id 만** 여기 담는다.
+///
+/// 잔여 좌석처럼 검증 대상인 것은 담지 않는다 — 파일로 넘기면 서버가 아니라 앞
+/// 단계의 기억을 검증하게 된다.
+class E2eState {
+  const E2eState(this.values);
+
+  final Map<String, Object?> values;
+
+  static File get _file {
+    expect(e2eStateFile, isNotEmpty, reason: 'E2E_STATE_FILE 이 필요합니다.');
+    return File(e2eStateFile);
+  }
+
+  static E2eState read() {
+    final File file = _file;
+    if (!file.existsSync()) return const E2eState(<String, Object?>{});
+    // 러너가 실행 시작에 파일을 비운다 — 빈 파일은 "아직 아무 단계도 안 지났다" 다.
+    final String raw = file.readAsStringSync().trim();
+    if (raw.isEmpty) return const E2eState(<String, Object?>{});
+    return E2eState(jsonDecode(raw) as Map<String, Object?>);
+  }
+
+  static void merge(Map<String, Object?> patch) {
+    final Map<String, Object?> next = <String, Object?>{
+      ...read().values,
+      ...patch,
+    };
+    _file.writeAsStringSync(jsonEncode(next));
+  }
+
+  String require(String key) {
+    final Object? value = values[key];
+    expect(value, isA<String>(), reason: '앞 단계가 남긴 $key 가 없습니다.');
+    return value! as String;
+  }
+
+  int requireInt(String key) {
+    final Object? value = values[key];
+    expect(value, isA<int>(), reason: '앞 단계가 남긴 $key 가 없습니다.');
+    return value! as int;
+  }
+}
+
+/// 화면을 거치지 않고 서버 상태를 직접 확인할 때 쓰는 클라이언트.
+///
+/// UI 검증을 대신하라고 있는 것이 아니다 — "화면에 보였다" 와 "서버에 저장됐다" 는
+/// 다른 주장이고, 이슈의 완료 조건은 둘 다 요구한다.
+class E2eApi {
+  E2eApi._(this._dio, this._auth);
+
+  final Dio _dio;
+  final Options _auth;
+
+  static Future<E2eApi> login(String email) async {
+    final Dio dio = Dio(
+      BaseOptions(
+        // 분석 시점에는 dart-define 이 없어 이 상수가 '' 로 보인다. 기본값과 같다고
+        // 잡히지만, 실행 시에는 러너가 넘긴 주소가 들어온다.
+        // ignore: avoid_redundant_argument_values
+        baseUrl: apiBaseUrl,
+        connectTimeout: const Duration(seconds: 15),
+        sendTimeout: const Duration(seconds: 15),
+        receiveTimeout: const Duration(seconds: 15),
+        // 4xx 를 예외가 아니라 응답으로 받는다 — 예외 케이스 검증이 상태 코드를
+        // 직접 비교하기 때문이다.
+        validateStatus: (int? status) => status != null && status < 500,
+      ),
+    );
+    final Response<Map<String, dynamic>> res = await dio
+        .post<Map<String, dynamic>>(
+          '/auth/login',
+          data: <String, String>{'username': email, 'password': demoPassword},
+          options: Options(contentType: Headers.formUrlEncodedContentType),
+        );
+    expect(res.statusCode, 200, reason: '$email 로그인 실패');
+    return E2eApi._(
+      dio,
+      Options(
+        headers: <String, String>{
+          'Authorization': 'Bearer ${res.data!['access_token']}',
+        },
+      ),
+    );
+  }
+
+  Future<List<Map<String, dynamic>>> _list(String path) async {
+    final Response<List<dynamic>> res = await _dio.get<List<dynamic>>(
+      path,
+      options: _auth,
+    );
+    return <Map<String, dynamic>>[
+      for (final Object? row in res.data ?? const <Object?>[])
+        row! as Map<String, dynamic>,
+    ];
+  }
+
+  Future<List<Map<String, dynamic>>> myReservations() =>
+      _list('/reservations/me');
+
+  Future<List<Map<String, dynamic>>> trainerSlots() =>
+      _list('/trainers/$trainerId/slots');
+
+  /// 회원에게 보이는 슬롯 하나. 마감·과거 슬롯은 목록에서 빠질 수 있어 null 을 준다.
+  Future<Map<String, dynamic>?> slotById(String id) async {
+    for (final Map<String, dynamic> slot in await trainerSlots()) {
+      if (slot['id'] == id) return slot;
+    }
+    return null;
+  }
+
+  Future<Map<String, dynamic>?> reservationForSlot(String slotId) async {
+    for (final Map<String, dynamic> row in await myReservations()) {
+      if (row['slot_id'] == slotId) return row;
+    }
+    return null;
+  }
+
+  /// 상태 코드까지 보고 싶을 때 쓰는 원시 예약 호출(예외 케이스 검증용).
+  Future<Response<Object?>> reserveRaw(String slotId) => _dio.post<Object?>(
+    '/reservations',
+    data: <String, String>{'slot_id': slotId},
+    options: _auth,
+  );
+
+  Future<Response<Object?>> cancelRaw(String reservationId) =>
+      _dio.delete<Object?>('/reservations/$reservationId', options: _auth);
+
+  /// 픽스처용 — 트레이너 계정으로 정원 [capacity] 짜리 슬롯을 연다.
+  ///
+  /// 마지막 좌석 경쟁은 **정원이 1 인 자리**에서만 정직하게 재현된다. 담당 회원 계정이
+  /// 둘뿐이라, 정원 2 짜리 자리에서는 한쪽이 먼저 자리를 채우는 순간 다른 쪽의 두 번째
+  /// 요청이 '중복' 으로 걸려 경쟁이 아니게 된다.
+  Future<Map<String, dynamic>> createSlotAsTrainer({
+    required DateTime startsAt,
+    required int capacity,
+  }) async {
+    final Response<Map<String, dynamic>> res = await _dio
+        .post<Map<String, dynamic>>(
+          '/trainer/reservation-slots',
+          data: <String, Object?>{
+            'starts_at': startsAt.toUtc().toIso8601String(),
+            'capacity': capacity,
+          },
+          options: _auth,
+        );
+    expect(res.statusCode, 201, reason: '경쟁 검증용 슬롯 생성 실패');
+    return res.data!;
+  }
+
+  Future<void> closeSlotAsTrainer(String slotId) async {
+    await _dio.delete<Object?>(
+      '/trainer/reservation-slots/$slotId',
+      options: _auth,
+    );
+  }
+}
+
+/// VM 에는 구현이 없는 플러그인을 채운다.
+///
+/// 이 셋이 없으면 앱은 부팅 도중 `MissingPluginException` 으로 멈춘다. 실제 기기에서는
+/// 플랫폼이 제공하는 것들이라, 여기서만 대신 준다.
+void installPluginFakes() {
+  SharedPreferences.setMockInitialValues(<String, Object>{});
+  FlutterSecureStorage.setMockInitialValues(<String, String>{});
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(
+        const MethodChannel('plugins.flutter.io/path_provider'),
+        (MethodCall call) async =>
+            Directory.systemTemp.createTempSync('oncare_e2e').path,
+      );
+}
+
+Future<void> pumpUntil(
+  WidgetTester tester,
+  Finder finder, {
+  required String step,
+  Duration timeout = const Duration(seconds: 20),
+}) async {
+  final DateTime deadline = DateTime.now().add(timeout);
+  while (finder.evaluate().isEmpty && DateTime.now().isBefore(deadline)) {
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+  expect(
+    finder,
+    findsWidgets,
+    reason: '[$e2ePhase] $step 이(가) $timeout 안에 나타나지 않았습니다.',
+  );
+}
+
+Future<void> pumpUntilAbsent(
+  WidgetTester tester,
+  Finder finder, {
+  required String step,
+  Duration timeout = const Duration(seconds: 20),
+}) async {
+  final DateTime deadline = DateTime.now().add(timeout);
+  while (finder.evaluate().isNotEmpty && DateTime.now().isBefore(deadline)) {
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+  expect(
+    finder,
+    findsNothing,
+    reason: '[$e2ePhase] $step 이(가) $timeout 안에 사라지지 않았습니다.',
+  );
+}
+
+/// 목업으로 통과하는 것을 막는 관문.
+///
+/// 이슈의 완료 조건이 "mock repository 만으로 테스트가 통과하지 않는다" 라, 설정이
+/// 목업으로 새면 조용히 초록불이 뜨는 대신 여기서 멈춘다.
+void assertRealApiConfig() {
+  final AppConfig config = AppConfig.fromEnvironment();
+  expect(
+    config.useMockApi,
+    isFalse,
+    reason: '--dart-define=USE_MOCK_API=false 로 실행해야 합니다.',
+  );
+  expect(apiBaseUrl, isNotEmpty, reason: 'API_BASE_URL 이 필요합니다.');
+  expect(
+    config.apiBaseUrl,
+    apiBaseUrl,
+    reason: '앱과 검증용 API 클라이언트가 같은 백엔드를 봐야 합니다.',
+  );
+}
+
+/// 회원 앱의 기준 뷰포트. 기본 800×600 은 이 앱의 레이아웃과 어긋난다.
+void useMobileViewport(WidgetTester tester) {
+  tester.view.physicalSize = const Size(430, 1200);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+}
+
+/// 로그아웃 상태에서 앱을 새로 띄운다. 재시작·재로그인 검증도 이것을 다시 부른다.
+Future<void> bootSignedOut(WidgetTester tester) async {
+  useMobileViewport(tester);
+  assertRealApiConfig();
+  // 앞선 부팅이 남아 있으면 그 ProviderScope 의 세션이 그대로 살아 있어, 토큰을
+  // 지워도 새 트리가 로그인 화면 대신 대시보드로 간다. 재시작 검증이 조용히
+  // "로그인된 채로 계속" 을 통과시키지 않도록 먼저 트리를 비운다.
+  await tester.pumpWidget(const SizedBox.shrink());
+  await tester.pump();
+  await const FlutterSecureStorage().deleteAll();
+  await bootstrap();
+  await pumpUntil(tester, find.byType(SignInPage), step: '로그인 화면');
+}
+
+Future<void> loginAsMember(WidgetTester tester, {String? email}) async {
+  await tester.enterText(
+    find.descendant(
+      of: find.byKey(const ValueKey<String>('member-login-email')),
+      matching: find.byType(TextField),
+    ),
+    email ?? memberEmail,
+  );
+  await tester.enterText(
+    find.descendant(
+      of: find.byKey(const ValueKey<String>('member-login-password')),
+      matching: find.byType(TextField),
+    ),
+    demoPassword,
+  );
+  await tester.tap(find.byKey(const ValueKey<String>('member-login-submit')));
+  await pumpUntil(tester, find.byType(DashboardPage), step: '회원 로그인');
+}
+
+/// 슬롯 하나를 골라 예약 확정 버튼이 뜬 상태로 만든다.
+///
+/// 칩은 **토글**이라(같은 칩을 다시 누르면 선택이 풀린다) 한 번 누르는 것으로는
+/// "선택됨" 을 보장할 수 없다. 앞선 조작이 이미 이 칩을 골라 둔 상태였다면 그 한 번이
+/// 선택을 푸는 쪽으로 작동한다. 그래서 결과(확정 버튼)를 보고 필요하면 한 번 더 누른다.
+Future<Finder> selectSlotForReserve(WidgetTester tester, String slotId) async {
+  final Finder chip = find.byKey(ValueKey<String>('slot-chip-$slotId'));
+  final Finder confirm = find.byKey(const ValueKey<String>('reserve-confirm'));
+  await pumpUntil(tester, chip, step: '슬롯 칩');
+
+  for (int attempt = 0; attempt < 3; attempt++) {
+    // 목록이 길면(내 예약이 쌓였거나 자리가 많으면) 칩이 화면 밖으로 밀린다. 그 상태의
+    // `tap` 은 예외 없이 **엉뚱한 곳을 누르고** 조용히 지나간다.
+    await tester.ensureVisible(chip);
+    await tester.pump();
+    await tester.tap(chip);
+    await tester.pump();
+    final DateTime deadline = DateTime.now().add(const Duration(seconds: 5));
+    while (confirm.evaluate().isEmpty && DateTime.now().isBefore(deadline)) {
+      await tester.pump(const Duration(milliseconds: 100));
+    }
+    if (confirm.evaluate().isNotEmpty) return confirm;
+  }
+  fail('[$e2ePhase] 슬롯 $slotId 를 골랐는데 예약 확정 버튼이 뜨지 않았습니다.');
+}
+
+/// 운동 탭 → 헬스장 서브탭. 담당 트레이너의 예약 패널이 있는 자리다.
+Future<void> openGymTab(WidgetTester tester) async {
+  await tester.tap(find.byKey(const ValueKey<String>('nav-exercise')));
+  await pumpUntil(tester, find.byType(ExercisePage), step: '운동 화면');
+  await tester.tap(find.byKey(const ValueKey<String>('exercise-subtab-1')));
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 300));
+}

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
@@ -298,6 +298,7 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
           },
         ),
         ActionButton(
+          key: const ValueKey<String>('schedule-open-slots'),
           label: l.schedSlots,
           icon: Icons.event_available_outlined,
           onPressed: () => _openReservationSlotsSheet(),
@@ -1844,6 +1845,7 @@ class _TimelineRow extends StatelessWidget {
           child: session.isGap
               ? const _GapSlot()
               : _SessionCard(
+                  key: ValueKey<String>('schedule-session-${session.id}'),
                   session: session,
                   expanded: expanded,
                   onToggle: onToggle,
@@ -1888,6 +1890,7 @@ class _GapSlot extends StatelessWidget {
 
 class _SessionCard extends StatelessWidget {
   const _SessionCard({
+    super.key,
     required this.session,
     required this.expanded,
     required this.onToggle,

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/reservation_slots_sheet.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/reservation_slots_sheet.dart
@@ -281,6 +281,7 @@ class _ReservationSlotsSheetState extends ConsumerState<ReservationSlotsSheet> {
                   SizedBox(
                     width: 100,
                     child: TextField(
+                      key: const ValueKey<String>('slot-capacity-input'),
                       controller: _capacity,
                       enabled: !_saving,
                       keyboardType: TextInputType.number,
@@ -292,6 +293,7 @@ class _ReservationSlotsSheetState extends ConsumerState<ReservationSlotsSheet> {
                   ),
                   const SizedBox(width: AppSpacing.sm),
                   FilledButton.icon(
+                    key: const ValueKey<String>('slot-create'),
                     onPressed: _saving ? null : _create,
                     icon: const Icon(Icons.add),
                     label: Text(l.slotOpenAction),
@@ -333,6 +335,7 @@ class _ReservationSlotsSheetState extends ConsumerState<ReservationSlotsSheet> {
                       itemBuilder: (context, index) {
                         final slot = daySlots[index];
                         return Container(
+                          key: ValueKey<String>('slot-row-${slot.id}'),
                           padding: const EdgeInsets.all(AppSpacing.md),
                           decoration: BoxDecoration(
                             color: slot.isClosed

--- a/frontend/flutter_trainer/test_e2e/reservation_trainer_test.dart
+++ b/frontend/flutter_trainer/test_e2e/reservation_trainer_test.dart
@@ -1,0 +1,206 @@
+/// 예약·취소 실 API E2E — 트레이너 웹 단계 (#637).
+///
+/// 회원 앱 단계와 번갈아 실행된다. 순서와 실행 방법은
+/// `scripts/run_reservation_e2e.sh` 와 `docs/local_fullstack.md` 참고.
+///
+///  1. `create-slot`            — 트레이너가 UI 로 미래 슬롯을 연다.
+///  2. (회원) `reserve`
+///  3. `verify-schedule`        — 그 예약이 만든 일정이 트레이너 일정에 보인다.
+///  4. (회원) `cancel`
+///  5. `verify-schedule-removed`— 취소하면 그 일정이 사라진다.
+///  6. `cleanup`                — 이번 실행이 연 슬롯을 닫는다.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:oncare_trainer/app/router/routes.dart';
+import 'package:oncare_trainer/features/schedule/presentation/pages/schedule_page.dart';
+import 'package:oncare_trainer/features/schedule/presentation/widgets/reservation_slots_sheet.dart';
+
+import 'support/e2e_harness.dart';
+
+/// 슬롯을 여는 날. 시트의 기본 시각이 10:00 이라 **오늘이면 이미 지난 시각**이 될 수
+/// 있어 하루 뒤를 쓴다. 시각 선택은 `showTimePicker` 라 기본값을 그대로 쓰는 편이
+/// 다이얼을 흉내 내는 것보다 깨질 거리가 적다.
+DateTime get _slotDay => DateTime.now().add(const Duration(days: 1));
+const int _capacity = 2;
+
+Future<void> _openSchedule(WidgetTester tester, DateTime day) async {
+  await tester.tap(find.byKey(ValueKey<String>('sidebar-${AppRoutes.schedule}')));
+  await pumpUntil(tester, find.byType(SchedulePage), step: '스케줄 화면');
+  await tester.tap(find.byKey(ValueKey<String>('schedule-day-${ymd(day)}')));
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 300));
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(installPluginFakes);
+
+  testWidgets('트레이너 단계: $e2ePhase', (WidgetTester tester) async {
+    final E2eApi api = await E2eApi.login(trainerEmail);
+
+    switch (e2ePhase) {
+      case 'create-slot':
+        // 같은 시각에 이미 슬롯이 있을 수 있다(앞선 실행의 잔여). id 를 시각으로
+        // 찾으면 남의 것을 잡으므로, 만들기 전후의 차집합으로 이번 것을 고른다.
+        final Set<String> before = <String>{
+          for (final Map<String, dynamic> slot in await api.trainerSlots())
+            slot['id'] as String,
+        };
+
+        await bootSignedOut(tester);
+        await loginAsTrainer(tester);
+        await _openSchedule(tester, _slotDay);
+
+        await tester.tap(find.byKey(const ValueKey<String>('schedule-open-slots')));
+        await pumpUntil(
+          tester,
+          find.byKey(const ValueKey<String>('slot-create')),
+          step: '예약 슬롯 시트',
+        );
+        await tester.enterText(
+          find.byKey(const ValueKey<String>('slot-capacity-input')),
+          '$_capacity',
+        );
+        await tester.tap(find.byKey(const ValueKey<String>('slot-create')));
+
+        // 서버가 만든 슬롯을 먼저 확정하고, 그 id 로 화면을 확인한다. 화면의 행만
+        // 보면 "무엇이든 하나 생겼다" 까지만 알 수 있다.
+        Map<String, dynamic>? created;
+        final DateTime deadline = DateTime.now().add(const Duration(seconds: 20));
+        while (created == null && DateTime.now().isBefore(deadline)) {
+          await tester.pump(const Duration(milliseconds: 200));
+          for (final Map<String, dynamic> slot in await api.trainerSlots()) {
+            if (!before.contains(slot['id'])) {
+              created = slot;
+              break;
+            }
+          }
+        }
+        expect(created, isNotNull, reason: '슬롯 열기 UI 가 서버에 슬롯을 만들지 못했습니다.');
+
+        expect(created!['capacity'], _capacity);
+        expect(
+          created['remaining'],
+          _capacity,
+          reason: '새로 연 슬롯의 잔여 좌석은 정원과 같아야 합니다.',
+        );
+        expect(created['is_closed'], isFalse);
+
+        await pumpUntilVisibleInList(
+          tester,
+          find.byKey(ValueKey<String>('slot-row-${created['id']}')),
+          // `Scrollable` 로 찾으면 정원 입력칸의 내부 편집 스크롤까지 잡힌다.
+          list: find.descendant(
+            of: find.byType(ReservationSlotsSheet),
+            matching: find.byType(ListView),
+          ),
+          step: '새 슬롯이 시트 목록에 표시',
+        );
+
+        // 이 시각에 **이미 있던** 예약 일정들. 앞선 실행이 남긴 것과 이번 예약이
+        // 만들 것을 구분하는 기준선이다.
+        final DateTime startsAt = DateTime.parse(
+          created['starts_at'] as String,
+        ).toLocal();
+        E2eState.merge(<String, Object?>{
+          'slotId': created['id'],
+          'slotStartsAt': created['starts_at'],
+          'slotCapacity': _capacity,
+          'sessionIdsBefore': <String>[
+            for (final Map<String, dynamic> session
+                in await api.reservationSessionsAt(startsAt))
+              session['id'] as String,
+          ],
+        });
+
+      case 'verify-schedule':
+        final E2eState state = E2eState.read();
+        final DateTime startsAt = state.slotStartsAt;
+
+        // 회원이 잡은 자리가 트레이너의 일정으로 파생됐는지 — 서버에서 먼저 확정한다.
+        // 앞선 실행이 남긴 같은 시각의 일정과 섞이지 않도록 기준선과의 차집합으로 고른다.
+        final Set<String> before = state.sessionIdsBefore;
+        final List<Map<String, dynamic>> fresh = <Map<String, dynamic>>[
+          for (final Map<String, dynamic> row
+              in await api.reservationSessionsAt(startsAt))
+            if (!before.contains(row['id'])) row,
+        ];
+        expect(
+          fresh,
+          hasLength(1),
+          reason: '회원 예약으로 생긴 일정이 정확히 하나여야 합니다(발견: ${fresh.length}건).',
+        );
+        final Map<String, dynamic> session = fresh.single;
+
+        await bootSignedOut(tester);
+        await loginAsTrainer(tester);
+        await _openSchedule(tester, startsAt);
+
+        // 그리고 그 일정이 실제로 트레이너 화면에 그려지는지.
+        await pumpUntil(
+          tester,
+          find.byKey(ValueKey<String>('schedule-session-${session['id']}')),
+          step: '회원 예약으로 생긴 일정 표시',
+        );
+        expect(find.text(memberName), findsWidgets);
+
+        E2eState.merge(<String, Object?>{'scheduleId': session['id']});
+
+      case 'verify-schedule-removed':
+        final E2eState state = E2eState.read();
+        final DateTime startsAt = state.slotStartsAt;
+        final String scheduleId = state.require('scheduleId');
+
+        // 이번 실행이 만든 그 일정이 사라졌는가. "그 시각에 아무 일정도 없다" 가
+        // 아니라 **우리 것이 없다** 를 본다 — 앞선 실행의 잔여가 있어도 판정이 흔들리지
+        // 않아야 한다.
+        expect(
+          <String>[
+            for (final Map<String, dynamic> row
+                in await api.reservationSessionsAt(startsAt))
+              row['id'] as String,
+          ],
+          isNot(contains(scheduleId)),
+          reason: '취소했는데 파생 일정이 서버에 남아 있습니다.',
+        );
+
+        await bootSignedOut(tester);
+        await loginAsTrainer(tester);
+        await _openSchedule(tester, startsAt);
+
+        await pumpUntilAbsent(
+          tester,
+          find.byKey(ValueKey<String>('schedule-session-$scheduleId')),
+          step: '취소된 일정 사라짐',
+        );
+
+        // 좌석도 함께 돌아왔는지. 예약 전 정원과 같아야 한다.
+        final Map<String, dynamic> slot = await api.slotById(
+          state.require('slotId'),
+        );
+        expect(
+          slot['remaining'],
+          slot['capacity'],
+          reason: '취소 후 잔여 좌석이 정원까지 복구되지 않았습니다.',
+        );
+
+      case 'cleanup':
+        // 슬롯 삭제 API 는 없다(닫기만 가능). 닫아 두면 다음 실행이 이 자리를 다시
+        // 잡지 않으므로 반복 실행이 서로 간섭하지 않는다.
+        final E2eState state = E2eState.read();
+        await api.closeSlot(state.require('slotId'));
+        final Map<String, dynamic> slot = await api.slotById(
+          state.require('slotId'),
+        );
+        expect(slot['is_closed'], isTrue);
+
+      default:
+        fail('알 수 없는 E2E_PHASE: "$e2ePhase"');
+    }
+  });
+}

--- a/frontend/flutter_trainer/test_e2e/support/e2e_harness.dart
+++ b/frontend/flutter_trainer/test_e2e/support/e2e_harness.dart
@@ -1,0 +1,339 @@
+/// 실 API E2E 공통 하네스 (트레이너 웹) — #637.
+///
+/// ## 왜 `test_e2e/` 이고 `integration_test/` 가 아닌가
+///
+/// `flutter test integration_test/...` 는 실기기·브라우저 러너를 요구한다(브라우저는
+/// ChromeDriver). 이 스위트는 **브라우저 없이** 실 백엔드를 검증하므로 그 러너가 필요
+/// 없다. 대신 `IntegrationTestWidgetsFlutterBinding`(LiveBinding)을 그대로 써서 실제
+/// 위젯 트리와 실제 HTTP 를 얻는다 — `flutter test` 기본 바인딩은 FakeAsync 라 실 네트워크
+/// 응답이 영원히 오지 않는다.
+///
+/// 디렉터리를 `test/` 밖에 둔 이유는 CI 다. `trainer-ci.yml` 의 `flutter test` 는 인자
+/// 없이 돌아 `test/` 만 훑는다. 백엔드가 없는 CI 에서 이 스위트가 딸려 돌면 무조건 깨진다.
+///
+/// ## 단계를 나눈 이유
+///
+/// 회원 앱과 트레이너 웹은 **서로 다른 Dart 패키지**라 한 프로세스에 함께 띄울 수 없다.
+/// 그래서 한 시나리오를 단계로 쪼개 번갈아 실행하고, 단계 사이의 상태는 두 가지로 넘긴다.
+///
+///  * **서버 DB** — 이 테스트가 실제로 검증하려는 것. 슬롯·예약·일정이 여기 남는다.
+///  * **상태 파일** — id 처럼 화면에서 읽을 수 없는 값만. [E2eState] 참고.
+library;
+
+// `test_e2e/` 는 분석기가 테스트 디렉터리로 인정하는 경로(`test/`)가 아니다. 그래서
+// 테스트에서만 쓰라고 표시된 플러그인 페이크 진입점이 경고로 잡힌다 — 이 파일은
+// 테스트 전용이고 앱 코드에서 import 되지 않으므로 그 경고만 끈다.
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oncare_trainer/app/bootstrap.dart';
+import 'package:oncare_trainer/core/config/app_config.dart';
+import 'package:oncare_trainer/features/auth/presentation/pages/trainer_sign_in_page.dart';
+import 'package:oncare_trainer/features/dashboard/presentation/pages/dashboard_page.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const String trainerEmail = 'trainer@oncare.com';
+const String memberEmail = 'minsu@oncare.com';
+const String memberId = 'user-demo';
+const String memberName = '김민수';
+const String demoPassword = 'oncare123';
+
+const String apiBaseUrl = String.fromEnvironment('API_BASE_URL');
+const String e2ePhase = String.fromEnvironment('E2E_PHASE');
+const String e2eStateFile = String.fromEnvironment('E2E_STATE_FILE');
+
+/// 단계 사이로 넘기는 값. **화면에서 읽을 수 없는 id 만** 여기 담는다.
+///
+/// 잔여 좌석이나 일정 표시 여부처럼 검증 대상인 것은 절대 담지 않는다 — 그것을
+/// 파일로 넘기면 서버가 아니라 앞 단계의 기억을 검증하게 된다.
+class E2eState {
+  const E2eState(this.values);
+
+  final Map<String, Object?> values;
+
+  static File get _file {
+    expect(e2eStateFile, isNotEmpty, reason: 'E2E_STATE_FILE 이 필요합니다.');
+    return File(e2eStateFile);
+  }
+
+  static E2eState read() {
+    final File file = _file;
+    if (!file.existsSync()) return const E2eState(<String, Object?>{});
+    // 러너가 실행 시작에 파일을 비운다 — 빈 파일은 "아직 아무 단계도 안 지났다" 다.
+    final String raw = file.readAsStringSync().trim();
+    if (raw.isEmpty) return const E2eState(<String, Object?>{});
+    return E2eState(jsonDecode(raw) as Map<String, Object?>);
+  }
+
+  static void merge(Map<String, Object?> patch) {
+    final Map<String, Object?> next = <String, Object?>{
+      ...read().values,
+      ...patch,
+    };
+    _file.writeAsStringSync(jsonEncode(next));
+  }
+
+  String require(String key) {
+    final Object? value = values[key];
+    expect(value, isA<String>(), reason: '앞 단계가 남긴 $key 가 없습니다.');
+    return value! as String;
+  }
+
+  /// 이번 실행이 쓰는 슬롯의 시작 시각(로컬).
+  DateTime get slotStartsAt => DateTime.parse(require('slotStartsAt')).toLocal();
+
+  /// 회원이 예약하기 **전에** 이미 그 시각에 있던 예약 일정 id 들.
+  ///
+  /// 슬롯 시각이 매 실행 같은 10:00 이라, 이 기준선이 없으면 앞선 실행이 남긴 일정을
+  /// 이번 것으로 착각한다.
+  Set<String> get sessionIdsBefore => <String>{
+    for (final Object? id
+        in (values['sessionIdsBefore'] as List<Object?>?) ?? const <Object?>[])
+      id! as String,
+  };
+}
+
+/// 화면을 거치지 않고 서버 상태를 직접 확인할 때 쓰는 클라이언트.
+///
+/// UI 검증을 대신하라고 있는 것이 아니다 — "화면에 보였다" 와 "서버에 저장됐다" 는
+/// 다른 주장이고, 이슈의 완료 조건은 둘 다 요구한다.
+class E2eApi {
+  E2eApi._(this._dio, this._auth);
+
+  final Dio _dio;
+  final Options _auth;
+
+  static Future<E2eApi> login(String email) async {
+    final Dio dio = Dio(
+      BaseOptions(
+        // 분석 시점에는 dart-define 이 없어 이 상수가 '' 로 보인다. 기본값과 같다고
+        // 잡히지만, 실행 시에는 러너가 넘긴 주소가 들어온다.
+        // ignore: avoid_redundant_argument_values
+        baseUrl: apiBaseUrl,
+        connectTimeout: const Duration(seconds: 15),
+        sendTimeout: const Duration(seconds: 15),
+        receiveTimeout: const Duration(seconds: 15),
+      ),
+    );
+    final Response<Map<String, dynamic>> res = await dio
+        .post<Map<String, dynamic>>(
+          '/auth/login',
+          data: <String, String>{'username': email, 'password': demoPassword},
+          options: Options(contentType: Headers.formUrlEncodedContentType),
+        );
+    return E2eApi._(
+      dio,
+      Options(
+        headers: <String, String>{
+          'Authorization': 'Bearer ${res.data!['access_token']}',
+        },
+      ),
+    );
+  }
+
+  Future<List<Map<String, dynamic>>> trainerSlots() async {
+    final Response<List<dynamic>> res = await _dio.get<List<dynamic>>(
+      '/trainer/reservation-slots',
+      options: _auth,
+    );
+    return <Map<String, dynamic>>[
+      for (final Object? row in res.data ?? const <Object?>[])
+        row! as Map<String, dynamic>,
+    ];
+  }
+
+  /// 시작 시각이 [startsAt] 인 슬롯. 이번 실행이 만든 자리를 id 없이 찾아낸다.
+  Future<Map<String, dynamic>?> slotAt(DateTime startsAt) async {
+    for (final Map<String, dynamic> slot in await trainerSlots()) {
+      final DateTime at = DateTime.parse(slot['starts_at'] as String).toUtc();
+      if (at == startsAt.toUtc()) return slot;
+    }
+    return null;
+  }
+
+  Future<Map<String, dynamic>> slotById(String id) async {
+    for (final Map<String, dynamic> slot in await trainerSlots()) {
+      if (slot['id'] == id) return slot;
+    }
+    fail('슬롯 $id 를 서버에서 찾지 못했습니다.');
+  }
+
+  /// 그 날짜의 트레이너 일정. 예약이 만든 일정은 `note` 가 '회원 앱 예약' 이다
+  /// (`reservation_service.reserve`).
+  Future<List<Map<String, dynamic>>> sessionsOn(DateTime day) async {
+    final Response<List<dynamic>> res = await _dio.get<List<dynamic>>(
+      '/trainer/schedule',
+      queryParameters: <String, Object?>{'date': ymd(day)},
+      options: _auth,
+    );
+    return <Map<String, dynamic>>[
+      for (final Object? row in res.data ?? const <Object?>[])
+        row! as Map<String, dynamic>,
+    ];
+  }
+
+  /// 그 시각에 회원 앱 예약으로 생긴 일정들.
+  ///
+  /// 날짜·시각·회원 이름만으로는 **이번 실행의 것을 특정할 수 없다.** 슬롯 시각이
+  /// 매 실행 같은 10:00 이라, 앞선 실행이 남긴 일정도 똑같이 걸린다. 그래서 호출부는
+  /// 예약 전후의 id 차집합으로 이번 것을 고른다([E2eState] 의 `sessionIdsBefore`).
+  Future<List<Map<String, dynamic>>> reservationSessionsAt(
+    DateTime startsAt,
+  ) async {
+    final String hhmm =
+        '${startsAt.hour.toString().padLeft(2, '0')}:'
+        '${startsAt.minute.toString().padLeft(2, '0')}';
+    return <Map<String, dynamic>>[
+      for (final Map<String, dynamic> session in await sessionsOn(startsAt))
+        if (session['time'] == hhmm &&
+            session['note'] == '회원 앱 예약' &&
+            session['client_name'] == memberName)
+          session,
+    ];
+  }
+
+  Future<void> closeSlot(String id) async {
+    await _dio.delete<Object?>(
+      '/trainer/reservation-slots/$id',
+      options: _auth,
+    );
+  }
+}
+
+/// VM 에는 구현이 없는 플러그인을 채운다.
+///
+/// 이 셋이 없으면 앱은 부팅 도중 `MissingPluginException` 으로 멈춘다. 실제 기기·
+/// 브라우저에서는 플랫폼이 제공하는 것들이라, 여기서만 대신 준다.
+void installPluginFakes() {
+  SharedPreferences.setMockInitialValues(<String, Object>{});
+  FlutterSecureStorage.setMockInitialValues(<String, String>{});
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(
+        const MethodChannel('plugins.flutter.io/path_provider'),
+        (MethodCall call) async =>
+            Directory.systemTemp.createTempSync('oncare_trainer_e2e').path,
+      );
+}
+
+Future<void> pumpUntil(
+  WidgetTester tester,
+  Finder finder, {
+  required String step,
+  Duration timeout = const Duration(seconds: 20),
+}) async {
+  final DateTime deadline = DateTime.now().add(timeout);
+  while (finder.evaluate().isEmpty && DateTime.now().isBefore(deadline)) {
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+  expect(finder, findsWidgets, reason: '[$e2ePhase] $step 이(가) $timeout 안에 나타나지 않았습니다.');
+}
+
+Future<void> pumpUntilAbsent(
+  WidgetTester tester,
+  Finder finder, {
+  required String step,
+  Duration timeout = const Duration(seconds: 20),
+}) async {
+  final DateTime deadline = DateTime.now().add(timeout);
+  while (finder.evaluate().isNotEmpty && DateTime.now().isBefore(deadline)) {
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+  expect(finder, findsNothing, reason: '[$e2ePhase] $step 이(가) $timeout 안에 사라지지 않았습니다.');
+}
+
+/// 스크롤 목록 안에서 [target] 이 나올 때까지 끌어 내린다.
+///
+/// `ListView` 는 보이는 자식만 만든다. 실행을 거듭할수록 슬롯 목록이 길어져 새로 만든
+/// 자리가 화면 밖으로 밀리는데, 그때 `find.byKey` 는 "없음" 을 돌려준다 — 화면에 안
+/// 그려진 것과 만들어지지 않은 것이 구분되지 않는다.
+Future<void> pumpUntilVisibleInList(
+  WidgetTester tester,
+  Finder target, {
+  required Finder list,
+  required String step,
+  int maxDrags = 30,
+}) async {
+  for (int i = 0; i < maxDrags && target.evaluate().isEmpty; i++) {
+    await tester.drag(list, const Offset(0, -160));
+    await tester.pump(const Duration(milliseconds: 120));
+  }
+  expect(
+    target,
+    findsWidgets,
+    reason: '[$e2ePhase] $step 을(를) 목록 끝까지 내려도 찾지 못했습니다.',
+  );
+}
+
+/// 목업으로 통과하는 것을 막는 관문.
+///
+/// 이슈의 완료 조건이 "mock repository 만으로 통과하지 않는다" 라, 설정이 목업으로
+/// 새면 조용히 초록불이 뜨는 대신 여기서 멈춘다.
+void assertRealApiConfig() {
+  final AppConfig config = AppConfig.fromEnvironment();
+  expect(
+    config.useMockApi,
+    isFalse,
+    reason: '--dart-define=USE_MOCK_API=false 로 실행해야 합니다.',
+  );
+  expect(apiBaseUrl, isNotEmpty, reason: 'API_BASE_URL 이 필요합니다.');
+  expect(
+    config.apiBaseUrl,
+    apiBaseUrl,
+    reason: '앱과 검증용 API 클라이언트가 같은 백엔드를 봐야 합니다.',
+  );
+}
+
+/// 트레이너 웹의 기준 뷰포트(desktop 1440×1024 계약, 여유 폭 1600).
+///
+/// 기본 테스트 화면은 800×600 이라 사이드바가 접힌다 — 그 상태에서는 `sidebar-*`
+/// 가 트리에 아예 없어서, 화면 이동이 전부 "위젯을 찾지 못함" 으로 깨진다.
+void useDesktopViewport(WidgetTester tester) {
+  tester.view.physicalSize = const Size(1600, 1024);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+}
+
+/// 로그아웃 상태에서 앱을 새로 띄운다. 재시작·재로그인 검증도 이것을 다시 부른다.
+Future<void> bootSignedOut(WidgetTester tester) async {
+  useDesktopViewport(tester);
+  assertRealApiConfig();
+  // 앞선 부팅이 남아 있으면 그 ProviderScope 의 세션이 그대로 살아 있어, 토큰을
+  // 지워도 새 트리가 로그인 화면 대신 대시보드로 간다. 재시작 검증이 조용히
+  // "로그인된 채로 계속" 을 통과시키지 않도록 먼저 트리를 비운다.
+  await tester.pumpWidget(const SizedBox.shrink());
+  await tester.pump();
+  await const FlutterSecureStorage().deleteAll();
+  await bootstrap();
+  await pumpUntil(tester, find.byType(TrainerSignInPage), step: '로그인 화면');
+}
+
+Future<void> loginAsTrainer(WidgetTester tester) async {
+  await tester.enterText(
+    find.descendant(
+      of: find.byKey(const ValueKey<String>('trainer-login-email')),
+      matching: find.byType(TextField),
+    ),
+    trainerEmail,
+  );
+  await tester.enterText(
+    find.descendant(
+      of: find.byKey(const ValueKey<String>('trainer-login-password')),
+      matching: find.byType(TextField),
+    ),
+    demoPassword,
+  );
+  await tester.tap(find.byKey(const ValueKey<String>('trainer-login-submit')));
+  await pumpUntil(tester, find.byType(DashboardPage), step: '트레이너 로그인');
+}
+
+String ymd(DateTime value) =>
+    '${value.year.toString().padLeft(4, '0')}-'
+    '${value.month.toString().padLeft(2, '0')}-'
+    '${value.day.toString().padLeft(2, '0')}';

--- a/frontend/flutter_trainer/tool/run_web_e2e.sh
+++ b/frontend/flutter_trainer/tool/run_web_e2e.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if ! curl --fail --silent http://localhost:8000/health >/dev/null; then
+# 헬스 체크는 `/v1/healthz` 다. `/health` 로 물으면 백엔드가 멀쩡해도 404 가 돌아와
+# `--fail` 이 0 이 아닌 코드를 내고, 이 스크립트가 "준비 안 됨" 으로 멈춘다.
+if ! curl --fail --silent http://localhost:8000/v1/healthz >/dev/null; then
   echo 'backend is not ready at http://localhost:8000'
   exit 1
 fi

--- a/tool/run_reservation_e2e.sh
+++ b/tool/run_reservation_e2e.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# 회원↔트레이너 예약·취소 실 API E2E (#637).
+#
+# 회원 앱과 트레이너 웹은 **서로 다른 Dart 패키지**라 한 프로세스에 함께 띄울 수 없다.
+# 그래서 한 시나리오를 단계로 쪼개 번갈아 실행하고, 단계 사이의 상태는 서버 DB 와
+# 상태 파일(id 만)로 넘긴다. 이 스크립트가 그 순서를 강제한다 — 순서가 곧 계약이다.
+#
+#   1. (트레이너) create-slot            미래 슬롯을 UI 로 연다
+#   2. (회원)     reserve                그 자리를 보고 예약 · 재로그인 후에도 유지
+#   3. (트레이너) verify-schedule        예약이 만든 일정이 트레이너 화면에 보인다
+#   4. (회원)     cancel                 취소 · 좌석 복구 · 재예약 가능
+#   5. (트레이너) verify-schedule-removed 일정이 사라지고 좌석이 정원까지 복구
+#   6. (회원)     edge-cases             중복·권한·정원 경쟁이 초과 예약을 못 만든다
+#   7. (트레이너) cleanup                이번 실행이 연 슬롯을 닫는다
+#
+# 매 실행은 **새 슬롯**을 연다. 앞선 실행이 중간에 죽어 예약이 남아 있어도 다음 실행이
+# 그것을 건드리지 않는다 — 반복 실행이 서로 간섭하지 않는 것이 완료 조건이다.
+#
+# 사용법:
+#   bash tool/run_reservation_e2e.sh
+#   API_BASE_URL=http://localhost:8000/v1 bash tool/run_reservation_e2e.sh
+set -euo pipefail
+
+readonly ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly API_BASE_URL="${API_BASE_URL:-http://localhost:8000/v1}"
+readonly STATE_FILE="${E2E_STATE_FILE:-$(mktemp -t oncare_e2e_XXXXXX.json)}"
+readonly FLUTTER="${FLUTTER:-flutter}"
+
+# 백엔드 확인은 `/v1/healthz` 로 한다. `/health` 는 존재한 적 없거나 옮겨졌고,
+# 그 경로로 확인하면 백엔드가 멀쩡해도 "준비 안 됨" 으로 읽힌다.
+if ! curl --fail --silent --max-time 10 "${API_BASE_URL%/v1}/v1/healthz" >/dev/null; then
+  echo "백엔드가 준비되지 않았습니다: ${API_BASE_URL%/v1}/v1/healthz" >&2
+  echo "  cd backend && docker compose up -d" >&2
+  exit 1
+fi
+
+: >"$STATE_FILE"
+echo "상태 파일: $STATE_FILE"
+echo "백엔드:    $API_BASE_URL"
+echo
+
+# 단계 실행. $1=패키지 디렉터리, $2=테스트 파일, $3=단계 이름
+run_phase() {
+  local package="$1" target="$2" phase="$3"
+  echo "── [$phase] $package"
+  (
+    cd "$ROOT/$package"
+    "$FLUTTER" test "$target" \
+      --dart-define=USE_MOCK_API=false \
+      --dart-define=API_BASE_URL="$API_BASE_URL" \
+      --dart-define=E2E_PHASE="$phase" \
+      --dart-define=E2E_STATE_FILE="$STATE_FILE"
+  )
+  echo
+}
+
+trainer() { run_phase frontend/flutter_trainer test_e2e/reservation_trainer_test.dart "$1"; }
+member() { run_phase frontend/flutter test_e2e/reservation_member_test.dart "$1"; }
+
+# 어느 단계에서 멈췄는지 남긴다. 단계 이름만으로 실패 지점이 특정된다.
+failed_phase=''
+report_failure() {
+  if [ -n "$failed_phase" ]; then
+    echo "::error::[$failed_phase] 에서 실패했습니다. 상태 파일: $STATE_FILE" >&2
+    echo "이번 실행이 만든 슬롯·예약은 남아 있을 수 있습니다(다음 실행은 새 슬롯을 씁니다)." >&2
+  fi
+}
+trap report_failure EXIT
+
+for phase in create-slot reserve verify-schedule cancel verify-schedule-removed; do
+  failed_phase="$phase"
+  case "$phase" in
+    reserve | cancel) member "$phase" ;;
+    *) trainer "$phase" ;;
+  esac
+done
+
+failed_phase='edge-cases'
+member edge-cases
+
+failed_phase='cleanup'
+trainer cleanup
+
+failed_phase=''
+echo "✅ 예약·취소 실 API E2E 전 단계 통과"


### PR DESCRIPTION
## Summary

* 트레이너가 연 자리를 회원이 예약하고, 그 예약이 트레이너 일정으로 파생됐다가, 회원이 취소하면 좌석과 일정이 함께 돌아오는 양방향 흐름 전체를 실 백엔드로 검증합니다.
* 두 앱은 서로 다른 Dart 패키지라 한 프로세스에 함께 띄울 수 없어, 한 시나리오를 7단계로 쪼개 번갈아 실행하고 단계 사이의 상태는 서버 DB와 상태 파일(id만)로 넘깁니다.
* 브라우저를 쓰지 않습니다. 회원 앱의 배포 타깃은 iOS/Android라 ChromeDriver를 붙일 이유가 없고, `IntegrationTestWidgetsFlutterBinding`을 `flutter test`로 돌리면 실제 위젯 트리와 실제 HTTP가 그대로 동작합니다.
* 스위트는 `test/` 밖의 `test_e2e/`에 두어, 백엔드가 없는 CI에서 딸려 돌며 깨지지 않게 했습니다.
* 매 실행이 새 슬롯을 열어 앞선 실행의 잔여와 간섭하지 않습니다. 연속 2회 실행으로 확인했습니다.

---

## Changes

### ✨ Features

* `tool/run_reservation_e2e.sh` — 7단계 순서를 강제하는 오케스트레이터. 실패 시 어느 단계에서 멈췄는지와 상태 파일 경로를 남깁니다.
* `frontend/flutter/test_e2e/` — 회원 앱 실 API E2E 하네스와 `reserve` / `cancel` / `edge-cases` 단계.
* `frontend/flutter_trainer/test_e2e/` — 트레이너 웹 하네스와 `create-slot` / `verify-schedule` / `verify-schedule-removed` / `cleanup` 단계.

### 🔧 Improvements

* 각 단계가 UI와 서버 응답을 **둘 다** 확인합니다. "화면에 보였다"와 "서버에 저장됐다"는 다른 주장이고, 완료 조건은 둘 다 요구합니다.
* `USE_MOCK_API=false`가 아니거나 앱과 검증용 클라이언트의 `API_BASE_URL`이 다르면 즉시 실패합니다 — 목업으로 새면서 초록불이 뜨는 것을 막습니다.
* 화면 이동에 필요한 위젯 키를 두 앱에 추가했습니다(`member-login-*`, `nav-exercise`, `exercise-subtab-*`, `slot-chip-*`, `reserve-confirm`, `cancel-dialog-*`, `schedule-open-slots`, `slot-capacity-input`, `slot-create`, `slot-row-*`, `schedule-session-*`).

### 🎨 UI/UX

* 화면 변경 없음 — 추가한 것은 테스트가 위젯을 지목하기 위한 키뿐이고 렌더링 결과는 그대로입니다.

### 📝 Docs

* `docs/local_fullstack.md` — 실행 방법, 단계 구성표, 브라우저를 쓰지 않는 이유, 반복 실행 시 남는 데이터, 테스트가 고정하는 계약을 추가했습니다.

### 🐛 Fixes

* `frontend/flutter_trainer/tool/run_web_e2e.sh`의 헬스 체크 경로를 `/v1/healthz`로 고쳤습니다. `/health`는 404라 백엔드가 멀쩡해도 `curl --fail`이 실패해 스크립트가 "backend is not ready"로 멈췄습니다.

---

## Commits

1. `ee770f26` test(member): 회원↔트레이너 예약·취소 실 API E2E 검증 추가

---

## Notes

* **단계를 나눈 이유**: 회원 앱(`oncare`)과 트레이너 웹(`oncare_trainer`)은 서로 다른 Dart 패키지라 한 테스트 프로세스에 함께 띄울 수 없습니다. 예약 → 트레이너 확인 → 취소 → 트레이너 재확인은 본질적으로 번갈아 일어나므로 단계 분리가 불가피합니다.
* **상태 파일에 담는 것**: 화면에서 읽을 수 없는 id만 담습니다. 잔여 좌석처럼 검증 대상인 값을 담으면 서버가 아니라 앞 단계의 기억을 검증하게 됩니다.
* **슬롯 시각**: 시트 기본값 10:00을 그대로 쓰고 날짜만 하루 뒤로 잡습니다. `showTimePicker` 다이얼을 자동화하는 쪽이 깨질 거리가 더 많습니다. 대신 매 실행 시각이 같아지므로, 이번 실행의 일정을 특정할 때 예약 전후 id 차집합을 씁니다.
* **남는 데이터**: 슬롯 삭제 API가 없고 닫기만 가능하므로(`DELETE /trainer/reservation-slots/{id}`는 `is_closed`를 켭니다) 실행마다 닫힌 슬롯이 하나씩 남습니다. 닫힌 자리는 회원 조회에 나오지 않아 다음 실행과 간섭하지 않습니다.
* **`jisu@oncare.com`도 담당 회원입니다**(시드). 그래서 이 계정의 예약은 거절되지 않고 두 번째 좌석을 정상적으로 가져갑니다. 마지막 좌석 경쟁은 정원 1짜리 별도 슬롯에서 확인합니다 — 정원 2에서는 한쪽이 첫 좌석을 채우는 순간 다른 요청이 '중복'으로 걸려 경쟁이 아니게 됩니다.
* **CI 영향 없음**: 두 CI의 `flutter test`는 인자 없이 돌아 `test/`만 훑습니다. 이 스위트는 `test_e2e/`에 있어 포함되지 않습니다.

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. `cd backend && docker compose up -d` 로 백엔드를 띄우고 `curl localhost:8000/v1/healthz` 가 200인지 확인합니다.
2. `bash tool/run_reservation_e2e.sh` 를 실행해 7단계가 모두 통과하는지 확인합니다.
3. 같은 명령을 한 번 더 실행해, 앞선 실행의 잔여와 무관하게 다시 통과하는지 확인합니다.
4. `cd frontend/flutter && flutter analyze && flutter test`, `cd ../flutter_trainer && flutter analyze && flutter test` 로 기존 스위트가 그대로 통과하는지 확인합니다.

---

## Related Issues

Closes #637

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인