### PR TITLE
feat(trainer): 대시보드 4-3-1 업무 카드 재구성

### DIFF
--- a/frontend/flutter_trainer/lib/features/dashboard/presentation/pages/dashboard_page.dart
+++ b/frontend/flutter_trainer/lib/features/dashboard/presentation/pages/dashboard_page.dart
@@ -156,15 +156,11 @@ class _TodayTasksCard extends StatelessWidget {
               children: <Widget>[
                 for (final task in tasks)
                   _TaskRow(
-                    key: ValueKey<String>(
-                      'dashboard-task-${task.alert.name}',
-                    ),
+                    key: ValueKey<String>('dashboard-task-${task.alert.name}'),
                     task: task,
                     onTap: () {
                       if (task.alert == ClientAlert.unanswered) {
-                        context.go(
-                          AppRoutes.messagesFor(task.entry.client.id),
-                        );
+                        context.go(AppRoutes.messagesFor(task.entry.client.id));
                         return;
                       }
                       context.go(
@@ -189,12 +185,21 @@ List<_DashboardTask> _buildTodayTasks(List<AttentionClient> entries) {
     ClientAlert.lowCompletion,
     ClientAlert.sodiumOver,
   ];
-  return <_DashboardTask>[
-    for (final alert in order)
-      if (entries.where((entry) => entry.alerts.contains(alert)).firstOrNull
-          case final entry?)
-        _DashboardTask(entry: entry, alert: alert),
-  ];
+  final usedClientIds = <String>{};
+  final tasks = <_DashboardTask>[];
+  for (final alert in order) {
+    final matching = entries
+        .where((entry) => entry.alerts.contains(alert))
+        .toList(growable: false);
+    final entry = matching
+        .where((candidate) => !usedClientIds.contains(candidate.client.id))
+        .firstOrNull;
+    final selected = entry ?? matching.firstOrNull;
+    if (selected == null) continue;
+    tasks.add(_DashboardTask(entry: selected, alert: alert));
+    usedClientIds.add(selected.client.id);
+  }
+  return tasks;
 }
 
 class _DashboardTask {

--- a/frontend/flutter_trainer/lib/features/dashboard/presentation/pages/dashboard_page.dart
+++ b/frontend/flutter_trainer/lib/features/dashboard/presentation/pages/dashboard_page.dart
@@ -84,18 +84,23 @@ class DashboardPage extends ConsumerWidget {
                 const SizedBox(height: AppSpacing.lg),
                 if (wide) ...<Widget>[
                   Row(
+                    key: const ValueKey<String>('dashboard-action-row'),
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
-                      const Expanded(flex: 15, child: TodayTimelineCard()),
+                      const Expanded(child: TodayTimelineCard()),
                       const SizedBox(width: AppSpacing.lg),
                       Expanded(
-                        flex: 10,
+                        child: AttentionCard(
+                          entries: summary.attention,
+                          maxRows: 5,
+                        ),
+                      ),
+                      const SizedBox(width: AppSpacing.lg),
+                      Expanded(
                         child: _TodayTasksCard(entries: summary.attention),
                       ),
                     ],
                   ),
-                  const SizedBox(height: AppSpacing.lg),
-                  AttentionCard(entries: summary.attention, maxRows: 5),
                   const SizedBox(height: AppSpacing.lg),
                   AiSummaryCard(
                     summary: coachingSummary,
@@ -105,9 +110,9 @@ class DashboardPage extends ConsumerWidget {
                 ] else ...<Widget>[
                   const TodayTimelineCard(),
                   const SizedBox(height: AppSpacing.lg),
-                  _TodayTasksCard(entries: summary.attention),
-                  const SizedBox(height: AppSpacing.lg),
                   AttentionCard(entries: summary.attention),
+                  const SizedBox(height: AppSpacing.lg),
+                  _TodayTasksCard(entries: summary.attention),
                   const SizedBox(height: AppSpacing.lg),
                   AiSummaryCard(
                     summary: coachingSummary,
@@ -132,7 +137,7 @@ class _TodayTasksCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
-    final tasks = entries.take(4).toList();
+    final tasks = _buildTodayTasks(entries);
     return SectionCard(
       title: l.dashTodayTasks,
       trailing: Text(
@@ -149,18 +154,23 @@ class _TodayTasksCard extends StatelessWidget {
           ? EmptyHint(message: l.dashTasksEmpty, icon: Icons.task_alt)
           : Column(
               children: <Widget>[
-                for (final entry in tasks)
+                for (final task in tasks)
                   _TaskRow(
-                    entry: entry,
+                    key: ValueKey<String>(
+                      'dashboard-task-${task.alert.name}',
+                    ),
+                    task: task,
                     onTap: () {
-                      if (entry.primary == ClientAlert.unanswered) {
-                        context.go(AppRoutes.messagesFor(entry.client.id));
+                      if (task.alert == ClientAlert.unanswered) {
+                        context.go(
+                          AppRoutes.messagesFor(task.entry.client.id),
+                        );
                         return;
                       }
                       context.go(
                         AppRoutes.clientDetail(
-                          entry.client.id,
-                          section: AttentionCard.sectionFor(entry.primary),
+                          task.entry.client.id,
+                          section: AttentionCard.sectionFor(task.alert),
                         ),
                       );
                     },
@@ -171,16 +181,40 @@ class _TodayTasksCard extends StatelessWidget {
   }
 }
 
-class _TaskRow extends StatelessWidget {
-  const _TaskRow({required this.entry, required this.onTap});
+/// Selects at most one task per action type so a sodium-heavy roster does not
+/// turn the whole checklist into duplicate diet reviews.
+List<_DashboardTask> _buildTodayTasks(List<AttentionClient> entries) {
+  const order = <ClientAlert>[
+    ClientAlert.unanswered,
+    ClientAlert.lowCompletion,
+    ClientAlert.sodiumOver,
+  ];
+  return <_DashboardTask>[
+    for (final alert in order)
+      if (entries.where((entry) => entry.alerts.contains(alert)).firstOrNull
+          case final entry?)
+        _DashboardTask(entry: entry, alert: alert),
+  ];
+}
+
+class _DashboardTask {
+  const _DashboardTask({required this.entry, required this.alert});
 
   final AttentionClient entry;
+  final ClientAlert alert;
+}
+
+class _TaskRow extends StatelessWidget {
+  const _TaskRow({super.key, required this.task, required this.onTap});
+
+  final _DashboardTask task;
   final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
-    final alert = entry.primary;
+    final alert = task.alert;
+    final entry = task.entry;
     final tone = switch (alert) {
       ClientAlert.unanswered => AppColors.primary,
       ClientAlert.sodiumOver => AppColors.overTarget,

--- a/frontend/flutter_trainer/test/features/dashboard/dashboard_page_test.dart
+++ b/frontend/flutter_trainer/test/features/dashboard/dashboard_page_test.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 
 import 'package:oncare_trainer/app/router/routes.dart';
 import 'package:oncare_trainer/features/dashboard/presentation/widgets/attention_card.dart';
+import 'package:oncare_trainer/shared/services/chat_repository.dart';
 import 'package:oncare_trainer/shared/widgets/stat_card.dart';
 import 'package:oncare_trainer/shared/models/client_alerts.dart';
 import 'package:oncare_trainer/shared/models/trainer_client.dart';
@@ -22,7 +23,10 @@ import '../../helpers/pump_app.dart';
 /// replies (4 in total), and today has 4 booked sessions (6 slots − 2
 /// gaps).
 void main() {
-  Future<void> openDashboard(WidgetTester tester) async {
+  Future<void> openDashboard(
+    WidgetTester tester, {
+    List<Override> extraOverrides = const <Override>[],
+  }) async {
     tester.view.devicePixelRatio = 1.0;
     tester.view.physicalSize = const Size(1600, 1200);
     addTearDown(tester.view.resetPhysicalSize);
@@ -31,6 +35,7 @@ void main() {
       tester,
       token: 'demo-trainer-token',
       at: AppRoutes.dashboard,
+      extraOverrides: extraOverrides,
     );
   }
 
@@ -221,6 +226,86 @@ void main() {
       findsOneWidget,
     );
   });
+
+  testWidgets('today tasks prefer different clients for each action type', (
+    tester,
+  ) async {
+    final allAlerts = makeClient(
+      id: 'all-alerts',
+      name: '중복 고객',
+      sodiumMg: 2500,
+      weekCompletion: const <int>[40, 40, 0, 0, 0, 0, 0],
+    );
+    final replyOnly = makeClient(id: 'reply-only', name: '답장 고객');
+    final workoutOnly = makeClient(
+      id: 'workout-only',
+      name: '운동 고객',
+      weekCompletion: const <int>[40, 40, 0, 0, 0, 0, 0],
+    );
+    final dietOnly = makeClient(id: 'diet-only', name: '식단 고객', sodiumMg: 2500);
+    await openDashboard(
+      tester,
+      extraOverrides: <Override>[
+        clientsProvider.overrideWith(
+          (ref) => Stream<List<TrainerClient>>.value(<TrainerClient>[
+            allAlerts,
+            replyOnly,
+            workoutOnly,
+            dietOnly,
+          ]),
+        ),
+        unreadCountsProvider.overrideWith(
+          (ref) => Stream<Map<String, int>>.value(const <String, int>{
+            'all-alerts': 1,
+            'reply-only': 1,
+          }),
+        ),
+      ],
+    );
+
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey<String>('dashboard-task-unanswered')),
+        matching: find.textContaining('중복 고객'),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey<String>('dashboard-task-lowCompletion')),
+        matching: find.textContaining('운동 고객'),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey<String>('dashboard-task-sodiumOver')),
+        matching: find.textContaining('식단 고객'),
+      ),
+      findsOneWidget,
+    );
+  });
+
+  for (final scenario in <({String task, String route})>[
+    (task: 'unanswered', route: '/messages?client='),
+    (task: 'lowCompletion', route: '/workout'),
+    (task: 'sodiumOver', route: '/diet'),
+  ]) {
+    testWidgets('today ${scenario.task} task opens its action destination', (
+      tester,
+    ) async {
+      await openDashboard(tester);
+
+      final task = find.byKey(
+        ValueKey<String>('dashboard-task-${scenario.task}'),
+      );
+      await tester.ensureVisible(task);
+      await tester.tap(task);
+      await settle(tester);
+
+      expect(currentLocation(tester), contains(scenario.route));
+    });
+  }
 
   group('AttentionCard.sectionFor', () {
     test('each alert opens the sub-tab that actually addresses it', () {

--- a/frontend/flutter_trainer/test/features/dashboard/dashboard_page_test.dart
+++ b/frontend/flutter_trainer/test/features/dashboard/dashboard_page_test.dart
@@ -192,6 +192,36 @@ void main() {
     expect(find.textContaining('/ 5 완료'), findsNothing);
   });
 
+  testWidgets('wide dashboard follows the 4-3-1 card layout', (tester) async {
+    await openDashboard(tester);
+
+    expect(find.byType(StatCard), findsNWidgets(4));
+    final actionRow = tester.widget<Row>(
+      find.byKey(const ValueKey<String>('dashboard-action-row')),
+    );
+    expect(actionRow.children.whereType<Expanded>(), hasLength(3));
+    expect(find.text('AI 코칭 요약'), findsOneWidget);
+  });
+
+  testWidgets('today tasks show one item from each available action type', (
+    tester,
+  ) async {
+    await openDashboard(tester);
+
+    expect(
+      find.byKey(const ValueKey<String>('dashboard-task-unanswered')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey<String>('dashboard-task-lowCompletion')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey<String>('dashboard-task-sodiumOver')),
+      findsOneWidget,
+    );
+  });
+
   group('AttentionCard.sectionFor', () {
     test('each alert opens the sub-tab that actually addresses it', () {
       // The row is a shortcut to the fix, not just to the client.


### PR DESCRIPTION
## Summary

* 트레이너 대시보드의 넓은 화면을 `4-3-1` 카드 구조로 재구성
* 오늘 할 일의 나트륨 항목 반복 노출 방지
* 답장·운동·식단 유형별 업무 선별 및 이동 경로 연결
* 대시보드 레이아웃과 업무 다양성 회귀 테스트 추가

---

## Changes

### 🚀 Features

* 답장, 운동 이행률, 식단 확인 업무의 유형별 최대 1건 선별
* 업무 유형에 따른 메시지·운동·식단 상세 화면 연결

### 🛠 Improvements

* 나트륨 초과 고객이 많은 경우에도 동일 업무가 반복되지 않는 선별 방식 적용
* 좁은 화면의 카드 순서를 일정 → 확인 필요 고객 → 오늘 할 일 → AI 코칭 요약으로 정돈

### 🎨 UI/UX

* 넓은 화면의 대시보드 카드 구성 변경
  * 1행: KPI 카드 4개
  * 2행: 오늘의 일정, 확인 필요 고객, 오늘 할 일 카드 3개
  * 3행: AI 코칭 요약 카드 1개
* 주요 업무 카드 3개의 동일 행 배치

### 📚 Docs

* 별도 문서 변경 없음

### 🐛 Fixes

* 오늘 할 일에 나트륨 관련 업무가 연속 노출되는 문제 수정
* 확인 필요 고객 카드가 주요 업무 행과 분리되어 있던 레이아웃 문제 수정

---

## Commits

1. `cdaeaa8c` 대시보드 업무 카드 재구성

---

## Notes

* 최신 `main` 기준 독립 브랜치 구성
* 기존 작업공간의 다른 미커밋 변경 제외
* 새로운 사용자 노출 문구 및 현지화 키 추가 없음

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 정적 분석 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 트레이너 앱에서 대시보드 진입
2. 넓은 화면에서 KPI 4개, 업무 카드 3개, AI 요약 1개 구성 확인
3. 오늘 할 일에 답장·운동·식단 유형이 각각 최대 1건 노출되는지 확인
4. 각 업무 선택 시 메시지·운동·식단 화면으로 이동하는지 확인
5. 좁은 화면에서 카드가 세로 순서로 정상 배치되는지 확인

---

## Related Issues

Closes #748

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 관련 시나리오 영향 확인