### PR TITLE
fix(trainer): 프로그램 탭 반응형 및 식단 UI 통일

### DIFF
--- a/frontend/flutter_trainer/lib/features/coaching/presentation/pages/coaching_page.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/pages/coaching_page.dart
@@ -8,7 +8,6 @@ import 'package:oncare_trainer/core/utils/date_format.dart';
 import 'package:oncare_trainer/core/utils/request_id.dart';
 import 'package:oncare_trainer/core/utils/server_message.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
-import 'package:oncare_trainer/design_system/tokens/elevation.dart';
 import 'package:oncare_trainer/design_system/tokens/layout.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
@@ -25,6 +24,7 @@ import 'package:oncare_trainer/features/coaching/domain/program_template.dart';
 import 'package:oncare_trainer/features/coaching/domain/program_editor_state.dart';
 import 'package:oncare_trainer/features/coaching/presentation/pages/ai_routine_options_flow.dart';
 import 'package:oncare_trainer/features/coaching/presentation/widgets/program_editor_workspace.dart';
+import 'package:oncare_trainer/features/clients/presentation/widgets/nutrition_summary_card.dart';
 import 'package:oncare_trainer/features/schedule/data/repositories/schedule_repository.dart';
 import 'package:oncare_trainer/features/schedule/domain/entities/schedule_session.dart';
 import 'package:oncare_trainer/features/schedule/domain/entities/schedule_status.dart';
@@ -35,7 +35,6 @@ import 'package:oncare_trainer/shared/models/trainer_client.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
 import 'package:oncare_trainer/shared/widgets/client_avatar.dart';
 import 'package:oncare_trainer/shared/widgets/client_identity.dart';
-import 'package:oncare_trainer/shared/widgets/metric_tile.dart';
 import 'package:oncare_trainer/shared/widgets/page_scaffold.dart';
 import 'package:oncare_trainer/shared/widgets/section_card.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
@@ -509,7 +508,7 @@ class _CoachingPageState extends ConsumerState<CoachingPage> {
                           children: <Widget>[
                             _ProgramMemberSummary(client: selected),
                             const SizedBox(height: AppSpacing.lg),
-                            _DietSummaryCard(client: selected),
+                            NutritionSummaryCard(client: selected),
                             const SizedBox(height: AppSpacing.lg),
                             _AiAssistantPrompt(
                               clientName: selected.name,
@@ -561,9 +560,7 @@ class _CoachingPageState extends ConsumerState<CoachingPage> {
         ),
       ),
       const SizedBox(height: AppSpacing.lg),
-      _sectionLabel(l.coachTodayDiet),
-      const SizedBox(height: AppSpacing.sm),
-      _DietSummaryCard(client: client),
+      NutritionSummaryCard(client: client),
     ];
   }
 
