### PR TITLE
fix(trainer): 통합 검색의 현재 탭 고객 선택 및 검색 범위 명확화

### DIFF
--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
@@ -3515,7 +3515,7 @@ abstract class AppLocalizations {
   /// No description provided for @searchClientsHint.
   ///
   /// In en, this message translates to:
-  /// **'Search clients, goals, messages, or routines'**
+  /// **'Search clients, goals, recent messages, or routines'**
   String get searchClientsHint;
 
   /// No description provided for @searchClear.

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
@@ -3515,7 +3515,7 @@ abstract class AppLocalizations {
   /// No description provided for @searchClientsHint.
   ///
   /// In en, this message translates to:
-  /// **'Search clients, goals, recent messages, or routines'**
+  /// **'Search clients, goals, recent messages, or last routine sent date'**
   String get searchClientsHint;
 
   /// No description provided for @searchClear.

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
@@ -1948,7 +1948,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get searchClientsHint =>
-      'Search clients, goals, messages, or routines';
+      'Search clients, goals, recent messages, or routines';
 
   @override
   String get searchClear => 'Clear search';

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
@@ -1948,7 +1948,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get searchClientsHint =>
-      'Search clients, goals, recent messages, or routines';
+      'Search clients, goals, recent messages, or last routine sent date';
 
   @override
   String get searchClear => 'Clear search';

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
@@ -1887,7 +1887,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get searchClients => '고객 검색';
 
   @override
-  String get searchClientsHint => '고객, 목표, 최근 메시지, 루틴 통합 검색';
+  String get searchClientsHint => '고객, 목표, 최근 메시지, 마지막 루틴 전송 시점 통합 검색';
 
   @override
   String get searchClear => '검색어 지우기';

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
@@ -1887,7 +1887,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get searchClients => '고객 검색';
 
   @override
-  String get searchClientsHint => '고객, 목표, 메시지, 루틴 통합 검색';
+  String get searchClientsHint => '고객, 목표, 최근 메시지, 루틴 통합 검색';
 
   @override
   String get searchClear => '검색어 지우기';

--- a/frontend/flutter_trainer/lib/l10n/app_en.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_en.arb
@@ -1259,7 +1259,7 @@
   "@searchClients": {
     "description": "Label/tooltip of the console header's client search."
   },
-  "searchClientsHint": "Search clients, goals, recent messages, or routines",
+  "searchClientsHint": "Search clients, goals, recent messages, or last routine sent date",
   "searchClear": "Clear search",
   "searchQuickActions": "Open in another tab",
   "searchNoResults": "No client matches “{query}”",

--- a/frontend/flutter_trainer/lib/l10n/app_en.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_en.arb
@@ -1259,7 +1259,7 @@
   "@searchClients": {
     "description": "Label/tooltip of the console header's client search."
   },
-  "searchClientsHint": "Search clients, goals, messages, or routines",
+  "searchClientsHint": "Search clients, goals, recent messages, or routines",
   "searchClear": "Clear search",
   "searchQuickActions": "Open in another tab",
   "searchNoResults": "No client matches “{query}”",

--- a/frontend/flutter_trainer/lib/l10n/app_ko.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_ko.arb
@@ -589,7 +589,7 @@
   "routineFieldReason": "사유 (선택)",
   "routineDeleteBody": "{name} 배정이 회원 앱에서도 사라져요.",
   "searchClients": "고객 검색",
-  "searchClientsHint": "고객, 목표, 최근 메시지, 루틴 통합 검색",
+  "searchClientsHint": "고객, 목표, 최근 메시지, 마지막 루틴 전송 시점 통합 검색",
   "searchClear": "검색어 지우기",
   "searchQuickActions": "다른 탭에서 열기",
   "searchNoResults": "“{query}”와 일치하는 고객이 없어요",

--- a/frontend/flutter_trainer/lib/l10n/app_ko.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_ko.arb
@@ -589,7 +589,7 @@
   "routineFieldReason": "사유 (선택)",
   "routineDeleteBody": "{name} 배정이 회원 앱에서도 사라져요.",
   "searchClients": "고객 검색",
-  "searchClientsHint": "고객, 목표, 메시지, 루틴 통합 검색",
+  "searchClientsHint": "고객, 목표, 최근 메시지, 루틴 통합 검색",
   "searchClear": "검색어 지우기",
   "searchQuickActions": "다른 탭에서 열기",
   "searchNoResults": "“{query}”와 일치하는 고객이 없어요",


### PR DESCRIPTION
## Summary

* 통합 검색 결과 선택 시 현재 탭의 고객 화면 연결
* Enter, 결과 클릭, 모바일 검색 다이얼로그의 동일 이동 규칙 적용
* 고객 탭의 식단·운동 섹션 및 메시지 필터 유지
* 메시지 검색 범위를 `최근 메시지`로 명확화
* 탭별 이동 경로 및 검색 범위 회귀 테스트 보강

---

## Changes

### ✨ Features

* 메시지 탭의 고객 대화 선택 지원
* AI 코칭 탭의 고객 선택 지원
* 리포트 탭의 고객 리포트 선택 지원
* 일정 탭의 다음 예약 날짜 이동 지원

### 🔧 Improvements

* 현재 URL을 기준으로 통합 검색 기본 이동 경로 결정
* 고객 탭에서 기존 식단·운동 섹션 유지
* 메시지 탭에서 기존 대화 필터 유지
* 데스크톱 검색과 모바일 검색의 이동 규칙 통합
* 한·영 검색 placeholder의 최근 메시지 범위 명시

### 🎨 UI/UX

* 검색 전의 작업 탭을 벗어나지 않는 고객 선택 흐름
* `고객, 목표, 최근 메시지, 루틴 통합 검색` 안내 문구 적용
* 현재 탭에 따른 검색 결과 하단 이동 안내 적용

### 📝 Docs

* 해당 없음

### 🐛 Fixes

* 모든 검색 결과가 고객 상세 화면으로 이동하던 문제 수정
* 모바일 검색 결과 선택 시 고객 상세 화면으로 이동하던 문제 수정
* 전체 메시지 검색으로 오해할 수 있는 placeholder 문구 수정

---

## Commits

1. `aa11856b` fix(trainer): 통합 검색의 현재 탭 고객 선택 지원
2. `e2a95d46` fix(trainer): 통합 검색의 최근 메시지 범위 명시

---

## Notes

* 병합된 PR #712의 후속 수정
* 대시보드는 고객 단위 화면이 없어 고객 상세를 기본 경로로 사용
* 일정에 다음 예약이 없는 고객은 고객 상세를 대체 경로로 사용
* 빠른 이동 메뉴를 통한 다른 탭 이동 기능은 기존과 동일
* `루틴` 검색은 루틴명이 아닌 마지막 루틴 전송 시점 라벨을 대상으로 사용
  - 예: `오늘`, `어제`, `5일 전`, `3주 전`

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 빌드 영향 확인
* [x] 관련 테스트 통과

### Manual Test Steps

1. 메시지 탭에서 고객 검색 후 Enter 입력 및 해당 고객 대화 표시 확인
2. AI 코칭 탭에서 고객 검색 후 해당 고객 선택 확인
3. 리포트 탭에서 고객 검색 후 해당 고객 리포트 표시 확인
4. 고객 운동 화면에서 다른 고객 검색 후 운동 섹션 유지 확인
5. 좁은 화면의 검색 다이얼로그에서 동일 동작 확인
6. 한·영 검색 placeholder의 `최근 메시지` 문구 확인

### Automated Tests

* `flutter analyze --no-pub` 통과
* 현재 탭 이동 변경 기준 Flutter 전체 테스트 542건 통과
* 검색 및 영어 로케일 관련 테스트 21건 통과

---

## Related Issues

Closes #740

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인