### PR TITLE
fix(member): 담당 트레이너 소속이 비면 회원 앱 예약 패널이 통째로 사라짐

### DIFF
--- a/backend/app/api/v1/trainers.py
+++ b/backend/app/api/v1/trainers.py
@@ -49,7 +49,11 @@ def get_trainer(
     current_user: CurrentUser,
     db: Annotated[Session, Depends(get_db)],
 ) -> TrainerOut:
-    trainer = gym_service.get_trainer(db, trainer_id)
+    """트레이너 상세.
+
+    요청자를 넘기는 이유는 **내 담당 트레이너**만 소속 조건에서 빼기 위해서다(#691).
+    """
+    trainer = gym_service.get_trainer(db, trainer_id, viewer_id=current_user.id)
     if trainer is None:
         raise HTTPException(status_code=404, detail="트레이너를 찾을 수 없습니다.")
     return trainer

--- a/backend/app/services/gym_service.py
+++ b/backend/app/services/gym_service.py
@@ -165,7 +165,7 @@ def _to_trainer(
     )
 
 
-def _trainer_query():
+def _trainer_query(*, require_gym: bool = True):
     """디렉터리에 노출할 트레이너 — 상담 대상 조건과 같아야 한다. (#451)
 
     `consultation_service._validate_target` 은 상담 요청 시 트레이너의 소속을
@@ -184,16 +184,23 @@ def _trainer_query():
     소속이 빠진 트레이너를 숨기는 쪽을 골랐다. 상담을 걸 수 없는 트레이너를 목록에
     남기면 회원은 고를 수 있는데 마지막 단계에서만 막히고, 트레이너 앱이 소속을
     채우면(#452) 그대로 다시 노출된다.
+
+    `require_gym=False` 는 **이미 담당으로 배정된 트레이너를 그 회원이 읽을 때**만
+    쓴다(`get_trainer`). 그 자리는 디렉터리 노출이 아니라 이미 맺어진 관계를 읽는
+    것이라 소속 조건이 맞지 않는다. (#691)
     """