@@ -1100,6 +1097,7 @@ class _ClientChip extends StatelessWidget {
               const SizedBox(height: AppSpacing.xs),
               ClientIdentity(
                 client: client,
+                stacked: true,
                 nameStyle: TextStyle(
                   fontSize: 12,
                   fontWeight: FontWeight.w700,
@@ -1119,77 +1117,6 @@ class _ClientChip extends StatelessWidget {
             ],
           ),
         ),
-      ),
-    );
-  }
-}
-
-/// Diet summary — the shared metric tiles + the AI's verdict line.
-class _DietSummaryCard extends StatelessWidget {
-  const _DietSummaryCard({required this.client});
-
-  final TrainerClient client;
-
-  @override
-  Widget build(BuildContext context) {
-    final AppLocalizations l = AppLocalizations.of(context);
-    final over = client.sodiumOverBudget;
-    return Container(
-      padding: const EdgeInsets.all(AppSpacing.lg),
-      decoration: BoxDecoration(
-        color: AppColors.card,
-        borderRadius: const BorderRadius.all(AppRadius.card),
-        boxShadow: kCardShadow,
-        border: Border.all(color: AppColors.border),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: <Widget>[
-          Row(
-            children: <Widget>[
-              MetricTile(
-                label: l.metricCalories,
-                value: client.calories,
-                unit: 'kcal',
-                color: AppColors.accentDark,
-              ),
-              const SizedBox(width: AppSpacing.sm),
-              MetricTile(
-                label: l.metricSodium,
-                value: client.sodiumMg,
-                unit: 'mg',
-                color: AppColors.accentDark,
-                warn: over,
-              ),
-              const SizedBox(width: AppSpacing.sm),
-              MetricTile(
-                label: l.metricSugar,
-                value: client.sugarG,
-                unit: 'g',
-                color: AppColors.accentDark,
-                warn: client.sugarOverBudget,
-              ),
-            ],
-          ),
-          const SizedBox(height: AppSpacing.sm),
-          Container(
-            padding: const EdgeInsets.symmetric(
-              horizontal: AppSpacing.md,
-              vertical: AppSpacing.sm,
-            ),
-            decoration: const BoxDecoration(
-              color: AppColors.accentSurface,
-              borderRadius: BorderRadius.all(AppRadius.md),
-            ),
-            child: IconLabel(
-              icon: Icons.auto_awesome,
-              label: over ? l.coachVerdictSodium : l.coachVerdictBalanced,
-              color: AppColors.accent,
-              fontSize: 12,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-        ],
       ),
     );
   }

--- a/frontend/flutter_trainer/lib/shared/widgets/client_identity.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/client_identity.dart
@@ -43,6 +43,7 @@ class ClientIdentity extends StatelessWidget {
     this.nameStyle,
     this.demographicsStyle,
     this.maxLines = 1,
+    this.stacked = false,
     this.textAlign,
   });
 
@@ -50,6 +51,7 @@ class ClientIdentity extends StatelessWidget {
   final TextStyle? nameStyle;
   final TextStyle? demographicsStyle;
   final int maxLines;
+  final bool stacked;
   final TextAlign? textAlign;
 
   @override
@@ -68,29 +70,40 @@ class ClientIdentity extends StatelessWidget {
           fontSize: (resolvedNameStyle.fontSize ?? 14) - 3,
           fontWeight: FontWeight.w600,
         );
+    final name = Text(
+      client.name,
+      maxLines: maxLines,
+      overflow: TextOverflow.ellipsis,
+      textAlign: textAlign,
+      style: resolvedNameStyle,
+    );
+    final demographics = Text(
+      clientDemographicsLabel(context, client),
+      maxLines: maxLines,
+      overflow: TextOverflow.ellipsis,
+      textAlign: textAlign,
+      style: resolvedDemographicsStyle,
+    );
+
+    if (stacked) {
+      return Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: textAlign == TextAlign.center
+            ? CrossAxisAlignment.center
+            : CrossAxisAlignment.start,
+        children: <Widget>[name, const SizedBox(height: 2), demographics],
+      );
+    }
+
     return Row(
       mainAxisSize: MainAxisSize.min,
       mainAxisAlignment: textAlign == TextAlign.center
           ? MainAxisAlignment.center
           : MainAxisAlignment.start,
       children: <Widget>[
-        Flexible(
-          child: Text(
-            client.name,
-            maxLines: maxLines,
-            overflow: TextOverflow.ellipsis,
-            style: resolvedNameStyle,
-          ),
-        ),
+        Flexible(child: name),
         const SizedBox(width: AppSpacing.xs),
-        Flexible(
-          child: Text(
-            clientDemographicsLabel(context, client),
-            maxLines: maxLines,
-            overflow: TextOverflow.ellipsis,
-            style: resolvedDemographicsStyle,
-          ),
-        ),
+        Flexible(child: demographics),
       ],
     );
   }

--- a/frontend/flutter_trainer/test/features/coaching/coaching_page_test.dart
+++ b/frontend/flutter_trainer/test/features/coaching/coaching_page_test.dart
@@ -1140,6 +1140,10 @@ void main() {
       bool includeInitialSuggestions = true,
       void Function(_CapturingScheduleRepository repo)? captureSchedule,
     }) async {
+      tester.view.devicePixelRatio = 1.0;
+      tester.view.physicalSize = const Size(1600, 1200);
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
       final routineRepo = _SpyTrainerRoutineRepository(
         throwOnAssign: assignError,
       );

--- a/frontend/flutter_trainer/test/features/coaching/coaching_page_test.dart
+++ b/frontend/flutter_trainer/test/features/coaching/coaching_page_test.dart
@@ -21,6 +21,7 @@ import 'package:oncare_trainer/features/clients/domain/entities/client_diet_entr
 import 'package:oncare_trainer/features/clients/domain/entities/client_exercise_week.dart';
 import 'package:oncare_trainer/features/clients/domain/entities/member_health_profile.dart';
 import 'package:oncare_trainer/features/clients/domain/entities/routine_history_entry.dart';
+import 'package:oncare_trainer/features/clients/presentation/widgets/nutrition_summary_card.dart';
 import 'package:oncare_trainer/features/schedule/data/repositories/schedule_repository.dart';
 import 'package:oncare_trainer/features/schedule/domain/entities/schedule_session.dart';
 import 'package:oncare_trainer/shared/models/client_chat_message.dart';
@@ -30,6 +31,7 @@ import 'package:oncare_trainer/shared/services/chat_repository.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
 import 'package:oncare_trainer/shared/widgets/action_button.dart';
 import 'package:oncare_trainer/shared/widgets/client_avatar.dart';
+import 'package:oncare_trainer/shared/widgets/client_identity.dart';
 
 import '../../helpers/pump_app.dart';
 
@@ -442,36 +444,84 @@ void main() {
       );
     }
 
