### PR TITLE
fix(schedule): 달력 마지막 주가 하단 내비게이션에 가리는 문제 수정

### DIFF
--- a/frontend/flutter/lib/shared/widgets/modals/schedule_calendar_sheet.dart
+++ b/frontend/flutter/lib/shared/widgets/modals/schedule_calendar_sheet.dart
@@ -24,6 +24,10 @@ Future<void> showScheduleCalendarSheet(
 }) {
   return showModalBottomSheet<void>(
     context: context,
+    // 탭 페이지에는 저마다 Navigator 가 있고 MainShell 은 extendBody 라, 기본값
+    // 으로 열면 시트가 하단 내비게이션 **뒤쪽**까지 펼쳐져 마지막 주가 바에
+    // 가린다(#680). 루트에 올려 바 위를 덮는다 — 식단 추가 시트와 같은 규칙.
+    useRootNavigator: true,
     isScrollControlled: true,
     backgroundColor: AppColors.background,
     barrierColor: Colors.black54,

--- a/frontend/flutter/test/shared/widgets/schedule_calendar_sheet_test.dart
+++ b/frontend/flutter/test/shared/widgets/schedule_calendar_sheet_test.dart
@@ -257,4 +257,32 @@ void main() {
       reason: '달력이 하단 내비게이션 위를 덮어야 한다 — 바가 눌리면 시트가 그 뒤에 있다는 뜻',
     );
   });
+
+  testWidgets('시트 안에서 연 일정 추가 다이얼로그가 시트 위에 뜬다 (#680)', (
+    WidgetTester tester,
+  ) async {
+    // 시트를 루트 Navigator 로 옮기면서 시트가 여는 다이얼로그가 시트 뒤로
+    // 가지 않는지 확인한다. showDialog 도 기본이 루트라 나중에 밀린 쪽(다이얼로그)
+    // 이 위에 있어야 한다.
+    tester.view.physicalSize = const Size(900, 1600);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await _openSheet(tester, august2026);
+    expect(find.byType(Dialog), findsNothing);
+
+    await tester.tap(find.widgetWithText(FilledButton, '일정 추가'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Dialog), findsOneWidget);
+    // 시트도 아직 살아 있다(다이얼로그가 시트를 대체한 것이 아니다).
+    expect(find.byKey(const Key('calendar-day-1')), findsOneWidget);
+
+    // 다이얼로그를 닫으면 달력으로 돌아온다 — 닫힌 뒤 provider 새로고침 경로가
+    // 그대로 도는지까지 본다(예외가 나면 pumpAndSettle 이 잡는다).
+    Navigator.of(tester.element(find.byType(Dialog))).pop();
+    await tester.pumpAndSettle();
+    expect(find.byType(Dialog), findsNothing);
+    expect(find.byKey(const Key('calendar-day-31')), findsOneWidget);
+  });
 }

