### PR TITLE
fix(trainer): 통합 검색의 현재 탭 고객 선택 지원

### DIFF
--- a/frontend/flutter_trainer/lib/features/search/domain/client_search_facts.dart
+++ b/frontend/flutter_trainer/lib/features/search/domain/client_search_facts.dart
@@ -103,6 +103,53 @@ String clientSearchDetail(
   return details.join(' · ');
 }
 
-/// 결과 행을 직접 선택했을 때의 일관된 기본 이동 경로입니다.
-String clientSearchDestination(TrainerClient client) =>
-    AppRoutes.clientDetail(client.id);
+/// 통합 검색 결과를 현재 탭의 고객 화면으로 연결합니다.
+///
+/// 검색 대상과 결과 데이터는 모든 탭에서 동일하지만, 선택한 고객을 여는
+/// 위치는 현재 작업 흐름을 유지합니다. 고객 탭에서는 읽던 상세 섹션을
+/// 보존하고, 일정 탭에서는 고객의 다음 예약 날짜를 엽니다. 고객 단위
+/// 화면이 없는 대시보드와 다음 예약이 없는 일정만 고객 상세로 보냅니다.
+String clientSearchDestination(
+  Uri location,
+  TrainerClient client,
+  ClientSearchFacts facts,
+) {
+  final tab = location.pathSegments.firstOrNull;
+  switch (tab) {
+    case 'clients':
+      final currentSection = location.pathSegments.length >= 3
+          ? location.pathSegments[2]
+          : null;
+      final section = currentSection == AppRoutes.clientChatSection
+          ? null
+          : currentSection;
+      return AppRoutes.clientDetail(client.id, section: section);
+    case 'schedule':
+      final next = facts.nextSession[client.id];
+      return next == null
+          ? AppRoutes.clientDetail(client.id)
+          : AppRoutes.scheduleView('day', date: next.date);
+    case 'messages':
+      return AppRoutes.messagesFor(
+        client.id,
+        filter: location.queryParameters['f'],
+      );
+    case 'coaching':
+      return AppRoutes.coachingFor(client.id);
+    case 'reports':
+      return AppRoutes.reportFor(client.id);
+    default:
+      return AppRoutes.clientDetail(client.id);
+  }
+}
+
+/// Enter 또는 결과 행 선택이 어느 화면을 여는지 안내하는 문구입니다.
+String clientSearchFooter(AppLocalizations l, Uri location) {
+  return switch (location.pathSegments.firstOrNull) {
+    'schedule' => l.searchGoSchedule,
+    'messages' => l.navMessages,
+    'coaching' => l.searchGoCoaching,
+    'reports' => l.searchGoReport,
+    _ => l.searchGoClientDetail,
+  };
+}

--- a/frontend/flutter_trainer/lib/features/search/presentation/widgets/client_search_bar.dart
+++ b/frontend/flutter_trainer/lib/features/search/presentation/widgets/client_search_bar.dart
@@ -113,8 +113,8 @@ ClientSearchFacts watchClientSearchFacts(
 /// 고객 검색 — the console header's client picker.
 ///
 /// Sits in the middle of every main tab's header and always searches the same
-/// roster and related records. A direct pick consistently opens the customer
-/// detail; explicit actions open the schedule, messages, coaching, or report.
+/// roster and related records. A direct pick opens the customer inside the
+/// current tab; explicit actions can still cross to another tab.
 ///
 /// Two forms: the inline field with a dropdown, and an icon opening the
 /// same search in a dialog. The icon is used when the shell is in its
@@ -190,15 +190,22 @@ class _ClientSearchBarState extends ConsumerState<ClientSearchBar> {
     }
   }
 
