### PR TITLE
fix(trainer-web): '주의' 색을 회원 앱과 같은 빨강으로 맞춤

### DIFF
--- a/frontend/flutter_trainer/lib/design_system/tokens/colors.dart
+++ b/frontend/flutter_trainer/lib/design_system/tokens/colors.dart
@@ -22,7 +22,9 @@ class AppColors {
 
   /// Trainer identity orange — kept only as a small accent (the
   /// "트레이너" brand word, MY-tab highlights), not as the main color.
-  static const Color brandOrange = Color(0xFFFF953C); // 주의 오렌지(#FF953C)로 통일
+  /// 브랜드 주황 (`#FF953C`). **주의가 아닌** 강조에 쓴다 — 메모·안내 박스,
+  /// 진행 척도의 '부분', 지표 구분색 등. 주의는 [warning](빨강)이다.
+  static const Color brandOrange = Color(0xFFFF953C);
 
   // --- Accent (client navy) ---
   /// Navy used for client avatars, info chips, and the "AI 요약" card.
@@ -69,15 +71,18 @@ class AppColors {
   /// Success / "완료" green (`#34C759`).
   static const Color success = Color(0xFF34C759);
 
-  /// Warning orange (`#FF953C`) — a caution that is NOT a target being
-  /// exceeded: partial routine completion, a manual entry to double-check.
-  static const Color warning = Color(0xFFFF953C);
+  /// '주의' 빨강 (`#F04438`). [overTarget] 과 **같은 색이다.**
+  ///
+  /// 예전에는 주황(`#FF953C`)이었다. 목표 초과만 빨강이고 완만한 주의는 주황이라는
+  /// 규칙이었는데, 회원은 자기 폰에서 빨갛게 보고 있는 것을 트레이너는 주황으로
+  /// 봐서 **두 앱이 같은 사실을 다른 세기로** 말했다. 주의는 주의다. (#690)
+  ///
+  /// 메모·안내처럼 주의가 아닌 자리에는 쓰지 않는다 — 그런 곳은 [brandOrange].
+  static const Color warning = Color(0xFFF04438);
 
   /// "목표 초과" red (`#F04438`). Matches the member app's
   /// `FigmaColors.dangerRed` — a member who sees 나트륨 초과 in red on
   /// their phone must not see it in orange on their trainer's screen.
-  /// Reserved for a target actually being exceeded; use [warning] for
-  /// softer cautions.
   static const Color overTarget = Color(0xFFF04438);
 
   /// Destructive / delete red (`#FF3B30`).

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/workout_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/workout_view.dart
@@ -402,9 +402,12 @@ class _TypeChip extends StatelessWidget {
 
 /// Completion color scale shared by the bars and donuts: 100 = done
 /// (green), partial = orange, 0 = untouched (grey).
+///
+/// '부분' 은 진행 상태이지 주의가 아니다. 빨강으로 올리면 아무것도 하지 않은
+/// 0%(회색)보다 부분 완료가 더 위험해 보여 척도가 뒤집힌다(#690).
 Color _rateColor(int rate) {
   if (rate >= 100) return AppColors.success;
-  if (rate > 0) return AppColors.warning;
+  if (rate > 0) return AppColors.brandOrange;
   return AppColors.borderStrong;
 }
 
@@ -509,7 +512,7 @@ class _WeekCompletionCard extends StatelessWidget {
             children: <Widget>[
               _LegendDot(color: AppColors.success, label: l.legendDone),
               const SizedBox(width: AppSpacing.md),
-              _LegendDot(color: AppColors.warning, label: l.legendPartial),
+              _LegendDot(color: AppColors.brandOrange, label: l.legendPartial),
               const SizedBox(width: AppSpacing.md),
               _LegendDot(color: AppColors.borderStrong, label: l.legendMissed),
             ],
@@ -655,7 +658,8 @@ class _HistoryCardState extends ConsumerState<_HistoryCard> {
             _NoteBox(
               title: l.trainerNote,
               body: entry.trainerNote,
-              color: AppColors.warning,
+              // 노트다. 주의가 아니므로 빨강으로 올리지 않는다(#690).
+              color: AppColors.brandOrange,
             ),
           ],
           if (entry.assignedRoutineId != null) ...<Widget>[

--- a/frontend/flutter_trainer/lib/features/coaching/presentation/pages/ai_routine_options_flow.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/pages/ai_routine_options_flow.dart
@@ -895,7 +895,8 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
                 const Icon(
                   Icons.sticky_note_2_outlined,
                   size: 17,
-                  color: AppColors.warning,
+                  // 메모다. 주의가 아니므로 빨강으로 올리지 않는다(#690).
+                  color: AppColors.brandOrange,
                 ),
                 const SizedBox(width: AppSpacing.sm),
                 Expanded(
@@ -907,7 +908,7 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
                         style: TextStyle(
                           fontSize: 11,
                           fontWeight: FontWeight.w700,
-                          color: AppColors.warning,
+                          color: AppColors.brandOrange,
                         ),
                       ),
                       const SizedBox(height: 2),

--- a/frontend/flutter_trainer/lib/features/coaching/presentation/widgets/program_editor_workspace.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/widgets/program_editor_workspace.dart
@@ -427,13 +427,14 @@ class _UnsupportedBanner extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.all(AppSpacing.sm),
       decoration: BoxDecoration(
-        color: AppColors.warning.withValues(alpha: 0.1),
+        color: AppColors.brandOrange.withValues(alpha: 0.1),
         borderRadius: const BorderRadius.all(AppRadius.md),
-        border: Border.all(color: AppColors.warning.withValues(alpha: 0.25)),
+        border: Border.all(color: AppColors.brandOrange.withValues(alpha: 0.25)),
       ),
       child: Row(
         children: <Widget>[
-          const Icon(Icons.info_outline, color: AppColors.warning, size: 17),
+          // 안내다. 주의가 아니므로 빨강으로 올리지 않는다(#690).
+          const Icon(Icons.info_outline, color: AppColors.brandOrange, size: 17),
           const SizedBox(width: AppSpacing.sm),
           Expanded(
             child: Text(

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
@@ -2318,11 +2318,11 @@ class _NoteBox extends StatelessWidget {
         vertical: AppSpacing.sm,
       ),
       decoration: BoxDecoration(
-        color: AppColors.warning.withValues(alpha: 0.06),
+        color: AppColors.brandOrange.withValues(alpha: 0.06),
         borderRadius: const BorderRadius.all(AppRadius.md),
         border: Border(
           left: BorderSide(
-            color: AppColors.warning.withValues(alpha: 0.4),
+            color: AppColors.brandOrange.withValues(alpha: 0.4),
             width: 3,
           ),
         ),
@@ -2335,7 +2335,8 @@ class _NoteBox extends StatelessWidget {
             style: TextStyle(
               fontSize: 10,
               fontWeight: FontWeight.w700,
-              color: AppColors.warning,
+              // 메모지 표시다. 주의가 아니므로 빨강으로 올리지 않는다(#690).
+              color: AppColors.brandOrange,
             ),
           ),
           const SizedBox(height: 2),

--- a/frontend/flutter_trainer/lib/shared/widgets/alert_badge.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/alert_badge.dart
@@ -7,9 +7,12 @@ import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 
 /// The colour that carries [alert]'s meaning.
 ///
-/// 하나의 색은 하나의 뜻만: 남색 = 처리 필요, 빨강 = 목표 초과 (사용자 앱과
-/// 동일), 주황 = 완만한 주의. 답장 대기의 시급함은 색이 아니라 목록 맨 위에
-/// 오는 순서가 말한다.
+/// 하나의 색은 하나의 뜻만: 남색 = 처리 필요, 빨강 = 주의(목표 초과와 완료율
+/// 저조를 함께 포함). 답장 대기의 시급함은 색이 아니라 목록 맨 위에 오는 순서가
+/// 말한다.
+///
+/// 예전에는 완만한 주의를 주황으로 따로 두었는데, 회원이 자기 폰에서 빨갛게 보는
+/// 것을 트레이너는 주황으로 봐서 **두 앱이 같은 사실을 다른 세기로** 말했다(#690).
 Color alertColor(ClientAlert alert) => switch (alert) {
   ClientAlert.unanswered => AppColors.primary,
   ClientAlert.sodiumOver => AppColors.overTarget,

--- a/frontend/flutter_trainer/test/design_system/caution_color_test.dart
+++ b/frontend/flutter_trainer/test/design_system/caution_color_test.dart
@@ -1,0 +1,46 @@
+/// '주의' 는 회원 앱과 같은 빨강이다. (#690)
+///
+/// 색이 되돌아가면 화면에서는 조용히 주황으로 보일 뿐이라 리뷰에서 놓치기 쉽다.
+/// 회원이 자기 폰에서 빨갛게 보는 것을 트레이너가 주황으로 보는 상태로 돌아가지
+/// 않도록 여기서 못을 박는다.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare_trainer/design_system/tokens/colors.dart';
+import 'package:oncare_trainer/shared/models/client_alerts.dart';
+import 'package:oncare_trainer/shared/widgets/alert_badge.dart';
+
+void main() {
+  group('주의 색', () {
+    test('주의와 목표 초과가 같은 빨강이다', () {
+      // 회원 앱 `FigmaColors.dangerRed` 와 같은 값.
+      expect(AppColors.warning, const Color(0xFFF04438));
+      expect(AppColors.warning, AppColors.overTarget);
+    });
+
+    test('완료율 저조도 목표 초과와 같은 색으로 알린다', () {
+      // 예전에는 이쪽만 주황이라 같은 '주의' 가 두 세기로 보였다.
+      expect(
+        alertColor(ClientAlert.lowCompletion),
+        alertColor(ClientAlert.sodiumOver),
+      );
+      expect(alertColor(ClientAlert.lowCompletion), AppColors.warning);
+    });
+
+    test('처리 필요는 여전히 남색이다', () {
+      // 답장 대기는 주의가 아니다. 전부 빨갛게 만들면 목록에서 무엇이 급한지
+      // 색으로는 구분되지 않는다.
+      expect(alertColor(ClientAlert.unanswered), AppColors.primary);
+      expect(alertColor(ClientAlert.unanswered), isNot(AppColors.warning));
+    });
+
+    test('브랜드 주황은 주의와 다른 색으로 남는다', () {
+      // 메모·안내·진행 척도의 '부분' 이 쓰는 색. 주의와 같아지면 그 자리들이
+      // 없는 위험을 있다고 말하게 된다.
+      expect(AppColors.brandOrange, const Color(0xFFFF953C));
+      expect(AppColors.brandOrange, isNot(AppColors.warning));
+    });
+  });
+}


### PR DESCRIPTION
Closes #690

같은 '주의' 가 회원 폰에서는 빨강, 트레이너 화면에서는 주황으로 보였습니다. 두 앱이 같은 사실을 다른 세기로 말하고 있었습니다.

## Summary

`AppColors.warning` 토큰 자체를 빨강(`#F04438`)으로 바꿨습니다. 호출부를 하나씩 고치는 대신 토큰을 바꾼 이유는 **빠뜨릴 자리를 없애기 위해서**입니다 — 앞으로 이 토큰을 쓰는 새 화면도 자동으로 맞습니다.

빨강이 된 곳:

| 자리 | 무엇 |
| --- | --- |
| `ClientAlert.lowCompletion` | 주의 고객 배지 — 대시보드 행·고객 상세 |
| `StatTone.warn` | 지표 카드의 주의 톤 |
| 리포트 | 일정 경고 문구, 불러오기 실패 문구, 완료율 70% 미만 판정 |

## 주의가 아니라서 빨강으로 올리지 않은 곳

같은 토큰을 쓰고 있었지만 **뜻이 다른** 자리들입니다. 빨강으로 바꾸면 없는 위험을 있다고 말하게 되므로 `brandOrange` 로 옮겼습니다.

* **메모·노트** — 일정 메모 박스, 운동 기록의 트레이너 노트, AI 루틴 메모
* **안내(info) 박스** — `Icons.info_outline` 로 여는 설명
* **완료율 척도의 '부분'** — 100%=초록, 부분=주황, 0%=회색인 진행 척도입니다. 부분 완료가 아무것도 하지 않은 0%(회색)보다 빨갛게 보이면 **척도가 뒤집힙니다.**

## 회원 앱은 건드리지 않았습니다

주황이 쓰이는 자리를 전부 확인했더니 **나트륨 지표색·별점 아이콘·식단 태그**뿐이고 '주의' 가 아닙니다.

## Notes

`alert_badge.dart` 의 색 규약 주석이 "주황 = 완만한 주의" 라고 적혀 있었습니다. 이제 사실이 아니라 함께 고쳤습니다 — 주석만 남으면 다음 사람이 주황으로 되돌립니다.

## Tests

색이 되돌아가도 화면에서는 조용히 주황으로 보일 뿐이라 리뷰에서 놓치기 쉽습니다. 그래서 못을 박는 테스트를 넣었습니다.

* 주의와 목표 초과가 같은 빨강인지
* 완료율 저조가 나트륨 초과와 같은 색인지
* 처리 필요(답장 대기)는 여전히 남색인지 — 전부 빨갛게 만들면 목록에서 무엇이 급한지 색으로 구분되지 않습니다
* 브랜드 주황이 주의와 다른 색으로 남는지

트레이너 웹 테스트 534건 통과, `flutter analyze` 무이슈.

## 확인이 필요한 부분

브라우저 프리뷰 클릭이 되지 않아 **화면을 눈으로 확인하지 못했습니다.** 주황이 남아 있는 자리를 발견하시면 알려 주세요 — 위 "빨강으로 올리지 않은 곳" 중 주의로 봐야 할 것이 있으면 함께 옮기겠습니다.