--- a/frontend/flutter/test/shared/widgets/schedule_calendar_sheet_test.dart
+++ b/frontend/flutter/test/shared/widgets/schedule_calendar_sheet_test.dart
@@ -89,9 +89,7 @@ void main() {
   // 31일 = 37칸. 잘림 회귀(#669)가 가장 먼저 드러나는 모양.
   final DateTime august2026 = DateTime(2026, 8, 15);
 
-  testWidgets('세로가 넉넉하면 6주짜리 달의 말일까지 한 화면에 그린다', (
-    WidgetTester tester,
-  ) async {
+  testWidgets('세로가 넉넉하면 6주짜리 달의 말일까지 한 화면에 그린다', (WidgetTester tester) async {
     tester.view.physicalSize = const Size(900, 1600);
     tester.view.devicePixelRatio = 1;
     addTearDown(tester.view.reset);
@@ -107,9 +105,7 @@ void main() {
     expect(_gridCellCount(tester), 42);
   });
 
-  testWidgets('세로가 짧으면 잘라내지 않고 스크롤해서 말일에 닿는다', (
-    WidgetTester tester,
-  ) async {
+  testWidgets('세로가 짧으면 잘라내지 않고 스크롤해서 말일에 닿는다', (WidgetTester tester) async {
     // 이 높이라야 6주 그리드가 남은 공간을 넘어 실제로 스크롤이 생긴다.
     // 640 에서는 다 들어가 버려 스크롤 경로를 전혀 지나지 않는다.
     tester.view.physicalSize = const Size(400, 500);
@@ -140,9 +136,7 @@ void main() {
     expect(_gridCellCount(tester), 42);
   });
 
-  testWidgets('말일이 토요일이 아닌 달도 마지막 주가 7칸으로 닫힌다', (
-    WidgetTester tester,
-  ) async {
+  testWidgets('말일이 토요일이 아닌 달도 마지막 주가 7칸으로 닫힌다', (WidgetTester tester) async {
     tester.view.physicalSize = const Size(900, 1600);
     tester.view.devicePixelRatio = 1;
     addTearDown(tester.view.reset);
@@ -196,5 +190,71 @@ void main() {
     expect(find.byKey(const Key('calendar-day-3')), findsOneWidget);
     // 칸 안에서 잘리더라도 첫 칩은 그려진다.
     expect(find.text('00:00 일정 0'), findsOneWidget);
+  });
+
+  testWidgets('하단 내비게이션이 있는 화면에서도 달력이 그 위를 덮는다 (#680)', (
+    WidgetTester tester,
+  ) async {
+    tester.view.physicalSize = const Size(500, 900);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    int navTaps = 0;
+
+    // MainShell 과 같은 모양: extendBody 인 Scaffold + 하단 바, 그리고 탭
+    // 페이지마다 있는 중첩 Navigator. 기본값으로 시트를 열면 이 구조에서
+    // 마지막 주가 바 뒤로 들어간다.
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          scheduleRepositoryProvider.overrideWithValue(
+            _EmptyScheduleRepository(),
+          ),
+        ],
+        child: MaterialApp(
+          locale: const Locale('ko'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            extendBody: true,
+            bottomNavigationBar: SizedBox(
+              height: 82,
+              child: Center(
+                child: ElevatedButton(
+                  onPressed: () => navTaps++,
+                  child: const Text('홈'),
+                ),
+              ),
+            ),
+            body: Navigator(
+              onGenerateRoute: (RouteSettings _) => MaterialPageRoute<void>(
+                builder: (BuildContext context) => TextButton(
+                  onPressed: () => showScheduleCalendarSheet(
+                    context,
+                    initialDate: august2026,
+                  ),
+                  child: const Text('열기'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('열기'));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('calendar-day-31')), findsOneWidget);
+
+    // 하단 바 자리를 누른다. 시트가 위에 있으면 배리어가 먹어 시트가 닫히고,
+    // 바 뒤에 깔려 있으면 바의 버튼이 눌린다.
+    await tester.tap(find.text('홈'), warnIfMissed: false);
+    await tester.pumpAndSettle();
+
+    expect(
+      navTaps,
+      0,
+      reason: '달력이 하단 내비게이션 위를 덮어야 한다 — 바가 눌리면 시트가 그 뒤에 있다는 뜻',
+    );
   });
 }


### PR DESCRIPTION
## Summary

* #669 로 달력이 말일까지 그려지게 됐지만, **마지막 주가 하단 내비게이션 바에 가렸다.** 8월을 열면 30·31 줄이 바 뒤로 들어가 반쯤 잘려 보였다.
* 원인은 시트를 탭 브랜치의 Navigator 에 올린 것 — `MainShell` 이 `extendBody: true` 라 시트가 바 **뒤쪽** 영역까지 펼쳐졌다.
* 식단 추가 시트가 이미 쓰는 `useRootNavigator: true` 규칙에 맞췄다.

---

## Changes

### 🐛 Fixes

* `showScheduleCalendarSheet` 에 `useRootNavigator: true`. 시트가 하단 내비게이션 위를 덮고, 모달 배리어도 바까지 함께 덮는다.

---

## Commits

1. `4848036e` fix(schedule): 달력이 하단 내비게이션 위를 덮게 한다
2. `6cc689b7` test(schedule): 시트가 여는 다이얼로그가 시트 위에 뜨는지 확인한다

---

## Notes

**#669 의 하단 여백으로는 이 문제가 안 잡힌다.** 거기서 넣은 `MediaQuery.viewPaddingOf(context).bottom` 은 **시스템** 인셋만 본다. 웹·데스크톱에서는 0 이고, 모바일에서도 앱 자체 내비게이션 바 높이(`barHeight 58 + lift 24`)는 계산에 없다. 여백을 더 주는 방향으로 고치면 기기·플랫폼마다 숫자를 맞춰야 하는데, 시트를 루트에 올리면 그 계산 자체가 사라진다.

스크린샷에서 내비게이션 바가 **어둡게 깔리지 않고 또렷하게** 보이는 것이 근거였다 — 모달 배리어 위에 있다는 뜻이다.

**테스트가 실제로 이 회귀를 잡는지 확인했다.** `MainShell` 과 같은 모양(`extendBody` + 하단 바 + 중첩 Navigator)에서 시트를 연 뒤 바 자리를 누른다. 시트가 위에 있으면 배리어가 먹어 닫히고, 뒤에 깔려 있으면 바 버튼이 눌린다. `useRootNavigator` 를 빼고 돌리면 `Expected: <0> Actual: <1>` 로 실패한다.

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 아무 탭에서 헤더의 달력 아이콘을 누른다.
2. 8월(6주 달)에서 **30·31 이 하단 바에 가리지 않는지** 본다.
3. 배경이 어둡게 깔리는 범위에 하단 내비게이션까지 포함되는지 본다.
4. 바깥을 눌러 시트가 닫히는지, 닫힌 뒤 탭 전환이 정상인지 본다.

```bash
flutter test test/shared/widgets/schedule_calendar_sheet_test.dart
```

---

## Related Issues

Closes #680

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인

