### PR TITLE
test(backend): 공용 DB 재실행에서 깨지던 테스트의 정리

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -35,6 +35,63 @@ os.environ.setdefault("DATABASE_URL", DEFAULT_TEST_DATABASE_URL)
 
 DATABASE_URL = os.environ["DATABASE_URL"]
 
+#: 테스트는 오프라인 해시 임베더를 쓴다.
+#:
+#: DB 를 비우고 시작하면서 공공 RAG 문서(8건)가 매 실행 다시 적재된다. 로컬
+#: `.env` 에 실제 GEMINI_API_KEY 가 있으면 그 적재가 **네트워크 임베딩 호출**이
+#: 되어, 스위트가 느려질 뿐 아니라 외부 서비스에 의존하게 된다. 키가 없는 CI 는
+#: 이미 해시로 폴백하므로, 여기서 못 박아 로컬을 CI 와 같은 경로로 만든다
+#: (`recognizer` 를 stub 으로 고정하는 것과 같은 이유다).
+#:
+#: 두 임베더가 `embed_dim` 을 공유해 벡터 차원은 달라지지 않는다.
+os.environ.setdefault("EMBEDDER", "hash")
+
+
+#: 이 DB 를 비워도 되는가.
+#:
+#: 로컬은 같은 DB 를 계속 재사용한다. 그래서 고정 id 를 넣는 테스트가 두 번째
+#: 실행부터 중복 키로 깨지고, "첫 질문에는 이력이 없다" 처럼 빈 상태를 전제로 한
+#: 테스트도 지난 실행이 남긴 행에 걸린다. 매 실행을 CI 와 같은 빈 상태에서
+#: 시작하게 만드는 것이 이 판정의 목적이다(#762).
+#:
+#: **원격 DB 는 어떤 경우에도 건드리지 않는다.** 공유 DB(Neon)를 가리킨 채
+#: 스위트를 돌리는 실수가 팀 데이터를 지우는 일로 이어지면 안 된다. 로컬이라도
+#: 앱 기본 DB(개발·데모용)면 비우지 않는다 — 그쪽은 사람이 직접 쓰는 DB 다.
+def _is_disposable(url: str) -> bool:
+    from urllib.parse import urlparse
+
+    parsed = urlparse(url.replace("postgresql+psycopg://", "postgresql://"))
+    if parsed.hostname not in {"localhost", "127.0.0.1"}:
+        return False
+    name = (parsed.path or "").lstrip("/")
+    return bool(name) and name != "oncare"
+
+
+def _reset_database(url: str) -> None:
+    """스키마는 두고 행만 비운다.
+
+    `DROP SCHEMA` 가 아니라 `TRUNCATE` 인 이유는 pgvector 확장과 alembic 이력을
+    살려 두기 위해서다 — 확장 생성은 superuser 권한이 필요해 지우면 되살릴 수
+    없다. 테이블이 아직 없으면(새 DB) 지울 것도 없다.
+    """
+    engine = create_engine(url)
+    try:
+        with engine.begin() as conn:
+            names = [
+                row[0]
+                for row in conn.execute(
+                    text(
+                        "SELECT tablename FROM pg_tables "
+                        "WHERE schemaname = 'public' AND tablename <> 'alembic_version'"
+                    )
+                )
+            ]
+            if names:
+                joined = ", ".join(f'public."{n}"' for n in names)
+                conn.execute(text(f"TRUNCATE {joined} RESTART IDENTITY CASCADE"))
+    finally:
+        engine.dispose()
+
 
 def _db_available() -> bool:
     try:
@@ -52,6 +109,10 @@ def client():
     """FastAPI TestClient. DB 가 없으면 skip."""
     if not _db_available():
         pytest.skip("DB 연결 불가 — CI(Postgres 서비스)에서 실행됩니다.")
