### PR TITLE
fix(trainer): 예상 밖 음식 형태에도 고객 식단 조회 유지

### DIFF
--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -247,6 +247,38 @@ def build_roster(db: Session, trainer_id: str) -> list[TrainerClientOut]:
     return out
 
 
+def _food_names(foods_json: str | None) -> list[str]:
+    """저장된 `foods_json` → 표시용 음식 이름 목록.
+
+    항목이 딕셔너리라는 보장이 없다. 실제로 `["김치찌개", 42, null]` 처럼 문자열·숫자가
+    섞여 저장된 기록이 있고, 예전에는 `f.get("name")` 이 그 자리에서 AttributeError 를
+    내 **그 날짜 식단 조회 전체가 500** 이 됐다(#724). 회원 앱 경로
+    (`diet_service.load_foods`)는 같은 값을 받아도 죽지 않아, 한 기록인데 트레이너 쪽만
+    터졌다.
+
+    문자열은 이름으로 살린다 — 버리면 트레이너 화면에서 끼니 내용이 통째로 빈다.
+    이름을 만들 수 없는 나머지(숫자·null 등)는 건너뛴다.
+    """
+    try:
+        foods = json.loads(foods_json) if foods_json else []
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(foods, list):
+        return []
+
+    names: list[str] = []
+    for food in foods:
+        if isinstance(food, dict):
+            name = food.get("name")
+        elif isinstance(food, str):
+            name = food
+        else:
+            continue
+        if isinstance(name, str) and name.strip():
+            names.append(name.strip())
+    return names
+
+
 def build_client_diet(db: Session, member_id: str, day: str) -> list[ClientDietEntryOut]:
     """회원의 특정 날짜 식단(회원 실데이터)을 고객 식단 서브탭 형태로."""
     rows = db.scalars(
@@ -260,11 +292,7 @@ def build_client_diet(db: Session, member_id: str, day: str) -> list[ClientDietE
 
     out: list[ClientDietEntryOut] = []
     for r in rows:
-        try:
-            foods = json.loads(r.foods_json) if r.foods_json else []
-        except json.JSONDecodeError:
-            foods = []
-        items = ", ".join(f.get("name", "") for f in foods if f.get("name"))
+        items = ", ".join(_food_names(r.foods_json))
         photo_id = photo_ids.get(r.id)
         out.append(ClientDietEntryOut(
             meal=_meal_kr(r.meal_type),

--- a/backend/tests/test_trainer.py
+++ b/backend/tests/test_trainer.py
@@ -339,6 +339,46 @@ def test_trainer_client_diet_maps_member_meals(client):
     assert meals[0]["fat_g"] == 6
 
 
+def test_trainer_client_diet_survives_unexpected_food_shapes(client, db_session):
+    """음식 항목이 딕셔너리가 아니어도 그 날짜 식단이 죽지 않는다. (#724)
+
+    `["김치찌개", 42, null]` 처럼 저장된 기록이 실제로 있었고, 예전에는 이 한 건
+    때문에 담당 회원의 그 날짜 식단 조회 전체가 500 이 됐다. 문자열은 이름으로
+    살리고 나머지는 건너뛴다 — 칼로리·영양소는 그대로 보여 준다.
+    """
+    import json as _json
+
+    from app.models.models import DietEntry
+
+    day = "2099-02-02"
+    db_session.add(DietEntry(
+        id="diet-shape-test",
+        user_id="user-jisu",
+        date=day,
+        meal_type="lunch",
+        foods_json=_json.dumps(["김치찌개", 42, None], ensure_ascii=False),
+        total_calories=520,
+        carbs_g=60, protein_g=20, fat_g=15, sodium_mg=1200,
+    ))
+    db_session.commit()
+    try:
+        token = _trainer_token(client)
+        r = client.get(
+            f"/v1/trainer/clients/user-jisu/diet?date={day}",
+            headers=_auth(token),
+        )
+
+        assert r.status_code == 200, r.text
+        meal = r.json()[0]
+        assert meal["items"] == "김치찌개"
+        assert meal["calories"] == 520
+    finally:
+        db_session.query(DietEntry).filter(
+            DietEntry.id == "diet-shape-test"
+        ).delete()
+        db_session.commit()
+
+
 def test_trainer_client_macros_are_member_scoped_and_empty_day_is_empty(client):
     token = _trainer_token(client)
 


### PR DESCRIPTION
Closes #724

## Summary

트레이너가 담당 회원의 식단 탭을 열면 500 이 났습니다.

```
AttributeError: 'str' object has no attribute 'get'
  app/services/trainer_service.py:267, in build_client_diet
```

`build_client_diet` 이 `foods_json` 의 각 항목을 딕셔너리로 보고 `f.get("name")` 으로 읽는데, 저장된 값에 문자열이 섞여 있으면 그 자리에서 터지고 **그 날짜 식단 조회 전체**가 죽었습니다. 데모 DB 의 김민수 기록 2건이 `["김치찌개", 42, null]` 형태라, 시연 중 트레이너 웹에서 김민수 식단을 열면 화면이 그대로 깨집니다.

같은 값을 회원 앱 경로(`diet_service.load_foods`)는 `field in food` 로 읽어 죽지 않습니다 — 한 기록인데 트레이너 쪽만 터졌습니다.

## Changes

- 이름 추출을 `_food_names` 로 분리하고 항목 형태를 방어합니다. 딕셔너리면 `name`, 문자열이면 그 자체를 이름으로 쓰고, 이름을 만들 수 없는 값(숫자·null 등)은 건너뜁니다.
- 문자열을 살리는 이유: 버리면 트레이너 화면에서 끼니 내용이 통째로 빕니다. 칼로리·영양소·사진은 원래대로 나옵니다.

## Tests

`test_trainer_client_diet_survives_unexpected_food_shapes` — `["김치찌개", 42, null]` 을 저장하고 그 날짜를 조회해 200 과 `items == "김치찌개"`, 칼로리 유지를 확인합니다.

수정을 되돌리면 이 테스트가 실패하는 것까지 확인했습니다.

## Notes

데이터를 고쳐도 같은 입력이 다시 들어오면 재발하므로 읽는 쪽을 방어했습니다. 데모 DB 에 남아 있는 2건은 이 수정으로 그대로 표시되므로 손대지 않았습니다.