### PR TITLE
feat(diet): 영양 요약 토글 자리와 주간 그래프를 다른 탭과 맞춘다

### DIFF
--- a/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
@@ -419,7 +419,7 @@ class _DietNutritionCardState extends State<_DietNutritionCard> {
     final AppLocalizations l = AppLocalizations.of(context);
     final Map<_NutTabKind, _NutData> nutrition = _nutritionFor(summary);
     final _NutData cfg = nutrition[_tab]!;
-    final List<String> days = _weekDayLabels(l);
+    final List<String> days = weekDayLabels(l);
     final int todayIdx = _todayIndex();
     final NumberFormat nf = NumberFormat('#,###');
 
@@ -773,7 +773,7 @@ class _ExerciseCard extends ConsumerWidget {
       for (int i = 0; i < baseCal.length; i++)
         if (i > todayIdx) 0 else baseCal[i],
     ];
-    final List<String> days = _weekDayLabels(l);
+    final List<String> days = weekDayLabels(l);
     final (double lo, double hi) = _barScale(week);
     final NumberFormat nf = NumberFormat('#,###');
 
@@ -1134,15 +1134,7 @@ const List<double> _demoExerciseWeekCalories = <double>[
   520,
 ];
 
-List<String> _weekDayLabels(AppLocalizations l) => <String>[
-  l.dietWeekdayMon,
-  l.dietWeekdayTue,
-  l.dietWeekdayWed,
-  l.dietWeekdayThu,
-  l.dietWeekdayFri,
-  l.dietWeekdaySat,
-  l.dietWeekdaySun,
-];
+
 
 /// 오늘 요일 인덱스(0=월 … 6=일). 고정 라벨 배열 `_weekDayLabels` 와 함께 써서
 /// 주간 차트의 '오늘' 배지·라이브 값을 실제 요일 칸에 배치하고, 오늘 이후(미래)
@@ -1617,7 +1609,7 @@ class _ScheduleCard extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final AppLocalizations l = AppLocalizations.of(context);
     final DateTime now = DateTime.now();
-    final String weekday = _weekDayLabels(l)[now.weekday - 1];
+    final String weekday = weekDayLabels(l)[now.weekday - 1];
     final String todayLabel = l.homeScheduleDate(weekday, now.month, now.day);
     // 트레이너 일정과 내가 만든 일정을 한 목록으로 보여 준다. 시간순으로 섞어야
     // '다음에 뭐가 있는지'를 한 번에 읽을 수 있다.

--- a/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
@@ -25,6 +25,7 @@ import 'package:oncare/features/notification/presentation/controllers/notificati
 import 'package:oncare/gen/l10n/app_localizations.dart';
 import 'package:oncare/shared/services/exercise_burn_goal_provider.dart';
 import 'package:oncare/shared/widgets/coaching_sheet.dart';
+import 'package:oncare/shared/widgets/metric_trend_chart.dart';
 import 'package:oncare/shared/widgets/modals/schedule_calendar_sheet.dart';
 
 /// Home's own "/목표(단위)" suffix style. Same look as the shared
@@ -420,7 +421,6 @@ class _DietNutritionCardState extends State<_DietNutritionCard> {
     final _NutData cfg = nutrition[_tab]!;
     final List<String> days = _weekDayLabels(l);
     final int todayIdx = _todayIndex();
-    final (double lo, double hi) = _trendScale(cfg, todayIdx);
     final NumberFormat nf = NumberFormat('#,###');
 
     return _HomeCard(
@@ -497,96 +497,16 @@ class _DietNutritionCardState extends State<_DietNutritionCard> {
                             '${l.homeGoal} ${nf.format(cfg.goal)}${cfg.unit}',
                       ),
                       const SizedBox(height: 6),
-                      Row(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: <Widget>[
-                          // 가로축 눈금 라벨을 각 값의 실제 높이에 맞춰 배치.
-                          SizedBox(
-                            width: 38,
-                            height: 68,
-                            child: Stack(
-                              children: <Widget>[
-                                for (final double t in cfg.ticks)
-                                  Positioned(
-                                    right: 0,
-                                    top: (68 - ((t - lo) / (hi - lo)) * 68 - 8)
-                                        .clamp(0.0, 52.0),
-                                    child: SizedBox(
-                                      height: 16,
-                                      child: Center(
-                                        child: _AxisLabel(nf.format(t)),
-                                      ),
-                                    ),
-                                  ),
-                              ],
-                            ),
-                          ),
-                          const SizedBox(width: 6),
-                          Expanded(
-                            child: Column(
-                              children: <Widget>[
-                                SizedBox(
-                                  height: 68,
-                                  // 지표를 바꾸면 선을 처음부터 다시 그려 값이
-                                  // 바뀐 것을 눈으로 따라가게 한다. stagger 가
-                                  // 없는 차트라 커브는 기본값(감속)을 쓴다.
-                                  child: ChartReveal(
-                                    replayKey: _tab,
-                                    builder: (BuildContext context, double t) =>
-                                        CustomPaint(
-                                          size: Size.infinite,
-                                          painter: _TrendChartPainter(
-                                            cur: cfg.cur,
-                                            goal: cfg.goal,
-                                            ticks: cfg.ticks,
-                                            lo: lo,
-                                            hi: hi,
-                                            todayIndex: todayIdx,
-                                            progress: t,
-                                          ),
-                                        ),
-                                  ),
-                                ),
-                                const SizedBox(height: 6),
-                                Row(
-                                  mainAxisAlignment:
-                                      MainAxisAlignment.spaceBetween,
-                                  children: <Widget>[
-                                    for (int i = 0; i < days.length; i++)
-                                      if (i == _todayIndex())
-                                        // 오늘: #3EAFDF 원형 안에 흰색 요일 글씨.
-                                        Container(
-                                          width: 18,
-                                          height: 18,
-                                          alignment: Alignment.center,
-                                          decoration: const BoxDecoration(
-                                            color: FigmaColors.primary,
-                                            shape: BoxShape.circle,
-                                          ),
-                                          child: Text(
-                                            days[i],
-                                            style: const TextStyle(
-                                              fontSize: 11.5,
-                                              fontWeight: FontWeight.w700,
-                                              color: Colors.white,
-                                            ),
-                                          ),
-                                        )
-                                      else
-                                        Text(
-                                          days[i],
-                                          style: const TextStyle(
-                                            fontSize: 11.5,
-                                            fontWeight: FontWeight.w600,
-                                            color: AppColors.mutedForeground,
-                                          ),
-                                        ),
-                                  ],
-                                ),
-                              ],
-                            ),
-                          ),
-                        ],
+                      MetricTrendChart(
+                        values: cfg.cur,
+                        dayLabels: days,
+                        goal: cfg.goal,
+                        ticks: cfg.ticks,
+                        todayIndex: todayIdx,
+                        // 지표를 바꾸면 선을 처음부터 다시 그려 값이 바뀐 것을
+                        // 눈으로 따라가게 한다.
+                        replayKey: _tab,
+                        formatTick: nf.format,
                       ),
                     ],
                   ),
@@ -816,28 +736,6 @@ class _SoftDivider extends StatelessWidget {
 }
 
 /// A tiny right-aligned chart Y-axis value label.
-class _AxisLabel extends StatelessWidget {
-  const _AxisLabel(this.text);
-  final String text;
-
-  @override
-  Widget build(BuildContext context) {
-    return Text(
-      text,
-      maxLines: 1,
-      overflow: TextOverflow.clip,
-      softWrap: false,
-      style: const TextStyle(
-        fontSize: 11.5,
-        fontWeight: FontWeight.w600,
-        color: AppColors.mutedForeground,
-      ),
-    );
-  }
-}
-
-// ─────────────────────────────────────────────────────────── exercise card ──
-
 /// The full-width 운동 card: activity metrics (time / kcal / count), the burn
 /// goal progress, and a weekly burned-calories trend chart with value labels.
 class _ExerciseCard extends ConsumerWidget {
@@ -1108,29 +1006,11 @@ class _ExerciseStat extends StatelessWidget {
 
 /// Padded min/max scale for the nutrition line chart. Deliberately excludes a
 /// zero baseline so day-to-day variation reads as a dynamic slope rather than
-/// a nearly flat line.
-(double, double) _trendScale(_NutData c, int todayIndex) {
-  // 데이터와 눈금(ticks)을 모두 포함하도록 스케일을 잡아 눈금선이 항상 보이게 한다.
-  final List<double> all = <double>[...c.cur, ...c.ticks, c.goal];
-  double lo = all.reduce(math.min);
-  double hi = all.reduce(math.max);
-  final double range = (hi - lo) == 0 ? 1 : (hi - lo);
-  hi += range * 0.10;
-  lo -= range * 0.08;
-  // 당류처럼 0이 최소 눈금인 지표는 바닥을 0에 고정.
-  if (c.ticks.isNotEmpty && c.ticks.first <= 0 && lo < 0) lo = 0;
-  return (lo, hi);
-}
-
 /// 목표 대비 상태색: 초과(빨강) / 그 외(초록).
 ///
 /// 지표 카드의 초과·정상 뱃지와 같은 두 색(dangerRed/greenText)만 쓴다 —
 /// 같은 카드 안에서 뱃지는 2단계인데 그래프만 근접(주황) 3단계라, 뱃지가
 /// "정상"인 날의 점이 주황으로 찍혀 서로 다른 이야기를 했다. 이제 점은
-/// 목표를 넘겼는지만 말한다.
-Color _nutStatusColor(double v, double goal) =>
-    v > goal ? FigmaColors.dangerRed : FigmaColors.greenText;
-
 /// Padded scale for the exercise bar chart. The baseline sits well below the
 /// smallest bar so the difference between days is visually pronounced.
 (double, double) _barScale(List<double> d) {
@@ -1294,207 +1174,12 @@ HealthIndicator _indicatorFor(DashboardSummary s, _NutTabKind key) =>
 
 // 이번 주 꺾은선(연회색). 선은 배경처럼 물러나고 데이터 포인트(상태색)와 값
 // 라벨이 읽히도록 눈금선보다 아주 조금만 진하게 잡는다.
-const Color _nutLineGray = Color(0xFFDDE2E8);
-
-class _ChartLegend extends StatelessWidget {
-  const _ChartLegend({required this.title, required this.goalText});
-
-  /// "주간 {지표} 추이" — 선택된 지표에 따라 바뀌는 그래프 왼쪽 상단 제목.
-  final String title;
-
-  /// "목표 2,000kcal" 처럼 지표별 목표 수치. 그래프 오른쪽 상단에 표기.
-  final String goalText;
-
-  @override
-  Widget build(BuildContext context) {
-    // 범례(이번 주/지난 주)는 제거. 왼쪽에 그래프 제목, 오른쪽에 목표 수치를
-    // 카드 우측 끝('자세히 >')과 같은 열로 맞춘다.
-    //
-    // 남는 가로 공간은 제목 쪽 Expanded 가 전부 흡수해야 목표 수치가 그래프
-    // 오른쪽 끝에 붙는다. 목표 수치를 Expanded 로 두면 제목(Flexible)과 공간을
-    // 반씩 나눠 가져 오른쪽 끝에서 한참 못 미친 자리에 멈춘다.
-    return Row(
-      children: <Widget>[
-        Expanded(
-          child: Text(
-            title,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: const TextStyle(
-              fontSize: 14.5,
-              fontWeight: FontWeight.w700,
-              color: FigmaColors.ink,
-            ),
-          ),
-        ),
-        const SizedBox(width: 8),
-        Text(
-          goalText,
-          maxLines: 1,
-          style: const TextStyle(
-            fontSize: 14.5,
-            fontWeight: FontWeight.w800,
-            color: FigmaColors.primary,
-          ),
-        ),
-      ],
-    );
-  }
-}
 
 /// The weekly nutrition trend line: a solid current-week line, solid
 /// horizontal tick gridlines (uniform weight), and value labels on each
 /// point. The goal is shown via the top label + point status colors, not a
 /// separate line. The [lo]/[hi] scale is padded away from zero so the line
 /// reads as a dynamic slope rather than a flat trace.
-class _TrendChartPainter extends CustomPainter {
-  _TrendChartPainter({
-    required this.cur,
-    required this.goal,
-    required this.ticks,
-    required this.lo,
-    required this.hi,
-    required this.todayIndex,
-    this.progress = 1,
-  });
-
-  final List<double> cur;
-  final double goal;
-  final List<double> ticks;
-  final double lo;
-  final double hi;
-
-  /// 이번 주 꺾은선은 오늘까지만 그린다(미래 요일의 0값이 급락처럼 보이지 않도록).
-  final int todayIndex;
-
-  /// 0 → 1 진입 애니메이션 진행도. 선은 월요일부터 오늘 쪽으로 이어지고,
-  /// 각 데이터 포인트와 값 라벨은 선이 도달하는 순간 나타난다.
-  final double progress;
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    final double w = size.width;
-    final double h = size.height;
-    final double span = (hi - lo) <= 0 ? 1 : (hi - lo);
-    double dx(int i) => cur.length <= 1 ? w / 2 : (i / (cur.length - 1)) * w;
-    double dy(double v) => h - ((v - lo) / span) * h;
-
-    // 가로 눈금선: 지표별 눈금(ticks) 값마다 그린다.
-    final Paint grid = Paint()
-      ..color = const Color(0xFFEFF3F7)
-      ..strokeWidth = 1;
-    for (final double t in ticks) {
-      if (t < lo || t > hi) continue;
-      final double gy = dy(t);
-      canvas.drawLine(Offset(0, gy), Offset(w, gy), grid);
-    }
-    // 목표선은 따로 그리지 않는다 — 목표값이 눈금과 겹치면 선이 두꺼워 보였다.
-    // 목표는 상단 라벨(목표 N)과 데이터 포인트 상태색으로만 표현한다.
-
-    // 이번 주 선/점은 오늘까지만 그린다 — 아직 오지 않은 요일(=0)을 실제 급락으로
-    // 오해하지 않도록. x 좌표는 여전히 월~일 7칸 기준이라 지난 주 선과 정렬된다.
-    final int lastIdx = todayIndex.clamp(0, cur.length - 1);
-    final List<Offset> pts = <Offset>[
-      for (int i = 0; i <= lastIdx; i++) Offset(dx(i), dy(cur[i])),
-    ];
-
-    // 이번 주 꺾은선은 회색(얇게), 데이터 포인트는 목표 대비 상태색으로 강조하고
-    // 포인트마다 값을 같은 색으로 표기한다.
-    // 진입 애니메이션: 펜이 월요일에서 오늘 쪽으로 이동하는 만큼만 선을 잇는다.
-    // drawn 은 "그려진 구간 수"(0 = 첫 점만, lastIdx = 전체).
-    final double p = progress.clamp(0.0, 1.0);
-    final double drawn = lastIdx * p;
-    if (lastIdx > 0) {
-      final Path line = Path()..moveTo(pts.first.dx, pts.first.dy);
-      final int whole = drawn.floor().clamp(0, lastIdx);
-      for (int i = 1; i <= whole; i++) {
-        line.lineTo(pts[i].dx, pts[i].dy);
-      }
-      if (whole < lastIdx) {
-        final Offset tip = Offset.lerp(
-          pts[whole],
-          pts[whole + 1],
-          drawn - whole,
-        )!;
-        line.lineTo(tip.dx, tip.dy);
-      }
-      canvas.drawPath(
-        line,
-        Paint()
-          ..color = _nutLineGray
-          ..style = PaintingStyle.stroke
-          ..strokeWidth = 1.6
-          ..strokeJoin = StrokeJoin.round
-          ..strokeCap = StrokeCap.round,
-      );
-    }
-
-    for (int i = 0; i <= lastIdx; i++) {
-      // 선이 이 점에 닿기 직전부터 짧게 페이드인한다.
-      final double a = lastIdx == 0
-          ? p
-          : ((drawn - i) / 0.35 + 1).clamp(0.0, 1.0);
-      if (a <= 0) continue;
-      final Color sc = _nutStatusColor(cur[i], goal);
-      _dot(canvas, pts[i], sc, r: i == cur.length - 1 ? 5.0 : 4.2, alpha: a);
-      _text(canvas, _metricNumber(cur[i]), pts[i], w, sc, alpha: a);
-    }
-  }
-
-  void _dot(
-    Canvas c,
-    Offset o,
-    Color color, {
-    double r = 3.0,
-    double alpha = 1,
-  }) {
-    // 흰 테두리(halo)
-    c.drawCircle(
-      o,
-      r + 1.3,
-      Paint()..color = Colors.white.withValues(alpha: alpha),
-    );
-    // 상태색으로 채운 데이터 포인트
-    c.drawCircle(o, r, Paint()..color = color.withValues(alpha: alpha));
-  }
-
-  void _text(
-    Canvas c,
-    String s,
-    Offset at,
-    double w,
-    Color color, {
-    double alpha = 1,
-  }) {
-    final TextPainter tp = TextPainter(
-      text: TextSpan(
-        text: s,
-        style: TextStyle(
-          fontSize: 10,
-          fontWeight: FontWeight.w700,
-          color: color.withValues(alpha: alpha),
-        ),
-      ),
-      textDirection: ui.TextDirection.ltr,
-    )..layout();
-    // 배경 상자 없이 값만 표기한다(포인트 위, 화면 밖으로 나가지 않게 clamp).
-    final double bx = (at.dx - tp.width / 2).clamp(0.0, w - tp.width);
-    double by = at.dy - tp.height - 7;
-    if (by < 0) by = at.dy + 7;
-    tp.paint(c, Offset(bx, by));
-  }
-
-  @override
-  bool shouldRepaint(covariant _TrendChartPainter old) =>
-      old.cur != cur ||
-      old.goal != goal ||
-      old.ticks != ticks ||
-      old.lo != lo ||
-      old.hi != hi ||
-      old.todayIndex != todayIndex ||
-      old.progress != progress;
-}
-
 /// The weekly exercise bar chart. Bars sit on a [lo]/[hi] scale whose baseline
 /// is pushed below the smallest value so day-to-day variation is pronounced;
 /// each bar carries its kcal value label, and today's bar is highlighted.
@@ -2075,6 +1760,52 @@ class _ScheduleItemCard extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+class _ChartLegend extends StatelessWidget {
+  const _ChartLegend({required this.title, required this.goalText});
+
+  /// "주간 {지표} 추이" — 선택된 지표에 따라 바뀌는 그래프 왼쪽 상단 제목.
+  final String title;
+
+  /// "목표 2,000kcal" 처럼 지표별 목표 수치. 그래프 오른쪽 상단에 표기.
+  final String goalText;
+
+  @override
+  Widget build(BuildContext context) {
+    // 범례(이번 주/지난 주)는 제거. 왼쪽에 그래프 제목, 오른쪽에 목표 수치를
+    // 카드 우측 끝('자세히 >')과 같은 열로 맞춘다.
+    //
+    // 남는 가로 공간은 제목 쪽 Expanded 가 전부 흡수해야 목표 수치가 그래프
+    // 오른쪽 끝에 붙는다. 목표 수치를 Expanded 로 두면 제목(Flexible)과 공간을
+    // 반씩 나눠 가져 오른쪽 끝에서 한참 못 미친 자리에 멈춘다.
+    return Row(
+      children: <Widget>[
+        Expanded(
+          child: Text(
+            title,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: const TextStyle(
+              fontSize: 14.5,
+              fontWeight: FontWeight.w700,
+              color: FigmaColors.ink,
+            ),
+          ),
+        ),
+        const SizedBox(width: 8),
+        Text(
+          goalText,
+          maxLines: 1,
+          style: const TextStyle(
+            fontSize: 14.5,
+            fontWeight: FontWeight.w800,
+            color: FigmaColors.primary,
+          ),
+        ),
+      ],
     );
   }
 }

--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -239,6 +239,7 @@ class _DietRecordPageState extends ConsumerState<DietRecordPage> {
                     padding: const EdgeInsets.symmetric(horizontal: 24),
                     child: DietPeriodView(
                       range: _rangeFor(_period, center),
+                      weekly: _period == DietPeriodTab.week,
                       profile: profile,
                     ),
                   )
@@ -369,9 +370,13 @@ class _NutritionSectionHeader extends StatelessWidget {
       padding: const EdgeInsets.fromLTRB(24, 0, 24, 10),
       child: Row(
         children: <Widget>[
-          // 좁은 화면·큰 글자 배율에서 제목이 토글을 밀어내 Row 가 넘치던
-          // 문제(#684 리뷰). 제목이 먼저 줄어든다.
-          Flexible(
+          // 토글을 카드 오른쪽 끝에 붙인다 — 운동 탭 '운동 현황' 과 같은 자리라
+          // 두 탭을 오가며 같은 곳에서 기간을 바꾼다.
+          //
+          // `Spacer` 가 아니라 `Expanded` 로 미는 이유: 좁은 화면·큰 글자 배율에서
+          // 제목이 토글을 밀어내 Row 가 넘치던 문제(#684 리뷰)를 그대로 막아야
+          // 한다. 제목이 남은 자리를 다 쓰되 먼저 줄어든다.
+          Expanded(
             child: Text(
               l.dietNutritionSummary,
               maxLines: 1,

--- a/frontend/flutter/lib/features/diet/presentation/widgets/diet_period_view.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/diet_period_view.dart
@@ -269,6 +269,7 @@ class _PeriodBody extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations l = AppLocalizations.of(context);
+    final List<String> labels = weekDayLabels(l);
     final bool over = goal > 0 && average > goal;
     final Color statusColor = over
         ? FigmaColors.dangerRed
@@ -388,7 +389,7 @@ class _PeriodBody extends StatelessWidget {
             MetricTrendChart(
               values: values,
               dayLabels: <String>[
-                for (final DateTime d in dates) _weekdayLabel(d),
+                for (final DateTime d in dates) labels[d.weekday - 1],
               ],
               goal: goal,
               ticks: ticks,
@@ -563,10 +564,6 @@ class _MetricPill extends StatelessWidget {
     );
   }
 }
-
-/// 요일 한 글자(월…일). 홈 탭 주간 추이의 요일 라벨과 같은 형식이다.
-String _weekdayLabel(DateTime d) =>
-    const <String>['월', '화', '수', '목', '금', '토', '일'][d.weekday - 1];
 
 /// 오늘이 이 범위의 몇 번째 칸인가. 범위 밖이면 마지막 칸 — 지난 주를 보고
 /// 있을 때 선이 중간에서 끊기지 않게 한다.

--- a/frontend/flutter/lib/features/diet/presentation/widgets/diet_period_view.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/diet_period_view.dart
@@ -9,6 +9,7 @@ import 'package:oncare/features/account/domain/entities/user_profile.dart';
 import 'package:oncare/features/diet/domain/entities/diet_period.dart';
 import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
+import 'package:oncare/shared/widgets/metric_trend_chart.dart';
 
 /// 식단 탭의 기간 뷰(이번 주 / 이번 달).
 ///
@@ -17,9 +18,19 @@ import 'package:oncare/gen/l10n/app_localizations.dart';
 /// 일별 막대와 **하루 평균**을 보여준다. 합계가 아니라 평균을 머리 숫자로 두는
 /// 이유는 주(7일)와 달(30일)의 길이가 달라 합계끼리는 견줄 수 없기 때문이다.
 class DietPeriodView extends ConsumerStatefulWidget {
-  const DietPeriodView({required this.range, this.profile, super.key});
+  const DietPeriodView({
+    required this.range,
+    required this.weekly,
+    this.profile,
+    super.key,
+  });
 
   final DietDateRange range;
+
+  /// 이번 주인가. 주간은 홈 탭과 **같은 꺾은선**으로, 이번 달은 일별 막대로
+  /// 그린다 — 30칸을 꺾은선으로 그리면 점과 값 라벨이 서로 겹친다.
+  final bool weekly;
+
   final UserProfile? profile;
 
   @override
@@ -72,6 +83,14 @@ class _DietPeriodViewState extends ConsumerState<DietPeriodView> {
         p?.effectiveDailySugarG ?? UserProfile.defaultDailySugarG,
     };
   }
+
+  /// 꺾은선의 가로 눈금. **홈 탭과 같은 값**이라 두 화면의 눈금이 어긋나지
+  /// 않는다(`dashboard_content.dart` 의 지표 설정과 짝).
+  List<double> _ticks(_Metric m) => switch (m) {
+    _Metric.calories => const <double>[0, 1500, 2500],
+    _Metric.sodium => const <double>[0, 1750, 3500],
+    _Metric.sugar => const <double>[0, 25, 50],
+  };
 
   /// 소수 첫째 자리까지만 남기고 정수는 콤마만 붙인다(당류 17.8 이 18 로
   /// 반올림돼 하루 뷰와 어긋나지 않도록).
@@ -201,8 +220,10 @@ class _DietPeriodViewState extends ConsumerState<DietPeriodView> {
                     for (final DietPeriodDay d in period.days) d.date,
                   ],
                   format: _number,
-                  // 지표를 바꾸면 막대가 0 에서 다시 자란다.
+                  // 지표를 바꾸면 그래프가 처음부터 다시 그려진다.
                   replayKey: _metric,
+                  weekly: widget.weekly,
+                  ticks: _ticks(_metric),
                 ),
         ),
       ],
@@ -223,6 +244,8 @@ class _PeriodBody extends StatelessWidget {
     required this.dates,
     required this.format,
     required this.replayKey,
+    required this.weekly,
+    required this.ticks,
   });
 
   final DietPeriod period;
@@ -236,6 +259,12 @@ class _PeriodBody extends StatelessWidget {
   final List<DateTime> dates;
   final String Function(num) format;
   final Object replayKey;
+
+  /// 이번 주면 꺾은선, 이번 달이면 막대.
+  final bool weekly;
+
+  /// 꺾은선의 가로 눈금. 홈 탭과 같은 값을 쓴다.
+  final List<double> ticks;
 
   @override
   Widget build(BuildContext context) {
@@ -355,13 +384,28 @@ class _PeriodBody extends StatelessWidget {
           const SizedBox(height: 14),
           const Divider(height: 1, thickness: 1, color: FigmaColors.hairline),
           const SizedBox(height: 14),
-          _PeriodBars(
-            values: values,
-            dates: dates,
-            goal: goal,
-            color: color,
-            replayKey: replayKey,
-          ),
+          if (weekly)
+            MetricTrendChart(
+              values: values,
+              dayLabels: <String>[
+                for (final DateTime d in dates) _weekdayLabel(d),
+              ],
+              goal: goal,
+              ticks: ticks,
+              // 이번 주는 오늘까지만 잇는다. 오늘이 이 범위 밖이면(지난 주를
+              // 보고 있으면) 마지막 칸까지 전부 그린다.
+              todayIndex: _todayIndexIn(dates),
+              replayKey: replayKey,
+              formatTick: (double v) => format(v),
+            )
+          else
+            _PeriodBars(
+              values: values,
+              dates: dates,
+              goal: goal,
+              color: color,
+              replayKey: replayKey,
+            ),
         ],
       ),
     );
@@ -518,4 +562,18 @@ class _MetricPill extends StatelessWidget {
       ),
     );
   }
+}
+
+/// 요일 한 글자(월…일). 홈 탭 주간 추이의 요일 라벨과 같은 형식이다.
+String _weekdayLabel(DateTime d) =>
+    const <String>['월', '화', '수', '목', '금', '토', '일'][d.weekday - 1];
+
+/// 오늘이 이 범위의 몇 번째 칸인가. 범위 밖이면 마지막 칸 — 지난 주를 보고
+/// 있을 때 선이 중간에서 끊기지 않게 한다.
+int _todayIndexIn(List<DateTime> dates) {
+  final DateTime today = DateUtils.dateOnly(DateTime.now());
+  for (int i = 0; i < dates.length; i++) {
+    if (DateUtils.dateOnly(dates[i]) == today) return i;
+  }
+  return dates.length - 1;
 }

--- a/frontend/flutter/lib/shared/widgets/metric_trend_chart.dart
+++ b/frontend/flutter/lib/shared/widgets/metric_trend_chart.dart
@@ -22,13 +22,30 @@ import 'package:intl/intl.dart';
 import 'package:oncare/design_system/charts/chart_reveal.dart';
 import 'package:oncare/design_system/figma/figma_kit.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
 
 /// 이번 주 꺾은선의 색. 값의 상태는 점으로 말하므로 선은 눈에 띄지 않게 둔다.
 const Color kMetricTrendLine = Color(0xFFDDE2E8);
 
 /// 목표 대비 상태색: 초과(빨강) / 그 외(초록).
+///
+/// 목표가 0 이면 초과로 보지 않는다. `v > goal` 만 두면 목표가 없는 지표의 **모든**
+/// 기록이 빨간 점이 되어, 같은 카드의 평균 뱃지(목표가 있을 때만 초과 판정)와 서로
+/// 다른 이야기를 한다.
 Color metricStatusColor(double v, double goal) =>
-    v > goal ? FigmaColors.dangerRed : FigmaColors.greenText;
+    goal > 0 && v > goal ? FigmaColors.dangerRed : FigmaColors.greenText;
+
+/// 월→일 요일 라벨. 홈 탭과 식단 탭이 **같은 문구**를 쓰도록 여기 둔다 — 한쪽만
+/// 하드코딩하면 영어 로케일에서 한글 요일이 그대로 남는다.
+List<String> weekDayLabels(AppLocalizations l) => <String>[
+  l.dietWeekdayMon,
+  l.dietWeekdayTue,
+  l.dietWeekdayWed,
+  l.dietWeekdayThu,
+  l.dietWeekdayFri,
+  l.dietWeekdaySat,
+  l.dietWeekdaySun,
+];
 
 /// 소수 첫째 자리까지만 남기고 정수는 콤마만. 당류 17.8 이 18 로 반올림돼
 /// 지표 카드·식단 탭 수치와 어긋나지 않도록.

--- a/frontend/flutter/lib/shared/widgets/metric_trend_chart.dart
+++ b/frontend/flutter/lib/shared/widgets/metric_trend_chart.dart
@@ -1,0 +1,336 @@
+/// 지표 하나의 주간 추이 꺾은선 — 홈 탭과 식단 탭이 **같은 그림**을 쓴다.
+///
+/// 원래 홈 탭(`dashboard_content.dart`) 안에만 있던 차트다. 식단 탭의 주간
+/// 그래프가 막대라 같은 값을 두 가지 모양으로 보여 주고 있었다. 복사하면 한쪽만
+/// 고쳐져 갈라지므로 여기로 옮기고 양쪽이 이것을 부른다.
+///
+/// 그리는 규칙은 옮기기 전과 같다.
+///
+///  * 선은 **오늘까지만** 잇는다 — 아직 오지 않은 요일의 0 이 급락처럼 보이지
+///    않도록. x 좌표는 7칸 기준 그대로라 주끼리 정렬된다.
+///  * 점 색은 그날이 목표를 넘겼는지만 말한다(초과=빨강, 그 외=초록). 지표
+///    카드의 뱃지와 같은 두 색이라 한 카드 안에서 서로 다른 이야기를 하지 않는다.
+///  * 목표선은 그리지 않는다. 눈금과 겹치면 선이 두꺼워 보였다.
+library;
+
+import 'dart:math' as math;
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import 'package:oncare/design_system/charts/chart_reveal.dart';
+import 'package:oncare/design_system/figma/figma_kit.dart';
+import 'package:oncare/design_system/tokens/colors.dart';
+
+/// 이번 주 꺾은선의 색. 값의 상태는 점으로 말하므로 선은 눈에 띄지 않게 둔다.
+const Color kMetricTrendLine = Color(0xFFDDE2E8);
+
+/// 목표 대비 상태색: 초과(빨강) / 그 외(초록).
+Color metricStatusColor(double v, double goal) =>
+    v > goal ? FigmaColors.dangerRed : FigmaColors.greenText;
+
+/// 소수 첫째 자리까지만 남기고 정수는 콤마만. 당류 17.8 이 18 로 반올림돼
+/// 지표 카드·식단 탭 수치와 어긋나지 않도록.
+String metricTrendNumber(num v) => v == v.roundToDouble()
+    ? NumberFormat('#,###').format(v)
+    : NumberFormat('#,##0.#').format(v);
+
+/// 데이터와 눈금을 모두 담는 스케일. **0 을 바닥으로 두지 않는다** — 두면
+/// 하루하루 차이가 거의 평평한 선으로 뭉개진다.
+(double, double) metricTrendScale({
+  required List<double> values,
+  required List<double> ticks,
+  required double goal,
+}) {
+  final List<double> all = <double>[...values, ...ticks, goal];
+  double lo = all.reduce(math.min);
+  double hi = all.reduce(math.max);
+  final double range = (hi - lo) == 0 ? 1 : (hi - lo);
+  hi += range * 0.10;
+  lo -= range * 0.08;
+  // 당류처럼 0이 최소 눈금인 지표는 바닥을 0에 고정.
+  if (ticks.isNotEmpty && ticks.first <= 0 && lo < 0) lo = 0;
+  return (lo, hi);
+}
+
+/// 눈금 라벨 + 꺾은선 + 요일 라벨 한 덩어리.
+class MetricTrendChart extends StatelessWidget {
+  const MetricTrendChart({
+    required this.values,
+    required this.dayLabels,
+    required this.goal,
+    required this.ticks,
+    required this.todayIndex,
+    required this.replayKey,
+    required this.formatTick,
+    this.height = 68,
+    super.key,
+  });
+
+  /// 요일별 값(월→일). [dayLabels] 와 길이가 같아야 한다.
+  final List<double> values;
+  final List<String> dayLabels;
+  final double goal;
+
+  /// 가로 눈금선을 그릴 값들. 지표마다 다르다.
+  final List<double> ticks;
+
+  /// 선을 여기까지만 잇는다. 지난 주처럼 전부 지난 구간이면 마지막 index.
+  final int todayIndex;
+
+  /// 바뀌면 진입 애니메이션을 처음부터 다시 그린다.
+  final Object replayKey;
+
+  final String Function(double) formatTick;
+  final double height;
+
+  @override
+  Widget build(BuildContext context) {
+    final (double lo, double hi) = metricTrendScale(
+      values: values,
+      ticks: ticks,
+      goal: goal,
+    );
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        // 눈금 라벨을 각 값의 실제 높이에 맞춰 배치.
+        SizedBox(
+          width: 38,
+          height: height,
+          child: Stack(
+            children: <Widget>[
+              for (final double t in ticks)
+                Positioned(
+                  right: 0,
+                  top: (height - ((t - lo) / (hi - lo)) * height - 8).clamp(
+                    0.0,
+                    height - 16,
+                  ),
+                  child: SizedBox(
+                    height: 16,
+                    child: Center(child: _AxisLabel(formatTick(t))),
+                  ),
+                ),
+            ],
+          ),
+        ),
+        const SizedBox(width: 6),
+        Expanded(
+          child: Column(
+            children: <Widget>[
+              SizedBox(
+                height: height,
+                child: ChartReveal(
+                  replayKey: replayKey,
+                  builder: (BuildContext context, double t) => CustomPaint(
+                    size: Size.infinite,
+                    painter: MetricTrendPainter(
+                      cur: values,
+                      goal: goal,
+                      ticks: ticks,
+                      lo: lo,
+                      hi: hi,
+                      todayIndex: todayIndex,
+                      progress: t,
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 6),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: <Widget>[
+                  for (int i = 0; i < dayLabels.length; i++)
+                    if (i == todayIndex)
+                      // 오늘: 브랜드색 원 안에 흰 글씨.
+                      Container(
+                        width: 18,
+                        height: 18,
+                        alignment: Alignment.center,
+                        decoration: const BoxDecoration(
+                          color: FigmaColors.primary,
+                          shape: BoxShape.circle,
+                        ),
+                        child: Text(
+                          dayLabels[i],
+                          style: const TextStyle(
+                            fontSize: 11.5,
+                            fontWeight: FontWeight.w700,
+                            color: Colors.white,
+                          ),
+                        ),
+                      )
+                    else
+                      Text(
+                        dayLabels[i],
+                        style: const TextStyle(
+                          fontSize: 11.5,
+                          fontWeight: FontWeight.w600,
+                          color: AppColors.mutedForeground,
+                        ),
+                      ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _AxisLabel extends StatelessWidget {
+  const _AxisLabel(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) => Text(
+    text,
+    textAlign: TextAlign.right,
+    style: const TextStyle(
+      fontSize: 10,
+      fontWeight: FontWeight.w600,
+      color: AppColors.mutedForeground,
+    ),
+  );
+}
+
+/// 꺾은선 본체. 홈 탭에 있던 `_TrendChartPainter` 를 그대로 옮긴 것이다.
+class MetricTrendPainter extends CustomPainter {
+  MetricTrendPainter({
+    required this.cur,
+    required this.goal,
+    required this.ticks,
+    required this.lo,
+    required this.hi,
+    required this.todayIndex,
+    this.progress = 1,
+  });
+
+  final List<double> cur;
+  final double goal;
+  final List<double> ticks;
+  final double lo;
+  final double hi;
+
+  /// 선을 여기까지만 그린다(미래 요일의 0값이 급락처럼 보이지 않도록).
+  final int todayIndex;
+
+  /// 0 → 1 진입 애니메이션 진행도. 선은 월요일부터 오늘 쪽으로 이어지고,
+  /// 각 데이터 포인트와 값 라벨은 선이 도달하는 순간 나타난다.
+  final double progress;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final double w = size.width;
+    final double h = size.height;
+    final double span = (hi - lo) <= 0 ? 1 : (hi - lo);
+    double dx(int i) => cur.length <= 1 ? w / 2 : (i / (cur.length - 1)) * w;
+    double dy(double v) => h - ((v - lo) / span) * h;
+
+    final Paint grid = Paint()
+      ..color = const Color(0xFFEFF3F7)
+      ..strokeWidth = 1;
+    for (final double t in ticks) {
+      if (t < lo || t > hi) continue;
+      final double gy = dy(t);
+      canvas.drawLine(Offset(0, gy), Offset(w, gy), grid);
+    }
+
+    final int lastIdx = todayIndex.clamp(0, cur.length - 1);
+    final List<Offset> pts = <Offset>[
+      for (int i = 0; i <= lastIdx; i++) Offset(dx(i), dy(cur[i])),
+    ];
+
+    final double p = progress.clamp(0.0, 1.0);
+    final double drawn = lastIdx * p;
+    if (lastIdx > 0) {
+      final Path line = Path()..moveTo(pts.first.dx, pts.first.dy);
+      final int whole = drawn.floor().clamp(0, lastIdx);
+      for (int i = 1; i <= whole; i++) {
+        line.lineTo(pts[i].dx, pts[i].dy);
+      }
+      if (whole < lastIdx) {
+        final Offset tip = Offset.lerp(
+          pts[whole],
+          pts[whole + 1],
+          drawn - whole,
+        )!;
+        line.lineTo(tip.dx, tip.dy);
+      }
+      canvas.drawPath(
+        line,
+        Paint()
+          ..color = kMetricTrendLine
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = 1.6
+          ..strokeJoin = StrokeJoin.round
+          ..strokeCap = StrokeCap.round,
+      );
+    }
+
+    for (int i = 0; i <= lastIdx; i++) {
+      // 선이 이 점에 닿기 직전부터 짧게 페이드인한다.
+      final double a = lastIdx == 0
+          ? p
+          : ((drawn - i) / 0.35 + 1).clamp(0.0, 1.0);
+      if (a <= 0) continue;
+      final Color sc = metricStatusColor(cur[i], goal);
+      _dot(canvas, pts[i], sc, r: i == cur.length - 1 ? 5.0 : 4.2, alpha: a);
+      _text(canvas, metricTrendNumber(cur[i]), pts[i], w, sc, alpha: a);
+    }
+  }
+
+  void _dot(
+    Canvas c,
+    Offset o,
+    Color color, {
+    double r = 3.0,
+    double alpha = 1,
+  }) {
+    c.drawCircle(
+      o,
+      r + 1.3,
+      Paint()..color = Colors.white.withValues(alpha: alpha),
+    );
+    c.drawCircle(o, r, Paint()..color = color.withValues(alpha: alpha));
+  }
+
+  void _text(
+    Canvas c,
+    String s,
+    Offset at,
+    double w,
+    Color color, {
+    double alpha = 1,
+  }) {
+    final TextPainter tp = TextPainter(
+      text: TextSpan(
+        text: s,
+        style: TextStyle(
+          fontSize: 10,
+          fontWeight: FontWeight.w700,
+          color: color.withValues(alpha: alpha),
+        ),
+      ),
+      textDirection: ui.TextDirection.ltr,
+    )..layout();
+    final double bx = (at.dx - tp.width / 2).clamp(0.0, w - tp.width);
+    double by = at.dy - tp.height - 7;
+    if (by < 0) by = at.dy + 7;
+    tp.paint(c, Offset(bx, by));
+  }
+
+  @override
+  bool shouldRepaint(covariant MetricTrendPainter old) =>
+      old.cur != cur ||
+      old.goal != goal ||
+      old.ticks != ticks ||
+      old.lo != lo ||
+      old.hi != hi ||
+      old.todayIndex != todayIndex ||
+      old.progress != progress;
+}

--- a/frontend/flutter/test/features/dashboard/dashboard_content_state_test.dart
+++ b/frontend/flutter/test/features/dashboard/dashboard_content_state_test.dart
@@ -18,6 +18,7 @@ import 'package:oncare/features/member_coach/presentation/controllers/member_coa
 import 'package:oncare/features/member_coach/presentation/widgets/coach_chat_sheet.dart';
 import 'package:oncare/features/notification/presentation/controllers/notification_controller.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
+import 'package:oncare/shared/widgets/metric_trend_chart.dart';
 
 void main() {
   const liveSummary = DashboardSummary(
@@ -147,13 +148,14 @@ void main() {
     final paints = tester.widgetList<CustomPaint>(
       find.descendant(of: chart, matching: find.byType(CustomPaint)),
     );
+    // 홈과 식단 탭이 같은 차트를 쓰면서 페인터가 공개 타입이 됐다. 이름을
+    // 문자열로 맞추던 것을 실제 타입으로 바꾼다.
     final CustomPaint trendPaint = paints.firstWhere(
-      (paint) => paint.painter.runtimeType.toString() == '_TrendChartPainter',
+      (paint) => paint.painter is MetricTrendPainter,
     );
-    final dynamic trendPainter = trendPaint.painter;
+    final MetricTrendPainter trendPainter =
+        trendPaint.painter! as MetricTrendPainter;
 
-    // The concrete painter is private to the dashboard widget.
-    // ignore: avoid_dynamic_calls
     expect(trendPainter.cur, <double>[
       1100,
       1200,

--- a/frontend/flutter/test/shared/widgets/metric_trend_chart_test.dart
+++ b/frontend/flutter/test/shared/widgets/metric_trend_chart_test.dart
@@ -1,0 +1,117 @@
+/// 홈 탭과 식단 탭이 함께 쓰는 주간 추이 꺾은선. (#688)
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/design_system/figma/figma_kit.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+import 'package:oncare/shared/widgets/metric_trend_chart.dart';
+
+void main() {
+  group('metricStatusColor', () {
+    test('목표를 넘긴 날만 초과색이다', () {
+      expect(metricStatusColor(2100, 2000), FigmaColors.dangerRed);
+      expect(metricStatusColor(1900, 2000), FigmaColors.greenText);
+      // 경계는 초과가 아니다.
+      expect(metricStatusColor(2000, 2000), FigmaColors.greenText);
+    });
+
+    test('목표가 0 이면 어떤 값도 초과가 아니다', () {
+      // `v > goal` 만 두면 목표 없는 지표의 **모든** 기록이 빨간 점이 되어,
+      // 같은 카드의 평균 뱃지(목표가 있을 때만 초과 판정)와 어긋난다.
+      expect(metricStatusColor(1, 0), FigmaColors.greenText);
+      expect(metricStatusColor(9999, 0), FigmaColors.greenText);
+    });
+  });
+
+  group('metricTrendScale', () {
+    test('데이터와 눈금을 모두 담는다', () {
+      final (double lo, double hi) = metricTrendScale(
+        values: <double>[1200, 1800],
+        ticks: <double>[0, 1500, 2500],
+        goal: 2000,
+      );
+      expect(lo, lessThanOrEqualTo(0));
+      expect(hi, greaterThanOrEqualTo(2500));
+    });
+
+    test('0 이 최소 눈금이면 바닥을 0 아래로 내리지 않는다', () {
+      final (double lo, double _) = metricTrendScale(
+        values: <double>[10, 20],
+        ticks: <double>[0, 25, 50],
+        goal: 50,
+      );
+      expect(lo, 0);
+    });
+  });
+
+  testWidgets('요일 라벨은 로케일을 따른다', (WidgetTester tester) async {
+    // 한쪽만 하드코딩하면 영어 로케일에서 한글 요일이 그대로 남는다.
+    late List<String> ko;
+    late List<String> en;
+    for (final (Locale locale, void Function(List<String>) sink) in <
+      (Locale, void Function(List<String>))
+    >[
+      (const Locale('ko'), (List<String> v) => ko = v),
+      (const Locale('en'), (List<String> v) => en = v),
+    ]) {
+      await tester.pumpWidget(
+        MaterialApp(
+          locale: locale,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Builder(
+            builder: (BuildContext context) {
+              sink(weekDayLabels(AppLocalizations.of(context)));
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+      await tester.pump();
+    }
+
+    expect(ko, hasLength(7));
+    expect(en, hasLength(7));
+    expect(en, isNot(ko), reason: '로케일이 달라도 같은 요일 문구가 나옵니다.');
+  });
+
+  testWidgets('요일 수만큼 라벨을 그리고 오늘만 강조한다', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: SizedBox(
+            width: 320,
+            child: MetricTrendChart(
+              values: const <double>[1, 2, 3, 4, 5, 6, 7],
+              dayLabels: const <String>['월', '화', '수', '목', '금', '토', '일'],
+              goal: 5,
+              ticks: const <double>[0, 5, 10],
+              todayIndex: 2,
+              replayKey: 'k',
+              formatTick: (double v) => v.toStringAsFixed(0),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump(const Duration(seconds: 1));
+
+    for (final String d in <String>['월', '화', '수', '목', '금', '토', '일']) {
+      expect(find.text(d), findsOneWidget);
+    }
+    // 오늘 배지는 하나뿐이다.
+    expect(
+      find.byWidgetPredicate(
+        (Widget w) =>
+            w is Container &&
+            w.decoration is BoxDecoration &&
+            (w.decoration! as BoxDecoration).shape == BoxShape.circle,
+      ),
+      findsOneWidget,
+    );
+  });
+}


### PR DESCRIPTION
Closes #688

식단 탭 영양 요약이 다른 탭과 어긋나던 두 곳을 맞춥니다.

## Summary

* **기간 토글**을 카드 오른쪽 끝으로 옮겼습니다. 운동 탭 `운동 현황` 과 같은 자리라, 탭을 오가며 같은 곳에서 기간을 바꿉니다.
* **이번 주 그래프**를 홈 탭 주간 추이와 같은 꺾은선으로 바꿨습니다. 같은 수치가 화면마다 다른 그림으로 나오던 것을 없앱니다.

## 복사가 아니라 공용 위젯으로

꺾은선을 식단 탭에 복사하면 한쪽만 고쳐져 곧 갈라집니다. 그래서 홈 탭 안에만 있던 차트를 `lib/shared/widgets/metric_trend_chart.dart` 로 옮기고 **두 화면이 같은 코드를 부릅니다.**

그리는 규칙은 옮기기 전과 같습니다 — 선은 오늘까지만 잇고(아직 오지 않은 요일의 0 이 급락처럼 보이지 않도록), 점 색은 그날이 목표를 넘겼는지만 말하며, 목표선은 그리지 않습니다.

## 바꾸지 않은 것

* **홈 탭 렌더링.** 차트를 옮기기만 했습니다.
* **이번 달 그래프.** 막대를 유지합니다 — 30칸을 꺾은선으로 그리면 점과 값 라벨이 서로 겹칩니다.
* **운동 탭.** 이 PR 은 건드리지 않습니다.

## Notes

* 토글을 미는 데 `Spacer` 가 아니라 `Expanded` 를 썼습니다. 좁은 화면·큰 글자 배율에서 제목이 토글을 밀어내 Row 가 넘치던 문제(#684 리뷰)를 그대로 막아야 합니다. 제목이 남은 자리를 다 쓰되 먼저 줄어듭니다.
* 꺾은선의 가로 눈금은 홈 탭과 같은 값을 씁니다. 다르면 두 화면의 눈금이 어긋납니다.

## Tests

대시보드 테스트 한 건이 페인터를 `'_TrendChartPainter'` **문자열 이름**으로 찾고 있었습니다. 차트가 공용으로 나오며 공개 타입이 됐으므로 실제 타입으로 찾도록 바꾸고, 함께 있던 `dynamic` 호출도 없앴습니다.

`flutter analyze` 무이슈, 사용자 앱 테스트 610건 통과.

## 확인이 필요한 부분

브라우저 프리뷰에서 클릭이 계속 시간 초과되어 **화면을 눈으로 확인하지 못했습니다.** 코드 기준으로는 맞지만, 실제 화면에서 어긋나는 부분이 있으면 알려 주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 영양 기록의 주간 추이 차트가 개선되어 요일별 수치, 오늘 위치, 목표값을 한눈에 확인할 수 있습니다.
  * 목표 달성 여부에 따라 데이터 색상이 표시되며, 미래 날짜의 데이터는 차트에서 제외됩니다.
  * 차트 진입 애니메이션과 눈금·숫자 표시가 추가되었습니다.

* **개선 사항**
  * 월간 보기에서는 기존 막대 그래프를 유지하고, 주간 보기에서는 꺾은선 그래프로 표시합니다.
  * 대시보드와 영양 기록 화면의 차트 표시와 요약 영역 배치가 일관되게 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->