-  void _submit() {
+  void _submit(ClientSearchFacts facts) {
     if (_results.isEmpty) return;
     final index = _highlight.clamp(0, _results.length - 1);
-    _pick(_results[index]);
+    _pick(_results[index], facts);
   }
 
-  void _pick(TrainerClient client) {
+  void _pick(TrainerClient client, ClientSearchFacts facts) {
     _close(clear: true);
-    _apply((client: client, route: clientSearchDestination(client)));
+    _apply((
+      client: client,
+      route: clientSearchDestination(
+        GoRouterState.of(context).uri,
+        client,
+        facts,
+      ),
+    ));
   }
 
   void _apply(_Pick pick) {
@@ -211,9 +218,10 @@ class _ClientSearchBarState extends ConsumerState<ClientSearchBar> {
   }
 
   Future<void> _openDialog() async {
+    final location = GoRouterState.of(context).uri;
     final pick = await showDialog<_Pick>(
       context: context,
-      builder: (_) => const _ClientSearchDialog(),
+      builder: (_) => _ClientSearchDialog(location: location),
     );
     if (pick == null || !mounted) return;
     _apply(pick);
@@ -260,7 +268,7 @@ class _ClientSearchBarState extends ConsumerState<ClientSearchBar> {
                 child: TapRegion(
                   groupId: this,
                   onTapOutside: (_) => _close(),
-                  child: _field(l),
+                  child: _field(l, facts),
                 ),
               ),
             ),
@@ -270,7 +278,7 @@ class _ClientSearchBarState extends ConsumerState<ClientSearchBar> {
     );
   }
 
-  Widget _field(AppLocalizations l) {
+  Widget _field(AppLocalizations l, ClientSearchFacts facts) {
     return CallbackShortcuts(
       // The same keys the dropdown implies: ↑/↓ walk the rows, Esc backs
       // out. Enter is the field's own submit.
@@ -327,7 +335,7 @@ class _ClientSearchBarState extends ConsumerState<ClientSearchBar> {
           focusedBorder: _fieldBorder,
         ),
         onChanged: _onQueryChanged,
-        onSubmitted: (_) => _submit(),
+        onSubmitted: (_) => _submit(facts),
         onTap: () {
           if (_hasQuery) _dropdown.show();
         },
@@ -351,7 +359,11 @@ class _ClientSearchBarState extends ConsumerState<ClientSearchBar> {
             results: _results,
             facts: facts,
             highlighted: _highlight,
-            onPick: _pick,
+            footer: clientSearchFooter(
+              AppLocalizations.of(context),
+              GoRouterState.of(context).uri,
+            ),
+            onPick: (client) => _pick(client, facts),
             onOpenDestination: _openDestination,
           ),
         ),
@@ -376,6 +388,7 @@ class _ResultsCard extends StatelessWidget {
     required this.results,
     required this.facts,
     required this.highlighted,
+    required this.footer,
     required this.onPick,
     required this.onOpenDestination,
   });
@@ -385,6 +398,7 @@ class _ResultsCard extends StatelessWidget {
   final List<TrainerClient> results;
   final ClientSearchFacts facts;
   final int highlighted;
+  final String footer;
   final ValueChanged<TrainerClient> onPick;
   final void Function(TrainerClient client, String route) onOpenDestination;
 
@@ -448,7 +462,7 @@ class _ResultsCard extends StatelessWidget {
                 ),
               ),
             ),
-          _Footer(text: l.searchGoClientDetail),
+          _Footer(text: footer),
         ],
       ),
     );
