### PR TITLE
fix(trainer): 통합 검색 안내의 가독성 개선

### DIFF
--- a/frontend/flutter_trainer/lib/features/search/presentation/widgets/client_search_bar.dart
+++ b/frontend/flutter_trainer/lib/features/search/presentation/widgets/client_search_bar.dart
@@ -23,16 +23,16 @@ import 'package:oncare_trainer/shared/widgets/client_avatar.dart';
 import 'package:oncare_trainer/shared/widgets/client_identity.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 
-/// Widest the inline field grows. Past this it stops looking like a
-/// header control and starts competing with the page title.
-const double _fieldMaxWidth = 360;
+/// Width cap that keeps the full search scope readable without letting the
+/// field compete with the page title.
+const double _fieldMaxWidth = 520;
 
 /// Narrowest space the inline field is worth rendering in.
 ///
 /// Measured against what the header's title and actions leave over, not
 /// against the viewport: a page with four actions runs out of room long
 /// before a page with one does.
-const double _minInlineWidth = 240;
+const double _minInlineWidth = 400;
 
 /// Height cap of the results card (≈ five rows plus the footer).
 const double _dropdownMaxHeight = 360;
@@ -304,7 +304,7 @@ class _ClientSearchBarState extends ConsumerState<ClientSearchBar> {
           fillColor: AppColors.inputBackground,
           hintText: l.searchClientsHint,
           hintStyle: const TextStyle(
-            fontSize: 16,
+            fontSize: 13,
             color: AppColors.subtleForeground,
           ),
           prefixIcon: const Icon(
@@ -793,7 +793,7 @@ class _ClientSearchDialogState extends ConsumerState<_ClientSearchDialog> {
                     fillColor: AppColors.card,
                     hintText: l.searchClientsHint,
                     hintStyle: const TextStyle(
-                      fontSize: 16,
+                      fontSize: 13,
                       color: AppColors.subtleForeground,
                     ),
                     prefixIcon: const Icon(

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
@@ -3707,7 +3707,7 @@ abstract class AppLocalizations {
   /// No description provided for @searchClientsHint.
   ///
   /// In en, this message translates to:
-  /// **'Search clients, goals, recent messages, or last routine sent date'**
+  /// **'Clients, goals, recent messages, last routine sent date'**
   String get searchClientsHint;
 
   /// No description provided for @searchClear.

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
@@ -2075,7 +2075,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get searchClientsHint =>
-      'Search clients, goals, recent messages, or last routine sent date';
+      'Clients, goals, recent messages, last routine sent date';
 
   @override
   String get searchClear => 'Clear search';

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
@@ -2003,7 +2003,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get searchClients => '고객 검색';
 
   @override
-  String get searchClientsHint => '고객, 목표, 최근 메시지, 마지막 루틴 전송 시점 통합 검색';
+  String get searchClientsHint => '고객·목표·최근 메시지·마지막 루틴 전송일 검색';
 
   @override
   String get searchClear => '검색어 지우기';

--- a/frontend/flutter_trainer/lib/l10n/app_en.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_en.arb
@@ -1295,7 +1295,7 @@
   "@searchClients": {
     "description": "Label/tooltip of the console header's client search."
   },
-  "searchClientsHint": "Search clients, goals, recent messages, or last routine sent date",
+  "searchClientsHint": "Clients, goals, recent messages, last routine sent date",
   "searchClear": "Clear search",
   "searchQuickActions": "Open in another tab",
   "searchNoResults": "No client matches “{query}”",

--- a/frontend/flutter_trainer/lib/l10n/app_ko.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_ko.arb
@@ -621,7 +621,7 @@
   "routineFieldReason": "사유 (선택)",
   "routineDeleteBody": "{name} 배정이 고객 앱에서도 사라져요.",
   "searchClients": "고객 검색",
-  "searchClientsHint": "고객, 목표, 최근 메시지, 마지막 루틴 전송 시점 통합 검색",
+  "searchClientsHint": "고객·목표·최근 메시지·마지막 루틴 전송일 검색",
   "searchClear": "검색어 지우기",
   "searchQuickActions": "다른 탭에서 열기",
   "searchNoResults": "“{query}”와 일치하는 고객이 없어요",

--- a/frontend/flutter_trainer/test/features/search/client_search_bar_test.dart
+++ b/frontend/flutter_trainer/test/features/search/client_search_bar_test.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import 'package:oncare_trainer/app/router/routes.dart';
 import 'package:oncare_trainer/features/search/presentation/widgets/client_search_bar.dart';
+import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 
 import '../../helpers/pump_app.dart';
 
@@ -44,6 +45,41 @@ void main() {
       GoRouter.of(tester.element(find.byKey(clientSearchFieldKey))).go(route);
       await settle(tester);
       expect(find.byKey(clientSearchFieldKey), findsOneWidget, reason: route);
+    }
+  });
+
+  testWidgets('긴 검색 범위 안내를 생략하지 않는 너비와 글자 크기를 사용한다', (tester) async {
+    await openDesktop(tester, AppRoutes.dashboard);
+
+    for (final route in <String>[
+      AppRoutes.dashboard,
+      AppRoutes.clients,
+      AppRoutes.schedule,
+      AppRoutes.messages,
+      AppRoutes.coaching,
+      AppRoutes.reports,
+    ]) {
+      GoRouter.of(tester.element(find.byKey(clientSearchFieldKey))).go(route);
+      await settle(tester);
+
+      final field = find.byKey(clientSearchFieldKey);
+      final context = tester.element(field);
+      final input = tester.widget<TextField>(field);
+      final hintStyle = input.decoration?.hintStyle;
+      final hint = AppLocalizations.of(context).searchClientsHint;
+      final painter = TextPainter(
+        text: TextSpan(text: hint, style: hintStyle),
+        textDirection: Directionality.of(context),
+        maxLines: 1,
+      )..layout();
+      final availableWidth = tester.getSize(field).width - 40 - 16;
+
+      expect(hintStyle?.fontSize, 13, reason: route);
+      expect(
+        availableWidth,
+        greaterThan(painter.width),
+        reason: '$route: available=$availableWidth, hint=${painter.width}',
+      );
     }
   });
 


### PR DESCRIPTION
## Summary

- 통합 검색 바 최대 너비 확대
- placeholder 글자 크기 조정
- 검색 범위 안내 문구 압축
- 모든 주요 탭의 검색 안내 잘림 회귀 테스트 추가

---

## Changes

### ✨ Features

- 해당 없음

### 🔧 Improvements

- 검색 바 최대 너비를 `360px`에서 `520px`로 확대
- 검색 바 인라인 표시 최소 너비를 `240px`에서 `400px`로 조정
- placeholder 글자 크기를 `16px`에서 `13px`로 조정
- 데스크톱 검색 바와 모바일 검색 다이얼로그에 동일한 placeholder 글자 크기 적용
- 한·영 검색 안내 문구 압축

### 🎨 UI/UX

- 한국어 placeholder 변경

```text
고객·목표·최근 메시지·마지막 루틴 전송일 검색
```

- 영어 placeholder 변경

```text
Clients, goals, recent messages, last routine sent date
```

- 리포트 탭을 포함한 모든 주요 화면에서 검색 안내가 전체 표시되도록 개선
- 좁은 화면에서는 기존 검색 아이콘 전환 동작 유지

### 📝 Docs

- 해당 없음

### 🐛 Fixes

- 긴 통합 검색 안내가 말줄임표(`...`)로 잘리는 문제 수정
- `루틴`이 루틴명 검색으로 해석될 수 있는 모호한 안내 문구 수정

---

## Commits

1. `de9528bb` — `fix(trainer): 통합 검색 안내의 가독성 개선`

---

## Notes

- 병합된 PR #741의 후속 수정입니다.
- `마지막 루틴 전송일`은 루틴명이 아닌 **마지막 전송 시점 라벨 검색**을 의미합니다.
  - 예: `오늘`, `어제`, `5일 전`, `3주 전`
- 검색어 입력 글자 크기는 기존 `16px`을 유지합니다.
- placeholder 안내 글자만 `13px`로 조정했습니다.
- 헤더 공간이 부족한 화면의 검색 아이콘 전환 동작은 기존과 동일합니다.

---

## Test Plan

- [x] 기능 정상 동작 확인
- [x] 예외 케이스 확인
- [x] UI 확인
- [x] 빌드 영향 확인
- [x] 관련 테스트 통과

### Manual Test Steps

1. 대시보드에서 검색 안내 전체 표시 확인
2. 고객 탭에서 검색 안내 전체 표시 확인
3. 일정 탭에서 검색 안내 전체 표시 확인
4. 메시지 탭에서 검색 안내 전체 표시 확인
5. AI 코칭 탭에서 검색 안내 전체 표시 확인
6. 리포트 탭에서 검색 안내 전체 표시 확인
7. 좁은 화면에서 검색 아이콘 전환 확인
8. 검색어 입력 시 기존 `16px` 입력 글자 크기 유지 확인

### Automated Tests

- [x] `flutter analyze --no-pub` 통과
- [x] Trainer 전체 테스트 **609건 통과**
- [x] 주요 탭별 placeholder 실측 너비 회귀 테스트 통과

---

## Related Issues

Closes #744

## Checklist

- [x] 코드 리뷰 준비 완료
- [x] 불필요한 코드 제거
- [x] 하드코딩 값 점검
- [x] Merge 충돌 없음
- [x] 데모 시나리오 영향 확인