### PR TITLE
refactor(demo): 시드 식단 영양 수치 중복 제거

### DIFF
--- a/frontend/flutter/lib/core/storage/seed_data.dart
+++ b/frontend/flutter/lib/core/storage/seed_data.dart
@@ -511,6 +511,38 @@ class _SeedMeal {
   );
 }
 
+/// 여러 끼니에 함께 쓰이는 음식. 끼니 상수마다 다시 적으면 이 변경이 없애려는
+/// 중복이 그대로 남는다 — 한 곳에서만 고칠 수 있게 뽑아 둔다.
+const _SeedFood _foodDoenjangJjigae = _SeedFood(
+  '된장찌개',
+  calories: 300,
+  sodiumMg: 1300,
+  sugarG: 5,
+  carbsG: 18,
+  proteinG: 24,
+  fatG: 15,
+);
+
+const _SeedFood _foodRice = _SeedFood(
+  '밥',
+  calories: 310,
+  sodiumMg: 5,
+  sugarG: 0.7,
+  carbsG: 67,
+  proteinG: 6,
+  fatG: 2.5,
+);
+
+const _SeedFood _foodChickenSalad = _SeedFood(
+  '닭가슴살 샐러드',
+  calories: 315,
+  sodiumMg: 395,
+  sugarG: 10,
+  carbsG: 19,
+  proteinG: 34,
+  fatG: 11.1,
+);
+
 const _SeedMeal _mealOatmealBanana = _SeedMeal(
   slug: 'breakfast',
   mealType: 'breakfast',
@@ -607,17 +639,7 @@ const _SeedMeal _mealChickenSalad = _SeedMeal(
   timeLabel: '12:30',
   photoAsset: 'assets/images/diet-chicken-salad.jpg',
   aiComment: '닭가슴살과 채소로 단백질·식이섬유를 챙겼어요.',
-  foods: <_SeedFood>[
-    _SeedFood(
-      '닭가슴살 샐러드',
-      calories: 315,
-      sodiumMg: 395,
-      sugarG: 10,
-      carbsG: 19,
-      proteinG: 34,
-      fatG: 11.1,
-    ),
-  ],
+  foods: <_SeedFood>[_foodChickenSalad],
 );
 
 const _SeedMeal _mealVegetableBibimbap = _SeedMeal(
@@ -664,26 +686,7 @@ const _SeedMeal _mealDoenjangRiceLunch = _SeedMeal(
   timeLabel: '12:10',
   photoAsset: 'assets/images/diet-doenjang-rice.jpeg',
   aiComment: '집밥 한 상이에요. 찌개 국물만 조금 남겨 보세요.',
-  foods: <_SeedFood>[
-    _SeedFood(
-      '된장찌개',
-      calories: 300,
-      sodiumMg: 1300,
-      sugarG: 5,
-      carbsG: 18,
-      proteinG: 24,
-      fatG: 15,
-    ),
-    _SeedFood(
-      '밥',
-      calories: 310,
-      sodiumMg: 5,
-      sugarG: 0.7,
-      carbsG: 67,
-      proteinG: 6,
-      fatG: 2.5,
-    ),
-  ],
+  foods: <_SeedFood>[_foodDoenjangJjigae, _foodRice],
 );
 
 const List<_SeedMeal> _historyLunches = <_SeedMeal>[
@@ -727,26 +730,7 @@ const _SeedMeal _mealDoenjangRiceDinner = _SeedMeal(
   timeLabel: '19:10',
   photoAsset: 'assets/images/diet-doenjang-rice.jpeg',
   aiComment: '포만감은 좋지만 국물 나트륨이 높은 편이에요.',
-  foods: <_SeedFood>[
-    _SeedFood(
-      '된장찌개',
-      calories: 300,
-      sodiumMg: 1300,
-      sugarG: 5,
-      carbsG: 18,
-      proteinG: 24,
-      fatG: 15,
-    ),
-    _SeedFood(
-      '밥',
-      calories: 310,
-      sodiumMg: 5,
-      sugarG: 0.7,
-      carbsG: 67,
-      proteinG: 6,
-      fatG: 2.5,
-    ),
-  ],
+  foods: <_SeedFood>[_foodDoenjangJjigae, _foodRice],
 );
 
 const _SeedMeal _mealChickenSaladSweetPotato = _SeedMeal(
@@ -756,15 +740,7 @@ const _SeedMeal _mealChickenSaladSweetPotato = _SeedMeal(
   photoAsset: 'assets/images/diet-chicken-salad.jpg',
   aiComment: '가볍게 마무리한 저녁이에요.',
   foods: <_SeedFood>[
-    _SeedFood(
-      '닭가슴살 샐러드',
-      calories: 315,
-      sodiumMg: 395,
-      sugarG: 10,
-      carbsG: 19,
-      proteinG: 34,
-      fatG: 11.1,
-    ),
+    _foodChickenSalad,
     _SeedFood(
       '고구마',
       calories: 130,

--- a/frontend/flutter/lib/core/storage/seed_data.dart
+++ b/frontend/flutter/lib/core/storage/seed_data.dart
@@ -109,258 +109,64 @@ Future<void> seedIfEmpty(AppDatabase db) async {
     // ---- Diet entries (today plus two populated historical days) ----
     await db.batch((Batch b) {
       b.insertAll(db.dietEntries, <DietEntriesCompanion>[
-        DietEntriesCompanion.insert(
+        // 시연에 쓰는 큐레이션 사흘. 음식 구성과 영양 수치는 히스토리와 같은
+        // 템플릿에서 나오고, 여기서는 고정 id·시각·그날의 코치 문구만 덮어쓴다
+        // — 수치를 두 벌로 두면 한쪽만 고쳤을 때 조용히 어긋난다(#677).
+        _mealScrambledEggStrawberry.companion(
+          today,
           id: 'seed-diet-breakfast',
-          date: today,
-          mealType: 'breakfast',
           timeLabel: '08:20',
-          foodsJson: jsonEncode(<Map<String, Object?>>[
-            <String, Object?>{
-              'name': '스크램블 에그',
-              'calories': 185,
-              'sodium_mg': 220,
-              'sugar_g': 0.8,
-              'carbs_g': 2.0,
-              'protein_g': 13.0,
-              'fat_g': 14.0,
-            },
-            <String, Object?>{
-              'name': '딸기',
-              'calories': 32,
-              'sodium_mg': 1,
-              'sugar_g': 5.5,
-              'carbs_g': 8.0,
-              'protein_g': 0.5,
-              'fat_g': 0.5,
-            },
-          ]),
-          totalCalories: 217,
-          sodiumMg: const Value(221),
-          sugarG: const Value(6.3),
-          aiComment: const Value('단백질과 식이섬유의 깔끔한 조합으로, 소금 간과 기름만 조절하면 혈당과 혈압 모두 잡는 우수한 식단입니다.'),
-          photoAsset: const Value('assets/images/breakfast-scrambled-egg-strawberry.jpg'),
+          aiComment:
+              '단백질과 식이섬유의 깔끔한 조합으로, 소금 간과 기름만 조절하면 혈당과 혈압 모두 잡는 우수한 식단입니다.',
         ),
-        DietEntriesCompanion.insert(
+        _mealJjamppong.companion(
+          today,
           id: 'seed-diet-lunch',
-          date: today,
-          mealType: 'lunch',
           timeLabel: '12:40',
-          foodsJson: jsonEncode(<Map<String, Object?>>[
-            <String, Object?>{
-              'name': '짬뽕',
-              'calories': 750,
-              'sodium_mg': 3200,
-              'sugar_g': 8.5,
-              // 식단 탭과 홈 대시보드가 같은 행을 집계한다.
-              'carbs_g': 107.0,
-              'protein_g': 29.0,
-              'fat_g': 22.5,
-            },
-          ]),
-          totalCalories: 750,
-          sodiumMg: const Value(3200),
-          sugarG: const Value(8.5),
-          aiComment: const Value('정제 면과 높은 나트륨으로 혈압·혈당 부담이 매우 크니, 국물은 남기고 야채 위주로 드시는 것이 좋습니다.'),
-          photoAsset: const Value('assets/images/lunch-jjamppong.jpg'),
+          aiComment:
+              '정제 면과 높은 나트륨으로 혈압·혈당 부담이 매우 크니, 국물은 남기고 야채 위주로 드시는 것이 좋습니다.',
         ),
-        DietEntriesCompanion.insert(
+        _mealCoffeeNuts.companion(
+          today,
           id: 'seed-diet-snack',
-          date: today,
-          mealType: 'snack',
           timeLabel: '15:30',
-          foodsJson: jsonEncode(<Map<String, Object?>>[
-            <String, Object?>{
-              'name': '아이스 아메리카노',
-              'calories': 10,
-              'sodium_mg': 5,
-              'sugar_g': 0,
-              'carbs_g': 2.0,
-              'protein_g': 0.5,
-              'fat_g': 0.0,
-            },
-            <String, Object?>{
-              'name': '견과류 한 봉',
-              'calories': 90,
-              'sodium_mg': 2,
-              'sugar_g': 3,
-              'carbs_g': 1.0,
-              'protein_g': 2.0,
-              'fat_g': 8.0,
-            },
-          ]),
-          totalCalories: 100,
-          sodiumMg: const Value(7),
-          sugarG: const Value(3.0),
-          aiComment: const Value('당류와 칼로리가 낮고 견과류의 건강한 지방이 채워져 완벽한 간식입니다.'),
-          photoAsset: const Value('assets/images/snack-coffee-nuts.jpg'),
+          aiComment: '당류와 칼로리가 낮고 견과류의 건강한 지방이 채워져 완벽한 간식입니다.',
         ),
-        DietEntriesCompanion.insert(
+        _mealOatmealBanana.companion(
+          yesterday,
           id: 'seed-diet-yesterday-breakfast',
-          date: yesterday,
-          mealType: 'breakfast',
           timeLabel: '08:10',
-          foodsJson: jsonEncode(<Map<String, Object?>>[
-            <String, Object?>{
-              'name': '오트밀',
-              'calories': 250,
-              'sodium_mg': 100,
-              'sugar_g': 6,
-              'carbs_g': 42.0,
-              'protein_g': 10.0,
-              'fat_g': 6.0,
-            },
-            <String, Object?>{
-              'name': '바나나',
-              'calories': 105,
-              'sodium_mg': 1,
-              'sugar_g': 14,
-              'carbs_g': 27.0,
-              'protein_g': 1.3,
-              'fat_g': 0.4,
-            },
-          ]),
-          totalCalories: 355,
-          sodiumMg: const Value(101),
-          sugarG: const Value(20.0),
-          aiComment: const Value('오트밀로 식이섬유를 챙겼어요. 바나나가 들어가 당류는 다소 높은 편이에요.'),
-          photoAsset: const Value('assets/images/diet-oatmeal-banana.jpeg'),
+          aiComment: '오트밀로 식이섬유를 챙겼어요. 바나나가 들어가 당류는 다소 높은 편이에요.',
         ),
-        DietEntriesCompanion.insert(
+        _mealChickenSalad.companion(
+          yesterday,
           id: 'seed-diet-yesterday-lunch',
-          date: yesterday,
-          mealType: 'lunch',
           timeLabel: '12:30',
-          foodsJson: jsonEncode(<Map<String, Object?>>[
-            <String, Object?>{
-              'name': '닭가슴살 샐러드',
-              'calories': 315,
-              'sodium_mg': 395,
-              'sugar_g': 10,
-              'carbs_g': 19.0,
-              'protein_g': 34.0,
-              'fat_g': 11.1,
-            },
-          ]),
-          totalCalories: 315,
-          sodiumMg: const Value(395),
-          sugarG: const Value(10.0),
-          aiComment: const Value('닭가슴살과 채소로 단백질과 식이섬유를 고르게 섭취했어요.'),
-          photoAsset: const Value('assets/images/diet-chicken-salad.jpg'),
+          aiComment: '닭가슴살과 채소로 단백질과 식이섬유를 고르게 섭취했어요.',
         ),
-        DietEntriesCompanion.insert(
+        _mealDoenjangRiceDinner.companion(
+          yesterday,
           id: 'seed-diet-yesterday-dinner',
-          date: yesterday,
-          mealType: 'dinner',
           timeLabel: '18:45',
-          foodsJson: jsonEncode(<Map<String, Object?>>[
-            <String, Object?>{
-              'name': '된장찌개',
-              'calories': 300,
-              'sodium_mg': 1300,
-              'sugar_g': 5,
-              'carbs_g': 18.0,
-              'protein_g': 24.0,
-              'fat_g': 15.0,
-            },
-            <String, Object?>{
-              'name': '밥',
-              'calories': 310,
-              'sodium_mg': 5,
-              'sugar_g': 0.7,
-              'carbs_g': 67.0,
-              'protein_g': 6.0,
-              'fat_g': 2.5,
-            },
-          ]),
-          totalCalories: 610,
-          sodiumMg: const Value(1305),
-          sugarG: const Value(5.7),
-          aiComment: const Value('밥과 찌개를 함께 섭취해 포만감은 좋지만 국물은 조금 남기면 좋아요.'),
-          photoAsset: const Value('assets/images/diet-doenjang-rice.jpeg'),
+          aiComment: '밥과 찌개를 함께 섭취해 포만감은 좋지만 국물은 조금 남기면 좋아요.',
         ),
-        DietEntriesCompanion.insert(
+        _mealGreekYogurtNuts.companion(
+          twoDaysAgo,
           id: 'seed-diet-two-days-ago-breakfast',
-          date: twoDaysAgo,
-          mealType: 'breakfast',
           timeLabel: '08:35',
-          foodsJson: jsonEncode(<Map<String, Object?>>[
-            <String, Object?>{
-              'name': '그릭 요거트',
-              'calories': 170,
-              'sodium_mg': 75,
-              'sugar_g': 7,
-              'carbs_g': 8.0,
-              'protein_g': 18.0,
-              'fat_g': 8.0,
-            },
-            <String, Object?>{
-              'name': '견과류',
-              'calories': 150,
-              'sodium_mg': 5,
-              'sugar_g': 2,
-              'carbs_g': 6.0,
-              'protein_g': 5.0,
-              'fat_g': 13.0,
-            },
-          ]),
-          totalCalories: 320,
-          sodiumMg: const Value(80),
-          sugarG: const Value(9.0),
-          aiComment: const Value('그릭 요거트의 단백질과 견과류의 불포화지방을 고르게 섭취했어요.'),
-          photoAsset: const Value('assets/images/diet-greek-yogurt-nuts.jpeg'),
+          aiComment: '그릭 요거트의 단백질과 견과류의 불포화지방을 고르게 섭취했어요.',
         ),
-        DietEntriesCompanion.insert(
+        _mealVegetableBibimbap.companion(
+          twoDaysAgo,
           id: 'seed-diet-two-days-ago-lunch',
-          date: twoDaysAgo,
-          mealType: 'lunch',
           timeLabel: '12:20',
-          foodsJson: jsonEncode(<Map<String, Object?>>[
-            <String, Object?>{
-              'name': '야채비빔밥',
-              'calories': 610,
-              'sodium_mg': 900,
-              'sugar_g': 12,
-              'carbs_g': 92.0,
-              'protein_g': 20.0,
-              'fat_g': 16.0,
-            },
-          ]),
-          totalCalories: 610,
-          sodiumMg: const Value(900),
-          sugarG: const Value(12.0),
-          aiComment: const Value('야채가 풍부한 비빔밥이에요. 고추장을 줄이면 나트륨을 더 조절할 수 있어요.'),
-          photoAsset: const Value('assets/images/diet-vegetable-bibimbap.jpg'),
+          aiComment: '야채가 풍부한 비빔밥이에요. 고추장을 줄이면 나트륨을 더 조절할 수 있어요.',
         ),
-        DietEntriesCompanion.insert(
+        _mealSalmonBrownRice.companion(
+          twoDaysAgo,
           id: 'seed-diet-two-days-ago-dinner',
-          date: twoDaysAgo,
-          mealType: 'dinner',
           timeLabel: '18:50',
-          foodsJson: jsonEncode(<Map<String, Object?>>[
-            <String, Object?>{
-              'name': '연어구이',
-              'calories': 395,
-              'sodium_mg': 505,
-              'sugar_g': 9,
-              'carbs_g': 19.0,
-              'protein_g': 35.0,
-              'fat_g': 19.0,
-            },
-            <String, Object?>{
-              'name': '현미밥',
-              'calories': 280,
-              'sodium_mg': 5,
-              'sugar_g': 0,
-              'carbs_g': 58.0,
-              'protein_g': 6.0,
-              'fat_g': 2.0,
-            },
-          ]),
-          totalCalories: 675,
-          sodiumMg: const Value(510),
-          sugarG: const Value(9.0),
-          aiComment: const Value('연어의 지방과 현미밥의 복합 탄수화물 조합이 좋아요.'),
-          photoAsset: const Value('assets/images/diet-salmon-brown-rice.jpeg'),
+          aiComment: '연어의 지방과 현미밥의 복합 탄수화물 조합이 좋아요.',
         ),
         // 큐레이션 사흘 앞으로 한 달치를 더 채운다 — 날짜를 옮겨도 기록이
         // 이어지도록(#671).
@@ -678,275 +484,306 @@ class _SeedMeal {
   double get totalSugar =>
       foods.fold<double>(0, (double a, _SeedFood f) => a + f.sugarG);
 
-  DietEntriesCompanion companion(String date) => DietEntriesCompanion.insert(
-    id: 'seed-diet-$date-$slug',
+  /// 이 끼니를 [date] 의 행으로 만든다.
+  ///
+  /// [id]·[timeLabel]·[aiComment] 를 덮어쓸 수 있다. 시연에 쓰는 큐레이션
+  /// 사흘은 고정 id(`seed-diet-lunch` 등)와 그날만의 코치 문구를 갖는데, **음식
+  /// 구성과 영양 수치는 히스토리와 똑같다.** 덮어쓰기를 두어 수치는 한 곳에만
+  /// 남기고 표현만 갈아 끼운다.
+  DietEntriesCompanion companion(
+    String date, {
+    String? id,
+    String? timeLabel,
+    String? aiComment,
+  }) => DietEntriesCompanion.insert(
+    id: id ?? 'seed-diet-$date-$slug',
     date: date,
     mealType: mealType,
-    timeLabel: timeLabel,
+    timeLabel: timeLabel ?? this.timeLabel,
     foodsJson: jsonEncode(<Map<String, Object?>>[
       for (final _SeedFood f in foods) f.toJson(),
     ]),
     totalCalories: totalCalories,
     sodiumMg: Value(totalSodium),
     sugarG: Value(totalSugar),
-    aiComment: Value(aiComment),
+    aiComment: Value(aiComment ?? this.aiComment),
     photoAsset: Value(photoAsset),
   );
 }
 
+const _SeedMeal _mealOatmealBanana = _SeedMeal(
+  slug: 'breakfast',
+  mealType: 'breakfast',
+  timeLabel: '08:05',
+  photoAsset: 'assets/images/diet-oatmeal-banana.jpeg',
+  aiComment: '오트밀로 식이섬유를 챙긴 아침이에요.',
+  foods: <_SeedFood>[
+    _SeedFood(
+      '오트밀',
+      calories: 250,
+      sodiumMg: 100,
+      sugarG: 6,
+      carbsG: 42,
+      proteinG: 10,
+      fatG: 6,
+    ),
+    _SeedFood(
+      '바나나',
+      calories: 105,
+      sodiumMg: 1,
+      sugarG: 14,
+      carbsG: 27,
+      proteinG: 1.3,
+      fatG: 0.4,
+    ),
+  ],
+);
+
+const _SeedMeal _mealGreekYogurtNuts = _SeedMeal(
+  slug: 'breakfast',
+  mealType: 'breakfast',
+  timeLabel: '08:30',
+  photoAsset: 'assets/images/diet-greek-yogurt-nuts.jpeg',
+  aiComment: '단백질과 불포화지방을 고르게 섭취했어요.',
+  foods: <_SeedFood>[
+    _SeedFood(
+      '그릭 요거트',
+      calories: 170,
+      sodiumMg: 75,
+      sugarG: 7,
+      carbsG: 8,
+      proteinG: 18,
+      fatG: 8,
+    ),
+    _SeedFood(
+      '견과류',
+      calories: 150,
+      sodiumMg: 5,
+      sugarG: 2,
+      carbsG: 6,
+      proteinG: 5,
+      fatG: 13,
+    ),
+  ],
+);
+
+const _SeedMeal _mealScrambledEggStrawberry = _SeedMeal(
+  slug: 'breakfast',
+  mealType: 'breakfast',
+  timeLabel: '07:50',
+  photoAsset: 'assets/images/breakfast-scrambled-egg-strawberry.jpg',
+  aiComment: '달걀 단백질에 과일로 비타민을 더했어요.',
+  foods: <_SeedFood>[
+    _SeedFood(
+      '스크램블 에그',
+      calories: 185,
+      sodiumMg: 220,
+      sugarG: 0.8,
+      carbsG: 2,
+      proteinG: 13,
+      fatG: 14,
+    ),
+    _SeedFood(
+      '딸기',
+      calories: 32,
+      sodiumMg: 1,
+      sugarG: 5.5,
+      carbsG: 8,
+      proteinG: 0.5,
+      fatG: 0.5,
+    ),
+  ],
+);
+
 const List<_SeedMeal> _historyBreakfasts = <_SeedMeal>[
-  _SeedMeal(
-    slug: 'breakfast',
-    mealType: 'breakfast',
-    timeLabel: '08:05',
-    photoAsset: 'assets/images/diet-oatmeal-banana.jpeg',
-    aiComment: '오트밀로 식이섬유를 챙긴 아침이에요.',
-    foods: <_SeedFood>[
-      _SeedFood(
-        '오트밀',
-        calories: 250,
-        sodiumMg: 100,
-        sugarG: 6,
-        carbsG: 42,
-        proteinG: 10,
-        fatG: 6,
-      ),
-      _SeedFood(
-        '바나나',
-        calories: 105,
-        sodiumMg: 1,
-        sugarG: 14,
-        carbsG: 27,
-        proteinG: 1.3,
-        fatG: 0.4,
-      ),
-    ],
-  ),
-  _SeedMeal(
-    slug: 'breakfast',
-    mealType: 'breakfast',
-    timeLabel: '08:30',
-    photoAsset: 'assets/images/diet-greek-yogurt-nuts.jpeg',
-    aiComment: '단백질과 불포화지방을 고르게 섭취했어요.',
-    foods: <_SeedFood>[
-      _SeedFood(
-        '그릭 요거트',
-        calories: 170,
-        sodiumMg: 75,
-        sugarG: 7,
-        carbsG: 8,
-        proteinG: 18,
-        fatG: 8,
-      ),
-      _SeedFood(
-        '견과류',
-        calories: 150,
-        sodiumMg: 5,
-        sugarG: 2,
-        carbsG: 6,
-        proteinG: 5,
-        fatG: 13,
-      ),
-    ],
-  ),
-  _SeedMeal(
-    slug: 'breakfast',
-    mealType: 'breakfast',
-    timeLabel: '07:50',
-    photoAsset: 'assets/images/breakfast-scrambled-egg-strawberry.jpg',
-    aiComment: '달걀 단백질에 과일로 비타민을 더했어요.',
-    foods: <_SeedFood>[
-      _SeedFood(
-        '스크램블 에그',
-        calories: 185,
-        sodiumMg: 220,
-        sugarG: 0.8,
-        carbsG: 2,
-        proteinG: 13,
-        fatG: 14,
-      ),
-      _SeedFood(
-        '딸기',
-        calories: 32,
-        sodiumMg: 1,
-        sugarG: 5.5,
-        carbsG: 8,
-        proteinG: 0.5,
-        fatG: 0.5,
-      ),
-    ],
-  ),
+  _mealOatmealBanana,
+  _mealGreekYogurtNuts,
+  _mealScrambledEggStrawberry,
 ];
+
+const _SeedMeal _mealChickenSalad = _SeedMeal(
+  slug: 'lunch',
+  mealType: 'lunch',
+  timeLabel: '12:30',
+  photoAsset: 'assets/images/diet-chicken-salad.jpg',
+  aiComment: '닭가슴살과 채소로 단백질·식이섬유를 챙겼어요.',
+  foods: <_SeedFood>[
+    _SeedFood(
+      '닭가슴살 샐러드',
+      calories: 315,
+      sodiumMg: 395,
+      sugarG: 10,
+      carbsG: 19,
+      proteinG: 34,
+      fatG: 11.1,
+    ),
+  ],
+);
+
+const _SeedMeal _mealVegetableBibimbap = _SeedMeal(
+  slug: 'lunch',
+  mealType: 'lunch',
+  timeLabel: '12:20',
+  photoAsset: 'assets/images/diet-vegetable-bibimbap.jpg',
+  aiComment: '야채가 풍부해요. 고추장을 줄이면 나트륨이 더 좋아져요.',
+  foods: <_SeedFood>[
+    _SeedFood(
+      '야채비빔밥',
+      calories: 610,
+      sodiumMg: 900,
+      sugarG: 12,
+      carbsG: 92,
+      proteinG: 20,
+      fatG: 16,
+    ),
+  ],
+);
+
+const _SeedMeal _mealJjamppong = _SeedMeal(
+  slug: 'lunch',
+  mealType: 'lunch',
+  timeLabel: '12:50',
+  photoAsset: 'assets/images/lunch-jjamppong.jpg',
+  aiComment: '국물 나트륨이 높은 날이에요. 국물은 남기는 편이 좋아요.',
+  foods: <_SeedFood>[
+    _SeedFood(
+      '짬뽕',
+      calories: 750,
+      sodiumMg: 3200,
+      sugarG: 8.5,
+      carbsG: 107,
+      proteinG: 29,
+      fatG: 22.5,
+    ),
+  ],
+);
+
+const _SeedMeal _mealDoenjangRiceLunch = _SeedMeal(
+  slug: 'lunch',
+  mealType: 'lunch',
+  timeLabel: '12:10',
+  photoAsset: 'assets/images/diet-doenjang-rice.jpeg',
+  aiComment: '집밥 한 상이에요. 찌개 국물만 조금 남겨 보세요.',
+  foods: <_SeedFood>[
+    _SeedFood(
+      '된장찌개',
+      calories: 300,
+      sodiumMg: 1300,
+      sugarG: 5,
+      carbsG: 18,
+      proteinG: 24,
+      fatG: 15,
+    ),
+    _SeedFood(
+      '밥',
+      calories: 310,
+      sodiumMg: 5,
+      sugarG: 0.7,
+      carbsG: 67,
+      proteinG: 6,
+      fatG: 2.5,
+    ),
+  ],
+);
 
 const List<_SeedMeal> _historyLunches = <_SeedMeal>[
-  _SeedMeal(
-    slug: 'lunch',
-    mealType: 'lunch',
-    timeLabel: '12:30',
-    photoAsset: 'assets/images/diet-chicken-salad.jpg',
-    aiComment: '닭가슴살과 채소로 단백질·식이섬유를 챙겼어요.',
-    foods: <_SeedFood>[
-      _SeedFood(
-        '닭가슴살 샐러드',
-        calories: 315,
-        sodiumMg: 395,
-        sugarG: 10,
-        carbsG: 19,
-        proteinG: 34,
-        fatG: 11.1,
-      ),
-    ],
-  ),
-  _SeedMeal(
-    slug: 'lunch',
-    mealType: 'lunch',
-    timeLabel: '12:20',
-    photoAsset: 'assets/images/diet-vegetable-bibimbap.jpg',
-    aiComment: '야채가 풍부해요. 고추장을 줄이면 나트륨이 더 좋아져요.',
-    foods: <_SeedFood>[
-      _SeedFood(
-        '야채비빔밥',
-        calories: 610,
-        sodiumMg: 900,
-        sugarG: 12,
-        carbsG: 92,
-        proteinG: 20,
-        fatG: 16,
-      ),
-    ],
-  ),
-  _SeedMeal(
-    slug: 'lunch',
-    mealType: 'lunch',
-    timeLabel: '12:50',
-    photoAsset: 'assets/images/lunch-jjamppong.jpg',
-    aiComment: '국물 나트륨이 높은 날이에요. 국물은 남기는 편이 좋아요.',
-    foods: <_SeedFood>[
-      _SeedFood(
-        '짬뽕',
-        calories: 750,
-        sodiumMg: 3200,
-        sugarG: 8.5,
-        carbsG: 107,
-        proteinG: 29,
-        fatG: 22.5,
-      ),
-    ],
-  ),
-  _SeedMeal(
-    slug: 'lunch',
-    mealType: 'lunch',
-    timeLabel: '12:10',
-    photoAsset: 'assets/images/diet-doenjang-rice.jpeg',
-    aiComment: '집밥 한 상이에요. 찌개 국물만 조금 남겨 보세요.',
-    foods: <_SeedFood>[
-      _SeedFood(
-        '된장찌개',
-        calories: 300,
-        sodiumMg: 1300,
-        sugarG: 5,
-        carbsG: 18,
-        proteinG: 24,
-        fatG: 15,
-      ),
-      _SeedFood(
-        '밥',
-        calories: 310,
-        sodiumMg: 5,
-        sugarG: 0.7,
-        carbsG: 67,
-        proteinG: 6,
-        fatG: 2.5,
-      ),
-    ],
-  ),
+  _mealChickenSalad,
+  _mealVegetableBibimbap,
+  _mealJjamppong,
+  _mealDoenjangRiceLunch,
 ];
+
+const _SeedMeal _mealSalmonBrownRice = _SeedMeal(
+  slug: 'dinner',
+  mealType: 'dinner',
+  timeLabel: '18:40',
+  photoAsset: 'assets/images/diet-salmon-brown-rice.jpeg',
+  aiComment: '연어의 지방과 현미밥의 복합 탄수화물 조합이 좋아요.',
+  foods: <_SeedFood>[
+    _SeedFood(
+      '연어구이',
+      calories: 395,
+      sodiumMg: 505,
+      sugarG: 9,
+      carbsG: 19,
+      proteinG: 35,
+      fatG: 19,
+    ),
+    _SeedFood(
+      '현미밥',
+      calories: 280,
+      sodiumMg: 5,
+      sugarG: 0,
+      carbsG: 58,
+      proteinG: 6,
+      fatG: 2,
+    ),
+  ],
+);
+
+const _SeedMeal _mealDoenjangRiceDinner = _SeedMeal(
+  slug: 'dinner',
+  mealType: 'dinner',
+  timeLabel: '19:10',
+  photoAsset: 'assets/images/diet-doenjang-rice.jpeg',
+  aiComment: '포만감은 좋지만 국물 나트륨이 높은 편이에요.',
+  foods: <_SeedFood>[
+    _SeedFood(
+      '된장찌개',
+      calories: 300,
+      sodiumMg: 1300,
+      sugarG: 5,
+      carbsG: 18,
+      proteinG: 24,
+      fatG: 15,
+    ),
+    _SeedFood(
+      '밥',
+      calories: 310,
+      sodiumMg: 5,
+      sugarG: 0.7,
+      carbsG: 67,
+      proteinG: 6,
+      fatG: 2.5,
+    ),
+  ],
+);
+
+const _SeedMeal _mealChickenSaladSweetPotato = _SeedMeal(
+  slug: 'dinner',
+  mealType: 'dinner',
+  timeLabel: '18:20',
+  photoAsset: 'assets/images/diet-chicken-salad.jpg',
+  aiComment: '가볍게 마무리한 저녁이에요.',
+  foods: <_SeedFood>[
+    _SeedFood(
+      '닭가슴살 샐러드',
+      calories: 315,
+      sodiumMg: 395,
+      sugarG: 10,
+      carbsG: 19,
+      proteinG: 34,
+      fatG: 11.1,
+    ),
+    _SeedFood(
+      '고구마',
+      calories: 130,
+      sodiumMg: 20,
+      sugarG: 6.5,
+      carbsG: 30,
+      proteinG: 2,
+      fatG: 0.2,
+    ),
+  ],
+);
 
 const List<_SeedMeal> _historyDinners = <_SeedMeal>[
-  _SeedMeal(
-    slug: 'dinner',
-    mealType: 'dinner',
-    timeLabel: '18:40',
-    photoAsset: 'assets/images/diet-salmon-brown-rice.jpeg',
-    aiComment: '연어의 지방과 현미밥의 복합 탄수화물 조합이 좋아요.',
-    foods: <_SeedFood>[
-      _SeedFood(
-        '연어구이',
-        calories: 395,
-        sodiumMg: 505,
-        sugarG: 9,
-        carbsG: 19,
-        proteinG: 35,
-        fatG: 19,
-      ),
-      _SeedFood(
-        '현미밥',
-        calories: 280,
-        sodiumMg: 5,
-        sugarG: 0,
-        carbsG: 58,
-        proteinG: 6,
-        fatG: 2,
-      ),
-    ],
-  ),
-  _SeedMeal(
-    slug: 'dinner',
-    mealType: 'dinner',
-    timeLabel: '19:10',
-    photoAsset: 'assets/images/diet-doenjang-rice.jpeg',
-    aiComment: '포만감은 좋지만 국물 나트륨이 높은 편이에요.',
-    foods: <_SeedFood>[
-      _SeedFood(
-        '된장찌개',
-        calories: 300,
-        sodiumMg: 1300,
-        sugarG: 5,
-        carbsG: 18,
-        proteinG: 24,
-        fatG: 15,
-      ),
-      _SeedFood(
-        '밥',
-        calories: 310,
-        sodiumMg: 5,
-        sugarG: 0.7,
-        carbsG: 67,
-        proteinG: 6,
-        fatG: 2.5,
-      ),
-    ],
-  ),
-  _SeedMeal(
-    slug: 'dinner',
-    mealType: 'dinner',
-    timeLabel: '18:20',
-    photoAsset: 'assets/images/diet-chicken-salad.jpg',
-    aiComment: '가볍게 마무리한 저녁이에요.',
-    foods: <_SeedFood>[
-      _SeedFood(
-        '닭가슴살 샐러드',
-        calories: 315,
-        sodiumMg: 395,
-        sugarG: 10,
-        carbsG: 19,
-        proteinG: 34,
-        fatG: 11.1,
-      ),
-      _SeedFood(
-        '고구마',
-        calories: 130,
-        sodiumMg: 20,
-        sugarG: 6.5,
-        carbsG: 30,
-        proteinG: 2,
-        fatG: 0.2,
-      ),
-    ],
-  ),
+  _mealSalmonBrownRice,
+  _mealDoenjangRiceDinner,
+  _mealChickenSaladSweetPotato,
 ];
 
-const _SeedMeal _historySnack = _SeedMeal(
+const _SeedMeal _mealCoffeeNuts = _SeedMeal(
   slug: 'snack',
   mealType: 'snack',
   timeLabel: '15:40',
@@ -996,23 +833,22 @@ List<DietEntriesCompanion> _historyDietEntries(DateTime now) {
         _historyDinners[offset % _historyDinners.length].companion(date),
       );
     }
-    if (offset % 3 == 0) entries.add(_historySnack.companion(date));
+    if (offset % 3 == 0) entries.add(_mealCoffeeNuts.companion(date));
   }
   return entries;
 }
 
 /// 한 주의 운동 세션 한 벌. `minutes` 는 요일별 유산소·근력·스트레칭 분이다.
 const List<(String day, int cardio, int strength, int stretching)>
-_historyWeekPattern =
-    <(String, int, int, int)>[
-      ('월', 30, 10, 5),
-      ('화', 40, 0, 10),
-      ('수', 0, 0, 0),
-      ('목', 35, 20, 5),
-      ('금', 45, 0, 10),
-      ('토', 25, 30, 15),
-      ('일', 20, 0, 10),
-    ];
+_historyWeekPattern = <(String, int, int, int)>[
+  ('월', 30, 10, 5),
+  ('화', 40, 0, 10),
+  ('수', 0, 0, 0),
+  ('목', 35, 20, 5),
+  ('금', 45, 0, 10),
+  ('토', 25, 30, 15),
+  ('일', 20, 0, 10),
+];
 
 /// 지난 주들의 운동 세션. 주마다 강도를 조금씩 달리해(`scale`) 주간 비교가
 /// 의미를 갖게 한다. 이번 주는 큐레이션 값을 쓰므로 `weeksAgo` 는 1 부터다.

--- a/frontend/flutter/test/core/storage/seed_data_test.dart
+++ b/frontend/flutter/test/core/storage/seed_data_test.dart
@@ -179,52 +179,69 @@ void main() {
       }
     });
 
-    test('큐레이션 사흘의 표현(시각·코치 문구·사진)이 그대로 남는다', () async {
-      // 수치를 템플릿 한 곳으로 모으면서(#677) 데모 화면의 문구·사진이 바뀌면
-      // 안 된다. 합계는 다른 테스트가 보므로 여기서는 표현만 못박는다.
+    test('큐레이션 아홉 행의 표현(시각·코치 문구·사진)이 그대로 남는다', () async {
+      // 수치를 템플릿 한 곳으로 모으면서(#677) 데모 화면의 문구·사진·시각이
+      // 바뀌면 안 된다. 합계는 다른 테스트가 보므로 여기서는 표현만 못박는다.
+      // 세 필드를 아홉 행 모두 검증한다 — 일부만 보면 나머지가 조용히 바뀐다.
       await seedIfEmpty(db);
       final diet = await db.select(db.dietEntries).get();
       DietEntryRow row(String id) => diet.firstWhere((r) => r.id == id);
 
-      expect(row('seed-diet-lunch').timeLabel, '12:40');
-      expect(
-        row('seed-diet-lunch').aiComment,
-        '정제 면과 높은 나트륨으로 혈압·혈당 부담이 매우 크니, 국물은 남기고 야채 위주로 드시는 것이 좋습니다.',
-      );
-      expect(
-        row('seed-diet-lunch').photoAsset,
-        'assets/images/lunch-jjamppong.jpg',
-      );
+      const Map<String, (String time, String comment, String photo)> expected =
+          <String, (String, String, String)>{
+            'seed-diet-breakfast': (
+              '08:20',
+              '단백질과 식이섬유의 깔끔한 조합으로, 소금 간과 기름만 조절하면 혈당과 혈압 모두 잡는 우수한 식단입니다.',
+              'assets/images/breakfast-scrambled-egg-strawberry.jpg',
+            ),
+            'seed-diet-lunch': (
+              '12:40',
+              '정제 면과 높은 나트륨으로 혈압·혈당 부담이 매우 크니, 국물은 남기고 야채 위주로 드시는 것이 좋습니다.',
+              'assets/images/lunch-jjamppong.jpg',
+            ),
+            'seed-diet-snack': (
+              '15:30',
+              '당류와 칼로리가 낮고 견과류의 건강한 지방이 채워져 완벽한 간식입니다.',
+              'assets/images/snack-coffee-nuts.jpg',
+            ),
+            'seed-diet-yesterday-breakfast': (
+              '08:10',
+              '오트밀로 식이섬유를 챙겼어요. 바나나가 들어가 당류는 다소 높은 편이에요.',
+              'assets/images/diet-oatmeal-banana.jpeg',
+            ),
+            'seed-diet-yesterday-lunch': (
+              '12:30',
+              '닭가슴살과 채소로 단백질과 식이섬유를 고르게 섭취했어요.',
+              'assets/images/diet-chicken-salad.jpg',
+            ),
+            'seed-diet-yesterday-dinner': (
+              '18:45',
+              '밥과 찌개를 함께 섭취해 포만감은 좋지만 국물은 조금 남기면 좋아요.',
+              'assets/images/diet-doenjang-rice.jpeg',
+            ),
+            'seed-diet-two-days-ago-breakfast': (
+              '08:35',
+              '그릭 요거트의 단백질과 견과류의 불포화지방을 고르게 섭취했어요.',
+              'assets/images/diet-greek-yogurt-nuts.jpeg',
+            ),
+            'seed-diet-two-days-ago-lunch': (
+              '12:20',
+              '야채가 풍부한 비빔밥이에요. 고추장을 줄이면 나트륨을 더 조절할 수 있어요.',
+              'assets/images/diet-vegetable-bibimbap.jpg',
+            ),
+            'seed-diet-two-days-ago-dinner': (
+              '18:50',
+              '연어의 지방과 현미밥의 복합 탄수화물 조합이 좋아요.',
+              'assets/images/diet-salmon-brown-rice.jpeg',
+            ),
+          };
 
-      expect(row('seed-diet-breakfast').timeLabel, '08:20');
-      expect(row('seed-diet-snack').timeLabel, '15:30');
-      expect(row('seed-diet-yesterday-dinner').timeLabel, '18:45');
-      expect(
-        row('seed-diet-yesterday-dinner').aiComment,
-        '밥과 찌개를 함께 섭취해 포만감은 좋지만 국물은 조금 남기면 좋아요.',
-      );
-      expect(row('seed-diet-two-days-ago-dinner').timeLabel, '18:50');
-
-      // 사진은 큐레이션 쪽에서 덮어쓸 수 없고 템플릿에서 그대로 온다. 히스토리
-      // 템플릿의 사진을 바꾸면 데모 화면이 조용히 바뀌므로 아홉 장을 모두 못박는다.
-      const Map<String, String> photos = <String, String>{
-        'seed-diet-breakfast':
-            'assets/images/breakfast-scrambled-egg-strawberry.jpg',
-        'seed-diet-lunch': 'assets/images/lunch-jjamppong.jpg',
-        'seed-diet-snack': 'assets/images/snack-coffee-nuts.jpg',
-        'seed-diet-yesterday-breakfast':
-            'assets/images/diet-oatmeal-banana.jpeg',
-        'seed-diet-yesterday-lunch': 'assets/images/diet-chicken-salad.jpg',
-        'seed-diet-yesterday-dinner': 'assets/images/diet-doenjang-rice.jpeg',
-        'seed-diet-two-days-ago-breakfast':
-            'assets/images/diet-greek-yogurt-nuts.jpeg',
-        'seed-diet-two-days-ago-lunch':
-            'assets/images/diet-vegetable-bibimbap.jpg',
-        'seed-diet-two-days-ago-dinner':
-            'assets/images/diet-salmon-brown-rice.jpeg',
-      };
-      for (final MapEntry<String, String> e in photos.entries) {
-        expect(row(e.key).photoAsset, e.value, reason: e.key);
+      for (final MapEntry<String, (String, String, String)> e
+          in expected.entries) {
+        final DietEntryRow r = row(e.key);
+        expect(r.timeLabel, e.value.$1, reason: '${e.key} 시각');
+        expect(r.aiComment, e.value.$2, reason: '${e.key} 코치 문구');
+        expect(r.photoAsset, e.value.$3, reason: '${e.key} 사진');
       }
     });
 
@@ -270,7 +287,9 @@ void main() {
       await seedIfEmpty(db);
       final diet = await db.select(db.dietEntries).get();
 
-      final Map<String, Set<String>> byFoodName = <String, Set<String>>{};
+      final Map<String, Set<String>> fingerprintsByFood =
+          <String, Set<String>>{};
+      final Map<String, Set<String>> datesByFood = <String, Set<String>>{};
       for (final row in diet) {
         for (final food
             in (jsonDecode(row.foodsJson) as List<Object?>)
@@ -279,12 +298,13 @@ void main() {
           // 이름을 뺀 나머지(칼로리·나트륨·당류·탄단지)를 지문으로 삼는다.
           final Map<String, Object?> rest = Map<String, Object?>.of(food)
             ..remove('name');
-          (byFoodName[name] ??= <String>{}).add(jsonEncode(rest));
+          (fingerprintsByFood[name] ??= <String>{}).add(jsonEncode(rest));
+          (datesByFood[name] ??= <String>{}).add(row.date);
         }
       }
 
       final List<String> conflicting = <String>[
-        for (final entry in byFoodName.entries)
+        for (final entry in fingerprintsByFood.entries)
           if (entry.value.length > 1) entry.key,
       ];
       expect(
@@ -292,8 +312,23 @@ void main() {
         isEmpty,
         reason: '같은 음식이 서로 다른 영양 수치로 시드됐다: $conflicting',
       );
-      // 실제로 여러 날짜에 재사용되는 음식이 있어야 이 검증이 뜻을 갖는다.
-      expect(byFoodName['짬뽕'], isNotNull);
+
+      // 여러 날짜에 실제로 재사용되는 음식이 있어야 위 검증이 뜻을 갖는다.
+      // 존재 여부만 보면 재사용이 사라져도 통과한다(CodeRabbit).
+      final List<String> reused = <String>[
+        for (final entry in datesByFood.entries)
+          if (entry.value.length > 1) entry.key,
+      ];
+      expect(
+        reused,
+        isNotEmpty,
+        reason: '여러 날짜에 쓰이는 음식이 없으면 이 검증이 아무것도 지키지 못한다',
+      );
+      expect(
+        datesByFood['짬뽕']?.length ?? 0,
+        greaterThan(1),
+        reason: '짬뽕은 오늘(큐레이션)과 히스토리 양쪽에 쓰인다',
+      );
     });
 
     test('same-day re-run is a no-op (does not duplicate rows)', () async {

--- a/frontend/flutter/test/core/storage/seed_data_test.dart
+++ b/frontend/flutter/test/core/storage/seed_data_test.dart
@@ -161,11 +161,13 @@ void main() {
         now.month,
         now.day - (now.weekday - 1),
       );
-      final Set<String> weekStarts = exercise
-          .map((r) => r.weekStart)
-          .toSet();
+      final Set<String> weekStarts = exercise.map((r) => r.weekStart).toSet();
 
-      for (int weeksAgo = 0; weeksAgo <= kDemoExerciseHistoryWeeks; weeksAgo++) {
+      for (
+        int weeksAgo = 0;
+        weeksAgo <= kDemoExerciseHistoryWeeks;
+        weeksAgo++
+      ) {
         final DateTime monday = thisMonday.subtract(
           Duration(days: 7 * weeksAgo),
         );
@@ -173,12 +175,71 @@ void main() {
             '${monday.year.toString().padLeft(4, '0')}-'
             '${monday.month.toString().padLeft(2, '0')}-'
             '${monday.day.toString().padLeft(2, '0')}';
-        expect(
-          weekStarts,
-          contains(key),
-          reason: '$weeksAgo주 전 운동 기록이 있어야 한다',
-        );
+        expect(weekStarts, contains(key), reason: '$weeksAgo주 전 운동 기록이 있어야 한다');
       }
+    });
+
+    test('큐레이션 사흘의 표현(시각·코치 문구·사진)이 그대로 남는다', () async {
+      // 수치를 템플릿 한 곳으로 모으면서(#677) 데모 화면의 문구·사진이 바뀌면
+      // 안 된다. 합계는 다른 테스트가 보므로 여기서는 표현만 못박는다.
+      await seedIfEmpty(db);
+      final diet = await db.select(db.dietEntries).get();
+      DietEntryRow row(String id) => diet.firstWhere((r) => r.id == id);
+
+      expect(row('seed-diet-lunch').timeLabel, '12:40');
+      expect(
+        row('seed-diet-lunch').aiComment,
+        '정제 면과 높은 나트륨으로 혈압·혈당 부담이 매우 크니, 국물은 남기고 야채 위주로 드시는 것이 좋습니다.',
+      );
+      expect(
+        row('seed-diet-lunch').photoAsset,
+        'assets/images/lunch-jjamppong.jpg',
+      );
+
+      expect(row('seed-diet-breakfast').timeLabel, '08:20');
+      expect(row('seed-diet-snack').timeLabel, '15:30');
+      expect(row('seed-diet-yesterday-dinner').timeLabel, '18:45');
+      expect(
+        row('seed-diet-yesterday-dinner').aiComment,
+        '밥과 찌개를 함께 섭취해 포만감은 좋지만 국물은 조금 남기면 좋아요.',
+      );
+      expect(row('seed-diet-two-days-ago-dinner').timeLabel, '18:50');
+      expect(
+        row('seed-diet-two-days-ago-dinner').photoAsset,
+        'assets/images/diet-salmon-brown-rice.jpeg',
+      );
+    });
+
+    test('같은 음식은 어느 날짜에 쓰이든 영양 수치가 하나다', () async {
+      // #677 이 없애려는 상태: 큐레이션 쪽과 히스토리 쪽에 같은 음식의 수치가
+      // 두 벌 존재해, 한쪽만 고치면 조용히 갈린다.
+      await seedIfEmpty(db);
+      final diet = await db.select(db.dietEntries).get();
+
+      final Map<String, Set<String>> byFoodName = <String, Set<String>>{};
+      for (final row in diet) {
+        for (final food
+            in (jsonDecode(row.foodsJson) as List<Object?>)
+                .cast<Map<String, Object?>>()) {
+          final String name = food['name']! as String;
+          // 이름을 뺀 나머지(칼로리·나트륨·당류·탄단지)를 지문으로 삼는다.
+          final Map<String, Object?> rest = Map<String, Object?>.of(food)
+            ..remove('name');
+          (byFoodName[name] ??= <String>{}).add(jsonEncode(rest));
+        }
+      }
+
+      final List<String> conflicting = <String>[
+        for (final entry in byFoodName.entries)
+          if (entry.value.length > 1) entry.key,
+      ];
+      expect(
+        conflicting,
+        isEmpty,
+        reason: '같은 음식이 서로 다른 영양 수치로 시드됐다: $conflicting',
+      );
+      // 실제로 여러 날짜에 재사용되는 음식이 있어야 이 검증이 뜻을 갖는다.
+      expect(byFoodName['짬뽕'], isNotNull);
     });
 
     test('same-day re-run is a no-op (does not duplicate rows)', () async {

--- a/frontend/flutter/test/core/storage/seed_data_test.dart
+++ b/frontend/flutter/test/core/storage/seed_data_test.dart
@@ -204,10 +204,64 @@ void main() {
         '밥과 찌개를 함께 섭취해 포만감은 좋지만 국물은 조금 남기면 좋아요.',
       );
       expect(row('seed-diet-two-days-ago-dinner').timeLabel, '18:50');
+
+      // 사진은 큐레이션 쪽에서 덮어쓸 수 없고 템플릿에서 그대로 온다. 히스토리
+      // 템플릿의 사진을 바꾸면 데모 화면이 조용히 바뀌므로 아홉 장을 모두 못박는다.
+      const Map<String, String> photos = <String, String>{
+        'seed-diet-breakfast':
+            'assets/images/breakfast-scrambled-egg-strawberry.jpg',
+        'seed-diet-lunch': 'assets/images/lunch-jjamppong.jpg',
+        'seed-diet-snack': 'assets/images/snack-coffee-nuts.jpg',
+        'seed-diet-yesterday-breakfast':
+            'assets/images/diet-oatmeal-banana.jpeg',
+        'seed-diet-yesterday-lunch': 'assets/images/diet-chicken-salad.jpg',
+        'seed-diet-yesterday-dinner': 'assets/images/diet-doenjang-rice.jpeg',
+        'seed-diet-two-days-ago-breakfast':
+            'assets/images/diet-greek-yogurt-nuts.jpeg',
+        'seed-diet-two-days-ago-lunch':
+            'assets/images/diet-vegetable-bibimbap.jpg',
+        'seed-diet-two-days-ago-dinner':
+            'assets/images/diet-salmon-brown-rice.jpeg',
+      };
+      for (final MapEntry<String, String> e in photos.entries) {
+        expect(row(e.key).photoAsset, e.value, reason: e.key);
+      }
+    });
+
+    test('큐레이션 사흘의 행 id 는 고정이다', () async {
+      // companion() 의 id 는 선택 인자다. 큐레이션 호출에서 빠뜨리면
+      // `seed-diet-2026-08-14-lunch` 같은 날짜 id 로 조용히 바뀌는데, 화면과
+      // 테스트가 이 리터럴 id 로 행을 찾는다.
+      await seedIfEmpty(db);
+      final diet = await db.select(db.dietEntries).get();
+      final Set<String> ids = diet.map((r) => r.id).toSet();
+
       expect(
-        row('seed-diet-two-days-ago-dinner').photoAsset,
-        'assets/images/diet-salmon-brown-rice.jpeg',
+        ids,
+        containsAll(<String>[
+          'seed-diet-breakfast',
+          'seed-diet-lunch',
+          'seed-diet-snack',
+          'seed-diet-yesterday-breakfast',
+          'seed-diet-yesterday-lunch',
+          'seed-diet-yesterday-dinner',
+          'seed-diet-two-days-ago-breakfast',
+          'seed-diet-two-days-ago-lunch',
+          'seed-diet-two-days-ago-dinner',
+        ]),
       );
+      // 큐레이션 사흘이 날짜 id 로 새어 나가지 않았는지.
+      for (final String date in <String>[
+        _todayString(),
+        _daysAgoString(1),
+        _daysAgoString(2),
+      ]) {
+        expect(
+          ids.where((String id) => id.startsWith('seed-diet-$date-')),
+          isEmpty,
+          reason: '$date 의 큐레이션 행이 날짜 id 로 만들어졌다',
+        );
+      }
     });
 
     test('같은 음식은 어느 날짜에 쓰이든 영양 수치가 하나다', () async {


### PR DESCRIPTION
## Summary

* #671 에서 히스토리용 `_SeedMeal` 템플릿을 들이면서, 큐레이션 사흘(오늘·어제·그제)은 손으로 쓴 리터럴 그대로 남았다.
* 짬뽕·스크램블 에그·닭가슴살 샐러드·연어구이·아이스 아메리카노 **다섯 끼니의 영양 수치가 파일에 두 벌** 존재했다.
* 한쪽만 고치면 오늘 화면과 3주 전 화면이 다른 값을 보인다. 수치를 템플릿 한 곳으로 모았다.

---

## Changes

### 🔧 Improvements

* 끼니 템플릿을 이름 있는 상수로 쪼갰다(`_mealJjamppong`, `_mealSalmonBrownRice` …). 로테이션 목록(`_historyLunches` 등)은 그 상수를 참조만 한다.
* `_SeedMeal.companion()` 에 `id`·`timeLabel`·`aiComment` 덮어쓰기를 뒀다. 큐레이션 사흘은 고정 id(`seed-diet-lunch` 등)와 그날의 코치 문구를 유지하면서 **수치는 템플릿에서 받는다.**
* 손으로 쓴 큐레이션 9행을 템플릿 호출로 바꿨다. 순 감소 −103줄.

---

## Commits

1. `9703a29a` refactor(demo): 시드 식단 영양 수치 중복을 없앤다
2. `cc0820ab` refactor(demo): 리뷰 피드백을 반영한다
3. `e8547a95` test(demo): CodeRabbit 리뷰를 반영해 시드 검증을 조인다

---

## Notes

**데모 화면은 그대로지만, "완전히 동일" 은 틀린 말이었다.** 처음 PR 본문에 시드 99개 행이 리팩터링 전후로 완전히 동일하다고 적었는데, 리뷰에서 **7개 행의 `foods_json` 이 달라진다**는 것이 드러났다.

원인은 타입이다. `main` 은 일부 음식의 당류를 **정수 리터럴**로 적었는데(`'sugar_g': 6`), 템플릿의 `_SeedFood.sugarG` 는 `double` 이라 `jsonEncode` 가 `6.0` 으로 직렬화한다.

```
main   ... "name":"오트밀", ..., "sugar_g":6,   ...
branch ... "name":"오트밀", ..., "sugar_g":6.0, ...
```

**제 검증이 이걸 못 봤다.** 덤프를 Python `json` 으로 파싱해 비교했는데 Python 에서는 `6 == 6.0` 이 True 라, 이 차이가 보이지 않았다. 리뷰는 IEEE-754 비트 패턴까지 떠서 잡았다.

동작에는 영향이 없다 — 읽는 쪽이 모두 `as num` 을 거친다(`FoodItem.fromJson`, `local_api_interceptor`, `diet_analysis`). `foodsJson` 을 문자열로 비교하는 곳도 없다. 부동소수점 자체는 깨끗하다: 계산이 끼는 두 값(`0.8 + 5.5`, `5 + 0.7`)이 예전 상수와 **같은 double** 로 떨어지는 것을 비트로 확인했다(`5.7` → `4016cccccccccccd` 양쪽 동일).

그래서 정확한 표현은 **"의미상 동일, 다만 per-food `sugar_g` 가 JSON 실수로 직렬화된다"** 이다. 시드 플래그를 올리지 않은 판단은 그대로 유효하다 — 이미 시드된 설치가 `"sugar_g":6` 을 들고 있어도 읽는 쪽이 `as num` 이라 무해하다.

새 테스트 두 개의 성격이 다르다:

- `큐레이션 사흘의 표현(시각·코치 문구·사진)이 그대로 남는다` — 합계는 기존 단언이 이미 보고 있었지만 **표현은 아무도 보고 있지 않았다.** 이 리팩터링이 정확히 건드리는 지점이라 못박았다.
- `같은 음식은 어느 날짜에 쓰이든 영양 수치가 하나다` — 이 PR 이후로는 구조상 어길 수 없지만, **손으로 쓴 중복 항목을 다시 넣으면 실패한다.** 실제로 짬뽕 나트륨만 다른 항목을 주입해 실패하는 것을 확인했다(`같은 음식이 서로 다른 영양 수치로 시드됐다: [짬뽕]`). 반대로 템플릿 상수 하나만 바꾸면 큐레이션과 히스토리가 함께 움직여 통과한다.

시드 플래그(`seeded_v15`)는 올리지 않았다. 시드 결과가 한 바이트도 달라지지 않아 재시드할 이유가 없다.

---

### 리뷰에서 추가로 고친 것

- **중복이 다 지워지지 않았다.** `된장찌개`·`밥`·`닭가슴살 샐러드` 가 끼니 상수 두 곳에 리터럴로 남아 있었다 — 이 PR 이 없애려던 실패 모드가 그대로 살아 있던 셈. 음식 상수로 뽑았다.
- **사진이 무방비였다.** `photoAsset` 은 큐레이션 쪽에서 덮어쓸 수 없고 템플릿에서 그대로 온다. 히스토리 템플릿의 사진을 바꾸면 데모 화면이 조용히 바뀌는데 두 장만 검증하고 있었다. 아홉 장 모두 못박았다.
- **id 가 선택 인자다.** 큐레이션 호출에서 `id` 를 빠뜨리면 `seed-diet-2026-08-14-lunch` 같은 날짜 id 로 조용히 바뀌는데, 화면과 테스트가 리터럴 id 로 행을 찾는다. 아홉 id 가 그대로인지, 날짜 id 로 새어 나가지 않았는지 검증을 넣었다.

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 앱을 켜고 식단 탭에서 오늘·어제·그제의 사진·코치 문구·수치가 이전과 같은지 본다.
2. 날짜를 3주 전까지 옮기며 같은 음식(짬뽕 등)의 수치가 오늘과 같은지 본다.

```bash
flutter test test/core/storage/seed_data_test.dart
```

---

## Related Issues

Closes #677

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 큐레이션 식단과 과거 식단의 시드 데이터 일관성을 개선했습니다.
  * 날짜별 식단 정보와 음식 영양 데이터가 더 안정적으로 제공됩니다.

* **테스트**
  * 큐레이션 식단의 시간, 코치 문구, 이미지 및 식별 정보를 검증하는 테스트를 추가했습니다.
  * 동일 음식의 영양 정보 일관성 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