@@ -684,7 +698,9 @@ class _Footer extends StatelessWidget {
 /// caller owns the page context, so the snackbar and the `go` both land
 /// on the console rather than on a route that is being dismissed.
 class _ClientSearchDialog extends ConsumerStatefulWidget {
-  const _ClientSearchDialog();
+  const _ClientSearchDialog({required this.location});
+
+  final Uri location;
 
   @override
   ConsumerState<_ClientSearchDialog> createState() =>
@@ -720,10 +736,10 @@ class _ClientSearchDialogState extends ConsumerState<_ClientSearchDialog> {
     );
   }
 
-  void _submit() {
+  void _submit(ClientSearchFacts facts) {
     if (_results.isEmpty) return;
     final index = _highlight.clamp(0, _results.length - 1);
-    _pop(_results[index]);
+    _pop(_results[index], facts);
   }
 
   @override
@@ -794,7 +810,7 @@ class _ClientSearchDialogState extends ConsumerState<_ClientSearchDialog> {
                     focusedBorder: _fieldBorder,
                   ),
                   onChanged: _onQueryChanged,
-                  onSubmitted: (_) => _submit(),
+                  onSubmitted: (_) => _submit(facts),
                 ),
               ),
             ),
@@ -806,7 +822,8 @@ class _ClientSearchDialogState extends ConsumerState<_ClientSearchDialog> {
                 results: _results,
                 facts: facts,
                 highlighted: _highlight,
-                onPick: _pop,
+                footer: clientSearchFooter(l, widget.location),
+                onPick: (client) => _pop(client, facts),
                 onOpenDestination: (client, route) => _popRoute(client, route),
               ),
             ],
@@ -816,8 +833,8 @@ class _ClientSearchDialogState extends ConsumerState<_ClientSearchDialog> {
     );
   }
 
-  void _pop(TrainerClient client) {
-    _popRoute(client, clientSearchDestination(client));
+  void _pop(TrainerClient client, ClientSearchFacts facts) {
+    _popRoute(client, clientSearchDestination(widget.location, client, facts));
   }
 
   void _popRoute(TrainerClient client, String route) {

--- a/frontend/flutter_trainer/test/features/search/client_search_bar_test.dart
+++ b/frontend/flutter_trainer/test/features/search/client_search_bar_test.dart
@@ -70,15 +70,23 @@ void main() {
     );
   });
 
-  testWidgets('어느 탭에서 검색해도 기본 선택은 같은 고객 상세를 연다', (tester) async {
-    await openDesktop(tester, AppRoutes.dashboard);
-    for (final route in <String>[AppRoutes.dashboard, AppRoutes.reports]) {
+  testWidgets('Enter로 선택하면 현재 탭 안에서 해당 고객을 연다', (tester) async {
+    await openDesktop(tester, AppRoutes.messages);
+    for (final (route, expected) in <(String, String)>[
+      (
+        AppRoutes.clientDetail('seed-client-2', section: 'workout'),
+        AppRoutes.clientDetail('seed-client-1', section: 'workout'),
+      ),
+      (AppRoutes.messages, AppRoutes.messagesFor('seed-client-1')),
+      (AppRoutes.coaching, AppRoutes.coachingFor('seed-client-1')),
+      (AppRoutes.reports, AppRoutes.reportFor('seed-client-1')),
+    ]) {
       GoRouter.of(tester.element(find.byKey(clientSearchFieldKey))).go(route);
       await settle(tester);
       await search(tester, '김민수');
-      await tester.tap(resultRow('김민수'));
+      await tester.testTextInput.receiveAction(TextInputAction.search);
       await settle(tester);
-      expect(location(tester), '/clients/seed-client-1/diet');
+      expect(location(tester), expected, reason: route);
     }
   });
 
@@ -132,7 +140,7 @@ void main() {
       GoRouter.of(
         tester.element(find.byKey(clientSearchIconKey)),
       ).state.uri.toString(),
-      '/clients/seed-client-1/diet',
+      AppRoutes.messagesFor('seed-client-1'),
     );
   });
 }

--- a/frontend/flutter_trainer/test/features/search/client_search_facts_test.dart
+++ b/frontend/flutter_trainer/test/features/search/client_search_facts_test.dart
@@ -91,7 +91,40 @@ void main() {
     });
   });
 