+    # 앱 기동(lifespan)이 스키마와 데모 시드를 채우기 **전에** 비운다. 뒤에
+    # 비우면 시드까지 날아가 시드를 읽는 테스트가 전부 깨진다.
+    if _is_disposable(DATABASE_URL):
+        _reset_database(DATABASE_URL)
     from fastapi.testclient import TestClient
 
     from app.main import app


### PR DESCRIPTION
Closes #762

## Summary

로컬에서 백엔드 스위트를 **두 번째로 돌리면** 몇 건이 깨졌습니다. CI 는 항상 통과했습니다.

실행마다 실패 항목이 3~5건으로 달라져 불안정 테스트로 보였지만, 원인은 하나였습니다 — **테스트가 만든 행을 지우지 않습니다.** CI 는 실행마다 새 Postgres 컨테이너를 받아 빈 DB 로 시작하므로 드러나지 않고, 로컬은 같은 DB 를 재사용해 지난 실행의 행이 남습니다.

```
psycopg.errors.UniqueViolation: duplicate key value violates unique constraint "exercise_sessions_pkey"
DETAIL:  Key (id)=(user-made-not-seed-1) already exists.
```

매번 나오는 3건이 뒷정리를 안 하는 테스트이고, 나머지는 그 잔여 행이 다른 테스트의 집계·조회에 걸릴 때만 함께 실패했습니다.

## Changes

**스위트 시작 시 테스트 DB 의 행을 비웁니다.** 개별 테스트에 정리 코드를 심는 대신 모든 실행이 CI 와 같은 빈 상태에서 출발하게 했습니다 — 개별 정리는 "무엇이 테스트가 만든 것인지" 목록을 사람이 관리해야 해서 지금 문제를 다시 만듭니다.

안전장치를 뒀습니다.

- **원격 DB 는 어떤 경우에도 건드리지 않습니다.** 공유 DB(Neon)를 가리킨 채 스위트를 돌리는 실수가 팀 데이터를 지우는 일로 이어지면 안 됩니다.
- 로컬이라도 **앱 기본 DB(`oncare`)는 비우지 않습니다.** 사람이 직접 쓰는 개발·데모 DB 입니다.
- `DROP SCHEMA` 가 아니라 `TRUNCATE` 입니다. pgvector 확장과 alembic 이력을 살립니다 — 확장 생성은 superuser 권한이 필요해 지우면 되살릴 수 없습니다.

**임베더를 오프라인 해시로 고정합니다.** DB 를 비우면 공공 RAG 문서 8건이 매 실행 다시 적재되는데, 로컬 `.env` 에 실제 `GEMINI_API_KEY` 가 있으면 그 적재가 **네트워크 임베딩 호출**이 됩니다. 스위트가 느려질 뿐 아니라 외부 서비스에 의존하게 됩니다. 키가 없는 CI 는 이미 해시로 폴백하므로 로컬을 같은 경로로 맞췄습니다 — 이 파일이 `recognizer` 를 stub 으로 고정하는 것과 같은 이유입니다. 두 임베더가 `embed_dim` 을 공유해 벡터 차원은 달라지지 않습니다.

## Verification

두 번 연속 실행이 **같은 결과**를 냅니다(둘 다 exit 0). 이전에는 두 번째부터 깨졌습니다.

| | 이전 | 이후 |
|---|---|---|
| 결과 | 847 통과 · 3 실패 | **850 통과 · 0 실패** |
| 시간 | 374초 | **272초** |

느려질 것으로 봤는데 오히려 빨라졌습니다. 네트워크 임베딩이 사라진 몫입니다. 그래서 참조 데이터(공공 식품 2,133행)를 예외로 두는 최적화는 넣지 않았습니다 — 필요가 없고, 예외를 두면 "무엇이 남고 무엇이 지워지는가" 를 다시 관리해야 합니다.

## Notes

CI 동작은 달라지지 않습니다. CI 의 DB 는 `oncare` 라 비우기 대상이 아니고(이미 매번 새 컨테이너), 임베더도 키가 없어 이미 해시였습니다. 이 PR 은 **로컬을 CI 와 같게** 만듭니다.
