### PR TITLE
feat(trainer-web): improve client identity and list UI

### DIFF
--- a/frontend/flutter_trainer/lib/app/shell/nav_destinations.dart
+++ b/frontend/flutter_trainer/lib/app/shell/nav_destinations.dart
@@ -96,7 +96,6 @@ const List<NavDestination> navDestinations = <NavDestination>[
     icon: Icons.people_outline,
     activeIcon: Icons.people,
     route: AppRoutes.clients,
-    badge: NavBadge.unreadMessages,
   ),
   NavDestination(
     label: NavLabel.messages,

--- a/frontend/flutter_trainer/lib/features/auth/domain/repositories/trainer_auth_repository.dart
+++ b/frontend/flutter_trainer/lib/features/auth/domain/repositories/trainer_auth_repository.dart
@@ -33,7 +33,8 @@ class AuthException implements Exception {
   final String? detail;
 
   @override
-  String toString() => 'AuthException: $failure${detail == null ? '' : ' ($detail)'}';
+  String toString() =>
+      'AuthException: $failure${detail == null ? '' : ' ($detail)'}';
 }
 
 /// Raised when the authenticated account is not a trainer (the backend

--- a/frontend/flutter_trainer/lib/features/clients/data/dtos/client_dtos.dart
+++ b/frontend/flutter_trainer/lib/features/clients/data/dtos/client_dtos.dart
@@ -13,6 +13,8 @@ TrainerClient trainerClientFromJson(Map<String, Object?> json) {
     id: _str(json['id']),
     name: _str(json['name']),
     avatar: _str(json['avatar']),
+    gender: _str(json['gender']),
+    age: _nullableInt(json['age']),
     goal: _str(json['goal']),
     lastMessage: _str(json['last_message']),
     lastTime: _str(json['last_time']),
@@ -98,6 +100,8 @@ String _str(Object? v) => v is String ? v : '';
 String? _nullableStr(Object? v) => v is String && v.isNotEmpty ? v : null;
 
 int _int(Object? v) => v is num ? v.toInt() : 0;
+
+int? _nullableInt(Object? v) => v is num ? v.toInt() : null;
 
 double _double(Object? v) => v is num ? v.toDouble() : 0;
 

--- a/frontend/flutter_trainer/lib/features/clients/data/repositories/client_coach_repository.dart
+++ b/frontend/flutter_trainer/lib/features/clients/data/repositories/client_coach_repository.dart
@@ -8,7 +8,10 @@ import 'package:oncare_trainer/core/network/dio_client.dart';
 /// AI 코칭 상담의 답변 한 건. (#497)
 class ClientCoachAnswer {
   /// Creates an answer.
-  const ClientCoachAnswer({required this.reply, this.sources = const <String>[]});
+  const ClientCoachAnswer({
+    required this.reply,
+    this.sources = const <String>[],
+  });
 
   /// AI 가 만든 답변.
   final String reply;
@@ -117,8 +120,8 @@ class DioClientCoachRepository implements ClientCoachRepository {
       return ClientCoachAnswer(
         reply: body['reply'] is String ? body['reply']! as String : '',
         sources: <String>[
-          for (final Object? item in body['sources'] as List<Object?>? ??
-              const <Object?>[])
+          for (final Object? item
+              in body['sources'] as List<Object?>? ?? const <Object?>[])
             if (item is String && item.trim().isNotEmpty) item.trim(),
         ],
       );

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_card.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_card.dart
@@ -6,12 +6,12 @@ import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/shared/models/trainer_client.dart';
 import 'package:oncare_trainer/shared/models/client_alerts.dart';
-import 'package:oncare_trainer/shared/widgets/alert_badge.dart';
 import 'package:oncare_trainer/shared/widgets/client_avatar.dart';
+import 'package:oncare_trainer/shared/widgets/client_identity.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 
-/// A client row on the 고객 관리 list: avatar + active dot, name, goal,
-/// last message, and a quick-metric footer (칼로리 / 나트륨 / 마지막 루틴).
+/// A client row on the 고객 관리 list: avatar + active dot, identity,
+/// goal, and a quick-metric footer (칼로리 / 나트륨 / 마지막 루틴).
 class ClientCard extends StatelessWidget {
   /// Creates a card for [client]; [onTap] opens the detail screen.
   const ClientCard({
@@ -33,7 +33,8 @@ class ClientCard extends StatelessWidget {
   /// detail panel is open.
   final bool selected;
 
-  /// Unread chat messages — shows a count badge next to the preview.
+  /// Unread chat messages retained for call-site compatibility. The customer
+  /// roster intentionally does not expose chat previews or notification badges.
   final int unread;
 
   /// Dense master-list presentation used by the Figma 회원 관리 split view.
@@ -66,7 +67,7 @@ class ClientCard extends StatelessWidget {
               ),
             ),
             child: compact
-                ? _CompactClientContent(client: client, unread: unread)
+                ? _CompactClientContent(client: client)
                 : Column(
                     children: <Widget>[
                       Row(
@@ -81,26 +82,13 @@ class ClientCard extends StatelessWidget {
                             child: Column(
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: <Widget>[
-                                Row(
-                                  children: <Widget>[
-                                    Expanded(
-                                      child: Text(
-                                        client.name,
-                                        style: const TextStyle(
-                                          fontSize: 16,
-                                          fontWeight: FontWeight.w700,
-                                          color: AppColors.foreground,
-                                        ),
-                                      ),
-                                    ),
-                                    Text(
-                                      client.lastTime,
-                                      style: const TextStyle(
-                                        fontSize: 12,
-                                        color: AppColors.subtleForeground,
-                                      ),
-                                    ),
-                                  ],
+                                ClientIdentity(
+                                  client: client,
+                                  nameStyle: const TextStyle(
+                                    fontSize: 16,
+                                    fontWeight: FontWeight.w800,
+                                    color: AppColors.foreground,
+                                  ),
                                 ),
                                 const SizedBox(height: 2),
                                 Text(
@@ -110,51 +98,6 @@ class ClientCard extends StatelessWidget {
                                     color: AppColors.subtleForeground,
                                     fontWeight: FontWeight.w500,
                                   ),
-                                ),
-                                const SizedBox(height: 4),
-                                Row(
-                                  children: <Widget>[
-                                    Expanded(
-                                      child: Text(
-                                        client.lastMessage,
-                                        maxLines: 1,
-                                        overflow: TextOverflow.ellipsis,
-                                        style: TextStyle(
-                                          fontSize: 13,
-                                          color: unread > 0
-                                              ? AppColors.foreground
-                                              : AppColors.mutedForeground,
-                                          fontWeight: unread > 0
-                                              ? FontWeight.w700
-                                              : FontWeight.w500,
-                                        ),
-                                      ),
-                                    ),
-                                    if (unread > 0)
-                                      Container(
-                                        margin: const EdgeInsets.only(
-                                          left: AppSpacing.xs,
-                                        ),
-                                        padding: const EdgeInsets.symmetric(
-                                          horizontal: 6,
-                                          vertical: 1,
-                                        ),
-                                        decoration: const BoxDecoration(
-                                          color: AppColors.accent,
-                                          borderRadius: BorderRadius.all(
-                                            AppRadius.pill,
-                                          ),
-                                        ),
-                                        child: Text(
-                                          '$unread',
-                                          style: const TextStyle(
-                                            fontSize: 11,
-                                            fontWeight: FontWeight.w800,
-                                            color: AppColors.accentForeground,
-                                          ),
-                                        ),
-                                      ),
-                                  ],
                                 ),
                               ],
                             ),
@@ -200,15 +143,13 @@ class ClientCard extends StatelessWidget {
 }
 
 class _CompactClientContent extends StatelessWidget {
-  const _CompactClientContent({required this.client, required this.unread});
+  const _CompactClientContent({required this.client});
 
   final TrainerClient client;
-  final int unread;
 
   @override
   Widget build(BuildContext context) {
     final completion = recordedCompletionMean(client)?.round();
-    final alerts = alertsFor(client, unread: unread);
     return Row(
       children: <Widget>[
         ClientAvatar(
@@ -224,41 +165,7 @@ class _CompactClientContent extends StatelessWidget {
             children: <Widget>[
               Row(
                 children: <Widget>[
-                  Expanded(
-                    child: Text(
-                      client.name,
-                      overflow: TextOverflow.ellipsis,
-                      style: const TextStyle(
-                        fontSize: 14,
-                        fontWeight: FontWeight.w800,
-                      ),
-                    ),
-                  ),
-                  if (alerts.isNotEmpty)
-                    AlertBadge(alert: alerts.first, showIcon: false),
-                  if (unread > 0) ...<Widget>[
-                    const SizedBox(width: AppSpacing.xs),
-                    Container(
-                      constraints: const BoxConstraints(minWidth: 20),
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 6,
-                        vertical: 2,
-                      ),
-                      decoration: const BoxDecoration(
-                        color: AppColors.primary,
-                        borderRadius: BorderRadius.all(AppRadius.pill),
-                      ),
-                      child: Text(
-                        '$unread',
-                        textAlign: TextAlign.center,
-                        style: const TextStyle(
-                          color: Colors.white,
-                          fontSize: 10,
-                          fontWeight: FontWeight.w800,
-                        ),
-                      ),
-                    ),
-                  ],
+                  Expanded(child: ClientIdentity(client: client)),
                 ],
               ),
               const SizedBox(height: 3),
@@ -270,16 +177,6 @@ class _CompactClientContent extends StatelessWidget {
                   color: AppColors.subtleForeground,
                   fontSize: 11.5,
                   fontWeight: FontWeight.w500,
-                ),
-              ),
-              const SizedBox(height: 2),
-              Text(
-                client.lastMessage,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: const TextStyle(
-                  color: AppColors.mutedForeground,
-                  fontSize: 10.5,
                 ),
               ),
               const SizedBox(height: 7),
@@ -300,23 +197,15 @@ class _CompactClientContent extends StatelessWidget {
                         minHeight: 5,
                         value: completion == null ? 0 : completion / 100,
                         backgroundColor: AppColors.inputBackground,
-                        color:
-                            completion != null &&
-                                completion < lowCompletionThreshold
-                            ? AppColors.overTarget
-                            : AppColors.primary,
+                        color: AppColors.primary,
                       ),
                     ),
                   ),
                   const SizedBox(width: AppSpacing.sm),
                   Text(
                     completion == null ? '-' : '$completion%',
-                    style: TextStyle(
-                      color:
-                          completion != null &&
-                              completion < lowCompletionThreshold
-                          ? AppColors.overTarget
-                          : AppColors.primary,
+                    style: const TextStyle(
+                      color: AppColors.primary,
                       fontSize: 11,
                       fontWeight: FontWeight.w800,
                     ),

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_detail_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_detail_view.dart
@@ -20,6 +20,7 @@ import 'package:oncare_trainer/shared/models/trainer_client.dart';
 import 'package:oncare_trainer/shared/services/chat_repository.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
 import 'package:oncare_trainer/shared/widgets/client_avatar.dart';
+import 'package:oncare_trainer/shared/widgets/client_identity.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 
 /// Labels for [AppRoutes.clientTabSections], in the same order.
@@ -373,10 +374,9 @@ class _Header extends ConsumerWidget {
               Row(
                 children: <Widget>[
                   Flexible(
-                    child: Text(
-                      client.name,
-                      overflow: TextOverflow.ellipsis,
-                      style: const TextStyle(
+                    child: ClientIdentity(
+                      client: client,
+                      nameStyle: const TextStyle(
                         fontSize: 15,
                         fontWeight: FontWeight.w700,
                         color: AppColors.foreground,

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/nutrition_summary_card.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/nutrition_summary_card.dart
@@ -360,7 +360,10 @@ class _MacroItem extends StatelessWidget {
           ),
         ),
         const SizedBox(height: 7),
-        _Bar(progress: item.ratio, color: AppColors.primary.withValues(alpha: 0.65)),
+        _Bar(
+          progress: item.ratio,
+          color: AppColors.primary.withValues(alpha: 0.65),
+        ),
       ],
     );
   }
@@ -419,7 +422,11 @@ class _StatusCards extends StatelessWidget {
       builder: (BuildContext context, BoxConstraints c) {
         if (c.maxWidth < 310) {
           return Column(
-            children: <Widget>[a, const SizedBox(height: AppSpacing.sm), b],
+            children: <Widget>[
+              a,
+              const SizedBox(height: AppSpacing.sm),
+              b,
+            ],
           );
         }
         return Row(

--- a/frontend/flutter_trainer/lib/features/coaching/presentation/pages/coaching_page.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/pages/coaching_page.dart
@@ -29,6 +29,7 @@ import 'package:oncare_trainer/shared/models/client_alerts.dart';
 import 'package:oncare_trainer/shared/models/trainer_client.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
 import 'package:oncare_trainer/shared/widgets/client_avatar.dart';
+import 'package:oncare_trainer/shared/widgets/client_identity.dart';
 import 'package:oncare_trainer/shared/widgets/metric_tile.dart';
 import 'package:oncare_trainer/shared/widgets/page_scaffold.dart';
 import 'package:oncare_trainer/shared/widgets/section_card.dart';
@@ -626,6 +627,7 @@ class _MemberProgramList extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.only(bottom: AppSpacing.xs),
               child: Material(
+                key: ValueKey<String>('program-client-${client.id}'),
                 color: client.id == selectedId
                     ? AppColors.accentSurface
                     : Colors.transparent,
@@ -635,37 +637,47 @@ class _MemberProgramList extends StatelessWidget {
                   borderRadius: const BorderRadius.all(AppRadius.md),
                   child: Padding(
                     padding: const EdgeInsets.all(AppSpacing.sm),
-                    child: Column(
+                    child: Row(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: <Widget>[
-                        Text(
-                          client.name,
-                          style: const TextStyle(
-                            fontSize: 13.5,
-                            fontWeight: FontWeight.w800,
-                          ),
-                        ),
-                        const SizedBox(height: 3),
-                        Text(
-                          client.lastRoutine == '-'
-                              ? client.goal
-                              : client.lastRoutine,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: const TextStyle(
-                            color: AppColors.mutedForeground,
-                            fontSize: 11.5,
-                          ),
-                        ),
-                        const SizedBox(height: 3),
-                        Text(
-                          recordedCompletionMean(client) == null
-                              ? l.reportsDataInsufficient
-                              : '${l.reportsCompletionAvg} ${recordedCompletionMean(client)!.round()}%',
-                          style: const TextStyle(
-                            color: AppColors.primary,
-                            fontSize: 11,
-                            fontWeight: FontWeight.w700,
+                        ClientAvatar(label: client.avatar, size: 32),
+                        const SizedBox(width: AppSpacing.sm),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: <Widget>[
+                              ClientIdentity(
+                                client: client,
+                                nameStyle: const TextStyle(
+                                  fontSize: 13.5,
+                                  fontWeight: FontWeight.w800,
+                                  color: AppColors.foreground,
+                                ),
+                              ),
+                              const SizedBox(height: 3),
+                              Text(
+                                client.lastRoutine == '-'
+                                    ? client.goal
+                                    : client.lastRoutine,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: const TextStyle(
+                                  color: AppColors.mutedForeground,
+                                  fontSize: 11.5,
+                                ),
+                              ),
+                              const SizedBox(height: 3),
+                              Text(
+                                recordedCompletionMean(client) == null
+                                    ? l.reportsDataInsufficient
+                                    : '${l.reportsCompletionAvg} ${recordedCompletionMean(client)!.round()}%',
+                                style: const TextStyle(
+                                  color: AppColors.primary,
+                                  fontSize: 11,
+                                  fontWeight: FontWeight.w700,
+                                ),
+                              ),
+                            ],
                           ),
                         ),
                       ],
@@ -704,11 +716,12 @@ class _ProgramMemberSummary extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: <Widget>[
-                    Text(
-                      client.name,
-                      style: const TextStyle(
+                    ClientIdentity(
+                      client: client,
+                      nameStyle: const TextStyle(
                         fontSize: 15,
                         fontWeight: FontWeight.w800,
+                        color: AppColors.foreground,
                       ),
                     ),
                     Text(
@@ -834,15 +847,23 @@ class _ClientChip extends StatelessWidget {
                     )
                   : ClientAvatar(label: client.avatar, size: 32),
               const SizedBox(height: AppSpacing.xs),
-              Text(
-                client.name,
-                style: TextStyle(
+              ClientIdentity(
+                client: client,
+                nameStyle: TextStyle(
                   fontSize: 12,
                   fontWeight: FontWeight.w700,
                   color: selected
                       ? AppColors.primaryForeground
                       : AppColors.foreground,
                 ),
+                demographicsStyle: TextStyle(
+                  fontSize: 9,
+                  fontWeight: FontWeight.w600,
+                  color: selected
+                      ? AppColors.primaryForeground.withValues(alpha: 0.8)
+                      : AppColors.subtleForeground,
+                ),
+                textAlign: TextAlign.center,
               ),
             ],
           ),

--- a/frontend/flutter_trainer/lib/features/coaching/presentation/widgets/program_editor_workspace.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/widgets/program_editor_workspace.dart
@@ -429,12 +429,18 @@ class _UnsupportedBanner extends StatelessWidget {
       decoration: BoxDecoration(
         color: AppColors.brandOrange.withValues(alpha: 0.1),
         borderRadius: const BorderRadius.all(AppRadius.md),
-        border: Border.all(color: AppColors.brandOrange.withValues(alpha: 0.25)),
+        border: Border.all(
+          color: AppColors.brandOrange.withValues(alpha: 0.25),
+        ),
       ),
       child: Row(
         children: <Widget>[
           // 안내다. 주의가 아니므로 빨강으로 올리지 않는다(#690).
-          const Icon(Icons.info_outline, color: AppColors.brandOrange, size: 17),
+          const Icon(
+            Icons.info_outline,
+            color: AppColors.brandOrange,
+            size: 17,
+          ),
           const SizedBox(width: AppSpacing.sm),
           Expanded(
             child: Text(

--- a/frontend/flutter_trainer/lib/features/dashboard/presentation/widgets/attention_card.dart
+++ b/frontend/flutter_trainer/lib/features/dashboard/presentation/widgets/attention_card.dart
@@ -8,6 +8,7 @@ import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/features/dashboard/domain/dashboard_summary.dart';
 import 'package:oncare_trainer/shared/widgets/alert_badge.dart';
 import 'package:oncare_trainer/shared/widgets/client_avatar.dart';
+import 'package:oncare_trainer/shared/widgets/client_identity.dart';
 import 'package:oncare_trainer/shared/widgets/section_card.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 
@@ -91,11 +92,9 @@ class _Row extends StatelessWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: <Widget>[
-                  Text(
-                    entry.client.name,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(
+                  ClientIdentity(
+                    client: entry.client,
+                    nameStyle: const TextStyle(
                       fontSize: 13.5,
                       fontWeight: FontWeight.w700,
                       color: AppColors.foreground,

--- a/frontend/flutter_trainer/lib/features/dashboard/presentation/widgets/today_timeline_card.dart
+++ b/frontend/flutter_trainer/lib/features/dashboard/presentation/widgets/today_timeline_card.dart
@@ -8,6 +8,9 @@ import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/features/schedule/data/repositories/schedule_repository.dart';
 import 'package:oncare_trainer/features/schedule/domain/entities/schedule_session.dart';
+import 'package:oncare_trainer/shared/models/trainer_client.dart';
+import 'package:oncare_trainer/shared/services/client_repository.dart';
+import 'package:oncare_trainer/shared/widgets/client_identity.dart';
 import 'package:oncare_trainer/shared/widgets/section_card.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 import 'package:oncare_trainer/features/schedule/domain/entities/schedule_status.dart';
@@ -23,6 +26,8 @@ class TodayTimelineCard extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final AppLocalizations l = AppLocalizations.of(context);
     final schedule = ref.watch(todayScheduleProvider);
+    final clients =
+        ref.watch(clientsProvider).valueOrNull ?? const <TrainerClient>[];
 
     return SectionCard(
       title: l.dashTodaySchedule,
@@ -49,6 +54,11 @@ class TodayTimelineCard extends ConsumerWidget {
               for (final session in sessions)
                 _Row(
                   session: session,
+                  client: findClientIdentity(
+                    clients,
+                    clientId: session.clientId,
+                    clientName: session.clientName,
+                  ),
                   onTap: () => context.go(AppRoutes.scheduleView('day')),
                 ),
             ],
@@ -60,9 +70,14 @@ class TodayTimelineCard extends ConsumerWidget {
 }
 
 class _Row extends StatelessWidget {
-  const _Row({required this.session, required this.onTap});
+  const _Row({
+    required this.session,
+    required this.client,
+    required this.onTap,
+  });
 
   final ScheduleSession session;
+  final TrainerClient? client;
   final VoidCallback onTap;
 
   Color get _statusColor {
@@ -105,20 +120,27 @@ class _Row extends StatelessWidget {
                 ),
               ),
               Expanded(
-                child: Text(
-                  muted
-                      ? l.dashEmptySlot
-                      : '${session.clientName} · ${session.type}',
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: TextStyle(
-                    fontSize: 13.5,
-                    fontWeight: muted ? FontWeight.w500 : FontWeight.w600,
-                    color: muted
-                        ? AppColors.subtleForeground
-                        : AppColors.foreground,
-                  ),
-                ),
+                child: muted
+                    ? Text(
+                        l.dashEmptySlot,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          fontSize: 13.5,
+                          fontWeight: FontWeight.w500,
+                          color: AppColors.subtleForeground,
+                        ),
+                      )
+                    : Text(
+                        '${client == null ? session.clientName : clientIdentityLabel(context, client!)} · ${session.type}',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          fontSize: 13.5,
+                          fontWeight: FontWeight.w600,
+                          color: AppColors.foreground,
+                        ),
+                      ),
               ),
               if (!muted)
                 Text(

--- a/frontend/flutter_trainer/lib/features/messages/presentation/pages/messages_page.dart
+++ b/frontend/flutter_trainer/lib/features/messages/presentation/pages/messages_page.dart
@@ -17,6 +17,7 @@ import 'package:oncare_trainer/shared/services/client_repository.dart';
 import 'package:oncare_trainer/shared/widgets/action_button.dart';
 import 'package:oncare_trainer/shared/widgets/alert_badge.dart';
 import 'package:oncare_trainer/shared/widgets/client_avatar.dart';
+import 'package:oncare_trainer/shared/widgets/client_identity.dart';
 import 'package:oncare_trainer/shared/widgets/page_scaffold.dart';
 import 'package:oncare_trainer/shared/widgets/section_card.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
@@ -126,7 +127,7 @@ class _MessagesPageState extends ConsumerState<MessagesPage> {
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: <Widget>[
                   SizedBox(
-                    width: 340,
+                    width: AppLayout.splitListWidth,
                     child: _ConversationList(
                       clients: filtered,
                       selectedId: selected?.id,
@@ -136,7 +137,7 @@ class _MessagesPageState extends ConsumerState<MessagesPage> {
                       onSelected: _selectClient,
                     ),
                   ),
-                  const SizedBox(width: AppSpacing.lg),
+                  const SizedBox(width: AppSpacing.sm),
                   Expanded(
                     child: selected == null
                         ? const _EmptyThread()
@@ -180,72 +181,65 @@ class _ConversationList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
-    return _Panel(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: <Widget>[
-          Padding(
-            padding: const EdgeInsets.fromLTRB(
-              AppSpacing.md,
-              AppSpacing.md,
-              AppSpacing.md,
-              AppSpacing.sm,
-            ),
-            child: Text(
-              l.messagesConversations,
-              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w800),
-            ),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        Text(
+          l.messagesConversations,
+          style: const TextStyle(
+            color: AppColors.foreground,
+            fontSize: 16,
+            fontWeight: FontWeight.w800,
           ),
-          SingleChildScrollView(
-            scrollDirection: Axis.horizontal,
-            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
-            child: Row(
-              children: <Widget>[
-                for (final item in _ConversationFilter.values) ...<Widget>[
-                  _FilterChip(
-                    label: item == _ConversationFilter.unread
-                        ? l.messagesFilterUnreadCount(
-                            unread.values.where((n) => n > 0).length,
-                          )
-                        : item.label(l),
-                    selected: filter == item,
-                    onTap: () => onFilterChanged(item),
-                  ),
-                  if (item != _ConversationFilter.values.last)
-                    const SizedBox(width: AppSpacing.xs),
-                ],
+        ),
+        const SizedBox(height: AppSpacing.md),
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: Row(
+            children: <Widget>[
+              for (final item in _ConversationFilter.values) ...<Widget>[
+                _FilterChip(
+                  label: item == _ConversationFilter.unread
+                      ? l.messagesFilterUnreadCount(
+                          unread.values.where((n) => n > 0).length,
+                        )
+                      : item.label(l),
+                  selected: filter == item,
+                  onTap: () => onFilterChanged(item),
+                ),
+                if (item != _ConversationFilter.values.last)
+                  const SizedBox(width: AppSpacing.xs),
               ],
-            ),
+            ],
           ),
-          const SizedBox(height: AppSpacing.sm),
-          const Divider(height: 1, color: AppColors.borderStrong),
-          Expanded(
-            child: clients.isEmpty
-                ? EmptyHint(
-                    message: l.messagesEmpty,
-                    icon: Icons.forum_outlined,
-                  )
-                : ListView.separated(
-                    padding: const EdgeInsets.all(AppSpacing.md),
-                    itemCount: clients.length,
-                    separatorBuilder: (_, _) =>
-                        const SizedBox(height: AppSpacing.md),
-                    itemBuilder: (context, index) {
-                      final client = clients[index];
-                      return _ConversationTile(
-                        key: ValueKey<String>(
-                          'messages-conversation-${client.id}',
-                        ),
-                        client: client,
-                        selected: client.id == selectedId,
-                        unread: unread[client.id] ?? 0,
-                        onTap: () => onSelected(client.id),
-                      );
-                    },
+        ),
+        const SizedBox(height: AppSpacing.lg),
+        Expanded(
+          child: clients.isEmpty
+              ? EmptyHint(message: l.messagesEmpty, icon: Icons.forum_outlined)
+              : ListView.separated(
+                  padding: const EdgeInsets.only(
+                    right: AppSpacing.sm,
+                    bottom: AppLayout.pagePadding,
                   ),
-          ),
-        ],
-      ),
+                  itemCount: clients.length,
+                  separatorBuilder: (_, _) =>
+                      const SizedBox(height: AppSpacing.md),
+                  itemBuilder: (context, index) {
+                    final client = clients[index];
+                    return _ConversationTile(
+                      key: ValueKey<String>(
+                        'messages-conversation-${client.id}',
+                      ),
+                      client: client,
+                      selected: client.id == selectedId,
+                      unread: unread[client.id] ?? 0,
+                      onTap: () => onSelected(client.id),
+                    );
+                  },
+                ),
+        ),
+      ],
     );
   }
 }
@@ -314,7 +308,8 @@ class _ConversationTile extends StatelessWidget {
           onTap: onTap,
           borderRadius: const BorderRadius.all(AppRadius.card),
           child: Container(
-            padding: const EdgeInsets.all(AppSpacing.md),
+            constraints: const BoxConstraints(minHeight: 88),
+            padding: const EdgeInsets.all(AppSpacing.lg),
             decoration: BoxDecoration(
               borderRadius: const BorderRadius.all(AppRadius.card),
               border: Border.all(
@@ -340,11 +335,12 @@ class _ConversationTile extends StatelessWidget {
                       Row(
                         children: <Widget>[
                           Expanded(
-                            child: Text(
-                              client.name,
-                              style: const TextStyle(
+                            child: ClientIdentity(
+                              client: client,
+                              nameStyle: const TextStyle(
                                 fontSize: 14,
                                 fontWeight: FontWeight.w800,
+                                color: AppColors.foreground,
                               ),
                             ),
                           ),
@@ -357,7 +353,7 @@ class _ConversationTile extends StatelessWidget {
                           ),
                         ],
                       ),
-                      const SizedBox(height: 5),
+                      const SizedBox(height: 3),
                       Row(
                         children: <Widget>[
                           Expanded(
@@ -367,7 +363,7 @@ class _ConversationTile extends StatelessWidget {
                               overflow: TextOverflow.ellipsis,
                               style: TextStyle(
                                 color: AppColors.mutedForeground,
-                                fontSize: 12.5,
+                                fontSize: 11.5,
                                 fontWeight: unread > 0
                                     ? FontWeight.w700
                                     : FontWeight.w500,
@@ -376,11 +372,15 @@ class _ConversationTile extends StatelessWidget {
                           ),
                           if (unread > 0)
                             Container(
+                              key: ValueKey<String>(
+                                'messages-unread-${client.id}',
+                              ),
                               margin: const EdgeInsets.only(
                                 left: AppSpacing.xs,
                               ),
+                              constraints: const BoxConstraints(minWidth: 20),
                               padding: const EdgeInsets.symmetric(
-                                horizontal: 7,
+                                horizontal: 6,
                                 vertical: 2,
                               ),
                               decoration: const BoxDecoration(
@@ -389,6 +389,7 @@ class _ConversationTile extends StatelessWidget {
                               ),
                               child: Text(
                                 '$unread',
+                                textAlign: TextAlign.center,
                                 style: const TextStyle(
                                   color: Colors.white,
                                   fontSize: 10,
@@ -399,7 +400,7 @@ class _ConversationTile extends StatelessWidget {
                         ],
                       ),
                       if (alerts.isNotEmpty) ...<Widget>[
-                        const SizedBox(height: 6),
+                        const SizedBox(height: 7),
                         AlertBadge(alert: alerts.first),
                       ],
                     ],
@@ -447,11 +448,12 @@ class _ThreadPanel extends StatelessWidget {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
-                      Text(
-                        client.name,
-                        style: const TextStyle(
+                      ClientIdentity(
+                        client: client,
+                        nameStyle: const TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.w800,
+                          color: AppColors.foreground,
                         ),
                       ),
                       Text(

--- a/frontend/flutter_trainer/lib/features/my/presentation/pages/my_page.dart
+++ b/frontend/flutter_trainer/lib/features/my/presentation/pages/my_page.dart
@@ -206,11 +206,7 @@ class _MyPageState extends ConsumerState<MyPage> {
           ? l.myGymChangeFailed
           : '${l.myGymChangeFailed} $localizedDetail';
     }
-    return serverDetailOr(
-      l,
-      detail,
-      l.myProfileSaveFailed,
-    );
+    return serverDetailOr(l, detail, l.myProfileSaveFailed);
   }
 
   void _applySavedProfile(TrainerProfile saved) {

--- a/frontend/flutter_trainer/lib/features/notifications/data/repositories/notification_repository.dart
+++ b/frontend/flutter_trainer/lib/features/notifications/data/repositories/notification_repository.dart
@@ -131,10 +131,11 @@ final notificationInboxEnabledProvider = Provider<bool>(
 );
 
 /// 받은 알림 목록.
-final trainerNotificationsProvider =
-    FutureProvider<List<TrainerNotification>>((ref) {
-      return ref.watch(trainerNotificationRepositoryProvider).fetch();
-    }, name: 'trainerNotifications');
+final trainerNotificationsProvider = FutureProvider<List<TrainerNotification>>((
+  ref,
+) {
+  return ref.watch(trainerNotificationRepositoryProvider).fetch();
+}, name: 'trainerNotifications');
 
 /// 미읽음 수 — 사이드바 배지.
 final trainerUnreadNotificationsProvider = FutureProvider<int>((ref) {

--- a/frontend/flutter_trainer/lib/features/reports/presentation/pages/reports_page.dart
+++ b/frontend/flutter_trainer/lib/features/reports/presentation/pages/reports_page.dart
@@ -19,6 +19,7 @@ import 'package:oncare_trainer/shared/models/trainer_client.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
 import 'package:oncare_trainer/shared/widgets/action_button.dart';
 import 'package:oncare_trainer/shared/widgets/client_avatar.dart';
+import 'package:oncare_trainer/shared/widgets/client_identity.dart';
 import 'package:oncare_trainer/shared/widgets/mini_charts.dart';
 import 'package:oncare_trainer/shared/widgets/page_scaffold.dart';
 import 'package:oncare_trainer/shared/widgets/section_card.dart';
@@ -143,7 +144,7 @@ class _ReportsPageState extends ConsumerState<ReportsPage> {
             icon: Icons.today_outlined,
             onPressed: _goToCurrentWeek,
           ),
-        const _UnsupportedPrintAction(),
+        const _UnsupportedPdfExportAction(),
       ],
       child: clientsAsync.when(
         loading: () => const Padding(
@@ -351,11 +352,9 @@ class _ClientPicker extends StatelessWidget {
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: <Widget>[
-                              Text(
-                                client.name,
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                                style: TextStyle(
+                              ClientIdentity(
+                                client: client,
+                                nameStyle: TextStyle(
                                   fontSize: 13.5,
                                   fontWeight: client.id == selectedId
                                       ? FontWeight.w800
@@ -427,7 +426,21 @@ class _ClientReport extends StatelessWidget {
               color: AppColors.subtleForeground,
             ),
           ),
-          child: _WeekComparison(report: report),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              ClientIdentity(
+                client: client,
+                nameStyle: const TextStyle(
+                  fontSize: 13.5,
+                  fontWeight: FontWeight.w700,
+                  color: AppColors.foreground,
+                ),
+              ),
+              const SizedBox(height: AppSpacing.sm),
+              _WeekComparison(report: report),
+            ],
+          ),
         ),
         const SizedBox(height: AppSpacing.lg),
         SectionCard(
@@ -520,8 +533,6 @@ class _ClientReport extends StatelessWidget {
         ),
         const SizedBox(height: AppSpacing.lg),
         const _ReportAiCard(),
-        const SizedBox(height: AppSpacing.md),
-        const _UnsupportedPdfAction(),
       ],
     );
   }
@@ -934,39 +945,19 @@ class _ReportAiCard extends StatelessWidget {
   }
 }
 
-class _UnsupportedPrintAction extends StatelessWidget {
-  const _UnsupportedPrintAction();
+class _UnsupportedPdfExportAction extends StatelessWidget {
+  const _UnsupportedPdfExportAction();
 
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
     return Tooltip(
-      message: l.reportsPrintUnsupported,
+      message: l.reportsPdfUnsupported,
       child: ActionButton(
-        key: const ValueKey<String>('reports-print-action'),
-        label: l.reportsPrintLabel,
-        icon: Icons.print_outlined,
+        key: const ValueKey<String>('reports-pdf-export-action'),
+        label: l.reportsPdfLabel,
+        icon: Icons.picture_as_pdf_outlined,
         onPressed: null,
-      ),
-    );
-  }
-}
-
-class _UnsupportedPdfAction extends StatelessWidget {
-  const _UnsupportedPdfAction();
-
-  @override
-  Widget build(BuildContext context) {
-    final l = AppLocalizations.of(context);
-    return Align(
-      alignment: Alignment.centerRight,
-      child: Tooltip(
-        message: l.reportsPdfUnsupported,
-        child: ActionButton(
-          label: l.reportsPdfLabel,
-          icon: Icons.picture_as_pdf_outlined,
-          onPressed: null,
-        ),
       ),
     );
   }

--- a/frontend/flutter_trainer/lib/features/schedule/data/dtos/schedule_dtos.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/data/dtos/schedule_dtos.dart
@@ -11,9 +11,7 @@ ScheduleSession scheduleSessionFromJson(Map<String, dynamic> json) {
     time: _str(json['time']),
     // 서버는 고객을 member_id 로 참조한다. 빈 문자열은 미등록(상담) 슬롯이라
     // null 로 눕혀 이름 폴백 경로와 같은 의미가 되게 한다(#386).
-    clientId: _str(json['member_id']).isEmpty
-        ? null
-        : _str(json['member_id']),
+    clientId: _str(json['member_id']).isEmpty ? null : _str(json['member_id']),
     clientName: _str(json['client_name']),
     type: _str(json['type']),
     durationMinutes: _int(json['duration_minutes']),

--- a/frontend/flutter_trainer/lib/features/schedule/data/repositories/schedule_repository.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/data/repositories/schedule_repository.dart
@@ -382,15 +382,17 @@ class DriftScheduleRepository implements ScheduleRepository {
       // Conditional update: `changed` is 0 when a concurrent call already
       // completed this session, in which case we must not log again.
       final changed =
-          await (_db.update(
-            table,
-          )..where((t) => t.id.equals(id) & t.status.equals(ScheduleStatus.upcoming))).write(
-            TrainerScheduleEntriesCompanion(
-              status: const Value(ScheduleStatus.done),
-              // An empty memo must not wipe an existing note.
-              note: note.isEmpty ? const Value.absent() : Value(note),
-            ),
-          );
+          await (_db.update(table)..where(
+                (t) =>
+                    t.id.equals(id) & t.status.equals(ScheduleStatus.upcoming),
+              ))
+              .write(
+                TrainerScheduleEntriesCompanion(
+                  status: const Value(ScheduleStatus.done),
+                  // An empty memo must not wipe an existing note.
+                  note: note.isEmpty ? const Value.absent() : Value(note),
+                ),
+              );
       if (changed != 1) return;
 
       // 기록을 남길 고객도 id 로 찾는다. v3 이전 행만 이름으로 폴백한다.

--- a/frontend/flutter_trainer/lib/features/schedule/domain/entities/schedule_status.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/domain/entities/schedule_status.dart
@@ -33,14 +33,15 @@ abstract final class SessionType {
 }
 
 /// 저장된 상태값 → 화면 문구.
-String scheduleStatusLabel(AppLocalizations l, String status) => switch (status) {
-  ScheduleStatus.upcoming => l.scheduleStatusUpcoming,
-  ScheduleStatus.done => l.scheduleStatusDone,
-  ScheduleStatus.gap => l.scheduleStatusGap,
-  // 서버가 새 상태를 추가했는데 앱이 모르는 경우. 빈칸을 보여 주느니 원문을 그대로
-  // 내보낸다 — 무엇이 들어왔는지 화면에서 확인할 수 있다.
-  _ => status,
-};
+String scheduleStatusLabel(AppLocalizations l, String status) =>
+    switch (status) {
+      ScheduleStatus.upcoming => l.scheduleStatusUpcoming,
+      ScheduleStatus.done => l.scheduleStatusDone,
+      ScheduleStatus.gap => l.scheduleStatusGap,
+      // 서버가 새 상태를 추가했는데 앱이 모르는 경우. 빈칸을 보여 주느니 원문을 그대로
+      // 내보낸다 — 무엇이 들어왔는지 화면에서 확인할 수 있다.
+      _ => status,
+    };
 
 /// 저장된 종류값 → 화면 문구.
 String sessionTypeLabel(AppLocalizations l, String type) => switch (type) {

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
@@ -15,8 +15,10 @@ import 'package:oncare_trainer/features/schedule/presentation/widgets/reservatio
 import 'package:oncare_trainer/features/consultations/data/repositories/consultation_repository.dart';
 import 'package:oncare_trainer/features/consultations/presentation/widgets/consultation_inbox_sheet.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
+import 'package:oncare_trainer/shared/models/trainer_client.dart';
 import 'package:oncare_trainer/shared/widgets/action_button.dart';
 import 'package:oncare_trainer/shared/widgets/client_avatar.dart';
+import 'package:oncare_trainer/shared/widgets/client_identity.dart';
 import 'package:oncare_trainer/shared/widgets/page_scaffold.dart';
 import 'package:oncare_trainer/features/schedule/domain/entities/schedule_status.dart';
 import 'package:oncare_trainer/features/search/presentation/widgets/client_search_bar.dart';
@@ -1578,15 +1580,20 @@ class _DayColumn extends StatelessWidget {
   }
 }
 
-class _WeekChip extends StatelessWidget {
+class _WeekChip extends ConsumerWidget {
   const _WeekChip({required this.session, required this.onTap});
 
   final ScheduleSession session;
   final VoidCallback onTap;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final color = session.isDone ? AppColors.success : AppColors.primary;
+    final client = findClientIdentity(
+      ref.watch(clientsProvider).valueOrNull ?? const <TrainerClient>[],
+      clientId: session.clientId,
+      clientName: session.clientName,
+    );
     return Padding(
       padding: const EdgeInsets.only(bottom: 4),
       child: Material(
@@ -1612,16 +1619,31 @@ class _WeekChip extends StatelessWidget {
                     color: color,
                   ),
                 ),
-                Text(
-                  session.clientName,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(
-                    fontSize: 11.5,
-                    fontWeight: FontWeight.w600,
-                    color: AppColors.foreground,
+                if (client == null)
+                  Text(
+                    session.clientName,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      fontSize: 11.5,
+                      fontWeight: FontWeight.w600,
+                      color: AppColors.foreground,
+                    ),
+                  )
+                else
+                  ClientIdentity(
+                    client: client,
+                    nameStyle: const TextStyle(
+                      fontSize: 11.5,
+                      fontWeight: FontWeight.w600,
+                      color: AppColors.foreground,
+                    ),
+                    demographicsStyle: const TextStyle(
+                      fontSize: 8.5,
+                      fontWeight: FontWeight.w600,
+                      color: AppColors.subtleForeground,
+                    ),
                   ),
-                ),
               ],
             ),
           ),
@@ -1891,7 +1913,7 @@ class _GapSlot extends StatelessWidget {
   }
 }
 
-class _SessionCard extends StatelessWidget {
+class _SessionCard extends ConsumerWidget {
   const _SessionCard({
     super.key,
     required this.session,
@@ -1920,9 +1942,14 @@ class _SessionCard extends StatelessWidget {
   final VoidCallback? onComplete;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final AppLocalizations l = AppLocalizations.of(context);
     final s = session;
+    final client = findClientIdentity(
+      ref.watch(clientsProvider).valueOrNull ?? const <TrainerClient>[],
+      clientId: session.clientId,
+      clientName: session.clientName,
+    );
     return Container(
       decoration: BoxDecoration(
         color: AppColors.card,
@@ -1959,14 +1986,24 @@ class _SessionCard extends StatelessWidget {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: <Widget>[
-                        Text(
-                          s.clientName,
-                          style: const TextStyle(
-                            fontSize: 14,
-                            fontWeight: FontWeight.w700,
-                            color: AppColors.foreground,
+                        if (client == null)
+                          Text(
+                            s.clientName,
+                            style: const TextStyle(
+                              fontSize: 14,
+                              fontWeight: FontWeight.w700,
+                              color: AppColors.foreground,
+                            ),
+                          )
+                        else
+                          ClientIdentity(
+                            client: client,
+                            nameStyle: const TextStyle(
+                              fontSize: 14,
+                              fontWeight: FontWeight.w700,
+                              color: AppColors.foreground,
+                            ),
                           ),
-                        ),
                         Text(
                           l.sessionTypeAndDuration(
                             sessionTypeLabel(l, s.type),

--- a/frontend/flutter_trainer/lib/features/search/presentation/widgets/client_search_bar.dart
+++ b/frontend/flutter_trainer/lib/features/search/presentation/widgets/client_search_bar.dart
@@ -20,6 +20,7 @@ import 'package:oncare_trainer/shared/models/trainer_client.dart';
 import 'package:oncare_trainer/shared/services/chat_repository.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
 import 'package:oncare_trainer/shared/widgets/client_avatar.dart';
+import 'package:oncare_trainer/shared/widgets/client_identity.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 
 /// Widest the inline field grows. Past this it stops looking like a
@@ -519,10 +520,9 @@ class _ResultRowState extends State<_ResultRow> {
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: <Widget>[
-                              Text(
-                                widget.client.name,
-                                overflow: TextOverflow.ellipsis,
-                                style: const TextStyle(
+                              ClientIdentity(
+                                client: widget.client,
+                                nameStyle: const TextStyle(
                                   fontSize: 16,
                                   fontWeight: FontWeight.w700,
                                   color: AppColors.foreground,

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
@@ -4151,7 +4151,7 @@ abstract class AppLocalizations {
   /// No description provided for @reportsPdfLabel.
   ///
   /// In en, this message translates to:
-  /// **'Shareable PDF'**
+  /// **'Export PDF'**
   String get reportsPdfLabel;
 
   /// No description provided for @reportsPrintUnsupported.

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
@@ -2308,7 +2308,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get reportsPdfUnsupported => 'PDF generation isn\'t supported yet.';
 
   @override
-  String get reportsPdfLabel => 'Shareable PDF';
+  String get reportsPdfLabel => 'Export PDF';
 
   @override
   String get reportsPrintUnsupported =>

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
@@ -2237,7 +2237,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get reportsPdfUnsupported => 'PDF 생성 API가 아직 없어요.';
 
   @override
-  String get reportsPdfLabel => '회원 공유용 PDF';
+  String get reportsPdfLabel => 'PDF 내보내기';
 
   @override
   String get reportsPrintUnsupported =>

--- a/frontend/flutter_trainer/lib/l10n/app_en.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_en.arb
@@ -1429,7 +1429,7 @@
   "reportsAiTitle": "AI coaching assistant · Report summary",
   "reportsAiUnavailable": "Available after the report summary API is connected. No summary is generated now.",
   "reportsPdfUnsupported": "PDF generation isn't supported yet.",
-  "reportsPdfLabel": "Shareable PDF",
+  "reportsPdfLabel": "Export PDF",
   "reportsPrintUnsupported": "Available after PDF/print report snapshots are supported.",
   "reportsPrintLabel": "Print"
 }

--- a/frontend/flutter_trainer/lib/l10n/app_ko.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_ko.arb
@@ -695,7 +695,7 @@
   "reportsAiTitle": "AI 코칭 보조 · 리포트 요약",
   "reportsAiUnavailable": "실제 리포트 요약 API 연결 후 사용할 수 있어요. 현재 문구는 자동 생성하지 않습니다.",
   "reportsPdfUnsupported": "PDF 생성 API가 아직 없어요.",
-  "reportsPdfLabel": "회원 공유용 PDF",
+  "reportsPdfLabel": "PDF 내보내기",
   "reportsPrintUnsupported": "PDF/인쇄용 report snapshot 지원 후 사용할 수 있어요.",
   "reportsPrintLabel": "인쇄"
 }

--- a/frontend/flutter_trainer/lib/shared/models/trainer_client.dart
+++ b/frontend/flutter_trainer/lib/shared/models/trainer_client.dart
@@ -27,6 +27,8 @@ class TrainerClient {
     required this.lastRoutine,
     required this.weekCompletion,
     required this.sodiumWeek,
+    this.gender = '',
+    this.age,
   });
 
   /// Row id (e.g. `seed-client-1`).
@@ -37,6 +39,13 @@ class TrainerClient {
 
   /// Single-char avatar label (e.g. 김).
   final String avatar;
+
+  /// Optional roster demographic supplied by the API (`male` / `female` /
+  /// `other`). Older API and local-demo rows do not carry it yet.
+  final String gender;
+
+  /// Optional international age supplied by the API.
+  final int? age;
 
   /// Goal label (e.g. 혈압 관리 · 체중 감량).
   final String goal;
@@ -78,6 +87,24 @@ class TrainerClient {
   /// [sodiumMg]). Empty for pre-v2 rows (before the next re-seed
   /// backfills it).
   final List<int> sodiumWeek;
+
+  /// Stable display gender for roster rows that predate demographic fields.
+  ///
+  /// The demo roster is presentation fixture data. Keeping the fallback on
+  /// the stable client id means same-name members still receive distinct,
+  /// repeatable identity details without changing the persisted Drift schema.
+  String get rosterGender {
+    if (gender == 'male' || gender == 'female' || gender == 'other') {
+      return gender;
+    }
+    return _demographicSeed.isEven ? 'female' : 'male';
+  }
+
+  /// Roster age, constrained to the requested twenties/thirties fixture range
+  /// when the source does not provide one.
+  int get rosterAge => age ?? 20 + (_demographicSeed % 20);
+
+  int get _demographicSeed => id.runes.fold<int>(0, (sum, rune) => sum + rune);
 
   /// Sodium exceeds the [sodiumTargetMg] daily target — surfaced as a
   /// warning on the list card and counted by the AI summary.

--- a/frontend/flutter_trainer/lib/shared/widgets/client_identity.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/client_identity.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+
+import 'package:oncare_trainer/design_system/tokens/colors.dart';
+import 'package:oncare_trainer/design_system/tokens/spacing.dart';
+import 'package:oncare_trainer/shared/models/trainer_client.dart';
+
+/// Returns the localized demographic label used to distinguish clients who
+/// share a name.
+String clientDemographicsLabel(BuildContext context, TrainerClient client) {
+  final korean = Localizations.localeOf(context).languageCode == 'ko';
+  final gender = switch (client.rosterGender) {
+    'female' => korean ? '여성' : 'Female',
+    'male' => korean ? '남성' : 'Male',
+    _ => korean ? '기타' : 'Other',
+  };
+  final age = korean ? '${client.rosterAge}세' : 'Age ${client.rosterAge}';
+  return '$gender · $age';
+}
+
+/// Returns a plain-text identity for places that cannot compose text styles.
+String clientIdentityLabel(BuildContext context, TrainerClient client) =>
+    '${client.name} ${clientDemographicsLabel(context, client)}';
+
+/// Resolves display-only records that carry a client id and a legacy name.
+/// A name fallback is safe only when it identifies exactly one roster entry.
+TrainerClient? findClientIdentity(
+  List<TrainerClient> clients, {
+  required String? clientId,
+  required String clientName,
+}) {
+  for (final client in clients) {
+    if (clientId != null && client.id == clientId) return client;
+  }
+  final sameName = clients.where((client) => client.name == clientName);
+  return sameName.length == 1 ? sameName.single : null;
+}
+
+/// The shared client-name treatment used across trainer tabs.
+class ClientIdentity extends StatelessWidget {
+  const ClientIdentity({
+    super.key,
+    required this.client,
+    this.nameStyle,
+    this.demographicsStyle,
+    this.maxLines = 1,
+    this.textAlign,
+  });
+
+  final TrainerClient client;
+  final TextStyle? nameStyle;
+  final TextStyle? demographicsStyle;
+  final int maxLines;
+  final TextAlign? textAlign;
+
+  @override
+  Widget build(BuildContext context) {
+    final resolvedNameStyle =
+        nameStyle ??
+        const TextStyle(
+          color: AppColors.foreground,
+          fontSize: 14,
+          fontWeight: FontWeight.w800,
+        );
+    final resolvedDemographicsStyle =
+        demographicsStyle ??
+        resolvedNameStyle.copyWith(
+          color: AppColors.subtleForeground,
+          fontSize: (resolvedNameStyle.fontSize ?? 14) - 3,
+          fontWeight: FontWeight.w600,
+        );
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment: textAlign == TextAlign.center
+          ? MainAxisAlignment.center
+          : MainAxisAlignment.start,
+      children: <Widget>[
+        Flexible(
+          child: Text(
+            client.name,
+            maxLines: maxLines,
+            overflow: TextOverflow.ellipsis,
+            style: resolvedNameStyle,
+          ),
+        ),
+        const SizedBox(width: AppSpacing.xs),
+        Flexible(
+          child: Text(
+            clientDemographicsLabel(context, client),
+            maxLines: maxLines,
+            overflow: TextOverflow.ellipsis,
+            style: resolvedDemographicsStyle,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/flutter_trainer/test/app/shell/nav_destinations_test.dart
+++ b/frontend/flutter_trainer/test/app/shell/nav_destinations_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare_trainer/app/shell/nav_destinations.dart';
+
+void main() {
+  test('고객 메뉴는 숫자 배지를 표시하지 않는다', () {
+    final clients = navDestinations.singleWhere(
+      (destination) => destination.label == NavLabel.clients,
+    );
+    final messages = navDestinations.singleWhere(
+      (destination) => destination.label == NavLabel.messages,
+    );
+
+    expect(clients.badge, NavBadge.none);
+    expect(messages.badge, NavBadge.unreadMessages);
+  });
+}

--- a/frontend/flutter_trainer/test/features/clients/client_dtos_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_dtos_test.dart
@@ -27,6 +27,8 @@ void main() {
         'id': 'm1',
         'name': '김민수',
         'avatar': '김',
+        'gender': 'male',
+        'age': 36,
         'goal': '혈압 관리',
         'last_message': '점심 등록했어요',
         'last_time': '방금',
@@ -44,6 +46,8 @@ void main() {
 
       expect(c.id, 'm1');
       expect(c.name, '김민수');
+      expect(c.rosterGender, 'male');
+      expect(c.rosterAge, 36);
       expect(c.sodiumMg, 2100);
       expect(c.sugarG, 17.8);
       expect(c.carbsG, 150.5);
@@ -75,6 +79,7 @@ void main() {
       expect(c.weekCompletion, <int>[100, 50]);
       expect(c.sodiumWeek, isEmpty);
       expect(c.active, isFalse); // absent → false
+      expect(c.rosterAge, inInclusiveRange(20, 39));
     });
   });
 

--- a/frontend/flutter_trainer/test/features/clients/clients_page_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/clients_page_test.dart
@@ -329,40 +329,29 @@ void main() {
       expect(find.text('김민수'), findsOneWidget);
     });
 
-    testWidgets('unread badges show and clear after reading the thread', (
-      tester,
-    ) async {
+    testWidgets('고객 목록은 메시지 미리보기와 안 읽은 배지를 노출하지 않는다', (tester) async {
       await pumpTrainerApp(
         tester,
         token: 'demo-trainer-token',
         at: AppRoutes.clients,
       );
 
-      // Scoped to each card rather than counting '1' across the roster:
-      // several members are waiting on a reply now, and the list is long
-      // enough that what is built depends on scroll position.
-      Finder badgeOf(String name) => find.descendant(
-        of: find.ancestor(
-          of: find.text(name),
-          matching: find.byType(ClientCard),
-        ),
-        matching: find.text('1'),
+      final sunghoCard = find.ancestor(
+        of: find.text('박성호'),
+        matching: find.byType(ClientCard),
       );
-
-      // 박성호 is waiting; 김민수's thread is seeded already answered.
-      expect(badgeOf('박성호'), findsOneWidget);
-      expect(badgeOf('김민수'), findsNothing);
-
-      // Open 박성호's chat, then come back — his badge cleared. The badge
-      // clears once the messages are on screen.
-      await goTo(
-        tester,
-        AppRoutes.clientDetail('seed-client-3', section: 'chat'),
+      expect(
+        find.descendant(of: sunghoCard, matching: find.text('1')),
+        findsNothing,
       );
-      await goTo(tester, AppRoutes.clients);
-      await settle(tester);
-
-      expect(badgeOf('박성호'), findsNothing);
+      expect(
+        find.descendant(of: sunghoCard, matching: find.text('이번 주 운동 못했어요...')),
+        findsNothing,
+      );
+      expect(
+        find.descendant(of: sunghoCard, matching: find.textContaining('세')),
+        findsOneWidget,
+      );
     });
 
     testWidgets('tapping a client card opens the detail screen', (
@@ -403,9 +392,8 @@ void main() {
       await tester.tap(find.text('등록하기'));
       await settle(tester);
 
-      // New client appended at the end of the list (0 data, no badge).
-      // Scoped to her own card: a seeded brand-new client carries the
-      // same "아직 대화가 없어요" placeholder.
+      // New client appended at the end of the list. Customer cards show
+      // identity details instead of chat placeholders or unread badges.
       await tester.scrollUntilVisible(
         find.text('최수진'),
         150,
@@ -418,14 +406,16 @@ void main() {
             .first,
       );
       expect(find.text('최수진'), findsWidgets);
+      final card = find.ancestor(
+        of: find.text('최수진').last,
+        matching: find.byType(ClientCard),
+      );
       expect(
-        find.descendant(
-          of: find.ancestor(
-            of: find.text('최수진').last,
-            matching: find.byType(ClientCard),
-          ),
-          matching: find.text('아직 대화가 없어요'),
-        ),
+        find.descendant(of: card, matching: find.text('아직 대화가 없어요')),
+        findsNothing,
+      );
+      expect(
+        find.descendant(of: card, matching: find.textContaining('세')),
         findsOneWidget,
       );
     });

--- a/frontend/flutter_trainer/test/features/clients/clients_split_view_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/clients_split_view_test.dart
@@ -3,11 +3,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:oncare_trainer/app/router/routes.dart';
+import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/design_system/tokens/layout.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/features/clients/presentation/pages/clients_page.dart';
 import 'package:oncare_trainer/features/clients/presentation/widgets/client_detail_view.dart';
 import 'package:oncare_trainer/features/clients/presentation/widgets/client_card.dart';
+import 'package:oncare_trainer/shared/widgets/alert_badge.dart';
 
 import '../../helpers/pump_app.dart';
 
@@ -68,6 +70,13 @@ void main() {
 
     // No selection yet — list only, with the empty-panel hint.
     expect(find.textContaining('왼쪽에서 고객을 선택하면'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byType(ClientCard),
+        matching: find.byType(AlertBadge),
+      ),
+      findsNothing,
+    );
 
     await tester.tap(card('김민수'));
     await settle(tester);
@@ -219,6 +228,34 @@ void main() {
     }
     // The top of the list is where the trainer looks first.
     expect(rendered.first.client.sodiumOverBudget, isTrue);
+  });
+
+  testWidgets('낮은 이행률이어도 고객 목록 진행 바와 퍼센트는 남색을 유지한다', (tester) async {
+    await openWide(tester);
+    await scrollToCard(tester, '배준혁');
+
+    final clientCard = find.ancestor(
+      of: find.text('배준혁'),
+      matching: find.byType(ClientCard),
+    );
+    final progress = tester.widget<LinearProgressIndicator>(
+      find.descendant(
+        of: clientCard,
+        matching: find.byType(LinearProgressIndicator),
+      ),
+    );
+
+    expect(progress.color, AppColors.primary);
+
+    final percentage = tester.widget<Text>(
+      find.descendant(
+        of: clientCard,
+        matching: find.byWidgetPredicate(
+          (widget) => widget is Text && (widget.data?.endsWith('%') ?? false),
+        ),
+      ),
+    );
+    expect(percentage.style?.color, AppColors.primary);
   });
 
   testWidgets('the panel location is a path that encodes the section', (

--- a/frontend/flutter_trainer/test/features/coaching/coaching_page_test.dart
+++ b/frontend/flutter_trainer/test/features/coaching/coaching_page_test.dart
@@ -29,6 +29,7 @@ import 'package:oncare_trainer/shared/models/trainer_profile.dart';
 import 'package:oncare_trainer/shared/services/chat_repository.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
 import 'package:oncare_trainer/shared/widgets/action_button.dart';
+import 'package:oncare_trainer/shared/widgets/client_avatar.dart';
 
 import '../../helpers/pump_app.dart';
 
@@ -452,6 +453,25 @@ void main() {
       expect(find.text('17.8'), findsOneWidget);
       expect(find.text('저강도 유산소 (걷기)'), findsOneWidget);
       expect(find.text('혈압 안정에 효과적'), findsOneWidget);
+      final programCard = find.byKey(
+        const ValueKey<String>('program-client-seed-client-1'),
+      );
+      expect(programCard, findsOneWidget);
+      expect(
+        find.descendant(of: programCard, matching: find.text('운동 이행률')),
+        findsNothing,
+      );
+      expect(
+        find.descendant(
+          of: programCard,
+          matching: find.textContaining('운동 이행률 '),
+        ),
+        findsOneWidget,
+      );
+      final avatar = tester.widget<ClientAvatar>(
+        find.descendant(of: programCard, matching: find.byType(ClientAvatar)),
+      );
+      expect(avatar.size, 32);
     });
 
     testWidgets('opens the A/B assistant inline in the AI routine tab', (

--- a/frontend/flutter_trainer/test/features/dashboard/dashboard_page_test.dart
+++ b/frontend/flutter_trainer/test/features/dashboard/dashboard_page_test.dart
@@ -130,7 +130,7 @@ void main() {
     await openDashboard(tester);
 
     expect(find.text('오늘의 일정'), findsOneWidget);
-    expect(find.text('김민수 · 1:1 PT'), findsWidgets);
+    expect(find.text('김민수 남성 · 35세 · 1:1 PT'), findsWidgets);
     expect(find.text('완료'), findsWidgets);
     // Gaps are shown but muted — a free hour is information.
     expect(find.text('빈 시간'), findsWidgets);

--- a/frontend/flutter_trainer/test/features/messages/messages_page_test.dart
+++ b/frontend/flutter_trainer/test/features/messages/messages_page_test.dart
@@ -4,6 +4,9 @@ import 'package:go_router/go_router.dart';
 
 import 'package:oncare_trainer/app/router/routes.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
+import 'package:oncare_trainer/design_system/tokens/layout.dart';
+import 'package:oncare_trainer/design_system/tokens/radius.dart';
+import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/features/messages/data/chat_insight_memo_repository.dart';
 import 'package:oncare_trainer/shared/widgets/action_button.dart';
 import 'package:oncare_trainer/shared/widgets/client_avatar.dart';
@@ -37,8 +40,85 @@ void main() {
             .first,
       );
       expect(surface.color, AppColors.accentSurface);
+      final tappable = tester.widget<InkWell>(
+        find.descendant(of: selectedTile, matching: find.byType(InkWell)),
+      );
+      expect(tappable.borderRadius, const BorderRadius.all(AppRadius.card));
+      final cardBody = tester.widget<Container>(
+        find
+            .descendant(of: selectedTile, matching: find.byType(Container))
+            .first,
+      );
+      expect(cardBody.padding, const EdgeInsets.all(AppSpacing.lg));
+      expect(cardBody.constraints?.minHeight, 88);
+
+      final listColumn = tester.widget<SizedBox>(
+        find.ancestor(
+          of: selectedTile,
+          matching: find.byWidgetPredicate(
+            (widget) =>
+                widget is SizedBox && widget.width == AppLayout.splitListWidth,
+          ),
+        ),
+      );
+      expect(listColumn.width, AppLayout.splitListWidth);
     });
   });
+
+  testWidgets('conversation list keeps unread and status information', (
+    tester,
+  ) async {
+    await withWideSurface(tester, () async {
+      await pumpTrainerApp(tester, token: 'demo-trainer-token-existing');
+      await goTo(tester, AppRoutes.messages);
+
+      final conversation = find.byKey(
+        const ValueKey<String>('messages-conversation-seed-client-3'),
+      );
+      expect(conversation, findsOneWidget);
+      expect(
+        find.descendant(
+          of: conversation,
+          matching: find.text('이번 주 운동 못했어요...'),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey<String>('messages-unread-seed-client-3')),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(of: conversation, matching: find.text('나트륨 초과')),
+        findsOneWidget,
+      );
+    });
+  });
+
+  testWidgets(
+    'narrowest desktop split keeps message and time without overflow',
+    (tester) async {
+      await withWideSurface(tester, size: const Size(1024, 760), () async {
+        await pumpTrainerApp(tester, token: 'demo-trainer-token-existing');
+        await goTo(tester, AppRoutes.messagesFor('seed-client-1'));
+
+        final conversation = find.byKey(
+          const ValueKey<String>('messages-conversation-seed-client-1'),
+        );
+        expect(
+          find.descendant(
+            of: conversation,
+            matching: find.textContaining('확인했어요.'),
+          ),
+          findsOneWidget,
+        );
+        expect(
+          find.descendant(of: conversation, matching: find.text('18:18')),
+          findsOneWidget,
+        );
+        expect(tester.takeException(), isNull);
+      });
+    },
+  );
 
   testWidgets('client query keeps the selected member in the thread', (
     tester,

--- a/frontend/flutter_trainer/test/features/reports/reports_page_test.dart
+++ b/frontend/flutter_trainer/test/features/reports/reports_page_test.dart
@@ -106,16 +106,19 @@ void main() {
     );
     // Defaults to the first client rather than an empty right pane.
     expect(find.text('김민수님 주간 리포트'), findsOneWidget);
+    expect(find.text('남성 · 35세'), findsWidgets);
   });
 
-  testWidgets('인쇄 액션은 스크롤 본문이 아닌 상단 헤더에 표시된다', (tester) async {
+  testWidgets('PDF 내보내기는 상단에만 표시된다', (tester) async {
     await openReports(tester);
 
-    final printAction = find.byKey(
-      const ValueKey<String>('reports-print-action'),
+    final exportAction = find.byKey(
+      const ValueKey<String>('reports-pdf-export-action'),
     );
-    expect(printAction, findsOneWidget);
-    expect(tester.getCenter(printAction).dy, lessThan(88));
+    expect(exportAction, findsOneWidget);
+    expect(find.text('PDF 내보내기'), findsOneWidget);
+    expect(find.text('회원 공유용 PDF'), findsNothing);
+    expect(tester.getCenter(exportAction).dy, lessThan(88));
   });
 
   testWidgets('과거 주차에서는 미래 이동 없이 이번 주로 복귀할 수 있다', (tester) async {


### PR DESCRIPTION
## Summary

* 트레이너 웹의 고객 목록에서 메시지 미리보기와 알림 배지를 제거하고 고객 식별 정보를 정리했습니다.
* 메시지 탭의 왼쪽 대화 목록을 고객 목록과 같은 시각 언어로 통일했습니다.
* 고객 이름 옆 성별·나이 표시를 주요 탭과 검색 결과에 공통 적용했습니다.
* 프로그램과 리포트 탭의 요청된 UI 변경을 반영했습니다.

---

## Changes

### ✨ Features

* 공통 `ClientIdentity` 위젯을 추가해 이름, 성별, 20~30대 나이를 일관되게 표시했습니다.
* API에 성별·나이가 없을 때 고객 ID 기반의 안정적인 표시값을 제공했습니다.

### 🔧 Improvements

* 프로그램 목록은 기존 정보 구조를 유지하면서 고객 avatar와 공통 식별 정보를 추가했습니다.
* 일정 데이터는 고객 ID를 우선 사용하고, 구형 데이터는 이름이 유일할 때만 고객 식별 정보를 연결합니다.
* 리포트 상단 작업명을 `PDF 내보내기`로 변경하고 하단 중복 PDF 버튼을 제거했습니다.

### 🎨 UI/UX

* 고객 목록에서 최근 메시지와 unread/상태 배지를 제거했습니다.
* 고객 사이드바 메뉴의 숫자 배지를 제거했습니다.
* 고객 목록의 이행률 바와 퍼센트 숫자를 남색으로 통일했습니다.
* 메시지 탭 왼쪽 목록의 폭, 카드, 선택/hover, avatar, badge, padding, spacing을 고객 목록과 통일했습니다.

### 📝 Docs

* 없음

### 🐛 Fixes

* 좁은 데스크톱 폭에서 메시지와 시간이 잘리거나 overflow되지 않도록 목록 레이아웃을 조정했습니다.

---

## Commits

1. `057fa617` feat(trainer-web): improve client identity and list UI

---

## Notes

* 변경 범위는 `frontend/flutter_trainer`입니다.
* 메시지 송수신, unread/read, polling, route, provider, repository, API 호출 로직은 변경하지 않았습니다.
* 최신 `main` 위로 rebase했으며 충돌 없이 반영했습니다.

---

## Screenshots (Optional)

| Before | After |
| ------ | ----- |
| 미첨부 | 미첨부 |

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 위젯 테스트 확인
* [ ] 프로덕션 빌드 확인
* [x] 관련 테스트 통과

### Manual Test Steps

1. 고객 탭에서 메시지/배지가 제거되고 이름 옆 성별·나이 및 남색 이행률 표시가 보이는지 확인합니다.
2. 메시지 탭에서 왼쪽 목록만 고객 목록과 같은 시각 규칙으로 표시되고 채팅 기능이 유지되는지 확인합니다.
3. 프로그램과 리포트 탭에서 avatar, 고객 식별 정보, `PDF 내보내기` 버튼 구성이 반영됐는지 확인합니다.

---

## Related Issues

* 직접 종료할 이슈 없음
* 선행 작업: #710

## Checklist

* [ ] 코드 리뷰 준비 완료 (Draft)
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 고객 이름과 함께 성별·나이 등 식별 정보를 주요 화면에 표시합니다.
  * 고객 및 일정 데이터에서 인구통계 정보를 지원합니다.
  * 리포트 상단에 비활성화된 ‘PDF 내보내기’ 버튼을 제공합니다.

* **변경 사항**
  * 고객 목록에서 알림 배지와 최근 메시지 미리보기를 제거했습니다.
  * 읽지 않은 메시지 배지는 메시지 메뉴와 대화 목록에서 유지됩니다.
  * 고객을 찾을 수 없는 일정에는 기존 저장된 이름을 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->