### PR TITLE
fix(diet): 영어 로케일 좁은 화면의 날짜 스트립 넘침

### DIFF
--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -453,12 +453,18 @@ class _DateStrip extends StatelessWidget {
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: <Widget>[
-                Text(
-                  weekLabel,
-                  style: const TextStyle(
-                    fontSize: 13.5,
-                    fontWeight: FontWeight.w600,
-                    color: AppColors.mutedForeground,
+                // 영어의 주 라벨은 한국어보다 훨씬 길다. 고정 폭으로 두면
+                // 320px 에서 오늘 버튼을 밀어내며 넘친다(#743).
+                Flexible(
+                  child: Text(
+                    weekLabel,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      fontSize: 13.5,
+                      fontWeight: FontWeight.w600,
+                      color: AppColors.mutedForeground,
+                    ),
                   ),
                 ),
                 if (showTodayButton)
@@ -495,17 +501,21 @@ class _DateStrip extends StatelessWidget {
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: <Widget>[
+                    // 셀마다 제 크기를 요구하면 일곱의 합이 화면을 넘는다 —
+                    // 영어 요일 라벨(Mon/Tue)이 한글 한 글자보다 넓다(#743).
                     for (final DateTime d in days)
-                      _DayCell(
-                        // 날짜 셀을 지목할 수 있어야 '선택한 날' 계약을 테스트가
-                        // 확인할 수 있다(#687).
-                        key: ValueKey<String>(
-                          'diet-day-${d.year}-${d.month}-${d.day}',
+                      Expanded(
+                        child: _DayCell(
+                          // 날짜 셀을 지목할 수 있어야 '선택한 날' 계약을
+                          // 테스트가 확인할 수 있다(#687).
+                          key: ValueKey<String>(
+                            'diet-day-${d.year}-${d.month}-${d.day}',
+                          ),
+                          day: d,
+                          isToday: d == today,
+                          isSelected: d == selected,
+                          onTap: () => onSelect(d),
                         ),
-                        day: d,
-                        isToday: d == today,
-                        isSelected: d == selected,
-                        onTap: () => onSelect(d),
                       ),
                   ],
                 ),
@@ -571,12 +581,18 @@ class _DayCell extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
-          Text(
-            _weekdayLabel(l, day.weekday),
-            style: TextStyle(
-              fontSize: 12,
-              fontWeight: FontWeight.w600,
-              color: labelColor,
+          // 말줄임이 아니라 축소다. 'Mon' 이 'M…' 이 되면 무슨 요일인지가
+          // 사라진다 — 좁아도 읽을 수 있어야 한다(#743).
+          FittedBox(
+            fit: BoxFit.scaleDown,
+            child: Text(
+              _weekdayLabel(l, day.weekday),
+              maxLines: 1,
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+                color: labelColor,
+              ),
             ),
           ),
           const SizedBox(height: 3),
@@ -1576,15 +1592,20 @@ class _MealCard extends StatelessWidget {
                       ),
                     ),
                     const Spacer(),
+                    // 숫자는 말줄임하지 않는다. `1,850 kcal` 이 `1,85…` 가 되면
+                    // 넘치는 것보다 나쁘다 — 다른 값으로 읽힌다(#743).
                     Flexible(
-                      child: Text(
-                        '${_formatInt(meal.total)} ${l.unitKcal}',
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: const TextStyle(
-                          fontSize: 14,
-                          fontWeight: FontWeight.w800,
-                          color: FigmaColors.primary,
+                      child: FittedBox(
+                        fit: BoxFit.scaleDown,
+                        alignment: Alignment.centerRight,
+                        child: Text(
+                          '${_formatInt(meal.total)} ${l.unitKcal}',
+                          maxLines: 1,
+                          style: const TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.w800,
+                            color: FigmaColors.primary,
+                          ),
                         ),
                       ),
                     ),
@@ -1628,17 +1649,23 @@ class _MealCard extends StatelessWidget {
                                   // 영양 문자열도 접힌다. 이름만 접히게 두면
                                   // `350kcal · 1,200mg · 12g` 자체가 좁은 폭을
                                   // 넘겨(320px 에서 최대 122px) 줄이 잘렸다(#739).
+                                  //
+                                  // 다만 말줄임이 아니라 축소다 — `1,200mg` 이
+                                  // `1,2…` 가 되면 다른 값으로 읽힌다(#743).
                                   Flexible(
-                                    child: Text(
-                                      '${f.kcal}${l.unitKcal} · '
-                                      '${_formatInt(f.sodiumMg)}${l.dietUnitMg} · '
-                                      '${_formatG(f.sugarG)}${l.dietUnitG}',
-                                      maxLines: 1,
-                                      overflow: TextOverflow.ellipsis,
-                                      style: const TextStyle(
-                                        fontSize: 12,
-                                        fontWeight: FontWeight.w600,
-                                        color: AppColors.mutedForeground,
+                                    child: FittedBox(
+                                      fit: BoxFit.scaleDown,
+                                      alignment: Alignment.centerRight,
+                                      child: Text(
+                                        '${f.kcal}${l.unitKcal} · '
+                                        '${_formatInt(f.sodiumMg)}${l.dietUnitMg} · '
+                                        '${_formatG(f.sugarG)}${l.dietUnitG}',
+                                        maxLines: 1,
+                                        style: const TextStyle(
+                                          fontSize: 12,
+                                          fontWeight: FontWeight.w600,
+                                          color: AppColors.mutedForeground,
+                                        ),
                                       ),
                                     ),
                                   ),

--- a/frontend/flutter/test/features/diet/diet_narrow_layout_test.dart
+++ b/frontend/flutter/test/features/diet/diet_narrow_layout_test.dart
@@ -7,9 +7,10 @@
 /// 높이를 넉넉히 두는 이유는 `ListView` 가 보이는 자식만 만들기 때문이다 — 짧은
 /// 화면에서는 아래쪽 카드가 아예 그려지지 않아 검증 대상이 사라진다.
 ///
-/// **한국어만 검증한다.** 영어는 라벨이 훨씬 길어(`This month` vs `이번 달`) 날짜
-/// 스트립이 배율 1.0 에서도 넘친다. 그쪽은 아직 고치지 않았고 별도로 다룬다 —
-/// 이 파일을 en 으로 돌리면 네 배율 모두 실패한다.
+/// **로케일도 축이다(#743).** 영어는 라벨이 훨씬 길다(`This month` vs `이번 달`,
+/// `Mon` vs `월`). 한국어로만 검증하던 동안 날짜 스트립이 영어 배율 1.0 에서도
+/// 넘치고 있었고, 이 파일이 그것을 잡지 못했다. 8개 조합(2 로케일 × 4 배율)을
+/// 모두 돌린다.
 library;
 
 import 'package:flutter/material.dart';
@@ -25,40 +26,42 @@ import 'package:oncare/gen/l10n/app_localizations.dart';
 import '../../helpers/fake_diet_repository.dart';
 
 void main() {
-  group('식단 탭 좁은 화면 레이아웃 (#739)', () {
-    for (final double scale in <double>[1.0, 1.3, 1.6, 2.0]) {
-      testWidgets('폭 320 · 글자 배율 $scale 에서 넘치지 않는다', (
-        WidgetTester tester,
-      ) async {
-        tester.view.physicalSize = const Size(320, 4000);
-        tester.view.devicePixelRatio = 1.0;
-        tester.platformDispatcher.textScaleFactorTestValue = scale;
-        addTearDown(tester.view.reset);
-        addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
+  group('식단 탭 좁은 화면 레이아웃 (#739, #743)', () {
+    for (final String locale in <String>['ko', 'en']) {
+      for (final double scale in <double>[1.0, 1.3, 1.6, 2.0]) {
+        testWidgets('$locale · 폭 320 · 글자 배율 $scale 에서 넘치지 않는다', (
+          WidgetTester tester,
+        ) async {
+          tester.view.physicalSize = const Size(320, 4000);
+          tester.view.devicePixelRatio = 1.0;
+          tester.platformDispatcher.textScaleFactorTestValue = scale;
+          addTearDown(tester.view.reset);
+          addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
 
-        await tester.pumpWidget(
-          ProviderScope(
-            overrides: <Override>[
-              dietRepositoryProvider.overrideWithValue(FakeDietRepository()),
-              accountRepositoryProvider.overrideWithValue(
-                MockAccountRepository(),
+          await tester.pumpWidget(
+            ProviderScope(
+              overrides: <Override>[
+                dietRepositoryProvider.overrideWithValue(FakeDietRepository()),
+                accountRepositoryProvider.overrideWithValue(
+                  MockAccountRepository(),
+                ),
+              ],
+              child: MaterialApp(
+                locale: Locale(locale),
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: const DietRecordPage(),
               ),
-            ],
-            child: const MaterialApp(
-              locale: Locale('ko'),
-              localizationsDelegates: AppLocalizations.localizationsDelegates,
-              supportedLocales: AppLocalizations.supportedLocales,
-              home: DietRecordPage(),
             ),
-          ),
-        );
-        await tester.pumpAndSettle();
+          );
+          await tester.pumpAndSettle();
 
-        // overflow 는 렌더링 예외로 보고된다. `pumpAndSettle` 이 예외 없이 끝났고
-        // 화면이 그려졌다면 넘친 곳이 없다는 뜻이다.
-        expect(tester.takeException(), isNull);
-        expect(find.byType(DietRecordPage), findsOneWidget);
-      });
+          // overflow 는 렌더링 예외로 보고된다. `pumpAndSettle` 이 예외 없이 끝났고
+          // 화면이 그려졌다면 넘친 곳이 없다는 뜻이다.
+          expect(tester.takeException(), isNull);
+          expect(find.byType(DietRecordPage), findsOneWidget);
+        });
+      }
     }
   });
 }

--- a/frontend/flutter/test/features/diet/diet_period_test.dart
+++ b/frontend/flutter/test/features/diet/diet_period_test.dart
@@ -60,14 +60,17 @@ class _SparseDietRepository extends FakeDietRepository {
   }
 }
 
-Widget _app({List<Override> overrides = const <Override>[]}) {
+Widget _app({
+  List<Override> overrides = const <Override>[],
+  String locale = 'ko',
+}) {
   return ProviderScope(
     overrides: overrides,
-    child: const MaterialApp(
-      locale: Locale('ko'),
+    child: MaterialApp(
+      locale: Locale(locale),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
-      home: DietRecordPage(),
+      home: const DietRecordPage(),
     ),
   );
 }
@@ -240,72 +243,77 @@ void main() {
       expect(find.text(l.dietMealLog), findsOneWidget);
     });
 
-    testWidgets('좁은 화면·큰 글자 배율에서 먼저 접히는 것은 날짜다 (#687 리뷰)', (
-      WidgetTester tester,
-    ) async {
-      // 제목·날짜·추가 버튼이 한 줄이라, 폭이 좁거나 글자 배율이 크면 셋의 최소 폭
-      // 합이 화면을 넘긴다. 접히는 쪽은 날짜여야 한다 — 추가 버튼이 밀려나면 끼니를
-      // 넣을 수 없다.
-      // 폭만 좁힌다. 높이를 넉넉히 두는 이유는 `ListView` 가 보이는 자식만 만들기
-      // 때문이다 — 짧은 화면에서는 끼니 목록이 아래로 밀려 아예 그려지지 않는다.
-      tester.view.physicalSize = const Size(320, 2400);
-      tester.view.devicePixelRatio = 1.0;
-      tester.platformDispatcher.textScaleFactorTestValue = 1.6;
-      addTearDown(tester.view.reset);
-      addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
+    // 로케일도 축이다. 영어 라벨이 더 길어 같은 폭에서 먼저 넘친다 — 날짜
+    // 스트립이 딱 그래서 영어에서만 넘치고 있었다(#743).
+    for (final String locale in <String>['ko', 'en']) {
+      testWidgets('$locale · 좁은 화면·큰 글자 배율에서 먼저 접히는 것은 날짜다 (#687 리뷰)', (
+        WidgetTester tester,
+      ) async {
+        // 제목·날짜·추가 버튼이 한 줄이라, 폭이 좁거나 글자 배율이 크면 셋의 최소 폭
+        // 합이 화면을 넘긴다. 접히는 쪽은 날짜여야 한다 — 추가 버튼이 밀려나면 끼니를
+        // 넣을 수 없다.
+        // 폭만 좁힌다. 높이를 넉넉히 두는 이유는 `ListView` 가 보이는 자식만 만들기
+        // 때문이다 — 짧은 화면에서는 끼니 목록이 아래로 밀려 아예 그려지지 않는다.
+        tester.view.physicalSize = const Size(320, 2400);
+        tester.view.devicePixelRatio = 1.0;
+        tester.platformDispatcher.textScaleFactorTestValue = 1.6;
+        addTearDown(tester.view.reset);
+        addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
 
-      await tester.pumpWidget(
-        _app(
-          overrides: <Override>[
-            dietRepositoryProvider.overrideWithValue(FakeDietRepository()),
-            accountRepositoryProvider.overrideWithValue(
-              MockAccountRepository(),
-            ),
-          ],
-        ),
-      );
-      await tester.pumpAndSettle();
+        await tester.pumpWidget(
+          _app(
+            locale: locale,
+            overrides: <Override>[
+              dietRepositoryProvider.overrideWithValue(FakeDietRepository()),
+              accountRepositoryProvider.overrideWithValue(
+                MockAccountRepository(),
+              ),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
 
-      final Element context = tester.element(find.byType(DietRecordPage));
-      final AppLocalizations l = AppLocalizations.of(context);
-      final DateTime now = DateTime.now();
-      final String todayLabel = MaterialLocalizations.of(
-        context,
-      ).formatMediumDate(DateTime(now.year, now.month, now.day));
+        final Element context = tester.element(find.byType(DietRecordPage));
+        final AppLocalizations l = AppLocalizations.of(context);
+        final DateTime now = DateTime.now();
+        final String todayLabel = MaterialLocalizations.of(
+          context,
+        ).formatMediumDate(DateTime(now.year, now.month, now.day));
 
-      final Finder header = find.byKey(
-        const ValueKey<String>('meal-log-header'),
-      );
-      final Finder date = find.descendant(
-        of: header,
-        matching: find.text(todayLabel),
-      );
-      final Finder addButton = find.descendant(
-        of: header,
-        matching: find.text(l.dietAddMeal),
-      );
-      expect(date, findsOneWidget);
-      expect(addButton, findsOneWidget);
+        final Finder header = find.byKey(
+          const ValueKey<String>('meal-log-header'),
+        );
+        final Finder date = find.descendant(
+          of: header,
+          matching: find.text(todayLabel),
+        );
+        final Finder addButton = find.descendant(
+          of: header,
+          matching: find.text(l.dietAddMeal),
+        );
+        expect(date, findsOneWidget);
+        expect(addButton, findsOneWidget);
 
-      // 날짜는 한 줄로 접힌다.
-      final Text dateText = tester.widget<Text>(date);
-      expect(dateText.maxLines, 1);
-      expect(dateText.overflow, TextOverflow.ellipsis);
+        // 날짜는 한 줄로 접힌다.
+        final Text dateText = tester.widget<Text>(date);
+        expect(dateText.maxLines, 1);
+        expect(dateText.overflow, TextOverflow.ellipsis);
 
-      // 추가 버튼이 제목 줄 안에 남는다 — 밀려나면 끼니를 넣을 수 없다.
-      final Rect headerRect = tester.getRect(header);
-      final Rect addRect = tester.getRect(addButton);
-      expect(addRect.left, greaterThanOrEqualTo(headerRect.left));
-      expect(addRect.right, lessThanOrEqualTo(headerRect.right + 0.5));
+        // 추가 버튼이 제목 줄 안에 남는다 — 밀려나면 끼니를 넣을 수 없다.
+        final Rect headerRect = tester.getRect(header);
+        final Rect addRect = tester.getRect(addButton);
+        expect(addRect.left, greaterThanOrEqualTo(headerRect.left));
+        expect(addRect.right, lessThanOrEqualTo(headerRect.right + 0.5));
 
-      // 날짜와 추가 버튼이 겹치지 않는다. 겹치면 화면상 글자가 버튼을 파고든다.
-      expect(tester.getRect(date).right, lessThanOrEqualTo(addRect.left + 0.5));
+        // 날짜와 추가 버튼이 겹치지 않는다. 겹치면 화면상 글자가 버튼을 파고든다.
+        expect(tester.getRect(date).right, lessThanOrEqualTo(addRect.left + 0.5));
 
-      // 화면 어디에서도 넘치지 않는다. 화면 전체가 좁은 폭을 견디게 된 뒤로
-      // (#739) 이 단언을 이 자리에서 그대로 쓸 수 있다.
-      expect(tester.takeException(), isNull);
-      expect(find.text(l.dietMealLog), findsOneWidget);
-    });
+        // 화면 어디에서도 넘치지 않는다. 화면 전체가 좁은 폭을 견디게 된 뒤로
+        // (#739) 이 단언을 이 자리에서 그대로 쓸 수 있다.
+        expect(tester.takeException(), isNull);
+        expect(find.text(l.dietMealLog), findsOneWidget);
+      });
+    }
 
     testWidgets('토글은 영양 요약 섹션만 바꾸고, 날짜 스트립·끼니 목록은 남는다 (#681)', (
       WidgetTester tester,


### PR DESCRIPTION
Closes #743

## Summary

식단 탭을 **영어 + 폭 320px** 로 그리면 날짜 스트립이 넘쳤습니다. 배율을 올리지 않은 기본 배율에서도 재현됐습니다.

원인은 영어 라벨이 한국어보다 길다는 것입니다 — `Mon` 은 `월` 보다 넓고, 주 라벨(`This month` vs `이번 달`)도 마찬가지입니다. 넘치는 곳이 두 군데였습니다.

| 배율 | 넘침 |
|---|---|
| 1.0 | 25px |
| 1.3 | 101px |
| 1.6 | 56px + 176px |
| 2.0 | 137px + 277px |

## Changes

- **주 라벨 줄** — 라벨을 `Flexible` 로 감싸 남는 폭만 차지하게 했습니다. 고정 폭이라 오늘 버튼을 밀어냈습니다.
- **요일 셀 일곱 개** — 각각을 `Expanded` 로 감싸 폭을 나눠 갖게 했습니다. 셀마다 제 크기를 요구하니 합이 화면을 넘겼습니다.
- **요일 라벨은 말줄임이 아니라 축소**(`FittedBox`)입니다. `Mon` 이 `M…` 이 되면 무슨 요일인지가 사라집니다.
- **숫자의 말줄임을 걷어냈습니다.** 이슈가 함께 보자고 한 부분입니다 — `1,850 kcal` 이 `1,85…` 가 되면 넘치는 것보다 나쁩니다. 다른 값으로 읽힙니다. 끼니 합계와 음식 영양 문자열 두 곳을 축소로 바꿨습니다.

## Tests

**로케일을 축으로 세웠습니다.** 좁은 화면 회귀 테스트(`diet_narrow_layout_test.dart`)가 한국어로만 돌아 이 버그를 잡지 못했습니다. 그 파일에 "한국어만 검증한다"는 주석까지 달려 있었고, 그 주석이 버그를 눈감아 주던 자리입니다. 이제 **8개 조합(2 로케일 × 4 배율)** 을 돌립니다.

기간 뷰의 넘침 테스트에도 같은 축을 넣었습니다. 지금은 영어에서도 통과하지만, 축이 없으면 언제 무너져도 모릅니다. 그 파일의 나머지 테스트는 한국어 문구를 검증하므로 로케일을 고정한 채 두었습니다.

## Notes

이슈의 `다른 화면도 en 기준으로 훑는다` 를 확인했습니다.

- **홈 탭** — 이미 영어 폭 검증이 있습니다(#440, 360/390/480px).
- **식단 기간 뷰** — 320px 를 보지만 한국어 고정이었습니다. 영어로 돌려 보니 통과해서, 고칠 것 없이 축만 추가했습니다.

로컬: `flutter analyze` 무경고, 사용자 앱 640 테스트 통과.