-  test('기본 선택 경로는 현재 탭과 무관하게 고객 상세로 고정된다', () {
-    expect(clientSearchDestination(minsu), '/clients/c1/diet');
+  test('기본 선택 경로는 현재 탭의 고객 화면을 유지한다', () {
+    final facts = ClientSearchFacts(
+      nextSession: <String, ScheduleSession>{
+        minsu.id: session(
+          date: '2026-08-20',
+          time: '10:00',
+          clientId: minsu.id,
+        ),
+      },
+    );
+
+    expect(
+      clientSearchDestination(Uri.parse('/clients/c2/workout'), minsu, facts),
+      '/clients/c1/workout',
+    );
+    expect(
+      clientSearchDestination(Uri.parse('/messages?f=unread'), minsu, facts),
+      '/messages?client=c1&f=unread',
+    );
+    expect(
+      clientSearchDestination(Uri.parse('/coaching'), minsu, facts),
+      '/coaching?client=c1',
+    );
+    expect(
+      clientSearchDestination(Uri.parse('/reports'), minsu, facts),
+      '/reports?client=c1',
+    );
+    expect(
+      clientSearchDestination(Uri.parse('/schedule'), minsu, facts),
+      '/schedule?v=day&d=2026-08-20',
+    );
+    expect(
+      clientSearchDestination(Uri.parse('/dashboard'), minsu, facts),
+      '/clients/c1/diet',
+    );
   });
 }


### PR DESCRIPTION
## Summary

* 통합 검색 결과 선택 시 현재 탭의 고객 화면 연결
* Enter, 결과 클릭, 모바일 검색 다이얼로그의 동일 이동 규칙 적용
* 고객 탭의 식단·운동 섹션 및 메시지 필터 유지
* 탭별 검색 이동 경로 회귀 테스트 추가

---

## Changes

### ✨ Features

* 메시지 탭의 고객 대화 선택 지원
* AI 코칭 탭의 고객 선택 지원
* 리포트 탭의 고객 리포트 선택 지원
* 일정 탭의 다음 예약 날짜 이동 지원

### 🔧 Improvements

* 현재 URL을 기준으로 통합 검색 기본 이동 경로 결정
* 고객 탭에서 기존 식단·운동 섹션 유지
* 메시지 탭에서 기존 대화 필터 유지
* 데스크톱 검색과 모바일 검색의 이동 규칙 통합

### 🎨 UI/UX

* 검색 전의 작업 탭을 벗어나지 않는 고객 선택 흐름
* 현재 탭의 검색 동작을 안내하는 결과 하단 문구 적용

### 📝 Docs

* 해당 없음

### 🐛 Fixes

* 모든 검색 결과가 고객 상세 화면으로 이동하던 문제 수정
* 모바일 검색 결과 선택 시 고객 상세 화면으로 이동하던 문제 수정

---

## Commits

1. `aa11856b` fix(trainer): 통합 검색의 현재 탭 고객 선택 지원

---

## Notes

* 병합된 PR #712의 후속 수정
* 대시보드는 고객 단위 화면이 없어 고객 상세를 기본 경로로 사용
* 일정에 다음 예약이 없는 고객은 고객 상세를 대체 경로로 사용
* 빠른 이동 메뉴를 통한 다른 탭 이동 기능은 기존과 동일

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 빌드 영향 확인
* [x] 관련 테스트 통과

### Manual Test Steps

1. 메시지 탭에서 고객 검색 후 Enter 입력 및 해당 고객 대화 표시 확인
2. AI 코칭 탭에서 고객 검색 후 해당 고객 선택 확인
3. 리포트 탭에서 고객 검색 후 해당 고객 리포트 표시 확인
4. 고객 운동 화면에서 다른 고객 검색 후 운동 섹션 유지 확인
5. 좁은 화면의 검색 다이얼로그에서 동일 동작 확인

### Automated Tests

* `flutter analyze` 통과
* Flutter 전체 테스트 542건 통과

---

## Related Issues

Closes #713

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인