-    testWidgets('defaults to the first client with verdict and routine', (
+    testWidgets(
+      'defaults to the first client with nutrition graph and routine',
+      (tester) async {
+        await openTab(tester);
+
+        expect(find.text('프로그램'), findsWidgets);
+        expect(find.byType(NutritionSummaryCard), findsOneWidget);
+        expect(
+          find.byKey(const Key('client-nutrition-summary-card')),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(const Key('client-nutrition-calorie-progress')),
+          findsOneWidget,
+        );
+        expect(find.text('저강도 유산소 (걷기)'), findsOneWidget);
+        expect(find.text('혈압 안정에 효과적'), findsOneWidget);
+        final programCard = find.byKey(
+          const ValueKey<String>('program-client-seed-client-1'),
+        );
+        expect(programCard, findsOneWidget);
+        expect(
+          find.descendant(of: programCard, matching: find.text('운동 이행률')),
+          findsNothing,
+        );
+        expect(
+          find.descendant(
+            of: programCard,
+            matching: find.textContaining('운동 이행률 '),
+          ),
+          findsOneWidget,
+        );
+        final avatar = tester.widget<ClientAvatar>(
+          find.descendant(of: programCard, matching: find.byType(ClientAvatar)),
+        );
+        expect(avatar.size, 32);
+      },
+    );
+
+    testWidgets('compact client picker stacks demographics below the name', (
       tester,
     ) async {
-      await openTab(tester);
+      tester.view.devicePixelRatio = 1.0;
+      tester.view.physicalSize = const Size(800, 1200);
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      await pumpTrainerApp(
+        tester,
+        token: 'demo-trainer-token',
+        at: AppRoutes.coaching,
+      );
 
-      expect(find.text('프로그램'), findsWidgets);
-      // 김민수 (3428mg, over) → cardio-boost verdict.
-      expect(find.text('AI 판단: 나트륨 초과 → 유산소 강화 권장'), findsOneWidget);
-      expect(find.text('17.8'), findsOneWidget);
-      expect(find.text('저강도 유산소 (걷기)'), findsOneWidget);
-      expect(find.text('혈압 안정에 효과적'), findsOneWidget);
-      final programCard = find.byKey(
-        const ValueKey<String>('program-client-seed-client-1'),
+      final minsuIdentity = find.byWidgetPredicate(
+        (widget) =>
+            widget is ClientIdentity &&
+            widget.stacked &&
+            widget.client.id == 'seed-client-1',
       );
-      expect(programCard, findsOneWidget);
+      expect(minsuIdentity, findsOneWidget);
+      final identity = tester.widget<ClientIdentity>(minsuIdentity);
+      final demographics = clientDemographicsLabel(
+        tester.element(minsuIdentity),
+        identity.client,
+      );
+      final name = find.descendant(
+        of: minsuIdentity,
+        matching: find.text(identity.client.name),
+      );
+      final detail = find.descendant(
+        of: minsuIdentity,
+        matching: find.text(demographics),
+      );
       expect(
-        find.descendant(of: programCard, matching: find.text('운동 이행률')),
-        findsNothing,
+        tester.getTopLeft(detail).dy,
+        greaterThan(tester.getTopLeft(name).dy),
       );
-      expect(
-        find.descendant(
-          of: programCard,
-          matching: find.textContaining('운동 이행률 '),
-        ),
-        findsOneWidget,
-      );
-      final avatar = tester.widget<ClientAvatar>(
-        find.descendant(of: programCard, matching: find.byType(ClientAvatar)),
-      );
-      expect(avatar.size, 32);
+      expect(find.byType(NutritionSummaryCard), findsOneWidget);
+      expect(tester.takeException(), isNull);
     });
 
     testWidgets('opens the A/B assistant inline in the AI routine tab', (
@@ -527,19 +577,33 @@ void main() {
       expect(find.text('AI 생성 후 트레이너 검토 완료'), findsWidgets);
     });
 
-    testWidgets('switching client updates the verdict and suggestions', (
-      tester,
-    ) async {
-      await openTab(tester);
+    testWidgets(
+      'switching client updates the nutrition graph and suggestions',
+      (tester) async {
+        await openTab(tester);
 
-      await tester.tap(find.text('이지수'));
-      await settle(tester);
+        final progressFinder = find.byKey(
+          const Key('client-nutrition-calorie-progress'),
+        );
+        final initialProgress = tester
+            .widget<CircularProgressIndicator>(progressFinder)
+            .value;
 
-      // 이지수 (1800mg, under) → balanced verdict + her routine.
-      expect(find.text('AI 판단: 식단 균형 양호 → 근력 중심 루틴 유지'), findsOneWidget);
-      expect(find.text('인터벌 런닝'), findsOneWidget);
-      expect(find.text('저강도 유산소 (걷기)'), findsNothing);
-    });
+        await tester.tap(find.text('이지수'));
+        await settle(tester);
+
+        expect(
+          find.byKey(const Key('client-nutrition-summary-card')),
+          findsOneWidget,
+        );
+        expect(
+          tester.widget<CircularProgressIndicator>(progressFinder).value,
+          isNot(initialProgress),
+        );
+        expect(find.text('인터벌 런닝'), findsOneWidget);
+        expect(find.text('저강도 유산소 (걷기)'), findsNothing);
+      },
+    );
 
     testWidgets('adding and deleting a custom exercise', (tester) async {
       await openTab(tester);

--- a/frontend/flutter_trainer/test/features/coaching/program_draft_save_test.dart
+++ b/frontend/flutter_trainer/test/features/coaching/program_draft_save_test.dart
@@ -92,6 +92,10 @@ Future<void> _openCoaching(
   WidgetTester tester,
   TrainerProgramDraftRepository repository,
 ) async {
+  tester.view.devicePixelRatio = 1.0;
+  tester.view.physicalSize = const Size(1600, 1200);
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
   await pumpTrainerApp(
     tester,
     token: 'demo-trainer-token',


### PR DESCRIPTION
## Summary

* 좁은 프로그램 화면에서 고객 성별·나이 정보를 이름 아래에 배치
* 프로그램 탭의 식단 요약을 고객 탭의 영양 그래프 컴포넌트로 통일
* gstack 리뷰 결과를 반영하고 반응형 및 고객 전환 회귀 테스트 보강

---

## Changes

### ✨ Features

* 해당 없음

### 🔧 Improvements

* `ClientIdentity`에 선택적으로 사용할 수 있는 세로형 정보 배치 옵션 추가
* 고객 전환 시 영양 그래프 값이 실제로 변경되는지 검증하는 테스트 추가

### 🎨 UI/UX

* 좁은 프로그램 화면의 고객 선택 칩에서 이름과 성별·나이 정보를 두 줄로 배치
* 프로그램 탭에서 고객 탭과 동일한 `NutritionSummaryCard` 재사용
* 좁은 화면의 중복 식단 제목 제거
* 넓은 화면의 기존 고객 정보 배치 유지

### 📝 Docs

* 해당 없음

### 🐛 Fixes

* 좁은 화면에서 고객 정보가 한 줄에 몰려 레이아웃이 어그러지는 문제 수정
* 프로그램 탭과 고객 탭의 식단 UI가 서로 다른 문제 수정

---

## Commits

1. `<최종 커밋 SHA>` fix(trainer): 프로그램 탭 반응형 및 식단 UI 통일

---

## Notes

* 기존 고객 탭의 `NutritionSummaryCard`를 직접 재사용해 화면 간 디자인과 포맷을 통일
* gstack 테스트·유지보수성·성능·디자인·레드팀·적대적 리뷰 수행
* 고객 전환 그래프 검증과 좁은 화면 중복 제목 지적 반영
* 관련 없는 대시보드 및 `.gitignore` 변경은 PR 범위에서 제외

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [ ] UI 확인
* [ ] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 트레이너 앱의 프로그램 탭 진입
2. 화면 너비를 900px 미만으로 축소하고 성별·나이가 이름 아래에 표시되는지 확인
3. 화면 너비를 넓히고 기존 가로형 고객 정보 배치가 유지되는지 확인
4. 프로그램 탭과 고객 탭의 식단 그래프 디자인이 동일한지 확인
5. 프로그램 탭에서 고객을 전환하고 영양 그래프와 추천 운동이 함께 변경되는지 확인

---

## Related Issues

Closes #747

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [ ] 데모 시나리오 영향 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 코칭 페이지의 식단 요약 카드와 칼로리 진행률 표시를 개선했습니다.
  * 고객 정보가 화면 크기에 맞춰 가로 또는 세로로 배치됩니다.
  * 고객 전환 시 영양 그래프와 추천 루틴이 올바르게 갱신됩니다.

* **개선 사항**
  * 코칭 페이지의 불필요한 구성 요소를 정리하고 화면 구성을 간소화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->