-    return (
+    query = (
         select(User, TrainerProfile)
         .join(TrainerProfile, TrainerProfile.trainer_id == User.id)
-        .join(Place, Place.id == TrainerProfile.gym_id)
         .where(
             User.role == "trainer",
             User.is_active.is_(True),
-            Place.category == "fitness",
         )
+    )
+    if not require_gym:
+        return query
+    return query.join(Place, Place.id == TrainerProfile.gym_id).where(
+        Place.category == "fitness"
     )
 
 
@@ -237,9 +244,30 @@ def list_recommended_trainers(
     ]
 
 
-def get_trainer(db: Session, trainer_id: str) -> TrainerOut | None:
+def get_trainer(
+    db: Session, trainer_id: str, *, viewer_id: str | None = None
+) -> TrainerOut | None:
+    """트레이너 상세. 디렉터리 조건에 걸리면 None(라우터에서 404).
+
+    예외가 하나 있다. **요청자의 담당 트레이너**는 소속이 비어도 읽을 수 있다.
+    `/me/coach` 는 `trainer_clients` 기준으로 담당을 그대로 돌려주는데 상세만 소속
+    기준으로 404 를 내면, 회원은 담당이 있다고 표시되면서 그 트레이너를 읽지 못하는
+    상태가 된다 — 예약 패널·코치 카드가 통째로 빠진다. 디렉터리 노출 정책(#451)은
+    그대로 두고 "내 담당"만 예외로 둔다. (#691)
+    """
     row = db.execute(_trainer_query().where(User.id == trainer_id)).first()
+    if row is None and viewer_id is not None and _is_my_coach(db, viewer_id, trainer_id):
+        row = db.execute(
+            _trainer_query(require_gym=False).where(User.id == trainer_id)
+        ).first()
     if row is None:
         return None
     user, profile = row
     return _to_trainer(user, profile)
+
+
+def _is_my_coach(db: Session, member_id: str, trainer_id: str) -> bool:
+    """`trainer_id` 가 이 회원의 현재 담당인가 — `/me/coach` 와 같은 기준(활성 링크)."""
+    from app.services import trainer_service
+
+    return trainer_service.get_member_trainer_id(db, member_id) == trainer_id

--- a/backend/tests/test_gyms.py
+++ b/backend/tests/test_gyms.py
@@ -278,6 +278,95 @@ def test_trainer_at_non_fitness_place_is_hidden(client, directory_trainer):
     assert client.get(f"/v1/trainers/{trainer_id}").status_code == 404
 
 
+# ---- 담당 트레이너는 소속 조건의 예외 (#691) ----
+
+@pytest.fixture
+def member_of(client, db_session):
+    """주어진 트레이너를 담당으로 가진 새 회원을 만드는 팩토리. (member_id, token)
+
+    끝나면 링크를 지운다 — 담당 링크 수를 세는 테스트가 있어 남겨 두면 깨진다.
+    """
+    from uuid import uuid4
+
+    from app.models import models
+    from tests.test_consultations import _register_member
+
+    created: list[str] = []
+
+    def _make(trainer_id: str) -> tuple[str, str]:
+        member_id, token = _register_member(client)
+        link_id = f"tc-{uuid4().hex[:12]}"
+        db_session.add(models.TrainerClient(
+            id=link_id, trainer_id=trainer_id, member_id=member_id, active=True,
+        ))
+        db_session.commit()
+        created.append(link_id)
+        return member_id, token
+
+    yield _make
+
+    from app.models import models as _models
+
+    for link_id in created:
+        row = db_session.get(_models.TrainerClient, link_id)
+        if row is not None:
+            db_session.delete(row)
+    db_session.commit()
+
+
+def test_my_coach_detail_survives_a_missing_gym(client, directory_trainer, member_of):
+    """소속이 비어도 **내 담당**의 상세는 읽혀야 한다. (#691)
+
+    `/me/coach` 는 담당 배정(`trainer_clients`)을 그대로 돌려주는데 상세만 소속
+    기준으로 404 를 내면, 회원 앱은 담당이 있다고 표시하면서 그 트레이너를 읽지
+    못한다 — 운동 탭의 예약 패널이 통째로 빠진다.
+    """
+    from tests.test_consultations import _auth
+
+    trainer_id = directory_trainer(gym_id=None)
+    _member_id, token = member_of(trainer_id)
+
+    assert client.get("/v1/me/coach", headers=_auth(token)).status_code == 200
+
+    r = client.get(f"/v1/trainers/{trainer_id}", headers=_auth(token))
+    assert r.status_code == 200, r.text
+    assert r.json()["id"] == trainer_id
+    # 소속이 없다는 사실 자체는 그대로 드러난다 — 앱이 소속 카드를 감출 수 있게.
+    assert r.json()["gym_id"] is None
+
+
+def test_coach_exception_does_not_leak_into_the_directory(
+    client, directory_trainer, member_of
+):
+    """예외는 "내 담당" 상세 한 자리뿐 — 목록·추천은 소속 조건 그대로다. (#451)"""
+    from tests.test_consultations import _auth
+
+    trainer_id = directory_trainer(gym_id=None)
+    _member_id, token = member_of(trainer_id)
+
+    assert trainer_id not in {
+        t["id"] for t in client.get("/v1/trainers", headers=_auth(token)).json()
+    }
+    assert trainer_id not in {
+        t["id"]
+        for t in client.get("/v1/trainers/recommended", headers=_auth(token)).json()
+    }
+
+
+def test_gymless_trainer_stays_404_for_other_members(
+    client, directory_trainer, member_of
+):
+    """담당이 아닌 회원에게는 여전히 404 — 예외가 다른 회원까지 열어 주면 안 된다."""
+    from tests.test_consultations import _auth, _register_member
+
+    trainer_id = directory_trainer(gym_id=None)
+    member_of(trainer_id)  # 담당인 회원은 따로 있다
+    _other_id, other_token = _register_member(client)
+
+    r = client.get(f"/v1/trainers/{trainer_id}", headers=_auth(other_token))
+    assert r.status_code == 404, r.text
+
+
 def test_gym_trainer_list_stays_a_subset_of_the_directory(client):
     """헬스장 상세의 소속 트레이너는 디렉터리에도 있어야 한다.
 


### PR DESCRIPTION
Closes #691

## Summary

`/me/coach` 는 `trainer_clients` 기준으로 담당 배정을 그대로 돌려주는데, `/trainers/{id}` 는 `places`(category='fitness') 소속 기준으로 404 를 냈습니다. 두 경로의 기준이 달라 `TrainerProfile.gym_id` 가 비면 회원은 **담당 트레이너가 있다고 표시되면서 그 트레이너를 읽지 못하는** 상태가 됩니다. `GymTab` 은 `trainer != null` 일 때만 예약 패널을 붙이므로 패널이 통째로 빠지고, 코치 카드·트레이너 상세도 같이 영향을 받습니다.

이슈의 제안 1(권장)을 택했습니다 — 디렉터리 노출 정책(#451)은 그대로 두고 "내 담당"만 예외로 둡니다. 제안 2(상세 실패를 삼키고 요약으로 구성)는 화면은 살지만 자격증·추천 사유가 빈 트레이너를 보여 주고, 제안 3(시드/백필)은 근본 원인을 막지 못합니다.

## Changes

- `gym_service._trainer_query()` 에 `require_gym` 을 두어 소속 조인을 뗄 수 있게 했습니다. 기본값은 그대로 소속을 요구합니다.
- `gym_service.get_trainer()` 가 요청자를 받아, 조회 대상이 **요청자의 현재 담당**(활성 `trainer_clients` 링크, `/me/coach` 와 같은 기준)일 때만 소속 조건 없이 한 번 더 읽습니다.
- `/trainers/{trainer_id}` 라우터가 `current_user.id` 를 넘깁니다.

목록·추천은 손대지 않았습니다. 담당이 아닌 회원에게는 소속 없는 트레이너가 여전히 404 입니다.

## Tests

`backend/tests/test_gyms.py` 에 세 가지를 더했습니다.

- 소속이 빈 담당 트레이너의 상세가 200 이고 `gym_id` 는 null 로 그대로 드러난다
- 그 예외가 목록·추천으로는 새지 않는다
- 담당이 아닌 회원에게는 여전히 404 다

첫 번째 테스트는 이 커밋 없이는 실패합니다(404). `pytest tests/test_gyms.py` 전체 통과.

## Notes

- 이슈를 등록한 지수와 함께 assign 되어 있습니다. 담당 배정을 요청받아 이어받았습니다.
- #637 / #678 의 `reserve` 단계가 이 404 에 막혀 있었습니다.