### PR TITLE
feat(charts): 주간 추이 그래프의 눈금 제거와 목표선 표기

### DIFF
--- a/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
@@ -491,10 +491,10 @@ class _DietNutritionCardState extends State<_DietNutritionCard> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: <Widget>[
+                      // 목표는 그래프의 목표선 라벨이 말한다 — 카드 위에 또
+                      // 적으면 한 화면에서 같은 말이 두 번 나온다(#756).
                       _ChartLegend(
                         title: l.homeWeeklyMetricTrend(_nutLabel(l, _tab)),
-                        goalText:
-                            '${l.homeGoal} ${nf.format(cfg.goal)}${cfg.unit}',
                       ),
                       const SizedBox(height: 6),
                       MetricTrendChart(
@@ -506,6 +506,7 @@ class _DietNutritionCardState extends State<_DietNutritionCard> {
                         // 지표를 바꾸면 선을 처음부터 다시 그려 값이 바뀐 것을
                         // 눈으로 따라가게 한다.
                         replayKey: _tab,
+                        goalLabel: '${l.homeGoal}\n${nf.format(cfg.goal)}',
                         formatTick: nf.format,
                       ),
                     ],
@@ -1757,22 +1758,15 @@ class _ScheduleItemCard extends StatelessWidget {
 }
 
 class _ChartLegend extends StatelessWidget {
-  const _ChartLegend({required this.title, required this.goalText});
+  const _ChartLegend({required this.title});
 
   /// "주간 {지표} 추이" — 선택된 지표에 따라 바뀌는 그래프 왼쪽 상단 제목.
   final String title;
 
-  /// "목표 2,000kcal" 처럼 지표별 목표 수치. 그래프 오른쪽 상단에 표기.
-  final String goalText;
-
   @override
   Widget build(BuildContext context) {
-    // 범례(이번 주/지난 주)는 제거. 왼쪽에 그래프 제목, 오른쪽에 목표 수치를
-    // 카드 우측 끝('자세히 >')과 같은 열로 맞춘다.
-    //
-    // 남는 가로 공간은 제목 쪽 Expanded 가 전부 흡수해야 목표 수치가 그래프
-    // 오른쪽 끝에 붙는다. 목표 수치를 Expanded 로 두면 제목(Flexible)과 공간을
-    // 반씩 나눠 가져 오른쪽 끝에서 한참 못 미친 자리에 멈춘다.
+    // 범례(이번 주/지난 주)와 목표 수치는 제거. 목표는 그래프 안의 목표선
+    // 라벨이 말한다(#756).
     return Row(
       children: <Widget>[
         Expanded(
@@ -1785,16 +1779,6 @@ class _ChartLegend extends StatelessWidget {
               fontWeight: FontWeight.w700,
               color: FigmaColors.ink,
             ),
-          ),
-        ),
-        const SizedBox(width: 8),
-        Text(
-          goalText,
-          maxLines: 1,
-          style: const TextStyle(
-            fontSize: 14.5,
-            fontWeight: FontWeight.w800,
-            color: FigmaColors.primary,
           ),
         ),
       ],

--- a/frontend/flutter/lib/features/diet/presentation/widgets/diet_period_view.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/diet_period_view.dart
@@ -401,6 +401,7 @@ class _PeriodBody extends StatelessWidget {
               // 보고 있으면) 마지막 칸까지 전부 그린다.
               todayIndex: _todayIndexIn(dates),
               replayKey: replayKey,
+              goalLabel: '${AppLocalizations.of(context).homeGoal}\n${format(goal)}',
               formatTick: (double v) => format(v),
             )
           else

--- a/frontend/flutter/lib/shared/widgets/metric_trend_chart.dart
+++ b/frontend/flutter/lib/shared/widgets/metric_trend_chart.dart
@@ -80,6 +80,7 @@ class MetricTrendChart extends StatelessWidget {
     required this.ticks,
     required this.todayIndex,
     required this.replayKey,
+    this.goalLabel,
     required this.formatTick,
     this.height = 68,
     super.key,
@@ -90,7 +91,8 @@ class MetricTrendChart extends StatelessWidget {
   final List<String> dayLabels;
   final double goal;
 
-  /// 가로 눈금선을 그릴 값들. 지표마다 다르다.
+  /// 축의 위아래를 정하는 값들. 그리지는 않는다 — 지표별 축 성질을 잡는
+  /// [metricTrendScale] 의 입력이다.
   final List<double> ticks;
 
   /// 선을 여기까지만 잇는다. 지난 주처럼 전부 지난 구간이면 마지막 index.
@@ -98,6 +100,10 @@ class MetricTrendChart extends StatelessWidget {
 
   /// 바뀌면 진입 애니메이션을 처음부터 다시 그린다.
   final Object replayKey;
+
+  /// 목표선에 붙는 문구(예: `목표 2,000`). null 이면 선만 그린다. 문구를 밖에서
+  /// 받는 것은 두 앱의 로케일 자원이 갈라져 있어서다.
+  final String? goalLabel;
 
   final String Function(double) formatTick;
   final double height;
@@ -112,22 +118,27 @@ class MetricTrendChart extends StatelessWidget {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        // 눈금 라벨을 각 값의 실제 높이에 맞춰 배치.
+        // 목표선의 실제 높이에 맞춰 라벨 하나. 칸은 목표가 없어도 자리를
+        // 지킨다 — 지표를 바꿀 때 그래프 폭이 흔들리지 않는다.
+        //
+        // 폭은 눈금 라벨이 쓰던 38 그대로다. `목표 2,000` 을 한 줄로 두면 이
+        // 칸이 넓어져야 하는데, 그러면 360px 영어 로케일에서 요일 라벨 줄이
+        // 넘친다. 두 줄로 접어 폭을 지킨다.
         SizedBox(
           width: 38,
           height: height,
           child: Stack(
             children: <Widget>[
-              for (final double t in ticks)
+              if (goalLabel != null && goal > 0 && goal >= lo && goal <= hi)
                 Positioned(
                   right: 0,
-                  top: (height - ((t - lo) / (hi - lo)) * height - 8).clamp(
+                  top: (height - ((goal - lo) / (hi - lo)) * height - 13).clamp(
                     0.0,
-                    height - 16,
+                    height - 26,
                   ),
                   child: SizedBox(
-                    height: 16,
-                    child: Center(child: _AxisLabel(formatTick(t))),
+                    height: 26,
+                    child: Center(child: _AxisLabel(goalLabel!)),
                   ),
                 ),
             ],
@@ -207,6 +218,7 @@ class _AxisLabel extends StatelessWidget {
   Widget build(BuildContext context) => Text(
     text,
     textAlign: TextAlign.right,
+    maxLines: 2,
     style: const TextStyle(
       fontSize: 10,
       fontWeight: FontWeight.w600,
@@ -248,13 +260,23 @@ class MetricTrendPainter extends CustomPainter {
     double dx(int i) => cur.length <= 1 ? w / 2 : (i / (cur.length - 1)) * w;
     double dy(double v) => h - ((v - lo) / span) * h;
 
-    final Paint grid = Paint()
-      ..color = const Color(0xFFEFF3F7)
-      ..strokeWidth = 1;
-    for (final double t in ticks) {
-      if (t < lo || t > hi) continue;
-      final double gy = dy(t);
-      canvas.drawLine(Offset(0, gy), Offset(w, gy), grid);
+    // 목표선 하나. 점선이라 데이터 꺾은선과 경쟁하지 않는다. 축 밖으로 나가는
+    // 목표(범위를 벗어난 주)는 그리지 않는다 — 가장자리에 붙어 테두리처럼
+    // 보인다.
+    if (goal > 0 && goal >= lo && goal <= hi) {
+      final goalY = dy(goal);
+      final Paint dash = Paint()
+        ..color = AppColors.mutedForeground.withValues(alpha: 0.45)
+        ..strokeWidth = 1;
+      const double dashW = 4;
+      const double gapW = 3;
+      for (double x = 0; x < w; x += dashW + gapW) {
+        canvas.drawLine(
+          Offset(x, goalY),
+          Offset(math.min(x + dashW, w), goalY),
+          dash,
+        );
+      }
     }
 
     final int lastIdx = todayIndex.clamp(0, cur.length - 1);

--- a/frontend/flutter/test/features/dashboard/home_nutrition_axis_test.dart
+++ b/frontend/flutter/test/features/dashboard/home_nutrition_axis_test.dart
@@ -1,13 +1,13 @@
-/// 홈 "주간 추이" 그래프의 세로축 눈금 라벨.
+/// 홈 "주간 추이" 그래프의 세로축.
 ///
-/// 라벨은 값에 비례한 위치에 `Positioned` 로 겹쳐 놓이고 높이는 16px 로 고정이다.
-/// 축 높이가 68px 뿐이라 눈금을 촘촘히 두면 라벨끼리 물리적으로 겹쳐 숫자를 읽을
-/// 수 없다 — 실제로 칼로리 축이 1,000·1,500·2,000·2,500 네 개일 때 그렇게 겹쳤다.
-/// 여기서는 "겹치지 않는다"를 좌표로 못박는다. 눈금을 다시 늘리면 이 테스트가
-/// 먼저 깨진다.
+/// 눈금 격자와 눈금 라벨은 걷어냈다 — 점마다 값이 붙어 있어 중복이었다. 대신
+/// 목표선 하나와 그 라벨만 남는다(#756). 그래서 이 파일이 지키는 것은 둘이다.
 ///
-/// 세 지표 모두 맨 아래 눈금은 0 이어야 한다 — 한 카드에서 탭으로 바뀌는데
-/// 축의 바닥이 지표마다 다르면 같은 그래프를 다른 기준으로 읽게 된다 (#548).
+///  * 축 칸에 글자가 **하나뿐**이고 그게 목표선 라벨이다. 눈금 라벨이 되살아나면
+///    여기서 먼저 깨진다.
+///  * 세 지표 모두 축 바닥이 0 이다 — 한 카드에서 탭으로 바뀌는데 바닥이 지표마다
+///    다르면 같은 그래프를 다른 기준으로 읽게 된다(#548). 눈금을 그리지 않게 된
+///    뒤에도 `ticks` 가 스케일 입력으로 남아 이 성질을 잡는다.
 library;
 
 import 'package:flutter/material.dart';
@@ -24,6 +24,7 @@ import 'package:oncare/features/diet/domain/entities/diet_day.dart';
 import 'package:oncare/features/member_coach/data/repositories/mock_member_coach_repository.dart';
 import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
+import 'package:oncare/shared/widgets/metric_trend_chart.dart';
 
 void main() {
   const DashboardSummary summary = DashboardSummary(
@@ -95,16 +96,12 @@ void main() {
     ),
   );
 
-  /// 축 라벨을 위에서 아래 순서로 (문구, 사각형) 으로 읽는다.
-  ///
-  /// 사각형은 글자가 아니라 라벨이 차지한 16px 짜리 칸을 잰다 — 글꼴에 따라
-  /// 글자 높이는 달라져도 칸 높이는 레이아웃이 정한 값이라, 겹침 판정이
-  /// 테스트 글꼴의 자간에 흔들리지 않는다.
+  /// 축 칸의 글자를 위에서 아래 순서로 (문구, 사각형) 으로 읽는다.
   List<({String text, Rect rect})> axisLabels(WidgetTester tester) {
     final Finder slots = find.descendant(
       of: axis,
       matching: find.byWidgetPredicate(
-        (Widget w) => w is SizedBox && w.height == 16,
+        (Widget w) => w is SizedBox && w.height == 26,
       ),
     );
     return <({String text, Rect rect})>[
@@ -122,49 +119,48 @@ void main() {
     ]..sort((a, b) => a.rect.top.compareTo(b.rect.top));
   }
 
-  testWidgets('칼로리 축은 0 기준선 위에 1,500·2,500 두 눈금만 그린다', (
-    WidgetTester tester,
-  ) async {
+  testWidgets('축 칸에는 목표선 라벨 하나만 있다', (WidgetTester tester) async {
     await pumpHome(tester);
 
-    expect(
-      <String>[for (final label in axisLabels(tester)) label.text],
-      <String>['2,500', '1,500', '0'],
-    );
+    // 눈금 라벨(2,500 · 1,500 · 0)이 있던 자리다. 이제 목표 하나뿐이다.
+    // 칸 폭(38)을 지키려고 두 줄로 접는다.
+    expect(<String>[for (final label in axisLabels(tester)) label.text], <String>[
+      '목표\n2,000',
+    ]);
   });
 
-  testWidgets('세 지표 모두 맨 아래 눈금이 0 이다 (#548)', (WidgetTester tester) async {
+  testWidgets('지표를 바꾸면 목표선 라벨의 수치가 따라간다', (WidgetTester tester) async {
     await pumpHome(tester);
 
-    for (final String tab in <String>['칼로리', '나트륨', '당류']) {
-      await tester.tap(find.text(tab).first);
-      await tester.pumpAndSettle();
-
-      expect(
-        axisLabels(tester).last.text,
-        '0',
-        reason: '$tab 축의 맨 아래 눈금이 0 이 아니다',
-      );
-    }
-  });
-
-  testWidgets('지표를 바꿔도 축 라벨끼리 겹치지 않는다', (WidgetTester tester) async {
-    await pumpHome(tester);
-
-    for (final String tab in <String>['칼로리', '나트륨', '당류']) {
+    for (final (String tab, String goal) in <(String, String)>[
+      ('칼로리', '목표\n2,000'),
+      ('나트륨', '목표\n2,000'),
+      ('당류', '목표\n50'),
+    ]) {
       await tester.tap(find.text(tab).first);
       await tester.pumpAndSettle();
 
       final List<({String text, Rect rect})> labels = axisLabels(tester);
-      expect(labels.length, greaterThan(1), reason: '$tab 축에 눈금이 없다');
-      for (int i = 1; i < labels.length; i++) {
-        expect(
-          labels[i].rect.top,
-          greaterThanOrEqualTo(labels[i - 1].rect.bottom),
-          reason:
-              '$tab 축: "${labels[i - 1].text}" 와 "${labels[i].text}" 가 겹친다',
-        );
-      }
+      expect(labels.length, 1, reason: '$tab 축에 글자가 하나가 아니다');
+      expect(labels.single.text, goal);
+    }
+  });
+
+  test('세 지표 모두 축 바닥이 0 이다 (#548)', () {
+    // 눈금을 그리지 않게 된 뒤에도 `ticks` 는 스케일 입력으로 남는다. 지우면
+    // 세 지표의 축이 서로 다르게 움직인다.
+    for (final (String name, List<double> values, List<double> ticks, double goal)
+        in <(String, List<double>, List<double>, double)>[
+      ('칼로리', <double>[1860, 1700, 1990], <double>[0, 1500, 2500], 2000),
+      ('나트륨', <double>[2329, 1800, 2100], <double>[0, 1750, 3500], 2000),
+      ('당류', <double>[43, 31, 47], <double>[0, 25, 50], 50),
+    ]) {
+      final (double lo, _) = metricTrendScale(
+        values: values,
+        ticks: ticks,
+        goal: goal,
+      );
+      expect(lo, 0, reason: '$name 축의 바닥이 0 이 아니다');
     }
   });
 }

--- a/frontend/flutter_trainer/lib/features/reports/presentation/pages/reports_page.dart
+++ b/frontend/flutter_trainer/lib/features/reports/presentation/pages/reports_page.dart
@@ -719,6 +719,7 @@ class _MetricTrendSectionState extends State<_MetricTrendSection> {
             // 지표를 바꾸면 선을 처음부터 다시 그려 값이 바뀐 것을 눈으로
             // 따라가게 한다.
             replayKey: _metric,
+            goalLabel: l.chartGoalLabel(metricTrendNumber(_goal)),
             formatTick: metricTrendNumber,
           ),
         const Divider(height: AppSpacing.xl, color: AppColors.border),

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
@@ -4460,6 +4460,12 @@ abstract class AppLocalizations {
   /// **'Last 4 weekly averages'**
   String get reportsRecentWeeks;
 
+  /// No description provided for @chartGoalLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Goal\n{value}'**
+  String chartGoalLabel(String value);
+
   /// No description provided for @reportsGoalMarker.
   ///
   /// In en, this message translates to:

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
@@ -2519,6 +2519,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get reportsRecentWeeks => 'Last 4 weekly averages';
 
   @override
+  String chartGoalLabel(String value) {
+    return 'Goal\n$value';
+  }
+
+  @override
   String reportsGoalMarker(String value) {
     return '│ Goal $value';
   }

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
@@ -2431,6 +2431,11 @@ class AppLocalizationsKo extends AppLocalizations {
   String get reportsRecentWeeks => '최근 4주 평균';
 
   @override
+  String chartGoalLabel(String value) {
+    return '목표\n$value';
+  }
+
+  @override
   String reportsGoalMarker(String value) {
     return '│ 목표 $value';
   }

--- a/frontend/flutter_trainer/lib/l10n/app_en.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_en.arb
@@ -1495,6 +1495,8 @@
   "reportsFeedbackSave": "Save feedback",
   "reportsFeedbackHint": "Write coaching feedback for the client.",
   "reportsRecentWeeks": "Last 4 weekly averages",
+  "chartGoalLabel": "Goal\n{value}",
+  "@chartGoalLabel": {"placeholders": {"value": {"type": "String"}}},
   "reportsGoalMarker": "│ Goal {value}",
   "@reportsGoalMarker": {"placeholders": {"value": {"type": "String"}}},
   "reportsWeeksAgo": "{count}w ago",

--- a/frontend/flutter_trainer/lib/l10n/app_ko.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_ko.arb
@@ -758,6 +758,8 @@
   "reportsFeedbackSave": "피드백 저장",
   "reportsFeedbackHint": "고객에게 전달할 코칭 피드백을 작성하세요.",
   "reportsRecentWeeks": "최근 4주 평균",
+  "chartGoalLabel": "목표\n{value}",
+  "@chartGoalLabel": {"placeholders": {"value": {"type": "String"}}},
   "reportsGoalMarker": "│ 목표 {value}",
   "@reportsGoalMarker": {"placeholders": {"value": {"type": "String"}}},
   "reportsWeeksAgo": "{count}주 전",

--- a/frontend/flutter_trainer/lib/shared/widgets/metric_trend_chart.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/metric_trend_chart.dart
@@ -64,6 +64,7 @@ class MetricTrendChart extends StatelessWidget {
     required this.ticks,
     required this.todayIndex,
     required this.replayKey,
+    this.goalLabel,
     required this.formatTick,
     this.markToday = true,
     this.height = 68,
@@ -78,7 +79,8 @@ class MetricTrendChart extends StatelessWidget {
   /// 하루 목표. 점 색만 정한다(목표선은 그리지 않는다).
   final double goal;
 
-  /// 가로 눈금선을 그릴 값들. 지표마다 다르다.
+  /// 축의 위아래를 정하는 값들. 그리지는 않는다 — 지표별 축 성질을 잡는
+  /// [metricTrendScale] 의 입력이다.
   final List<double> ticks;
 
   /// 선을 여기까지만 잇는다. 지난 주처럼 전부 지난 구간이면 마지막 index.
@@ -92,7 +94,11 @@ class MetricTrendChart extends StatelessWidget {
   /// 바뀌면 진입 애니메이션을 처음부터 다시 그린다.
   final Object replayKey;
 
-  /// 눈금 라벨 포맷.
+  /// 목표선 문구 포맷.
+  /// 목표선에 붙는 문구(예: `목표 2,000`). null 이면 선만 그린다. 문구를 밖에서
+  /// 받는 것은 두 앱의 로케일 자원이 갈라져 있어서다.
+  final String? goalLabel;
+
   final String Function(double) formatTick;
 
   /// 꺾은선 영역 높이(요일 라벨 제외).
@@ -109,22 +115,27 @@ class MetricTrendChart extends StatelessWidget {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        // 눈금 라벨을 각 값의 실제 높이에 맞춰 배치.
+        // 목표선의 실제 높이에 맞춰 라벨 하나. 칸은 목표가 없어도 자리를
+        // 지킨다 — 지표를 바꿀 때 그래프 폭이 흔들리지 않는다.
+        //
+        // 폭은 눈금 라벨이 쓰던 38 그대로다. `목표 2,000` 을 한 줄로 두면 이
+        // 칸이 넓어져야 하는데, 그러면 360px 영어 로케일에서 요일 라벨 줄이
+        // 넘친다. 두 줄로 접어 폭을 지킨다.
         SizedBox(
           width: 38,
           height: height,
           child: Stack(
             children: <Widget>[
-              for (final t in ticks)
+              if (goalLabel != null && goal > 0 && goal >= lo && goal <= hi)
                 Positioned(
                   right: 0,
-                  top: (height - ((t - lo) / (hi - lo)) * height - 8).clamp(
+                  top: (height - ((goal - lo) / (hi - lo)) * height - 13).clamp(
                     0.0,
-                    height - 16,
+                    height - 26,
                   ),
                   child: SizedBox(
-                    height: 16,
-                    child: Center(child: _AxisLabel(formatTick(t))),
+                    height: 26,
+                    child: Center(child: _AxisLabel(goalLabel!)),
                   ),
                 ),
             ],
@@ -212,6 +223,7 @@ class _AxisLabel extends StatelessWidget {
   Widget build(BuildContext context) => Text(
     text,
     textAlign: TextAlign.right,
+    maxLines: 2,
     style: const TextStyle(
       fontSize: 10,
       fontWeight: FontWeight.w600,
@@ -239,7 +251,7 @@ class MetricTrendPainter extends CustomPainter {
   /// 하루 목표. 점 색만 정한다.
   final double goal;
 
-  /// 가로 눈금선을 그릴 값들.
+  /// 축의 위아래를 정하는 값들. 그리지는 않는다.
   final List<double> ticks;
 
   /// 축 바닥.
@@ -264,13 +276,23 @@ class MetricTrendPainter extends CustomPainter {
     double dx(int i) => cur.length <= 1 ? w / 2 : (i / (cur.length - 1)) * w;
     double dy(double v) => h - ((v - lo) / span) * h;
 
-    final grid = Paint()
-      ..color = const Color(0xFFEFF3F7)
-      ..strokeWidth = 1;
-    for (final t in ticks) {
-      if (t < lo || t > hi) continue;
-      final gy = dy(t);
-      canvas.drawLine(Offset(0, gy), Offset(w, gy), grid);
+    // 목표선 하나. 점선이라 데이터 꺾은선과 경쟁하지 않는다. 축 밖으로 나가는
+    // 목표(범위를 벗어난 주)는 그리지 않는다 — 가장자리에 붙어 테두리처럼
+    // 보인다.
+    if (goal > 0 && goal >= lo && goal <= hi) {
+      final goalY = dy(goal);
+      final Paint dash = Paint()
+        ..color = AppColors.mutedForeground.withValues(alpha: 0.45)
+        ..strokeWidth = 1;
+      const double dashW = 4;
+      const double gapW = 3;
+      for (double x = 0; x < w; x += dashW + gapW) {
+        canvas.drawLine(
+          Offset(x, goalY),
+          Offset(math.min(x + dashW, w), goalY),
+          dash,
+        );
+      }
     }
 
     final lastIdx = todayIndex.clamp(0, cur.length - 1);

--- a/frontend/flutter_trainer/test/shared/widgets/metric_trend_chart_test.dart
+++ b/frontend/flutter_trainer/test/shared/widgets/metric_trend_chart_test.dart
@@ -1,0 +1,76 @@
+/// 주간 추이 꺾은선의 목표선(#756).
+///
+/// 눈금 격자와 눈금 라벨을 걷어내고 목표선 하나만 남겼다. 점마다 값이 붙어
+/// 있어 격자는 중복이었고, 축 바닥이 0 이 아니라 데이터 범위에 맞춰 올라가므로
+/// 목표선이 없으면 점의 높이 자체에 뜻이 없다.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare_trainer/shared/widgets/metric_trend_chart.dart';
+
+void main() {
+  Future<void> pump(
+    WidgetTester tester, {
+    required double goal,
+    String? goalLabel,
+  }) => tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: MetricTrendChart(
+          values: const <double>[2200, 1900, 2050, 2300, 1850, 3428, 0],
+          dayLabels: const <String>['월', '화', '수', '목', '금', '토', '일'],
+          goal: goal,
+          ticks: const <double>[0, 1750, 3500],
+          todayIndex: 5,
+          replayKey: 'sodium',
+          goalLabel: goalLabel,
+          formatTick: metricTrendNumber,
+        ),
+      ),
+    ),
+  );
+
+  testWidgets('목표선 라벨이 축 칸에 붙는다', (WidgetTester tester) async {
+    await pump(tester, goal: 2000, goalLabel: '목표\n2,000');
+
+    expect(find.text('목표\n2,000'), findsOneWidget);
+    // 눈금 라벨이 있던 자리다 — 되살아나면 여기서 걸린다.
+    expect(find.text('1,750'), findsNothing);
+    expect(find.text('3,500'), findsNothing);
+  });
+
+  testWidgets('목표가 없는 지표에는 라벨을 그리지 않는다', (WidgetTester tester) async {
+    // 목표 0 은 "목표가 없다"는 뜻이다. `목표 0` 이라고 적으면 하루 섭취량을
+    // 0 으로 맞추라는 말이 된다.
+    await pump(tester, goal: 0, goalLabel: '목표\n0');
+
+    expect(find.text('목표\n0'), findsNothing);
+  });
+
+  testWidgets('라벨을 주지 않으면 선만 그린다', (WidgetTester tester) async {
+    await pump(tester, goal: 2000);
+
+    expect(find.byType(MetricTrendChart), findsOneWidget);
+    expect(find.textContaining('목표'), findsNothing);
+  });
+
+  test('눈금은 그리지 않아도 축의 위아래를 정한다', () {
+    // `ticks` 를 지우면 세 지표의 축이 서로 다르게 움직인다. 당류처럼 바닥이
+    // 0 에 고정되는 성질이 여기서 나온다.
+    for (final (String name, List<double> values, List<double> ticks, double goal)
+        in <(String, List<double>, List<double>, double)>[
+          ('칼로리', <double>[1710, 1830, 1560], <double>[0, 1500, 2500], 2000),
+          ('나트륨', <double>[2200, 1900, 2050], <double>[0, 1750, 3500], 2000),
+          ('당류', <double>[41.5, 28, 45.5], <double>[0, 25, 50], 50),
+        ]) {
+      final (double lo, _) = metricTrendScale(
+        values: values,
+        ticks: ticks,
+        goal: goal,
+      );
+      expect(lo, 0, reason: '$name 축의 바닥이 0 이 아니다');
+    }
+  });
+}


### PR DESCRIPTION
Closes #756

> [!NOTE]
> #753 위에 쌓은 PR 입니다. base 가 `feat/reports-past-weeks` 라 diff 에 아래 PR 의 커밋이 섞여 보이지 않습니다. **#753 을 병합하기 전에 이 PR 의 base 를 `main` 으로 옮겨 주세요** — 순서가 바뀌면 이 PR 이 자동으로 닫힙니다.

## Summary

칼로리·나트륨·당류 주간 추이 꺾은선에서 가로 눈금선을 걷어내고 **목표선 하나만** 남깁니다. 점의 높이가 "목표 대비 어디인가" 하나만 말하게 합니다.

두 가지가 걸렸습니다.

- 점마다 값 라벨이 이미 붙어 있어 **격자가 중복**이었습니다. 값을 읽는 데 격자가 필요하지 않습니다.
- y축이 0에서 시작하지 않습니다(`metricTrendScale` 이 데이터 범위에 맞춰 바닥을 올립니다). 그래서 **목표선이 없으면 점의 높이 자체에 뜻이 없었습니다.**

눈금을 없애니 목표선을 그리지 않던 이유("눈금과 겹치면 선이 두꺼워 보인다")도 함께 사라졌습니다.

## Changes

`MetricTrendChart` 를 쓰는 세 곳 전부입니다. 두 앱은 패키지가 갈라져 파일을 각자 갖고 있어 양쪽 다 고쳤습니다 — 한쪽만 고치면 회원이 보는 그래프와 트레이너가 보는 그래프가 다른 이야기를 합니다.

| 앱 | 화면 |
|---|---|
| 사용자 앱 | 홈 탭 식단 카드 |
| 사용자 앱 | 식단 탭 주간 보기 |
| 트레이너 웹 | 리포트 탭 주간 식단 추이 |

- 가로 격자선과 눈금 라벨(`0` / `1,750` / `3,500`)을 제거하고, 목표선을 점선·연한 색으로 한 줄 그립니다. 실선이면 데이터 꺾은선과 경쟁합니다. 축을 벗어난 목표는 그리지 않습니다 — 가장자리에 붙어 테두리처럼 보입니다.
- 왼쪽 축 칸에 `목표 2,000` 라벨을 붙입니다. 문구는 밖에서 받습니다(`goalLabel`) — 두 앱의 로케일 자원이 갈라져 있습니다.
- **사용자 앱 홈 카드의 `목표 2,000mg` 을 제거**했습니다. 목표선 라벨과 같은 말을 한 화면에서 두 번 하게 됩니다.
- 트레이너 웹은 목표 표시가 아예 없었으므로, 이 변경으로 없던 정보가 생깁니다.

## Notes

**이슈 명세에서 하나 벗어났습니다.** 명세는 축 칸 38px 을 그대로 쓰라고 했는데 `목표 2,000` 은 한 줄로 들어가지 않습니다. 52px 로 넓혔더니 **360px 영어 로케일에서 요일 라벨 줄이 넘쳤습니다**(#440 이 지키던 테스트가 잡아냈습니다). 폭은 38px 그대로 두고 라벨을 두 줄로 접었습니다.

`ticks` 는 그리지 않지만 인자로 남겼습니다. `metricTrendScale` 이 축의 위아래를 정하는 입력이라 지우면 세 지표의 축 바닥이 서로 다르게 움직입니다.

## Tests

- 눈금 라벨을 검사하던 `home_nutrition_axis_test.dart` 는 검사 대상이 사라져 다시 썼습니다. 지키려던 성질(축 바닥이 0, #548)은 `metricTrendScale` 단위 테스트로 옮겨 그대로 남깁니다.
- 트레이너에 `metric_trend_chart_test.dart` 를 추가해 목표선 라벨·목표가 0 인 지표·눈금 미표기를 검사합니다.
- 로컬: 두 앱 `flutter analyze` 무경고, 사용자 앱 635 · 트레이너 630 테스트 통과.
