### PR TITLE
fix(trainer): 식단 그래프 색상 적용 범위 수정

### DIFF
--- a/frontend/flutter_trainer/lib/design_system/tokens/colors.dart
+++ b/frontend/flutter_trainer/lib/design_system/tokens/colors.dart
@@ -26,10 +26,9 @@ class AppColors {
   /// 진행 척도의 '부분', 지표 구분색 등. 주의는 [warning](빨강)이다.
   static const Color brandOrange = Color(0xFFFF953C);
 
-  /// Brand green shared with the user app (`FigmaColors.green`).
-  /// Diet charts use this token so both apps present nutrition progress with
-  /// the same visual language.
-  static const Color brandUserGreen = Color(0xFF34C9A0);
+  /// Tone-down green used by the user app's normal sugar chart
+  /// (`FigmaColors.greenText`).
+  static const Color userSugarGreen = Color(0xFF22A882);
 
   // --- Accent (client navy) ---
   /// Navy used for client avatars, info chips, and the "AI 요약" card.

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/nutrition_summary_card.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/nutrition_summary_card.dart
@@ -198,7 +198,7 @@ class _CalorieRow extends StatelessWidget {
     final AppLocalizations l = AppLocalizations.of(context);
     final Color color = calories.isOverGoal
         ? AppColors.overTarget
-        : AppColors.brandUserGreen;
+        : AppColors.primary;
     return Row(
       children: <Widget>[
         Expanded(
@@ -362,7 +362,7 @@ class _MacroItem extends StatelessWidget {
         const SizedBox(height: 7),
         _Bar(
           progress: item.ratio,
-          color: AppColors.brandUserGreen.withValues(alpha: 0.65),
+          color: AppColors.primary.withValues(alpha: 0.65),
         ),
       ],
     );
@@ -453,7 +453,7 @@ class _StatusCard extends StatelessWidget {
     // 나트륨·당류는 같은 성격의 지표다. "정상" 을 서로 다른 색으로 말하지 않는다.
     final Color status = item.isOverGoal
         ? AppColors.overTarget
-        : AppColors.brandUserGreen;
+        : AppColors.userSugarGreen;
     return Container(
       padding: const EdgeInsets.all(AppSpacing.md),
       decoration: BoxDecoration(

--- a/frontend/flutter_trainer/test/features/clients/client_detail_diet_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_diet_test.dart
@@ -191,7 +191,7 @@ void main() {
       final calorieProgress = tester.widget<CircularProgressIndicator>(
         find.byKey(const Key('client-nutrition-calorie-progress')),
       );
-      expect(calorieProgress.valueColor?.value, AppColors.brandUserGreen);
+      expect(calorieProgress.valueColor?.value, AppColors.primary);
       for (final String label in <String>['탄수화물', '단백질', '지방']) {
         expect(
           find.byKey(Key('client-nutrition-macro-$label')),
@@ -207,12 +207,10 @@ void main() {
                 ),
               )
               .any(
-                (box) =>
-                    box.color ==
-                    AppColors.brandUserGreen.withValues(alpha: 0.65),
+                (box) => box.color == AppColors.primary.withValues(alpha: 0.65),
               ),
           isTrue,
-          reason: '$label 그래프가 사용자 앱 공통 초록색을 써야 합니다.',
+          reason: '$label 그래프가 기존 트레이너 앱 색상을 써야 합니다.',
         );
       }
       Finder inMacro(String label, String text) => find.descendant(
@@ -281,6 +279,30 @@ void main() {
         scrollable: detailScrollable('seed-client-1'),
       );
       expect(find.textContaining('나트륨이 목표치를 1428mg 초과했어요'), findsOneWidget);
+    });
+
+    testWidgets('normal sodium and sugar use the user app sugar green', (
+      tester,
+    ) async {
+      await openDiet(tester, '이지수');
+
+      for (final Key key in <Key>[
+        const Key('client-nutrition-sodium-status'),
+        const Key('client-nutrition-sugar-status'),
+      ]) {
+        expect(
+          tester
+              .widgetList<ColoredBox>(
+                find.descendant(
+                  of: find.byKey(key),
+                  matching: find.byType(ColoredBox),
+                ),
+              )
+              .any((box) => box.color == AppColors.userSugarGreen),
+          isTrue,
+          reason: '$key 정상 그래프가 사용자 앱 당류 초록색을 써야 합니다.',
+        );
+      }
     });
 
     testWidgets('integer-valued sugar keeps the existing compact format', (


### PR DESCRIPTION
## Summary

* 칼로리 그래프의 기존 트레이너 앱 색상 복원
* 탄수화물·단백질·지방 그래프의 기존 트레이너 앱 색상 복원
* 정상 나트륨·당류 그래프의 사용자 앱 당류용 톤다운 초록색 적용

---

## Changes

### ✨ Features

* 해당 없음

### 🔧 Improvements

* 사용자 앱 당류 그래프 색상과 대응하는 전용 트레이너 앱 색상 토큰 추가
* 칼로리·탄단지·정상 상태 그래프별 색상 역할 분리

### 🎨 UI/UX

* 칼로리 원형 그래프의 기존 네이비 색상 복원
* 탄단지 진행 그래프의 기존 네이비 색상 복원
* 정상 나트륨·당류 그래프에 #22A882 톤다운 초록색 적용

### 📝 Docs

* 색상 토큰 주석에 사용자 앱 FigmaColors.greenText 출처 명시

### 🐛 Fixes

* 식단 그래프 브랜드 초록색의 과도한 적용 범위 수정
* 정상 상태 나트륨·당류 그래프 색상 검증 테스트 추가

---

## Commits

1. 07bd293b fix(trainer): 식단 그래프 색상 적용 범위 수정

---

## Notes

* 사용자 앱 frontend/flutter의 FigmaColors.greenText 값 #22A882 기준
* 초과 상태 그래프의 기존 빨간색 유지
* 이슈 등록 후 Related Issues 번호 연결 필요

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 고객 상세 화면의 식단 탭 진입
2. 칼로리 원형 그래프와 탄단지 진행 그래프의 기존 네이비 색상 확인
3. 목표 이하 나트륨·당류 그래프의 #22A882 초록색 확인
4. 목표 초과 상태 그래프의 빨간색 유지 확인

---

## Related Issues

Closes #738

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인