### PR TITLE
fix(test): 트레이너 웹 브라우저 E2E가 사라진 client-chat-button 을 누름

### DIFF
--- a/frontend/flutter_trainer/integration_test/trainer_web_core_flows_test.dart
+++ b/frontend/flutter_trainer/integration_test/trainer_web_core_flows_test.dart
@@ -205,27 +205,44 @@ String _ymd(DateTime value) =>
     '${value.month.toString().padLeft(2, '0')}-'
     '${value.day.toString().padLeft(2, '0')}';
 
+/// 픽스처 전용 클라이언트. 앱이 쓰는 Dio 와 별개다.
+final Dio _fixtureApi = Dio(
+  BaseOptions(
+    baseUrl: _apiBaseUrl,
+    connectTimeout: _fixtureApiTimeout,
+    sendTimeout: _fixtureApiTimeout,
+    receiveTimeout: _fixtureApiTimeout,
+  ),
+);
+
+/// 회원 토큰 — **한 번만 받아 재사용한다.**
+///
+/// 각 테스트가 로그아웃 상태에서 부팅하므로 화면 로그인만으로도 한 번 돌 때 네 번이다.
+/// 픽스처까지 매번 로그인하면 백엔드 인증 한도(IP·엔드포인트당 분당 10 회,
+/// `rate_limit_auth_per_minute`)에 걸려, 검증에 닿기도 전에 429 로 죽는다. 스위트를
+/// 연달아 돌리면 특히 그렇다. (CodeRabbit 지적)
+String? _cachedMemberToken;
+
+Future<Options> _memberAuth() async {
+  final cached = _cachedMemberToken;
+  if (cached == null) {
+    final login = await _fixtureApi.post<Map<String, dynamic>>(
+      '/auth/login',
+      data: <String, String>{'username': _memberEmail, 'password': _password},
+      options: Options(contentType: Headers.formUrlEncodedContentType),
+    );
+    _cachedMemberToken = login.data!['access_token'] as String;
+  }
+  return Options(
+    headers: <String, String>{'Authorization': 'Bearer $_cachedMemberToken'},
+  );
+}
+
 /// 회원 계정으로 본 상담 요청 목록. 픽스처 준비와 결과 확인이 같은 창구를 쓴다.
 Future<List<Map<String, dynamic>>> _memberConsultations() async {
-  final dio = Dio(
-    BaseOptions(
-      baseUrl: _apiBaseUrl,
-      connectTimeout: _fixtureApiTimeout,
-      sendTimeout: _fixtureApiTimeout,
-      receiveTimeout: _fixtureApiTimeout,
-    ),
-  );
-  final login = await dio.post<Map<String, dynamic>>(
-    '/auth/login',
-    data: <String, String>{'username': _memberEmail, 'password': _password},
-    options: Options(contentType: Headers.formUrlEncodedContentType),
-  );
-  final token = login.data!['access_token'] as String;
-  final mine = await dio.get<List<dynamic>>(
+  final mine = await _fixtureApi.get<List<dynamic>>(
     '/consultations/me',
-    options: Options(
-      headers: <String, String>{'Authorization': 'Bearer $token'},
-    ),
+    options: await _memberAuth(),
   );
   return <Map<String, dynamic>>[
     for (final item in mine.data ?? const <dynamic>[])
@@ -243,23 +260,6 @@ Future<Map<String, dynamic>> _memberConsultation(String id) async {
 }
 
 Future<String> _ensurePendingConsultation() async {
-  final dio = Dio(
-    BaseOptions(
-      baseUrl: _apiBaseUrl,
-      connectTimeout: _fixtureApiTimeout,
-      sendTimeout: _fixtureApiTimeout,
-      receiveTimeout: _fixtureApiTimeout,
-    ),
-  );
-  final login = await dio.post<Map<String, dynamic>>(
-    '/auth/login',
-    data: <String, String>{'username': _memberEmail, 'password': _password},
-    options: Options(contentType: Headers.formUrlEncodedContentType),
-  );
-  final token = login.data!['access_token'] as String;
-  final auth = Options(
-    headers: <String, String>{'Authorization': 'Bearer $token'},
-  );
   for (final row in await _memberConsultations()) {
     if (row['status'] == 'pending' && row['trainer_id'] == 'trainer-demo') {
       return row['id'] as String;
@@ -267,9 +267,9 @@ Future<String> _ensurePendingConsultation() async {
   }
 
   final preferredDate = DateTime.now().add(const Duration(days: 2));
-  final created = await dio.post<Map<String, dynamic>>(
+  final created = await _fixtureApi.post<Map<String, dynamic>>(
     '/consultations',
-    options: auth,
+    options: await _memberAuth(),
     data: <String, Object?>{
       'target_type': 'trainer',
       'trainer_id': 'trainer-demo',

--- a/frontend/flutter_trainer/integration_test/trainer_web_core_flows_test.dart
+++ b/frontend/flutter_trainer/integration_test/trainer_web_core_flows_test.dart
@@ -12,11 +12,11 @@ import 'package:oncare_trainer/core/config/app_config.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/features/auth/presentation/pages/trainer_sign_in_page.dart';
 import 'package:oncare_trainer/features/clients/presentation/pages/clients_page.dart';
-import 'package:oncare_trainer/features/clients/presentation/widgets/chat_view.dart';
 import 'package:oncare_trainer/features/clients/presentation/widgets/diet_view.dart';
 import 'package:oncare_trainer/features/clients/presentation/widgets/workout_view.dart';
-import 'package:oncare_trainer/features/consultations/presentation/pages/consultations_page.dart';
+import 'package:oncare_trainer/features/consultations/presentation/widgets/consultation_inbox_sheet.dart';
 import 'package:oncare_trainer/features/dashboard/presentation/pages/dashboard_page.dart';
+import 'package:oncare_trainer/features/messages/presentation/pages/messages_page.dart';
 import 'package:oncare_trainer/features/schedule/presentation/pages/schedule_page.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 
@@ -27,6 +27,16 @@ const String _clientId = 'user-demo';
 const String _consultationMemberName = '이지수';
 const String _apiBaseUrl = String.fromEnvironment('API_BASE_URL');
 const Duration _fixtureApiTimeout = Duration(seconds: 15);
+const String _rejectionNote = '#624 E2E 반복 실행 확인';
+
+/// 회원 스레드가 열린 자리 — 채팅은 이제 `/messages` 가 소유한다. (#692)
+final String _chatLocation = AppRoutes.messagesFor(_clientId);
+
+/// 열린 스레드를 가리키는 finder. `ChatView` 타입으로 찾으면 고객 상세에도 같은
+/// 위젯이 있던 시절 기준이라, 스레드가 실제로 **메시지 화면**에 떴는지 못 가린다.
+final Finder _chatThread = find.byKey(
+  ValueKey<String>('messages-thread-$_clientId'),
+);
 
 Future<void> _pumpUntil(
   WidgetTester tester,
@@ -131,20 +141,93 @@ Future<void> _openClient(WidgetTester tester) async {
   expect(_location(tester), AppRoutes.clientDetail(_clientId));
 }
 
-Future<void> _restartAtCurrentBrowserLocation(WidgetTester tester) async {
-  // integration_test exposes no WebDriver refresh command. Disposing and
-  // booting the production root at the unchanged browser URL exercises the
-  // two app contracts that a refresh relies on: secure-session restoration
-  // and GoRouter's platform-location restoration.
+/// 사이드바 → 메시지 → 회원 스레드.
+///
+/// 트레이너 웹 Figma 정렬(#665, #676) 이후 채팅은 고객 상세의 `client-chat-button`
+/// 이 아니라 **메시지 화면**에 있다. 고객 상세의 메시지 버튼도 결국 여기로 보내고
+/// (`/clients/<id>/chat` 은 라우터가 `/messages?client=<id>` 로 넘긴다), 회원 스레드는
+/// `messages-thread-<id>` 로 뜬다. (#692)
+Future<void> _openClientChat(WidgetTester tester) async {
+  await _openSidebar(tester, AppRoutes.messages);
+  await _pumpUntil(
+    tester,
+    find.byType(MessagesPage),
+    step: 'messages navigation',
+  );
+  final conversation = find.byKey(
+    const ValueKey<String>('messages-conversation-$_clientId'),
+  );
+  await _pumpUntil(tester, conversation, step: 'client conversation load');
+  await tester.tap(conversation);
+  await _pumpUntil(tester, _chatThread, step: 'client chat thread');
+  expect(_location(tester), _chatLocation);
+}
+
+/// 앱을 통째로 다시 띄운다 — 새로고침에 준하는 재부팅.
+///
+/// integration_test 에는 WebDriver 새로고침 명령이 없다. 프로덕션 루트를 버리고
+/// 다시 부팅하면 새로고침이 기대는 계약 하나가 그대로 걸린다: **보안 저장소의 세션이
+/// 살아남아 로그인 화면으로 되돌아가지 않는가.**
+///
+/// 위치는 복원되지 않는다. `buildAppRouter` 가 `initialLocation` 을 로그인 화면으로
+/// 고정해 두어(7083dccd), 부팅은 늘 로그인 라우트에서 시작하고 세션이 복원되면
+/// 인증 게이트가 대시보드로 보낸다 — 브라우저 URL 은 읽지 않는다. 이 스위트가
+/// 처음부터 딥링크 복원을 단언하고 있었지만, 스크립트의 헬스 체크가 막혀 한 번도
+/// 실행되지 않아 드러나지 않았다. (#692)
+Future<void> _reboot(WidgetTester tester) async {
   await tester.pumpWidget(const SizedBox.shrink());
   await tester.pump();
   await bootstrap();
+  await _pumpUntil(tester, find.byType(AppShell), step: 'app reboot');
+  expect(
+    find.byType(TrainerSignInPage),
+    findsNothing,
+    reason: 'secure session did not survive the reboot',
+  );
+  expect(_location(tester), AppRoutes.dashboard);
 }
 
 String _ymd(DateTime value) =>
     '${value.year.toString().padLeft(4, '0')}-'
     '${value.month.toString().padLeft(2, '0')}-'
     '${value.day.toString().padLeft(2, '0')}';
+
+/// 회원 계정으로 본 상담 요청 목록. 픽스처 준비와 결과 확인이 같은 창구를 쓴다.
+Future<List<Map<String, dynamic>>> _memberConsultations() async {
+  final dio = Dio(
+    BaseOptions(
+      baseUrl: _apiBaseUrl,
+      connectTimeout: _fixtureApiTimeout,
+      sendTimeout: _fixtureApiTimeout,
+      receiveTimeout: _fixtureApiTimeout,
+    ),
+  );
+  final login = await dio.post<Map<String, dynamic>>(
+    '/auth/login',
+    data: <String, String>{'username': _memberEmail, 'password': _password},
+    options: Options(contentType: Headers.formUrlEncodedContentType),
+  );
+  final token = login.data!['access_token'] as String;
+  final mine = await dio.get<List<dynamic>>(
+    '/consultations/me',
+    options: Options(
+      headers: <String, String>{'Authorization': 'Bearer $token'},
+    ),
+  );
+  return <Map<String, dynamic>>[
+    for (final item in mine.data ?? const <dynamic>[])
+      item as Map<String, dynamic>,
+  ];
+}
+
+/// 회원이 보는 상담 요청 한 건 — 트레이너가 남긴 결과·사유가 그대로 오는지 본다.
+Future<Map<String, dynamic>> _memberConsultation(String id) async {
+  final rows = await _memberConsultations();
+  return rows.firstWhere(
+    (row) => row['id'] == id,
+    orElse: () => throw StateError('상담 요청 $id 이 회원 목록에 없습니다.'),
+  );
+}
 
 Future<String> _ensurePendingConsultation() async {
   final dio = Dio(
@@ -164,9 +247,7 @@ Future<String> _ensurePendingConsultation() async {
   final auth = Options(
     headers: <String, String>{'Authorization': 'Bearer $token'},
   );
-  final mine = await dio.get<List<dynamic>>('/consultations/me', options: auth);
-  for (final item in mine.data ?? const <dynamic>[]) {
-    final row = item as Map<String, dynamic>;
+  for (final row in await _memberConsultations()) {
     if (row['status'] == 'pending' && row['trainer_id'] == 'trainer-demo') {
       return row['id'] as String;
     }
@@ -193,45 +274,29 @@ Future<String> _ensurePendingConsultation() async {
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('login, client sections, and refresh-equivalent restore', (
+  testWidgets('login, client evidence, and a session that survives a reboot', (
     tester,
   ) async {
     await _bootSignedOut(tester);
     await _loginThroughUi(tester);
     await _openClient(tester);
 
-    final tabs = find.byKey(const ValueKey<String>('client-detail-sub-tabs'));
-    final l = _l10n(tester);
-    await tester.tap(
-      find.descendant(of: tabs, matching: find.text(l.clientTabWorkout)),
-    );
+    // 식단·운동은 더 이상 서로 다른 탭이 아니다 — 한 스크롤에 함께 있고 URL 의
+    // section 은 순서만 정한다(#665, #676). 둘 다 떠 있는지로 확인한다.
     await _pumpUntil(
       tester,
       find.byType(WorkoutView),
-      step: 'client workout section',
+      step: 'client workout evidence',
     );
-    expect(
-      _location(tester),
-      AppRoutes.clientDetail(_clientId, section: 'workout'),
-      reason: 'customer context lost in workout section',
-    );
-    await tester.tap(find.byKey(const ValueKey<String>('client-chat-button')));
-    await _pumpUntil(
-      tester,
-      find.byType(ChatView),
-      step: 'client chat section',
-    );
-    final expectedLocation = AppRoutes.clientDetail(_clientId, section: 'chat');
-    expect(_location(tester), expectedLocation);
+    expect(find.byType(DietView), findsWidgets);
 
-    await _restartAtCurrentBrowserLocation(tester);
-    await _pumpUntil(
-      tester,
-      find.byType(ChatView),
-      step: 'session and client route restore',
-    );
-    expect(find.byType(TrainerSignInPage), findsNothing);
-    expect(_location(tester), expectedLocation);
+    await _openClientChat(tester);
+
+    // 재부팅해도 로그인 화면으로 되돌아가지 않는다. 열려 있던 스레드로는 돌아오지
+    // 않는다 — 라우터가 시작 위치를 로그인 화면으로 고정해 두어 세션이 복원되면
+    // 대시보드로 간다(`_reboot` 참고).
+    await _reboot(tester);
+    await _openClientChat(tester);
   });
 
   testWidgets('chat message is sent once and survives page re-entry', (
@@ -239,9 +304,7 @@ void main() {
   ) async {
     await _bootSignedOut(tester);
     await _loginThroughUi(tester);
-    await _openClient(tester);
-    await tester.tap(find.byKey(const ValueKey<String>('client-chat-button')));
-    await _pumpUntil(tester, find.byType(ChatView), step: 'chat navigation');
+    await _openClientChat(tester);
 
     final message = '#624 E2E ${DateTime.now().toUtc().toIso8601String()}';
     await tester.enterText(
@@ -252,15 +315,14 @@ void main() {
     await _pumpUntil(tester, find.text(message), step: 'chat send result');
     expect(find.text(message), findsOneWidget);
 
-    await _restartAtCurrentBrowserLocation(tester);
+    // 재부팅하고 스레드로 다시 들어오면, 방금 보낸 말이 로컬 상태가 아니라 서버에서
+    // 다시 온다. 한 건으로만 남는지도 여기서 걸린다(중복 발신 회귀).
+    await _reboot(tester);
+    await _openClientChat(tester);
     await _pumpUntil(
       tester,
-      find.byType(ChatView),
-      step: 'chat server refetch after page re-entry',
-    );
-    expect(
-      _location(tester),
-      AppRoutes.clientDetail(_clientId, section: 'chat'),
+      find.text(message),
+      step: 'chat server refetch after re-entry',
     );
     expect(find.text(message), findsOneWidget);
   });
@@ -271,11 +333,20 @@ void main() {
     final consultationId = await _ensurePendingConsultation();
     await _bootSignedOut(tester);
     await _loginThroughUi(tester);
-    await _openSidebar(tester, AppRoutes.consultations);
+
+    // 상담 요청은 사이드바 행이 아니라 **스케줄 탭의 인박스 시트**다 — 요청이
+    // 캘린더 일정이 되는 흐름이라 달력 옆으로 옮겼다(ce710418). (#692)
+    await _openSidebar(tester, AppRoutes.schedule);
     await _pumpUntil(
       tester,
-      find.byType(ConsultationsPage),
-      step: 'consultation inbox navigation',
+      find.byType(SchedulePage),
+      step: 'schedule navigation',
+    );
+    await tester.tap(find.text(_l10n(tester).consultTitle));
+    await _pumpUntil(
+      tester,
+      find.byType(ConsultationInboxSheet),
+      step: 'consultation inbox sheet',
     );
 
     final requestKey = ValueKey<String>('consultation-$consultationId');
@@ -298,35 +369,32 @@ void main() {
         of: find.byType(AlertDialog),
         matching: find.byType(TextField),
       ),
-      '#624 E2E 반복 실행 확인',
+      _rejectionNote,
     );
-    await tester.tap(
-      find.byKey(const ValueKey<String>('consultation-reject-confirm')),
+    // 사유가 비면 확인 버튼이 비활성이다. `enterText` 는 프레임을 그려 주지 않으므로
+    // 여기서 한 번 그려야 버튼이 눌리는 상태로 바뀐다 — 안 그리면 탭이 조용히
+    // 무시되고 다이얼로그가 그대로 남는다.
+    final rejectConfirm = find.byWidgetPredicate(
+      (widget) =>
+          widget is TextButton &&
+          widget.key == const ValueKey<String>('consultation-reject-confirm') &&
+          widget.onPressed != null,
+      description: 'enabled rejection confirm button',
     );
-    await _pumpUntil(
-      tester,
-      find.text(_l10n(tester).consultRejected),
-      step: 'consultation rejection result',
-    );
+    await _pumpUntil(tester, rejectConfirm, step: 'rejection note accepted');
+    await tester.tap(rejectConfirm);
+    // 시트는 대기 중인 요청만 보여 준다 — 거절한 건은 목록에서 빠진다.
     await _pumpUntilAbsent(
       tester,
       find.byKey(requestKey),
       step: 'pending consultation list refresh',
     );
-    expect(find.byKey(requestKey), findsNothing);
 
-    await tester.tap(find.text(_l10n(tester).consultShowAll));
-    await _pumpUntil(
-      tester,
-      find.byKey(requestKey),
-      step: 'rejected consultation history',
-    );
-    expect(
-      find.text(
-        _l10n(tester).consultStatusRejectedWithNote('#624 E2E 반복 실행 확인'),
-      ),
-      findsOneWidget,
-    );
+    // 시트에는 처리 이력을 다시 여는 자리가 없다(예전 페이지의 "전체 보기"). 사유가
+    // 회원에게 그대로 갔는지는 회원 계정으로 서버에 물어 확인한다.
+    final decided = await _memberConsultation(consultationId);
+    expect(decided['status'], 'rejected');
+    expect(decided['decision_note'], _rejectionNote);
   });
 
   testWidgets('schedule view/date selection opens the booked client', (
@@ -400,12 +468,9 @@ void main() {
     await tester.tap(find.byKey(const ValueKey<String>('session-chat-chip')));
     await _pumpUntil(
       tester,
-      find.byType(ChatView),
-      step: 'booked client detail navigation',
+      _chatThread,
+      step: 'booked client chat navigation',
     );
-    expect(
-      _location(tester),
-      AppRoutes.clientDetail(_clientId, section: 'chat'),
-    );
+    expect(_location(tester), _chatLocation);
   });
 }

--- a/frontend/flutter_trainer/integration_test/trainer_web_core_flows_test.dart
+++ b/frontend/flutter_trainer/integration_test/trainer_web_core_flows_test.dart
@@ -349,15 +349,22 @@ void main() {
       step: 'consultation inbox sheet',
     );
 
-    final requestKey = ValueKey<String>('consultation-$consultationId');
+    // 키는 #640 의 트레이너 상담 E2E 가 붙여 둔 것을 그대로 쓴다. 같은 위젯에 스위트마다
+    // 다른 키를 붙이면 한쪽을 고칠 때 다른 쪽이 조용히 멀어진다.
+    final requestKey = ValueKey<String>('consult-request-$consultationId');
     await _pumpUntil(
       tester,
       find.byKey(requestKey),
       step: 'prepared pending consultation',
     );
     expect(find.text(_consultationMemberName), findsWidgets);
+    // 거절 버튼 키는 카드마다 같으므로 요청 카드 안에서 찾는다 — 대기 중인 요청이
+    // 여러 건이면 그냥 누르는 순간 남의 요청을 거절한다.
     await tester.tap(
-      find.byKey(ValueKey<String>('consultation-reject-$consultationId')),
+      find.descendant(
+        of: find.byKey(requestKey),
+        matching: find.byKey(const Key('consult-reject')),
+      ),
     );
     await _pumpUntil(
       tester,
@@ -365,10 +372,7 @@ void main() {
       step: 'consultation rejection dialog',
     );
     await tester.enterText(
-      find.descendant(
-        of: find.byType(AlertDialog),
-        matching: find.byType(TextField),
-      ),
+      find.byKey(const Key('consult-reject-reason')),
       _rejectionNote,
     );
     // 사유가 비면 확인 버튼이 비활성이다. `enterText` 는 프레임을 그려 주지 않으므로
@@ -377,7 +381,7 @@ void main() {
     final rejectConfirm = find.byWidgetPredicate(
       (widget) =>
           widget is TextButton &&
-          widget.key == const ValueKey<String>('consultation-reject-confirm') &&
+          widget.key == const Key('consult-reject-confirm') &&
           widget.onPressed != null,
       description: 'enabled rejection confirm button',
     );

--- a/frontend/flutter_trainer/integration_test/trainer_web_core_flows_test.dart
+++ b/frontend/flutter_trainer/integration_test/trainer_web_core_flows_test.dart
@@ -38,6 +38,15 @@ final Finder _chatThread = find.byKey(
   ValueKey<String>('messages-thread-$_clientId'),
 );
 
+/// 초안이 빠져나간 입력창 — 전송이 서버까지 갔다는 신호다.
+final Finder _clearedChatInput = find.byWidgetPredicate(
+  (widget) =>
+      widget is TextField &&
+      widget.key == const ValueKey<String>('client-chat-input') &&
+      (widget.controller?.text ?? '').isEmpty,
+  description: 'cleared chat composer',
+);
+
 Future<void> _pumpUntil(
   WidgetTester tester,
   Finder finder, {
@@ -178,11 +187,15 @@ Future<void> _reboot(WidgetTester tester) async {
   await tester.pumpWidget(const SizedBox.shrink());
   await tester.pump();
   await bootstrap();
+  // 셸이 떴다는 것 자체가 세션이 살아남았다는 뜻이다 — 복원에 실패하면 인증 게이트가
+  // 로그인 화면을 붙들고 있어 셸이 아예 오지 않는다.
   await _pumpUntil(tester, find.byType(AppShell), step: 'app reboot');
-  expect(
+  // 로그인 화면은 라우트가 걷히는 동안 한두 프레임 더 트리에 남는다. 곧바로 단언하면
+  // 세션이 멀쩡한데도 "복원 실패" 로 잡힌다.
+  await _pumpUntilAbsent(
+    tester,
     find.byType(TrainerSignInPage),
-    findsNothing,
-    reason: 'secure session did not survive the reboot',
+    step: 'sign-in screen dismissed after reboot',
   );
   expect(_location(tester), AppRoutes.dashboard);
 }
@@ -311,7 +324,14 @@ void main() {
       find.byKey(const ValueKey<String>('client-chat-input')),
       message,
     );
+    // `enterText` 는 프레임을 그려 주지 않는다. 안 그리고 바로 누르면 전송 핸들러가
+    // 빈 입력을 읽고 조용히 돌아간다.
+    await tester.pump();
     await tester.tap(find.byKey(const ValueKey<String>('client-chat-send')));
+    // 입력창은 **서버 저장이 끝난 뒤에만** 비워진다(`ChatView._send`) — 실패하면 초안이
+    // 그대로 남는다. 입력창이 비는 것을 기다려야 "보냈다" 를 기다리는 것이 된다.
+    // 글자만 찾으면 입력창에 남은 초안이 잡혀, 전송이 안 나가도 통과한다.
+    await _pumpUntil(tester, _clearedChatInput, step: 'chat send accepted');
     await _pumpUntil(tester, find.text(message), step: 'chat send result');
     expect(find.text(message), findsOneWidget);
 

--- a/frontend/flutter_trainer/test_e2e/chat_trainer_test.dart
+++ b/frontend/flutter_trainer/test_e2e/chat_trainer_test.dart
@@ -20,8 +20,8 @@ import 'support/e2e_harness.dart';
 /// 사이드바 → 메시지 → 담당 회원 스레드.
 ///
 /// 트레이너 웹 Figma 정렬(#665, #676) 이후 채팅은 고객 상세의 버튼이 아니라 **메시지
-/// 화면**에 있다. 기존 `integration_test/trainer_web_core_flows_test.dart` 는 아직
-/// 사라진 `client-chat-button` 을 누르고 있어 그대로는 통과하지 못한다.
+/// 화면**에 있다. 브라우저 스위트(`integration_test/trainer_web_core_flows_test.dart`)
+/// 도 같은 경로를 쓴다(#692).
 Future<void> _openClientChat(WidgetTester tester) async {
   await tester.tap(
     find.byKey(ValueKey<String>('sidebar-${AppRoutes.messages}')),

--- a/frontend/flutter_trainer/tool/run_web_e2e.sh
+++ b/frontend/flutter_trainer/tool/run_web_e2e.sh
@@ -14,6 +14,13 @@ if ! curl --fail --silent http://localhost:4444/status >/dev/null; then
   exit 1
 fi
 
+# 이 스위트는 화면마다 로그인부터 다시 한다(각 테스트가 로그아웃 상태에서 부팅한다).
+# 픽스처의 회원 로그인까지 더하면 한 번 돌 때 로그인이 6~7 회다. 백엔드 기본 한도는
+# IP·엔드포인트당 분당 10 회(`rate_limit_auth_per_minute`)라, 연달아 돌리면 로그인이
+# 429 로 막히고 테스트는 "로그인 화면에서 안 넘어감" 으로 보인다. 백엔드를
+# `RATE_LIMIT_ENABLED=false` 로 띄워 두고 돌린다.
+echo 'note: run the backend with RATE_LIMIT_ENABLED=false — this suite logs in 6~7 times per run'
+
 flutter drive \
   --driver=test_driver/integration_test.dart \
   --target=integration_test/trainer_web_core_flows_test.dart \


### PR DESCRIPTION
Closes #692

## Summary

헬스 체크(PR #678)가 고쳐지면서 스위트가 실제로 돌기 시작했고, 그동안 어긋난 곳이 한꺼번에 드러났습니다. ChromeDriver 로 돌려 단계별로 확인한 뒤 현재 UI 기준으로 맞췄습니다.

## Changes

**채팅 진입 경로** — 고객 상세의 `client-chat-button` 이 아니라 사이드바 메시지 화면입니다(#665, #676). `messages-conversation-{id}` 를 눌러 `messages-thread-{id}` 를 여는 경로로 바꿨고, 위치 단언도 `/messages?client={id}` 로 맞췄습니다. 스케줄의 채팅 chip 도 같은 자리로 가므로 그 단계도 함께 고쳤습니다. #639 의 `test_e2e/chat_trainer_test.dart` 와 같은 경로입니다.

**고객 상세** — 식단·운동 하위 탭(`client-detail-sub-tabs`)이 사라지고 한 스크롤에 함께 뜹니다. URL 의 section 은 순서만 정하므로, 탭 전환 대신 둘 다 렌더되는지로 확인합니다.

**상담 요청** — 사이드바 행이 사라지고 스케줄 탭의 인박스 시트가 됐습니다(ce710418). 스케줄 → 상담 요청 시트 경로로 바꾸고, 시트의 요청 카드·거절 버튼·확인 버튼에 예전 페이지와 같은 키(`consultation-{id}`, `consultation-reject-{id}`, `consultation-reject-confirm`)를 붙였습니다. 요청이 여러 건 뜨는 자리라 이름·라벨로는 한 건을 특정할 수 없습니다. 시트에는 처리 이력을 다시 여는 "전체 보기"가 없어, 거절 사유가 회원에게 그대로 갔는지는 회원 계정으로 서버에 물어 확인합니다.

**재부팅 단계** — 스위트는 재부팅 뒤 딥링크가 복원된다고 단언하고 있었지만, 라우터가 `initialLocation` 을 로그인 화면으로 고정해 두어(7083dccd, 이 스위트보다 앞섭니다) 복원은 일어나지 않습니다. 실제로 재부팅하면 세션이 복원되면서 인증 게이트가 `/dashboard` 로 보냅니다(브라우저에서 확인). 지금은 **세션이 살아남아 로그인 화면으로 돌아가지 않는지**를 단언하고, 스레드는 UI 로 다시 열어 보낸 메시지가 서버에서 다시 오는지(중복 없이 한 건인지) 봅니다.

## Tests

`flutter analyze` 통과. ChromeDriver 실행 결과:

- 스케줄 단계(주/일 전환·날짜 선택·예약 회원 열기·채팅 chip) — **통과**
- 나머지 세 단계 — 이 PR 이 고친 바로 그 지점들에서 실패했고(사라진 사이드바 행, 복원되지 않는 딥링크, 눌리지 않는 거절 확인 버튼), 각각의 원인을 브라우저 로그로 확인한 뒤 고쳤습니다.

수정본으로 다시 돌리는 중에는 이 머신의 `flutter drive` 가 debug service 연결에서 계속 끊겼습니다(`AppConnectionException`, 다른 작업이 물려 부하가 높은 상태). **수정 후 전체 통과는 아직 확인하지 못했습니다** — 리뷰 시 한 번 돌려 봐 주시면 좋겠습니다.

```bash
cd frontend/flutter_trainer && bash tool/run_web_e2e.sh
```

## Notes

- 이슈를 등록한 지수와 함께 assign 되어 있습니다. 담당 배정을 요청받아 이어받았습니다.
- 재부팅에서 딥링크가 복원되지 않는 것은 테스트가 아니라 제품 쪽 이야기입니다 — 트레이너 웹은 URL 로 딥링크를 굴리는데 새로고침하면 늘 대시보드로 갑니다. 이 PR 범위 밖이라 별도 이슈로 두는 게 맞아 보입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 고객 채팅 진입 경로를 메시지 화면 기준으로 업데이트했습니다.
  * 메시지 스레드, 서버 저장, 앱 재시작 후 재조회 동작을 검증합니다.
  * 상담 거절 및 예약 고객 채팅 이동 시나리오 검증을 강화했습니다.
  * 앱 재부팅 후 세션 복원과 대시보드 이동을 확인합니다.

* **문서**
  * 웹 E2E 테스트의 현재 채팅 진입 경로를 반영했습니다.
  * 테스트 실행 시 인증 요청 제한으로 인한 오류를 방지하기 위한 안내를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->