### PR TITLE
chore(demo): 김민수 데모 데이터의 앱·백엔드 공유 픽스처

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -4,10 +4,14 @@ on:
   push:
     paths:
       - "backend/**"
+      # 김민수 데모 픽스처는 세 곳이 함께 읽는다 — 이것만 바뀌어도 돌아야 한다(#757).
+      - "shared/demo_fixture/**"
       - ".github/workflows/backend-ci.yml"
   pull_request:
     paths:
       - "backend/**"
+      # 김민수 데모 픽스처는 세 곳이 함께 읽는다 — 이것만 바뀌어도 돌아야 한다(#757).
+      - "shared/demo_fixture/**"
       - ".github/workflows/backend-ci.yml"
 
 jobs:

--- a/.github/workflows/trainer-ci.yml
+++ b/.github/workflows/trainer-ci.yml
@@ -7,11 +7,15 @@ on:
   pull_request:
     paths:
       - "frontend/flutter_trainer/**"
+      # 김민수 데모 픽스처는 세 곳이 함께 읽는다 — 이것만 바뀌어도 돌아야 한다(#757).
+      - "shared/demo_fixture/**"
       - ".github/workflows/trainer-ci.yml"
   push:
     branches: [main]
     paths:
       - "frontend/flutter_trainer/**"
+      # 김민수 데모 픽스처는 세 곳이 함께 읽는다 — 이것만 바뀌어도 돌아야 한다(#757).
+      - "shared/demo_fixture/**"
       - ".github/workflows/trainer-ci.yml"
 
 permissions:

--- a/.github/workflows/user-app-ci.yml
+++ b/.github/workflows/user-app-ci.yml
@@ -50,6 +50,16 @@ jobs:
           flutter-version: '3.44.9'
           cache: true
 
+      # 김민수 데모 픽스처는 두 앱과 백엔드가 함께 읽는다(#757). 픽스처 자체의
+      # 불변식(큐레이션 합계·이행률 산출·앱에 심긴 Dart 상수가 원본 JSON 과 같은지)은
+      # 앱 테스트가 보지 않으므로 여기서 한 번 돌린다. 트레이너 CI 에도 두면 같은
+      # 검사를 두 번 하게 되므로 이 한 곳에만 둔다.
+      - name: Test shared demo fixture
+        working-directory: shared/demo_fixture
+        run: |
+          dart pub get
+          dart test
+
       - name: Install dependencies
         run: flutter pub get
 

--- a/.github/workflows/user-app-ci.yml
+++ b/.github/workflows/user-app-ci.yml
@@ -8,11 +8,15 @@ on:
   pull_request:
     paths:
       - "frontend/flutter/**"
+      # 김민수 데모 픽스처는 세 곳이 함께 읽는다 — 이것만 바뀌어도 돌아야 한다(#757).
+      - "shared/demo_fixture/**"
       - ".github/workflows/user-app-ci.yml"
   push:
     branches: [main]
     paths:
       - "frontend/flutter/**"
+      # 김민수 데모 픽스처는 세 곳이 함께 읽는다 — 이것만 바뀌어도 돌아야 한다(#757).
+      - "shared/demo_fixture/**"
       - ".github/workflows/user-app-ci.yml"
 
 permissions:

--- a/backend/app/db/demo_fixture.py
+++ b/backend/app/db/demo_fixture.py
@@ -1,0 +1,253 @@
+"""김민수 데모 데이터의 단일 원본을 읽는다.
+
+사용자 앱의 `user-demo` 와 트레이너 앱의 `seed-client-1` 은 같은 사람이다.
+예전에는 두 앱과 백엔드가 각자 알고리즘으로 그의 과거를 만들어서, 같은 날짜를
+나란히 놓으면 숫자가 어긋났다(#757). 이제 셋 다 이 픽스처만 읽는다 — 여기에
+계산은 없고, 픽스처에 적힌 값을 날짜에 붙이는 일만 한다.
+
+**이행률은 저장하지 않는다.** [FixtureDay.completion] 은 그날 루틴 항목 중
+`done` 인 것의 비율이다. 퍼센트를 따로 적어 두면 화면의 "3개 중 2개 완료" 와
+숫자가 갈라진다.
+
+Dart 쪽 짝은 `shared/demo_fixture/lib/demo_fixture.dart` 다 — 날짜를 붙이는
+규칙(주 격자 + 최근 사흘 덮어쓰기)을 양쪽이 똑같이 구현한다.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import date, timedelta
+from functools import lru_cache
+from pathlib import Path
+
+#: 픽스처 파일. `shared/demo_fixture/assets/kim_minsu.json` 과 내용이 같다 —
+#: 백엔드 이미지가 `backend/` 만 담기 때문에 여기에도 둔다(`tool/gen_demo_fixture.py`
+#: 가 두 곳에 함께 쓴다).
+FIXTURE_PATH = Path(__file__).with_name("demo_fixture_data.json")
+
+_DAY_LABELS = ("월", "화", "수", "목", "금", "토", "일")
+
+
+@dataclass(frozen=True)
+class FixtureFood:
+    name: str
+    calories: int
+    sodium_mg: int
+    sugar_g: float
+    carbs_g: float
+    protein_g: float
+    fat_g: float
+
+    def as_row(self) -> dict:
+        """화면·저장소가 읽는 키 이름 그대로. 세 곳이 같은 키를 쓴다."""
+        return {
+            "name": self.name,
+            "calories": self.calories,
+            "sodium_mg": self.sodium_mg,
+            "sugar_g": self.sugar_g,
+            "carbs_g": self.carbs_g,
+            "protein_g": self.protein_g,
+            "fat_g": self.fat_g,
+        }
+
+
+@dataclass(frozen=True)
+class FixtureMeal:
+    slug: str
+    #: 시연 중 화면에서 지목하는 행만 id 를 못 박는다. 나머지는 None 이고 호출부가
+    #: 날짜로 만든다.
+    row_id: str | None
+    meal_type: str
+    time_label: str
+    photo_asset: str
+    ai_comment: str
+    foods: tuple[FixtureFood, ...]
+
+    @property
+    def calories(self) -> int:
+        return sum(f.calories for f in self.foods)
+
+    @property
+    def sodium_mg(self) -> int:
+        return sum(f.sodium_mg for f in self.foods)
+
+    @property
+    def sugar_g(self) -> float:
+        return round(sum(f.sugar_g for f in self.foods), 1)
+
+    @property
+    def carbs_g(self) -> float:
+        return round(sum(f.carbs_g for f in self.foods), 1)
+
+    @property
+    def protein_g(self) -> float:
+        return round(sum(f.protein_g for f in self.foods), 1)
+
+    @property
+    def fat_g(self) -> float:
+        return round(sum(f.fat_g for f in self.foods), 1)
+
+    def foods_json(self) -> str:
+        return json.dumps([f.as_row() for f in self.foods], ensure_ascii=False)
+
+
+@dataclass(frozen=True)
+class FixtureExercise:
+    name: str
+    #: `cardio` | `strength` | `stretching`.
+    type: str
+    minutes: int
+    calories: int
+    done: bool
+
+    @property
+    def label(self) -> str:
+        """트레이너 화면이 쓰는 표기. 이행률과 이 목록이 같은 자리에서 나온다(#754)."""
+        return f"{self.name} {'✓' if self.done else '✗'}"
+
+
+@dataclass(frozen=True)
+class FixtureDay:
+    day: date
+    meals: tuple[FixtureMeal, ...]
+    exercises: tuple[FixtureExercise, ...]
+    routine_label: str
+    is_pt: bool
+    client_feedback: str
+    trainer_note: str
+    day_message: str
+
+    @property
+    def iso(self) -> str:
+        return self.day.isoformat()
+
+    @property
+    def week_start(self) -> str:
+        """그 주 월요일. 운동은 주 단위로 조회된다."""
+        return (self.day - timedelta(days=self.day.weekday())).isoformat()
+
+    @property
+    def day_label(self) -> str:
+        return _DAY_LABELS[self.day.weekday()]
+
+    @property
+    def has_record(self) -> bool:
+        return bool(self.meals or self.exercises)
+
+    @property
+    def calories(self) -> int:
+        return sum(m.calories for m in self.meals)
+
+    @property
+    def sodium_mg(self) -> int:
+        return sum(m.sodium_mg for m in self.meals)
+
+    @property
+    def sugar_g(self) -> float:
+        return round(sum(m.sugar_g for m in self.meals), 1)
+
+    @property
+    def completion(self) -> int:
+        """이행률(%) — 저장된 값이 아니라 `done` 개수에서 나온다. 휴식일은 0."""
+        if not self.exercises:
+            return 0
+        done = sum(1 for e in self.exercises if e.done)
+        return round(done * 100 / len(self.exercises))
+
+    @property
+    def done_exercises(self) -> tuple[FixtureExercise, ...]:
+        """실제로 한 운동만. 주간 활동 합계가 이걸 쌓는다."""
+        return tuple(e for e in self.exercises if e.done)
+
+
+class DemoFixture:
+    """픽스처 파일 한 벌."""
+
+    def __init__(self, payload: dict) -> None:
+        member = payload["member"]
+        self.member_name: str = member["name"]
+        #: 사용자 앱 데모 계정 id.
+        self.user_app_seed_id: str = member["userAppSeedId"]
+        #: 트레이너 앱에서 같은 사람을 가리키는 고객 id.
+        self.trainer_client_id: str = member["trainerClientId"]
+        #: 픽스처가 덮는 주 수(이번 주 포함).
+        self.history_weeks: int = payload["historyWeeks"]
+        self._foods = {
+            key: FixtureFood(
+                name=value["name"],
+                calories=value["calories"],
+                sodium_mg=value["sodiumMg"],
+                sugar_g=value["sugarG"],
+                carbs_g=value["carbsG"],
+                protein_g=value["proteinG"],
+                fat_g=value["fatG"],
+            )
+            for key, value in payload["foods"].items()
+        }
+        self._meals: dict[str, dict] = payload["meals"]
+        self._recent: list[dict] = payload["recent"]
+        self._weeks: list[dict] = payload["weeks"]
+
+    def days_for(self, today: date) -> list[FixtureDay]:
+        """[today] 기준으로 날짜가 붙은 하루들을 오래된 → 오늘 순으로 돌려준다.
+
+        주 격자가 달력 주를 채우고, 최근 사흘(오늘·어제·그제)이 그 위를 덮는다.
+        아직 오지 않은 요일은 넣지 않는다 — 넣으면 주간 추이 그래프가 빈 날을
+        막대로 그리고 주 평균도 실제보다 높아진다(#752).
+        """
+        this_monday = today - timedelta(days=today.weekday())
+        by_date: dict[date, FixtureDay] = {}
+
+        for week in self._weeks:
+            week_monday = this_monday - timedelta(days=7 * week["weeksAgo"])
+            for entry in week["days"]:
+                day = week_monday + timedelta(days=entry["weekday"])
+                if day > today:
+                    continue
+                by_date[day] = self._day_from(entry, day)
+
+        for entry in self._recent:
+            day = today - timedelta(days=entry["offset"])
+            by_date[day] = self._day_from(entry, day)
+
+        return [by_date[key] for key in sorted(by_date)]
+
+    def _day_from(self, entry: dict, day: date) -> FixtureDay:
+        return FixtureDay(
+            day=day,
+            meals=tuple(self._meal_from(meal) for meal in entry["meals"]),
+            exercises=tuple(
+                FixtureExercise(
+                    name=item["name"],
+                    type=item["type"],
+                    minutes=item["minutes"],
+                    calories=item["calories"],
+                    done=item["done"],
+                )
+                for item in entry["exercises"]
+            ),
+            routine_label=entry.get("label", ""),
+            is_pt=entry.get("pt", False),
+            client_feedback=entry.get("clientFeedback", ""),
+            trainer_note=entry.get("trainerNote", ""),
+            day_message=entry.get("dayMessage", ""),
+        )
+
+    def _meal_from(self, entry: dict) -> FixtureMeal:
+        slug = entry["meal"]
+        template = self._meals[slug]
+        return FixtureMeal(
+            slug=slug,
+            row_id=entry.get("id"),
+            meal_type=template["mealType"],
+            time_label=entry.get("timeLabel", template["timeLabel"]),
+            photo_asset=template["photoAsset"],
+            ai_comment=entry.get("aiComment", template["aiComment"]),
+            foods=tuple(self._foods[key] for key in template["foods"]),
+        )
+
+
+@lru_cache(maxsize=1)
+def load_fixture() -> DemoFixture:
+    """픽스처를 읽는다. 파일은 바뀌지 않으므로 한 번만 읽는다."""
+    return DemoFixture(json.loads(FIXTURE_PATH.read_text(encoding="utf-8")))

--- a/backend/app/db/demo_fixture_data.json
+++ b/backend/app/db/demo_fixture_data.json
@@ -1,0 +1,3364 @@
+{
+  "version": 1,
+  "readme": "김민수 데모 데이터의 단일 원본. 사용자앱·트레이너웹·백엔드가 이 파일만 읽는다. 날짜는 상대값이다 — weeks[].weeksAgo 는 이번 주 월요일에서 몇 주 거슬러 올라가는지, days[].weekday 는 월(0)~일(6). recent[].offset 은 오늘로부터의 일수이고 주 격자 위를 덮는다. 이행률은 exercises[].done 개수에서 계산한다 — 퍼센트를 따로 적지 않는다.",
+  "member": {
+    "name": "김민수",
+    "userAppSeedId": "user-demo",
+    "trainerClientId": "seed-client-1"
+  },
+  "historyWeeks": 12,
+  "foods": {
+    "oatmeal": {
+      "name": "오트밀",
+      "calories": 250,
+      "sodiumMg": 100,
+      "sugarG": 6.0,
+      "carbsG": 42.0,
+      "proteinG": 10.0,
+      "fatG": 6.0
+    },
+    "banana": {
+      "name": "바나나",
+      "calories": 105,
+      "sodiumMg": 1,
+      "sugarG": 14.0,
+      "carbsG": 27.0,
+      "proteinG": 1.3,
+      "fatG": 0.4
+    },
+    "greek-yogurt": {
+      "name": "그릭 요거트",
+      "calories": 170,
+      "sodiumMg": 75,
+      "sugarG": 7.0,
+      "carbsG": 8.0,
+      "proteinG": 18.0,
+      "fatG": 8.0
+    },
+    "nuts": {
+      "name": "견과류",
+      "calories": 150,
+      "sodiumMg": 5,
+      "sugarG": 2.0,
+      "carbsG": 6.0,
+      "proteinG": 5.0,
+      "fatG": 13.0
+    },
+    "scrambled-egg": {
+      "name": "스크램블 에그",
+      "calories": 185,
+      "sodiumMg": 220,
+      "sugarG": 0.8,
+      "carbsG": 2.0,
+      "proteinG": 13.0,
+      "fatG": 14.0
+    },
+    "strawberry": {
+      "name": "딸기",
+      "calories": 32,
+      "sodiumMg": 1,
+      "sugarG": 5.5,
+      "carbsG": 8.0,
+      "proteinG": 0.5,
+      "fatG": 0.5
+    },
+    "chicken-salad": {
+      "name": "닭가슴살 샐러드",
+      "calories": 315,
+      "sodiumMg": 395,
+      "sugarG": 10.0,
+      "carbsG": 19.0,
+      "proteinG": 34.0,
+      "fatG": 11.1
+    },
+    "bibimbap": {
+      "name": "야채비빔밥",
+      "calories": 610,
+      "sodiumMg": 900,
+      "sugarG": 12.0,
+      "carbsG": 92.0,
+      "proteinG": 20.0,
+      "fatG": 16.0
+    },
+    "jjamppong": {
+      "name": "짬뽕",
+      "calories": 750,
+      "sodiumMg": 3200,
+      "sugarG": 8.5,
+      "carbsG": 107.0,
+      "proteinG": 29.0,
+      "fatG": 22.5
+    },
+    "doenjang-jjigae": {
+      "name": "된장찌개",
+      "calories": 300,
+      "sodiumMg": 1300,
+      "sugarG": 5.0,
+      "carbsG": 18.0,
+      "proteinG": 24.0,
+      "fatG": 15.0
+    },
+    "rice": {
+      "name": "밥",
+      "calories": 310,
+      "sodiumMg": 5,
+      "sugarG": 0.7,
+      "carbsG": 67.0,
+      "proteinG": 6.0,
+      "fatG": 2.5
+    },
+    "grilled-salmon": {
+      "name": "연어구이",
+      "calories": 395,
+      "sodiumMg": 505,
+      "sugarG": 9.0,
+      "carbsG": 19.0,
+      "proteinG": 35.0,
+      "fatG": 19.0
+    },
+    "brown-rice": {
+      "name": "현미밥",
+      "calories": 280,
+      "sodiumMg": 5,
+      "sugarG": 0.0,
+      "carbsG": 58.0,
+      "proteinG": 6.0,
+      "fatG": 2.0
+    },
+    "sweet-potato": {
+      "name": "고구마",
+      "calories": 130,
+      "sodiumMg": 20,
+      "sugarG": 6.5,
+      "carbsG": 30.0,
+      "proteinG": 2.0,
+      "fatG": 0.2
+    },
+    "iced-americano": {
+      "name": "아이스 아메리카노",
+      "calories": 10,
+      "sodiumMg": 5,
+      "sugarG": 0.0,
+      "carbsG": 2.0,
+      "proteinG": 0.5,
+      "fatG": 0.0
+    },
+    "nut-pack": {
+      "name": "견과류 한 봉",
+      "calories": 90,
+      "sodiumMg": 2,
+      "sugarG": 3.0,
+      "carbsG": 1.0,
+      "proteinG": 2.0,
+      "fatG": 8.0
+    },
+    "samgyeopsal": {
+      "name": "삼겹살 2인분",
+      "calories": 620,
+      "sodiumMg": 880,
+      "sugarG": 1.0,
+      "carbsG": 2.0,
+      "proteinG": 42.0,
+      "fatG": 50.0
+    },
+    "soju": {
+      "name": "소주 1병",
+      "calories": 55,
+      "sodiumMg": 0,
+      "sugarG": 0.0,
+      "carbsG": 0.0,
+      "proteinG": 0.0,
+      "fatG": 0.0
+    },
+    "choco-cake": {
+      "name": "초코 케이크 한 조각",
+      "calories": 330,
+      "sodiumMg": 280,
+      "sugarG": 24.0,
+      "carbsG": 42.0,
+      "proteinG": 5.0,
+      "fatG": 15.0
+    },
+    "cafe-latte": {
+      "name": "카페라떼",
+      "calories": 100,
+      "sodiumMg": 95,
+      "sugarG": 5.3,
+      "carbsG": 10.0,
+      "proteinG": 5.0,
+      "fatG": 4.0
+    }
+  },
+  "meals": {
+    "breakfast-oatmeal-banana": {
+      "mealType": "breakfast",
+      "timeLabel": "08:05",
+      "photoAsset": "assets/images/diet-oatmeal-banana.jpeg",
+      "aiComment": "오트밀로 식이섬유를 챙긴 아침이에요.",
+      "foods": [
+        "oatmeal",
+        "banana"
+      ]
+    },
+    "breakfast-greek-yogurt-nuts": {
+      "mealType": "breakfast",
+      "timeLabel": "08:30",
+      "photoAsset": "assets/images/diet-greek-yogurt-nuts.jpeg",
+      "aiComment": "단백질과 불포화지방을 고르게 섭취했어요.",
+      "foods": [
+        "greek-yogurt",
+        "nuts"
+      ]
+    },
+    "breakfast-egg-strawberry": {
+      "mealType": "breakfast",
+      "timeLabel": "07:50",
+      "photoAsset": "assets/images/breakfast-scrambled-egg-strawberry.jpg",
+      "aiComment": "달걀 단백질에 과일로 비타민을 더했어요.",
+      "foods": [
+        "scrambled-egg",
+        "strawberry"
+      ]
+    },
+    "lunch-chicken-salad": {
+      "mealType": "lunch",
+      "timeLabel": "12:30",
+      "photoAsset": "assets/images/diet-chicken-salad.jpg",
+      "aiComment": "닭가슴살과 채소로 단백질·식이섬유를 챙겼어요.",
+      "foods": [
+        "chicken-salad"
+      ]
+    },
+    "lunch-bibimbap": {
+      "mealType": "lunch",
+      "timeLabel": "12:20",
+      "photoAsset": "assets/images/diet-vegetable-bibimbap.jpg",
+      "aiComment": "야채가 풍부해요. 고추장을 줄이면 나트륨이 더 좋아져요.",
+      "foods": [
+        "bibimbap"
+      ]
+    },
+    "lunch-jjamppong": {
+      "mealType": "lunch",
+      "timeLabel": "12:50",
+      "photoAsset": "assets/images/lunch-jjamppong.jpg",
+      "aiComment": "국물 나트륨이 높은 날이에요. 국물은 남기는 편이 좋아요.",
+      "foods": [
+        "jjamppong"
+      ]
+    },
+    "lunch-doenjang-rice": {
+      "mealType": "lunch",
+      "timeLabel": "12:10",
+      "photoAsset": "assets/images/diet-doenjang-rice.jpeg",
+      "aiComment": "집밥 한 상이에요. 찌개 국물만 조금 남겨 보세요.",
+      "foods": [
+        "doenjang-jjigae",
+        "rice"
+      ]
+    },
+    "dinner-salmon-brown-rice": {
+      "mealType": "dinner",
+      "timeLabel": "18:40",
+      "photoAsset": "assets/images/diet-salmon-brown-rice.jpeg",
+      "aiComment": "연어의 지방과 현미밥의 복합 탄수화물 조합이 좋아요.",
+      "foods": [
+        "grilled-salmon",
+        "brown-rice"
+      ]
+    },
+    "dinner-doenjang-rice": {
+      "mealType": "dinner",
+      "timeLabel": "19:10",
+      "photoAsset": "assets/images/diet-doenjang-rice.jpeg",
+      "aiComment": "포만감은 좋지만 국물 나트륨이 높은 편이에요.",
+      "foods": [
+        "doenjang-jjigae",
+        "rice"
+      ]
+    },
+    "dinner-chicken-salad-sweet-potato": {
+      "mealType": "dinner",
+      "timeLabel": "18:20",
+      "photoAsset": "assets/images/diet-chicken-salad.jpg",
+      "aiComment": "가볍게 마무리한 저녁이에요.",
+      "foods": [
+        "chicken-salad",
+        "sweet-potato"
+      ]
+    },
+    "dinner-samgyeopsal": {
+      "mealType": "dinner",
+      "timeLabel": "19:30",
+      "photoAsset": "assets/images/diet-doenjang-rice.jpeg",
+      "aiComment": "고기와 술이 함께여서 칼로리가 크게 올라갔어요. 다음 날은 가볍게 시작해 보세요.",
+      "foods": [
+        "samgyeopsal",
+        "rice",
+        "soju"
+      ]
+    },
+    "snack-coffee-nuts": {
+      "mealType": "snack",
+      "timeLabel": "15:40",
+      "photoAsset": "assets/images/snack-coffee-nuts.jpg",
+      "aiComment": "당류가 낮고 건강한 지방을 채운 간식이에요.",
+      "foods": [
+        "iced-americano",
+        "nut-pack"
+      ]
+    },
+    "snack-cake-latte": {
+      "mealType": "snack",
+      "timeLabel": "21:10",
+      "photoAsset": "assets/images/snack-coffee-nuts.jpg",
+      "aiComment": "디저트로 당류가 하루 목표를 넘었어요.",
+      "foods": [
+        "choco-cake",
+        "cafe-latte"
+      ]
+    }
+  },
+  "recent": [
+    {
+      "offset": 0,
+      "label": "PT 세션 · 트레이너 지도",
+      "pt": true,
+      "clientFeedback": "무릎이 좀 당겼지만 트레이너님 덕분에 잘 마쳤어요 😊",
+      "trainerNote": "무릎 가동범위 체크 필요. 다음 세션 중량 조절 예정.",
+      "dayMessage": "점심 짬뽕으로 오늘 나트륨 섭취가 많았어요. 저녁은 양념을 줄인 채소와 단백질 위주로 구성해 보세요.",
+      "exercises": [
+        {
+          "name": "레그프레스 3세트",
+          "type": "strength",
+          "minutes": 25,
+          "calories": 125,
+          "done": true
+        },
+        {
+          "name": "레그컬 3세트",
+          "type": "strength",
+          "minutes": 20,
+          "calories": 100,
+          "done": true
+        },
+        {
+          "name": "하체 스트레칭 15분",
+          "type": "stretching",
+          "minutes": 15,
+          "calories": 45,
+          "done": true
+        }
+      ],
+      "meals": [
+        {
+          "meal": "breakfast-egg-strawberry",
+          "id": "seed-diet-breakfast",
+          "timeLabel": "08:20",
+          "aiComment": "단백질과 식이섬유의 깔끔한 조합으로, 소금 간과 기름만 조절하면 혈당과 혈압 모두 잡는 우수한 식단입니다."
+        },
+        {
+          "meal": "lunch-jjamppong",
+          "id": "seed-diet-lunch",
+          "timeLabel": "12:40",
+          "aiComment": "정제 면과 높은 나트륨으로 혈압·혈당 부담이 매우 크니, 국물은 남기고 야채 위주로 드시는 것이 좋습니다."
+        },
+        {
+          "meal": "snack-coffee-nuts",
+          "id": "seed-diet-snack",
+          "timeLabel": "15:30",
+          "aiComment": "당류와 칼로리가 낮고 견과류의 건강한 지방이 채워져 완벽한 간식입니다."
+        }
+      ]
+    },
+    {
+      "offset": 1,
+      "label": "AI 루틴 · 자율 운동",
+      "pt": false,
+      "clientFeedback": "스트레칭은 시간이 없어서 못 했어요",
+      "trainerNote": "",
+      "dayMessage": "약속이 있어 칼로리와 당류가 목표를 넘은 하루예요. 오늘은 가볍게 시작해 보세요.",
+      "exercises": [
+        {
+          "name": "저강도 유산소 (걷기) 30분",
+          "type": "cardio",
+          "minutes": 30,
+          "calories": 225,
+          "done": true
+        },
+        {
+          "name": "코어 강화 10분",
+          "type": "strength",
+          "minutes": 10,
+          "calories": 50,
+          "done": true
+        },
+        {
+          "name": "하체 스트레칭 15분",
+          "type": "stretching",
+          "minutes": 15,
+          "calories": 45,
+          "done": false
+        }
+      ],
+      "meals": [
+        {
+          "meal": "breakfast-oatmeal-banana",
+          "id": "seed-diet-yesterday-breakfast",
+          "timeLabel": "08:10",
+          "aiComment": "오트밀로 식이섬유를 챙겼어요. 바나나가 들어가 당류는 다소 높은 편이에요."
+        },
+        {
+          "meal": "lunch-bibimbap",
+          "id": "seed-diet-yesterday-lunch",
+          "timeLabel": "12:30",
+          "aiComment": "야채가 풍부한 비빔밥이에요. 고추장을 줄이면 나트륨을 더 조절할 수 있어요."
+        },
+        {
+          "meal": "dinner-samgyeopsal",
+          "id": "seed-diet-yesterday-dinner"
+        },
+        {
+          "meal": "snack-cake-latte",
+          "id": "seed-diet-yesterday-snack"
+        }
+      ]
+    },
+    {
+      "offset": 2,
+      "label": "AI 루틴 · 자율 운동",
+      "pt": false,
+      "clientFeedback": "오늘은 다 했어요! 뿌듯해요 💪",
+      "trainerNote": "",
+      "dayMessage": "연어와 현미밥으로 탄단지 균형을 잘 맞췄어요.",
+      "exercises": [
+        {
+          "name": "저강도 유산소 (걷기) 30분",
+          "type": "cardio",
+          "minutes": 30,
+          "calories": 225,
+          "done": true
+        },
+        {
+          "name": "코어 강화 10분",
+          "type": "strength",
+          "minutes": 10,
+          "calories": 50,
+          "done": true
+        },
+        {
+          "name": "하체 스트레칭 15분",
+          "type": "stretching",
+          "minutes": 15,
+          "calories": 45,
+          "done": true
+        }
+      ],
+      "meals": [
+        {
+          "meal": "breakfast-greek-yogurt-nuts",
+          "id": "seed-diet-two-days-ago-breakfast",
+          "timeLabel": "08:35",
+          "aiComment": "그릭 요거트의 단백질과 견과류의 불포화지방을 고르게 섭취했어요."
+        },
+        {
+          "meal": "lunch-bibimbap",
+          "id": "seed-diet-two-days-ago-lunch",
+          "timeLabel": "12:20",
+          "aiComment": "야채가 풍부한 비빔밥이에요. 고추장을 줄이면 나트륨을 더 조절할 수 있어요."
+        },
+        {
+          "meal": "dinner-salmon-brown-rice",
+          "id": "seed-diet-two-days-ago-dinner",
+          "timeLabel": "18:50",
+          "aiComment": "연어의 지방과 현미밥의 복합 탄수화물 조합이 좋아요."
+        }
+      ]
+    }
+  ],
+  "weeks": [
+    {
+      "weeksAgo": 0,
+      "note": "평소의 한 주 — 국물이 잦지만 기록은 성실하다.",
+      "days": [
+        {
+          "weekday": 0,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 30분",
+              "type": "cardio",
+              "minutes": 30,
+              "calories": 225,
+              "done": true
+            },
+            {
+              "name": "코어 강화 10분",
+              "type": "strength",
+              "minutes": 10,
+              "calories": 50,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 1,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 40분",
+              "type": "cardio",
+              "minutes": 40,
+              "calories": 300,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 2,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-doenjang-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 3,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 35분",
+              "type": "cardio",
+              "minutes": 35,
+              "calories": 262,
+              "done": true
+            },
+            {
+              "name": "코어 강화 20분",
+              "type": "strength",
+              "minutes": 20,
+              "calories": 100,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 4,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 45분",
+              "type": "cardio",
+              "minutes": 45,
+              "calories": 338,
+              "done": true
+            },
+            {
+              "name": "어깨 관절 보호 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-doenjang-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 5,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 25분",
+              "type": "cardio",
+              "minutes": 25,
+              "calories": 188,
+              "done": true
+            },
+            {
+              "name": "코어 강화 30분",
+              "type": "strength",
+              "minutes": 30,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 15분",
+              "type": "stretching",
+              "minutes": 15,
+              "calories": 45,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 6,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 20분",
+              "type": "cardio",
+              "minutes": 20,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "weeksAgo": 1,
+      "note": "가볍게 간 한 주 — 세 지표가 모두 목표 안에 든다.",
+      "days": [
+        {
+          "weekday": 0,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 30분",
+              "type": "cardio",
+              "minutes": 30,
+              "calories": 225,
+              "done": true
+            },
+            {
+              "name": "코어 강화 10분",
+              "type": "strength",
+              "minutes": 10,
+              "calories": 50,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 1,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 40분",
+              "type": "cardio",
+              "minutes": 40,
+              "calories": 300,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 2,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 3,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 35분",
+              "type": "cardio",
+              "minutes": 35,
+              "calories": 262,
+              "done": true
+            },
+            {
+              "name": "코어 강화 20분",
+              "type": "strength",
+              "minutes": 20,
+              "calories": 100,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 4,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 45분",
+              "type": "cardio",
+              "minutes": 45,
+              "calories": 338,
+              "done": true
+            },
+            {
+              "name": "어깨 관절 보호 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 5,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 25분",
+              "type": "cardio",
+              "minutes": 25,
+              "calories": 188,
+              "done": true
+            },
+            {
+              "name": "코어 강화 30분",
+              "type": "strength",
+              "minutes": 30,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 15분",
+              "type": "stretching",
+              "minutes": 15,
+              "calories": 45,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            }
+          ]
+        },
+        {
+          "weekday": 6,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 20분",
+              "type": "cardio",
+              "minutes": 20,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "weeksAgo": 2,
+      "note": "회식이 몰린 주 — 칼로리와 당류가 함께 목표를 넘는다.",
+      "days": [
+        {
+          "weekday": 0,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 30분",
+              "type": "cardio",
+              "minutes": 30,
+              "calories": 225,
+              "done": true
+            },
+            {
+              "name": "코어 강화 10분",
+              "type": "strength",
+              "minutes": 10,
+              "calories": 50,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-samgyeopsal"
+            },
+            {
+              "meal": "snack-cake-latte"
+            }
+          ]
+        },
+        {
+          "weekday": 1,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 40분",
+              "type": "cardio",
+              "minutes": 40,
+              "calories": 300,
+              "done": false
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-cake-latte"
+            }
+          ]
+        },
+        {
+          "weekday": 2,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-samgyeopsal"
+            }
+          ]
+        },
+        {
+          "weekday": 3,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 35분",
+              "type": "cardio",
+              "minutes": 35,
+              "calories": 262,
+              "done": true
+            },
+            {
+              "name": "코어 강화 20분",
+              "type": "strength",
+              "minutes": 20,
+              "calories": 100,
+              "done": false
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-doenjang-rice"
+            },
+            {
+              "meal": "snack-cake-latte"
+            }
+          ]
+        },
+        {
+          "weekday": 4,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 45분",
+              "type": "cardio",
+              "minutes": 45,
+              "calories": 338,
+              "done": true
+            },
+            {
+              "name": "어깨 관절 보호 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-samgyeopsal"
+            },
+            {
+              "meal": "snack-cake-latte"
+            }
+          ]
+        },
+        {
+          "weekday": 5,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 25분",
+              "type": "cardio",
+              "minutes": 25,
+              "calories": 188,
+              "done": true
+            },
+            {
+              "name": "코어 강화 30분",
+              "type": "strength",
+              "minutes": 30,
+              "calories": 150,
+              "done": false
+            },
+            {
+              "name": "하체 스트레칭 15분",
+              "type": "stretching",
+              "minutes": 15,
+              "calories": 45,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-cake-latte"
+            }
+          ]
+        },
+        {
+          "weekday": 6,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 20분",
+              "type": "cardio",
+              "minutes": 20,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "weeksAgo": 3,
+      "note": "코칭이 먹힌 주 — 국물을 줄여 나트륨이 목표 안으로 들어온다.",
+      "days": [
+        {
+          "weekday": 0,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 30분",
+              "type": "cardio",
+              "minutes": 30,
+              "calories": 225,
+              "done": true
+            },
+            {
+              "name": "코어 강화 10분",
+              "type": "strength",
+              "minutes": 10,
+              "calories": 50,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 1,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 40분",
+              "type": "cardio",
+              "minutes": 40,
+              "calories": 300,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 2,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 3,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 35분",
+              "type": "cardio",
+              "minutes": 35,
+              "calories": 262,
+              "done": true
+            },
+            {
+              "name": "코어 강화 20분",
+              "type": "strength",
+              "minutes": 20,
+              "calories": 100,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 4,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 45분",
+              "type": "cardio",
+              "minutes": 45,
+              "calories": 338,
+              "done": true
+            },
+            {
+              "name": "어깨 관절 보호 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 5,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 25분",
+              "type": "cardio",
+              "minutes": 25,
+              "calories": 188,
+              "done": true
+            },
+            {
+              "name": "코어 강화 30분",
+              "type": "strength",
+              "minutes": 30,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 15분",
+              "type": "stretching",
+              "minutes": 15,
+              "calories": 45,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 6,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 20분",
+              "type": "cardio",
+              "minutes": 20,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "weeksAgo": 4,
+      "note": "평범한 한 주 — 구내식당 국물이 나트륨을 밀어 올린다.",
+      "days": [
+        {
+          "weekday": 0,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 30분",
+              "type": "cardio",
+              "minutes": 30,
+              "calories": 225,
+              "done": true
+            },
+            {
+              "name": "코어 강화 10분",
+              "type": "strength",
+              "minutes": 10,
+              "calories": 50,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 1,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 40분",
+              "type": "cardio",
+              "minutes": 40,
+              "calories": 300,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-doenjang-rice"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 2,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            }
+          ]
+        },
+        {
+          "weekday": 3,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 35분",
+              "type": "cardio",
+              "minutes": 35,
+              "calories": 262,
+              "done": true
+            },
+            {
+              "name": "코어 강화 20분",
+              "type": "strength",
+              "minutes": 20,
+              "calories": 100,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 4,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 45분",
+              "type": "cardio",
+              "minutes": 45,
+              "calories": 338,
+              "done": true
+            },
+            {
+              "name": "어깨 관절 보호 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-doenjang-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 5,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 25분",
+              "type": "cardio",
+              "minutes": 25,
+              "calories": 188,
+              "done": true
+            },
+            {
+              "name": "코어 강화 30분",
+              "type": "strength",
+              "minutes": 30,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 15분",
+              "type": "stretching",
+              "minutes": 15,
+              "calories": 45,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 6,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 20분",
+              "type": "cardio",
+              "minutes": 20,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "weeksAgo": 5,
+      "note": "야근이 많던 주 — 늦은 저녁은 기록이 비어 있다.",
+      "days": [
+        {
+          "weekday": 0,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 30분",
+              "type": "cardio",
+              "minutes": 30,
+              "calories": 225,
+              "done": true
+            },
+            {
+              "name": "코어 강화 10분",
+              "type": "strength",
+              "minutes": 10,
+              "calories": 50,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 1,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 40분",
+              "type": "cardio",
+              "minutes": 40,
+              "calories": 300,
+              "done": false
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 2,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-doenjang-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 3,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 35분",
+              "type": "cardio",
+              "minutes": 35,
+              "calories": 262,
+              "done": true
+            },
+            {
+              "name": "코어 강화 20분",
+              "type": "strength",
+              "minutes": 20,
+              "calories": 100,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 4,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 45분",
+              "type": "cardio",
+              "minutes": 45,
+              "calories": 338,
+              "done": true
+            },
+            {
+              "name": "어깨 관절 보호 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 5,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 25분",
+              "type": "cardio",
+              "minutes": 25,
+              "calories": 188,
+              "done": true
+            },
+            {
+              "name": "코어 강화 30분",
+              "type": "strength",
+              "minutes": 30,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 15분",
+              "type": "stretching",
+              "minutes": 15,
+              "calories": 45,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            }
+          ]
+        },
+        {
+          "weekday": 6,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 20분",
+              "type": "cardio",
+              "minutes": 20,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "weeksAgo": 6,
+      "note": "기록을 막 시작한 주 — 아예 빠진 날이 있다.",
+      "days": [
+        {
+          "weekday": 0,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 30분",
+              "type": "cardio",
+              "minutes": 30,
+              "calories": 225,
+              "done": true
+            },
+            {
+              "name": "코어 강화 10분",
+              "type": "strength",
+              "minutes": 10,
+              "calories": 50,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-doenjang-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 1,
+          "exercises": [],
+          "meals": []
+        },
+        {
+          "weekday": 2,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 3,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 35분",
+              "type": "cardio",
+              "minutes": 35,
+              "calories": 262,
+              "done": true
+            },
+            {
+              "name": "코어 강화 20분",
+              "type": "strength",
+              "minutes": 20,
+              "calories": 100,
+              "done": false
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 4,
+          "exercises": [],
+          "meals": []
+        },
+        {
+          "weekday": 5,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 25분",
+              "type": "cardio",
+              "minutes": 25,
+              "calories": 188,
+              "done": true
+            },
+            {
+              "name": "코어 강화 30분",
+              "type": "strength",
+              "minutes": 30,
+              "calories": 150,
+              "done": false
+            },
+            {
+              "name": "하체 스트레칭 15분",
+              "type": "stretching",
+              "minutes": 15,
+              "calories": 45,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 6,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 20분",
+              "type": "cardio",
+              "minutes": 20,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "weeksAgo": 7,
+      "note": "평소의 한 주 — 국물이 잦지만 기록은 성실하다.",
+      "days": [
+        {
+          "weekday": 0,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 30분",
+              "type": "cardio",
+              "minutes": 30,
+              "calories": 225,
+              "done": true
+            },
+            {
+              "name": "코어 강화 10분",
+              "type": "strength",
+              "minutes": 10,
+              "calories": 50,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 1,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 40분",
+              "type": "cardio",
+              "minutes": 40,
+              "calories": 300,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 2,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-doenjang-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 3,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 35분",
+              "type": "cardio",
+              "minutes": 35,
+              "calories": 262,
+              "done": true
+            },
+            {
+              "name": "코어 강화 20분",
+              "type": "strength",
+              "minutes": 20,
+              "calories": 100,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 4,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 45분",
+              "type": "cardio",
+              "minutes": 45,
+              "calories": 338,
+              "done": true
+            },
+            {
+              "name": "어깨 관절 보호 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-doenjang-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 5,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 25분",
+              "type": "cardio",
+              "minutes": 25,
+              "calories": 188,
+              "done": true
+            },
+            {
+              "name": "코어 강화 30분",
+              "type": "strength",
+              "minutes": 30,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 15분",
+              "type": "stretching",
+              "minutes": 15,
+              "calories": 45,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 6,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 20분",
+              "type": "cardio",
+              "minutes": 20,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "weeksAgo": 8,
+      "note": "가볍게 간 한 주 — 세 지표가 모두 목표 안에 든다.",
+      "days": [
+        {
+          "weekday": 0,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 30분",
+              "type": "cardio",
+              "minutes": 30,
+              "calories": 225,
+              "done": true
+            },
+            {
+              "name": "코어 강화 10분",
+              "type": "strength",
+              "minutes": 10,
+              "calories": 50,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 1,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 40분",
+              "type": "cardio",
+              "minutes": 40,
+              "calories": 300,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 2,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 3,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 35분",
+              "type": "cardio",
+              "minutes": 35,
+              "calories": 262,
+              "done": true
+            },
+            {
+              "name": "코어 강화 20분",
+              "type": "strength",
+              "minutes": 20,
+              "calories": 100,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 4,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 45분",
+              "type": "cardio",
+              "minutes": 45,
+              "calories": 338,
+              "done": true
+            },
+            {
+              "name": "어깨 관절 보호 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 5,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 25분",
+              "type": "cardio",
+              "minutes": 25,
+              "calories": 188,
+              "done": true
+            },
+            {
+              "name": "코어 강화 30분",
+              "type": "strength",
+              "minutes": 30,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 15분",
+              "type": "stretching",
+              "minutes": 15,
+              "calories": 45,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            }
+          ]
+        },
+        {
+          "weekday": 6,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 20분",
+              "type": "cardio",
+              "minutes": 20,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "weeksAgo": 9,
+      "note": "회식이 몰린 주 — 칼로리와 당류가 함께 목표를 넘는다.",
+      "days": [
+        {
+          "weekday": 0,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 30분",
+              "type": "cardio",
+              "minutes": 30,
+              "calories": 225,
+              "done": true
+            },
+            {
+              "name": "코어 강화 10분",
+              "type": "strength",
+              "minutes": 10,
+              "calories": 50,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-samgyeopsal"
+            },
+            {
+              "meal": "snack-cake-latte"
+            }
+          ]
+        },
+        {
+          "weekday": 1,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 40분",
+              "type": "cardio",
+              "minutes": 40,
+              "calories": 300,
+              "done": false
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-cake-latte"
+            }
+          ]
+        },
+        {
+          "weekday": 2,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-samgyeopsal"
+            }
+          ]
+        },
+        {
+          "weekday": 3,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 35분",
+              "type": "cardio",
+              "minutes": 35,
+              "calories": 262,
+              "done": true
+            },
+            {
+              "name": "코어 강화 20분",
+              "type": "strength",
+              "minutes": 20,
+              "calories": 100,
+              "done": false
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-doenjang-rice"
+            },
+            {
+              "meal": "snack-cake-latte"
+            }
+          ]
+        },
+        {
+          "weekday": 4,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 45분",
+              "type": "cardio",
+              "minutes": 45,
+              "calories": 338,
+              "done": true
+            },
+            {
+              "name": "어깨 관절 보호 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-samgyeopsal"
+            },
+            {
+              "meal": "snack-cake-latte"
+            }
+          ]
+        },
+        {
+          "weekday": 5,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 25분",
+              "type": "cardio",
+              "minutes": 25,
+              "calories": 188,
+              "done": true
+            },
+            {
+              "name": "코어 강화 30분",
+              "type": "strength",
+              "minutes": 30,
+              "calories": 150,
+              "done": false
+            },
+            {
+              "name": "하체 스트레칭 15분",
+              "type": "stretching",
+              "minutes": 15,
+              "calories": 45,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-cake-latte"
+            }
+          ]
+        },
+        {
+          "weekday": 6,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 20분",
+              "type": "cardio",
+              "minutes": 20,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "weeksAgo": 10,
+      "note": "코칭이 먹힌 주 — 국물을 줄여 나트륨이 목표 안으로 들어온다.",
+      "days": [
+        {
+          "weekday": 0,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 30분",
+              "type": "cardio",
+              "minutes": 30,
+              "calories": 225,
+              "done": true
+            },
+            {
+              "name": "코어 강화 10분",
+              "type": "strength",
+              "minutes": 10,
+              "calories": 50,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 1,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 40분",
+              "type": "cardio",
+              "minutes": 40,
+              "calories": 300,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 2,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 3,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 35분",
+              "type": "cardio",
+              "minutes": 35,
+              "calories": 262,
+              "done": true
+            },
+            {
+              "name": "코어 강화 20분",
+              "type": "strength",
+              "minutes": 20,
+              "calories": 100,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 4,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 45분",
+              "type": "cardio",
+              "minutes": 45,
+              "calories": 338,
+              "done": true
+            },
+            {
+              "name": "어깨 관절 보호 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 5,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 25분",
+              "type": "cardio",
+              "minutes": 25,
+              "calories": 188,
+              "done": true
+            },
+            {
+              "name": "코어 강화 30분",
+              "type": "strength",
+              "minutes": 30,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 15분",
+              "type": "stretching",
+              "minutes": 15,
+              "calories": 45,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 6,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 20분",
+              "type": "cardio",
+              "minutes": 20,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "weeksAgo": 11,
+      "note": "평범한 한 주 — 구내식당 국물이 나트륨을 밀어 올린다.",
+      "days": [
+        {
+          "weekday": 0,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 30분",
+              "type": "cardio",
+              "minutes": 30,
+              "calories": 225,
+              "done": true
+            },
+            {
+              "name": "코어 강화 10분",
+              "type": "strength",
+              "minutes": 10,
+              "calories": 50,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 1,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 40분",
+              "type": "cardio",
+              "minutes": 40,
+              "calories": 300,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-doenjang-rice"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 2,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            }
+          ]
+        },
+        {
+          "weekday": 3,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 35분",
+              "type": "cardio",
+              "minutes": 35,
+              "calories": 262,
+              "done": true
+            },
+            {
+              "name": "코어 강화 20분",
+              "type": "strength",
+              "minutes": 20,
+              "calories": 100,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 4,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 45분",
+              "type": "cardio",
+              "minutes": 45,
+              "calories": 338,
+              "done": true
+            },
+            {
+              "name": "어깨 관절 보호 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-doenjang-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 5,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 25분",
+              "type": "cardio",
+              "minutes": 25,
+              "calories": 188,
+              "done": true
+            },
+            {
+              "name": "코어 강화 30분",
+              "type": "strength",
+              "minutes": 30,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 15분",
+              "type": "stretching",
+              "minutes": 15,
+              "calories": 45,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 6,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 20분",
+              "type": "cardio",
+              "minutes": 20,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/backend/app/db/seed_member_data.py
+++ b/backend/app/db/seed_member_data.py
@@ -31,7 +31,7 @@ import logging
 import time
 from datetime import date, datetime, timedelta, timezone
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -608,8 +608,15 @@ def _seed_from_fixture(db: Session, member_id: str) -> None:
     today = clock.today()
     days = fixture.days_for(today)
 
-    # 오늘치가 이미 픽스처로 깔려 있으면 아무것도 하지 않는다. 기동마다 수백 행을
-    # 지웠다 넣는 것을 막는 문지기다.
+    # 이 회원의 행 id 는 픽스처와 오늘 날짜만으로 정해진다 — 넣기 전에도 알 수 있다.
+    kept_refs = _fixture_row_ids(member_id, days)
+
+    # 문지기보다 **먼저** 쓸어낸다. 뒤에 두면, 이미 픽스처로 한 번 깔린 DB 는 문지기에
+    # 걸려 되돌아가므로 예전 행을 가리키던 문서가 영영 남는다.
+    _drop_orphaned_personal_docs(db, member_id, kept_refs)
+
+    # 오늘치가 이미 픽스처로 깔려 있으면 여기서 끝낸다. 기동마다 수백 행을 지웠다
+    # 넣는 것을 막는 문지기다.
     #
     # 접두사가 `seed-fix-` 인 이유: 예전 시드도 오늘 3끼를 `seed-diet-{회원}-{날짜}-0`
     # 으로 넣었다. 그 id 를 문지기로 삼으면 이미 돌던 DB 에서는 옛 행이 문지기에
@@ -618,6 +625,7 @@ def _seed_from_fixture(db: Session, member_id: str) -> None:
     if db.scalar(
         select(models.DietEntry.id).where(models.DietEntry.id == marker).limit(1)
     ) is not None:
+        _safe_commit(db)
         return
 
     for model in (models.DietEntry, models.ExerciseSession):
@@ -684,7 +692,54 @@ def _seed_from_fixture(db: Session, member_id: str) -> None:
                 calories=calories,
                 intensity="moderate",
             ))
+
     _safe_commit(db)
+
+
+def _fixture_row_ids(member_id: str, days: list) -> set[str]:
+    """픽스처가 이 회원에게 넣을 식단·운동 행 id 전부.
+
+    삽입과 **같은 규칙**으로 만든다 — 한쪽만 고치면 멀쩡한 문서가 고아로 몰려
+    지워진다. 개인 RAG 문서 정리(`_drop_orphaned_personal_docs`)가 이 집합을 쓴다.
+    """
+    ids: set[str] = set()
+    for day in days:
+        for index in range(len(day.meals)):
+            ids.add(f"{_FIXTURE_ID_PREFIX}diet-{member_id}-{day.iso}-{index}")
+        for kind in _by_type(day.done_exercises):
+            ids.add(f"{_FIXTURE_ID_PREFIX}ex-{member_id}-{day.iso}-{kind}")
+    return ids
+
+
+def _drop_orphaned_personal_docs(
+    db: Session, member_id: str, kept_refs: set[str]
+) -> None:
+    """지워진 시드 행을 가리키는 개인 RAG 문서를 함께 지운다.
+
+    개인 문서는 행 id(`source_ref`)로 그 기록을 가리킨다. 픽스처를 다시 깔면서 행을
+    지우면 문서만 남는데, 적재는 **추가만** 하므로 그 문서는 영영 남아 **옛 수치를
+    말한다** — 코치가 같은 날짜에 대해 새 값과 옛 값을 함께 인용하게 된다.
+
+    식단·운동 문서만 대상이다. 대화(`seed-chat-…`)는 이 함수가 건드리는 행이
+    아니므로 그대로 둔다.
+    """
+    stale = db.query(models.CoachDocument).filter(
+        models.CoachDocument.user_id == member_id,
+        or_(
+            models.CoachDocument.source_ref.like("seed-diet-%"),
+            models.CoachDocument.source_ref.like("seed-ex-%"),
+            models.CoachDocument.source_ref.like(f"{_FIXTURE_ID_PREFIX}diet-%"),
+            models.CoachDocument.source_ref.like(f"{_FIXTURE_ID_PREFIX}ex-%"),
+        ),
+        models.CoachDocument.source_ref.notin_(kept_refs or {""}),
+    )
+    removed = stale.delete(synchronize_session=False)
+    if removed:
+        logger.info(
+            "dropped %s stale personal docs for %s (fixture reseed)",
+            removed,
+            member_id,
+        )
 
 
 def _has_diet_on(db: Session, member_id: str, day: str) -> bool:

--- a/backend/app/db/seed_member_data.py
+++ b/backend/app/db/seed_member_data.py
@@ -10,12 +10,19 @@
 실제 데이터"다. 트레이너 API 는 이 데이터를 그대로 읽어 로스터를 집계하므로,
 트레이너↔회원 데이터 공유가 시드 단계에서부터 실제로 성립한다.
 
+김민수(`user-demo`)만은 이 파일이 값을 만들지 않는다. 그는 사용자 앱의 데모 계정과
+같은 사람이라 두 앱을 나란히 놓고 시연하는데, 세 곳이 각자 계산하니 같은 날짜의
+숫자가 서로 달랐다(#757). 그의 하루는 `app/db/demo_fixture.py` 가 읽는 픽스처가
+정하고, 여기서는 그것을 테이블에 옮기기만 한다. 나머지 회원은 아래 상수들이 만든다.
+
 멱등 + 날짜 인식:
 - 오늘 식단은 회원에게 오늘 DietEntry 가 없을 때만 3끼를 넣는다.
 - 최근 6일 나트륨 추세는 해당 날짜에 DietEntry 가 없을 때만 1건씩 넣는다
   (이미 '오늘'로 들어갔던 날은 건너뛰어 중복 합산을 막는다).
 - 운동기록은 회원에게 오늘 기록이 없을 때만 최근 3세션을 넣는다.
 날짜가 넘어가면 자연히 '오늘'이 새로 시드되고 과거 데이터는 누적되어 실제 이력이 된다.
+픽스처 회원은 다르게 움직인다 — 날짜가 넘어가면 그의 `seed-` 행을 지우고 픽스처를
+다시 깐다. 픽스처는 "오늘로부터 며칠 전"으로 적혀 있어 그래야 하루씩 앞으로 미끄러진다.
 """
 from __future__ import annotations
 
@@ -30,6 +37,7 @@ from sqlalchemy.orm import Session
 
 from app.core import clock
 from app.core.config import get_settings
+from app.db.demo_fixture import FixtureExercise, load_fixture
 from app.db.seed_trainer import TRAINER_ID, _MEMBERS
 from app.db.session import SessionLocal
 from app.models import models
@@ -60,14 +68,12 @@ def _safe_commit(db: Session) -> None:
 # 회원별 오늘 3끼 (meal_type, 음식, 칼로리, 나트륨, 당류, 탄수화물, 단백질, 지방)
 # — 프론트 seed 와 동일 수치.
 # 하루 나트륨 합 == _SODIUM_WEEK[member][-1](오늘) 이 되도록 맞춰 둠.
+#
+# 김민수(`user-demo`)는 여기 없다 — 그의 하루는 픽스처가 정한다(#757). 아래 상수는
+# 전부 그를 뺀 나머지 회원용이다.
 _TODAY_MEALS: dict[
     str, list[tuple[str, str, int, int, float, float, float, float]]
 ] = {
-    "user-demo": [
-        ("breakfast", "스크램블 에그, 딸기", 217, 221, 6.3, 10, 13.5, 14.5),
-        ("lunch", "짬뽕", 750, 3200, 8.5, 107, 29, 22.5),
-        ("snack", "아이스 아메리카노, 견과류 한 봉", 100, 7, 3, 3, 2.5, 8),
-    ],
     "user-jisu": [
         ("breakfast", "그릭요거트, 과일", 280, 200, 38, 40, 15, 6),
         ("lunch", "현미밥, 불고기, 나물", 750, 980, 0, 90, 35, 20),
@@ -105,7 +111,6 @@ _FEAST_SODIUM_MG = 2261
 _FEAST_SUGAR_G = 63.0
 
 _SODIUM_WEEK: dict[str, list[int]] = {
-    "user-demo": [2400, 2200, 1900, 2050, 2300, 1850, 3428],
     "user-jisu": [1700, 1950, 1600, 1800, 2100, 1750, 1800],
     "user-sungho": [2600, 2500, 2300, 2450, 2200, 2550, 2400],
 }
@@ -113,15 +118,6 @@ _SODIUM_WEEK: dict[str, list[int]] = {
 # 최근 운동 세션(최신순): (완료율, 종류라벨, 운동목록, 회원피드백, 트레이너메모).
 # 오늘/이틀전/나흘전 날짜로 시드. PT 세션은 trainer_id 를 붙인다.
 _HISTORY: dict[str, list[tuple[int, str, list[str], str, str]]] = {
-    "user-demo": [
-        (100, "PT 세션 · 트레이너 지도", ["레그프레스 3세트", "레그컬 3세트", "하체 스트레칭"],
-         "무릎이 좀 당겼지만 트레이너님 덕분에 잘 마쳤어요 😊",
-         "무릎 가동범위 체크 필요. 다음 세션 중량 조절 예정."),
-        (67, "AI 루틴 · 자율 운동", ["걷기 30분 ✓", "코어 강화 10분 ✓", "스트레칭 ✗ (생략)"],
-         "스트레칭은 시간이 없어서 못 했어요", ""),
-        (100, "AI 루틴 · 자율 운동", ["걷기 30분 ✓", "코어 강화 10분 ✓", "하체 스트레칭 15분 ✓"],
-         "오늘은 다 했어요! 뿌듯해요 💪", ""),
-    ],
     "user-jisu": [
         (100, "AI 루틴 · 자율 운동", ["인터벌 런닝 25분 ✓", "스쿼트 3세트 ✓", "플랭크 10분 ✓"],
          "런닝이 힘들었는데 다 했어요! 숨이 많이 찼어요",
@@ -232,20 +228,12 @@ _ROUTINES: dict[str, list[tuple[str, int, str, str]]] = {
     ],
 }
 
-# 사용자 앱 데모 회원(김민수)의 이번 주 운동 세션 — 프론트 MockExerciseRepository 와 동일.
-# (요일, 종류, 분, 칼로리). 수요일은 휴식 → 목~일 4일 연속. 주간 칼로리 헤드라인은
-# 백엔드가 세션 합(=2450)으로 계산한다(프론트 목업의 튜닝 헤드라인 1980 은 세션 합과
-# 무관한 표시값이라 재현 대상이 아니다 — 실서비스는 합계가 정답).
-_EXERCISE_WEEK: dict[str, list[tuple[str, str, int, int]]] = {
-    "user-demo": [
-        ("월", "cardio", 40, 300),
-        ("화", "strength", 60, 420),
-        ("목", "cardio", 65, 480),
-        ("금", "cardio", 55, 400),
-        ("토", "cardio", 45, 330),
-        ("일", "strength", 50, 520),
-    ],
-}
+# 회원별 이번 주 운동 세션 — (요일, 종류, 분, 칼로리).
+#
+# 김민수는 여기 없다 — 그의 운동은 픽스처가 날짜별 루틴 항목으로 갖고 있고, 세션은
+# 그중 실제로 한 항목에서 나온다(#757). 지금은 다른 회원의 주간 세션이 없어 비어
+# 있지만, 생기면 여기에 적는다.
+_EXERCISE_WEEK: dict[str, list[tuple[str, str, int, int]]] = {}
 
 # day_label → 요일 인덱스(월=0 … 일=6, date.weekday() 와 동일). 운동 시드는 이 인덱스로
 # "오늘까지의 요일"만 넣어, 주중 실행 시 미래 요일이 이번 주 합계·streak 에 잡히는 것을 막는다.
@@ -316,11 +304,14 @@ def seed_member_health_data() -> None:
             if user_id not in valid:
                 # 계정/링크 없음(이메일 충돌 등) → FK 오류 방지 위해 건너뛴다.
                 continue
-            _seed_diet(db, user_id)
-            _seed_history(db, user_id)
+            if user_id == load_fixture().user_app_seed_id:
+                _seed_from_fixture(db, user_id)
+            else:
+                _seed_diet(db, user_id)
+                _seed_history(db, user_id)
+                _seed_exercise(db, user_id)
             _seed_chat(db, user_id)
             _seed_routines(db, user_id)
-            _seed_exercise(db, user_id)
             _seed_health_profile(db, user_id)
         _seed_schedule(db, valid)
     finally:
@@ -579,6 +570,120 @@ def _seed_routines(db: Session, member_id: str) -> None:
             source="ai",
             sort_order=i,
         ))
+    _safe_commit(db)
+
+
+#: 픽스처가 소유한 행의 id 접두사. `seed-` 로 시작하므로 기존의 "시드 행만 훑는다"
+#: 규칙(RAG 적재·사용자 데이터 보존)에 그대로 걸리고, 예전 시드가 만든 행과는
+#: 구별된다 — 그래야 이미 돌던 DB 에서 옛 행을 지우고 픽스처로 갈아끼울 수 있다.
+_FIXTURE_ID_PREFIX = "seed-fix-"
+
+
+def _by_type(
+    exercises: tuple[FixtureExercise, ...],
+) -> dict[str, tuple[int, int]]:
+    """운동을 종류별로 합친다 — {종류: (분, 칼로리)}. 픽스처 순서를 유지한다."""
+    totals: dict[str, tuple[int, int]] = {}
+    for exercise in exercises:
+        minutes, calories = totals.get(exercise.type, (0, 0))
+        totals[exercise.type] = (
+            minutes + exercise.minutes,
+            calories + exercise.calories,
+        )
+    return totals
+
+
+def _seed_from_fixture(db: Session, member_id: str) -> None:
+    """픽스처 회원(김민수)의 식단·운동기록·운동세션을 픽스처 그대로 깐다.
+
+    다른 회원과 달리 **다시 깐다**. 픽스처는 "오늘로부터 며칠 전"으로 적혀 있어서
+    날짜가 넘어가면 모든 날이 하루씩 앞으로 미끄러져야 하는데, 있는 날을 건너뛰는
+    방식으로는 예전 값이 그 자리에 남아 사용자 앱과 어긋난다. 사용자 앱 시드도
+    같은 규칙으로 움직인다.
+
+    지우는 것은 `seed-` 로 시작하는 행뿐이다 — 회원이 앱에서 직접 남긴 기록은 다른
+    id 를 갖고 그대로 살아남는다.
+    """
+    fixture = load_fixture()
+    today = clock.today()
+    days = fixture.days_for(today)
+
+    # 오늘치가 이미 픽스처로 깔려 있으면 아무것도 하지 않는다. 기동마다 수백 행을
+    # 지웠다 넣는 것을 막는 문지기다.
+    #
+    # 접두사가 `seed-fix-` 인 이유: 예전 시드도 오늘 3끼를 `seed-diet-{회원}-{날짜}-0`
+    # 으로 넣었다. 그 id 를 문지기로 삼으면 이미 돌던 DB 에서는 옛 행이 문지기에
+    # 걸려 픽스처가 영영 깔리지 않는다 — 실제로 그렇게 나왔다.
+    marker = f"{_FIXTURE_ID_PREFIX}diet-{member_id}-{today.isoformat()}-0"
+    if db.scalar(
+        select(models.DietEntry.id).where(models.DietEntry.id == marker).limit(1)
+    ) is not None:
+        return
+
+    for model in (models.DietEntry, models.ExerciseSession):
+        db.query(model).filter(
+            model.user_id == member_id, model.id.like("seed-%")
+        ).delete(synchronize_session=False)
+    db.query(models.RoutineHistory).filter(
+        models.RoutineHistory.member_id == member_id,
+        models.RoutineHistory.id.like("seed-%"),
+    ).delete(synchronize_session=False)
+
+    for day in days:
+        # 행 id 는 **날짜에서 만든다**. 픽스처가 시연용으로 못 박아 둔 id 는 사용자
+        # 앱의 로컬 DB 것이다 — 백엔드는 과거를 지우지 않고 쌓아 두므로 날짜가
+        # 없는 id 를 쓰면 다음 날 같은 id 로 부딪힌다.
+        for index, meal in enumerate(day.meals):
+            db.add(models.DietEntry(
+                id=f"{_FIXTURE_ID_PREFIX}diet-{member_id}-{day.iso}-{index}",
+                user_id=member_id,
+                date=day.iso,
+                meal_type=meal.meal_type,
+                time_label=meal.time_label,
+                foods_json=meal.foods_json(),
+                total_calories=meal.calories,
+                carbs_g=meal.carbs_g,
+                protein_g=meal.protein_g,
+                fat_g=meal.fat_g,
+                sodium_mg=meal.sodium_mg,
+                sugar_g=meal.sugar_g,
+                engine="seed",
+            ))
+
+        if not day.exercises:
+            continue  # 휴식일. 이력에도 세션에도 남기지 않는다.
+
+        db.add(models.RoutineHistory(
+            id=f"{_FIXTURE_ID_PREFIX}hist-{member_id}-{day.iso}",
+            member_id=member_id,
+            trainer_id=TRAINER_ID if day.is_pt else None,
+            date=day.iso,
+            kind_label=day.routine_label,
+            completion_rate=day.completion,
+            exercises_json=json.dumps(
+                [e.label for e in day.exercises], ensure_ascii=False
+            ),
+            client_feedback=day.client_feedback,
+            trainer_note=day.trainer_note,
+        ))
+
+        # 세션은 **실제로 한** 운동만 쌓는다. 못 한 항목까지 넣으면 이행률은 67% 인데
+        # 주간 운동 시간은 100% 인 날이 나온다.
+        #
+        # 하루에 같은 종류가 둘일 수 있어(PT 날의 레그프레스·레그컬은 둘 다 근력)
+        # 종류로 합친다. 주간 활동 그래프가 하루·종류당 한 칸을 그리므로 나눠 넣을
+        # 자리도 없다.
+        for kind, (minutes, calories) in _by_type(day.done_exercises).items():
+            db.add(models.ExerciseSession(
+                id=f"{_FIXTURE_ID_PREFIX}ex-{member_id}-{day.iso}-{kind}",
+                user_id=member_id,
+                week_start=day.week_start,
+                day_label=day.day_label,
+                type=kind,
+                minutes=minutes,
+                calories=calories,
+                intensity="moderate",
+            ))
     _safe_commit(db)
 
 

--- a/backend/tests/test_demo_fixture.py
+++ b/backend/tests/test_demo_fixture.py
@@ -1,0 +1,59 @@
+"""김민수 데모 픽스처 — 파일 자체와 백엔드 리더를 본다.
+
+시드가 DB 에 옮긴 결과는 `test_member_seed.py` 가 본다.
+"""
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+from app.db.demo_fixture import FIXTURE_PATH, load_fixture
+
+#: Flutter 두 앱이 읽는 원본. 백엔드 이미지는 `backend/` 만 담아서 같은 파일을
+#: 한 벌 더 갖고 있다 — 두 파일이 어긋나면 두 앱과 백엔드의 숫자가 갈라진다.
+SHARED_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "shared/demo_fixture/assets/kim_minsu.json"
+)
+
+
+def test_backend_copy_matches_the_shared_original():
+    # 손으로 맞추지 말 것 — `python3 tool/gen_demo_fixture.py` 가 두 곳에 함께 쓴다.
+    assert FIXTURE_PATH.read_bytes() == SHARED_PATH.read_bytes()
+
+
+def test_curated_days_keep_the_numbers_the_demo_says_out_loud():
+    days = load_fixture().days_for(date(2026, 8, 16))
+    today, yesterday = days[-1], days[-2]
+
+    assert (today.calories, today.sodium_mg, today.sugar_g) == (1067, 3428, 17.8)
+    assert (yesterday.calories, yesterday.sodium_mg, yesterday.sugar_g) == (
+        2380,
+        2261,
+        63.0,
+    )
+
+
+def test_no_day_lies_in_the_future():
+    # 주중에 열어도 이번 주 남은 요일이 채워지면 주 평균이 실제보다 높아진다(#752).
+    for today in (date(2026, 8, 10), date(2026, 8, 13), date(2026, 8, 16)):
+        days = load_fixture().days_for(today)
+        assert days[-1].day == today
+        assert not [d for d in days if d.day > today]
+
+
+def test_completion_comes_from_the_routine_items():
+    for day in load_fixture().days_for(date(2026, 8, 16)):
+        if not day.exercises:
+            assert day.completion == 0
+            continue
+        done = sum(1 for e in day.exercises if e.done)
+        assert day.completion == round(done * 100 / len(day.exercises))
+
+
+def test_the_fixture_covers_twelve_weeks_without_gaps():
+    fixture = load_fixture()
+    days = fixture.days_for(date(2026, 8, 16))  # 일요일 → 12주가 꽉 찬다
+    assert fixture.history_weeks == 12
+    assert len(days) == 84
+    assert len({d.iso for d in days}) == 84

--- a/backend/tests/test_member_seed.py
+++ b/backend/tests/test_member_seed.py
@@ -56,8 +56,12 @@ def test_exercise_seed_skips_future_weekdays(client, db_session):
 
 
 def test_exercise_seed_is_idempotent(client, db_session):
-    """재실행해도 세션 수가 늘지 않는다(세션 id 단위 멱등)."""
-    from app.db.seed_member_data import _seed_exercise
+    """재실행해도 세션 수가 늘지 않는다.
+
+    김민수는 픽스처 회원이라 `_seed_from_fixture` 가 그의 `seed-` 행을 통째로
+    다시 깐다 — 그래도 결과는 같아야 한다(오늘치가 이미 있으면 손대지 않는다).
+    """
+    from app.db.seed_member_data import _seed_from_fixture
     from app.models.models import ExerciseSession
 
     def _count() -> int:
@@ -72,9 +76,44 @@ def test_exercise_seed_is_idempotent(client, db_session):
 
     before = _count()
     assert before > 0
-    _seed_exercise(db_session, _MEMBER_ID)
-    _seed_exercise(db_session, _MEMBER_ID)
+    _seed_from_fixture(db_session, _MEMBER_ID)
+    _seed_from_fixture(db_session, _MEMBER_ID)
     assert _count() == before
+
+
+def test_seeded_days_match_the_fixture(client, db_session):
+    """DB 에 들어간 김민수의 하루가 픽스처가 말하는 값과 같다.
+
+    두 앱은 같은 픽스처를 읽으므로, 이 단정이 곧 "백엔드로 붙여도 데모에서 보던
+    숫자가 그대로"라는 뜻이다(#757).
+    """
+    from app.db.demo_fixture import load_fixture
+    from app.models.models import DietEntry, RoutineHistory
+
+    days = {d.iso: d for d in load_fixture().days_for(clock.today())}
+
+    rows = db_session.scalars(
+        select(DietEntry).where(DietEntry.user_id == _MEMBER_ID)
+    ).all()
+    totals: dict[str, int] = {}
+    for row in rows:
+        if not row.id.startswith("seed-"):
+            continue  # 회원이 직접 남긴 기록은 픽스처 소관이 아니다.
+        totals[row.date] = totals.get(row.date, 0) + row.total_calories
+    assert totals, "김민수 식단 시드가 없습니다."
+    for iso, calories in totals.items():
+        assert calories == days[iso].calories, f"{iso} 칼로리가 픽스처와 다릅니다."
+
+    history = db_session.scalars(
+        select(RoutineHistory).where(RoutineHistory.member_id == _MEMBER_ID)
+    ).all()
+    assert history, "김민수 운동 이력 시드가 없습니다."
+    for row in history:
+        if not row.id.startswith("seed-"):
+            continue
+        assert row.completion_rate == days[row.date].completion, (
+            f"{row.date} 이행률이 픽스처와 다릅니다."
+        )
 
 
 def test_health_profile_seeded_once(client, db_session):

--- a/backend/tests/test_member_seed.py
+++ b/backend/tests/test_member_seed.py
@@ -81,6 +81,48 @@ def test_exercise_seed_is_idempotent(client, db_session):
     assert _count() == before
 
 
+def test_no_personal_doc_points_at_a_deleted_seed_row(client, db_session):
+    """지워진 시드 행을 가리키는 개인 RAG 문서가 남지 않는다.
+
+    개인 문서 적재는 추가만 한다. 픽스처를 다시 깔며 행을 지우면 문서만 남아 **옛
+    수치를 말하고**, 코치가 같은 날짜에 새 값과 옛 값을 함께 인용하게 된다.
+    """
+    from app.models.models import CoachDocument, DietEntry, ExerciseSession
+
+    refs = db_session.scalars(
+        select(CoachDocument.source_ref).where(
+            CoachDocument.user_id == _MEMBER_ID
+        )
+    ).all()
+    diet_ids = set(
+        db_session.scalars(
+            select(DietEntry.id).where(DietEntry.user_id == _MEMBER_ID)
+        ).all()
+    )
+    exercise_ids = set(
+        db_session.scalars(
+            select(ExerciseSession.id).where(
+                ExerciseSession.user_id == _MEMBER_ID
+            )
+        ).all()
+    )
+
+    orphans = [
+        ref
+        for ref in refs
+        if ref
+        and (ref.startswith("seed-diet-") or ref.startswith("seed-fix-diet-"))
+        and ref not in diet_ids
+    ] + [
+        ref
+        for ref in refs
+        if ref
+        and (ref.startswith("seed-ex-") or ref.startswith("seed-fix-ex-"))
+        and ref not in exercise_ids
+    ]
+    assert not orphans, f"삭제된 행을 가리키는 개인 문서가 남았습니다: {orphans[:5]}"
+
+
 def test_seeded_days_match_the_fixture(client, db_session):
     """DB 에 들어간 김민수의 하루가 픽스처가 말하는 값과 같다.
 

--- a/frontend/flutter/lib/core/storage/seed_data.dart
+++ b/frontend/flutter/lib/core/storage/seed_data.dart
@@ -103,7 +103,7 @@ Future<void> seedIfEmpty(AppDatabase db, {DemoFixture? fixture}) async {
   await db.deleteValue('dashboard_ai_advice');
 
   // 김민수의 하루는 픽스처가 정한다 — 이 앱은 날짜에 붙여 저장하기만 한다(#757).
-  final DemoFixture demo = fixture ?? await DemoFixture.load();
+  final DemoFixture demo = fixture ?? DemoFixture.load();
   final List<FixtureDay> days = demo.daysFor(now);
 
   await db.transaction(() async {

--- a/frontend/flutter/lib/core/storage/seed_data.dart
+++ b/frontend/flutter/lib/core/storage/seed_data.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:demo_fixture/demo_fixture.dart';
 import 'package:drift/drift.dart';
 
 import 'package:oncare/core/demo/demo_ai_advice.dart';
@@ -14,20 +15,16 @@ import 'package:oncare/core/storage/app_database.dart';
 /// 키를 날짜마다 만들면 지난 날짜 키가 계속 쌓인다. 한 키를 통째로 덮어쓰면 그 문제가 없다.
 const String kDietDayMessagesKey = 'diet_day_messages';
 
-/// 큐레이션 사흘(오늘·어제·그제) **앞으로** 더 채우는 과거 일수.
+/// 데모가 채우는 날들은 이제 이 앱이 정하지 않는다.
 ///
-/// 데모에서 날짜를 옮기면 대부분 "기록이 없어요"만 나오던 문제(#671)를 없앤다.
-/// 주간 스트립은 오늘 앞뒤 3일을 보여주고 주 단위로 뒤로 넘어갈 수 있으므로,
-/// 한 달치를 채워 두면 지난주로 넘겨도 기록이 이어진다.
-const int kDemoDietHistoryDays = 30;
-
-/// 현재 주 **앞으로** 시드하는 지난 주 수. 운동은 주 단위(`weekStart`)로
-/// 조회하므로 날짜가 아니라 주로 센다.
-const int kDemoExerciseHistoryWeeks = 4;
+/// 김민수(`user-demo`)는 트레이너 앱의 `seed-client-1` 과 같은 사람이라 두 앱을
+/// 나란히 놓고 시연하는데, 예전에는 두 앱과 백엔드가 각자 알고리즘으로 그의 과거를
+/// 만들어서 같은 날짜의 숫자가 서로 달랐다(#757). 지금은 셋 다 같은 픽스처를 읽는다
+/// — 며칠치를 채울지도 픽스처가 갖고 있다(`DemoFixture.historyWeeks`).
 
 /// Date-aware idempotent seeder. Runs at bootstrap.
 ///
-/// **Flag format (v4+).** `AppKeyValues['seeded_v16']` stores the
+/// **Flag format (v4+).** `AppKeyValues['seeded_v17']` stores the
 /// *date string* the seed last ran with (`YYYY-MM-DD`). Behaviour:
 ///
 /// - `null` (first ever boot, or upgrading from v1/v2) — wipe any
@@ -51,14 +48,11 @@ const int kDemoExerciseHistoryWeeks = 4;
 /// v2 (vs v1) introduced multi-type exercise sessions per day so the
 /// `WeeklyActivity` stacked-bar chart renders the 유산소 / 근력 /
 /// 스트레칭 breakdown the prototype shows.
-Future<void> seedIfEmpty(AppDatabase db) async {
+Future<void> seedIfEmpty(AppDatabase db, {DemoFixture? fixture}) async {
   final now = DateTime.now();
   final today = _fmtDate(now);
-  final yesterday = _fmtDate(now.subtract(const Duration(days: 1)));
-  final twoDaysAgo = _fmtDate(now.subtract(const Duration(days: 2)));
-  final weekStart = _fmtDate(_mondayOfThisWeek(now));
 
-  final seedDate = await db.readValue('seeded_v16');
+  final seedDate = await db.readValue('seeded_v17');
   if (seedDate == today) {
     // Already seeded for today — leave both seed rows and user rows
     // untouched.
@@ -100,232 +94,62 @@ Future<void> seedIfEmpty(AppDatabase db) async {
   // v15: 과거 한 달치 식단·지난 4주 운동이 추가됐다(#671). 올리지 않으면 오늘
   // 이미 시드된 설치가 사흘치 그대로 남아 날짜를 옮겨도 여전히 비어 보인다.
   await db.deleteValue('seeded_v14');
+  // v17: 식단·운동이 공유 픽스처에서 온다(#757). 올리지 않으면 오늘 이미 시드된
+  // 설치가 예전 값을 들고 있어 트레이너 앱과 나란히 놓았을 때 숫자가 어긋난다.
+  await db.deleteValue('seeded_v16');
   // Also clear the curated KV advice so re-seed state is fully reset: this
   // version re-writes it below, but if a later seed drops or renames the key
   // an existing install would otherwise keep the stale text forever.
   await db.deleteValue('dashboard_ai_advice');
 
+  // 김민수의 하루는 픽스처가 정한다 — 이 앱은 날짜에 붙여 저장하기만 한다(#757).
+  final DemoFixture demo = fixture ?? await DemoFixture.load();
+  final List<FixtureDay> days = demo.daysFor(now);
+
   await db.transaction(() async {
-    // ---- Diet entries (today plus two populated historical days) ----
+    // ---- 식단 ----
+    // 끼니 단위로 저장한다. 하루 합계는 화면이 이 행들을 더해 만들므로, 끼니 화면과
+    // 일별 집계가 구조적으로 어긋날 수 없다.
     await db.batch((Batch b) {
       b.insertAll(db.dietEntries, <DietEntriesCompanion>[
-        // 시연에 쓰는 큐레이션 사흘. 음식 구성과 영양 수치는 히스토리와 같은
-        // 템플릿에서 나오고, 여기서는 고정 id·시각·그날의 코치 문구만 덮어쓴다
-        // — 수치를 두 벌로 두면 한쪽만 고쳤을 때 조용히 어긋난다(#677).
-        _mealScrambledEggStrawberry.companion(
-          today,
-          id: 'seed-diet-breakfast',
-          timeLabel: '08:20',
-          aiComment:
-              '단백질과 식이섬유의 깔끔한 조합으로, 소금 간과 기름만 조절하면 혈당과 혈압 모두 잡는 우수한 식단입니다.',
-        ),
-        _mealJjamppong.companion(
-          today,
-          id: 'seed-diet-lunch',
-          timeLabel: '12:40',
-          aiComment:
-              '정제 면과 높은 나트륨으로 혈압·혈당 부담이 매우 크니, 국물은 남기고 야채 위주로 드시는 것이 좋습니다.',
-        ),
-        _mealCoffeeNuts.companion(
-          today,
-          id: 'seed-diet-snack',
-          timeLabel: '15:30',
-          aiComment: '당류와 칼로리가 낮고 견과류의 건강한 지방이 채워져 완벽한 간식입니다.',
-        ),
-        // 어제는 약속이 있던 날 — 하루 합이 2,380kcal · 2,261mg · 63.0g 으로
-        // 칼로리와 당류가 목표(2,000kcal · 50g)를 넘는다. 목표선과 초과 색이
-        // 실제로 동작하는지 시연에서 눈으로 확인하려면 넘긴 날이 하나는 있어야
-        // 하고, **어제**여야 데모를 여는 날이 언제든 항상 화면에 들어온다.
-        //
-        // 트레이너 앱 데모(`flutter_trainer` 의 `seed_data.dart`)와 백엔드
-        // 시드가 같은 합계를 쓴다. 두 앱을 나란히 놓고 시연하므로 한쪽만
-        // 고치면 그 자리에서 티가 난다.
-        _mealOatmealBanana.companion(
-          yesterday,
-          id: 'seed-diet-yesterday-breakfast',
-          timeLabel: '08:10',
-          aiComment: '오트밀로 식이섬유를 챙겼어요. 바나나가 들어가 당류는 다소 높은 편이에요.',
-        ),
-        _mealVegetableBibimbap.companion(
-          yesterday,
-          id: 'seed-diet-yesterday-lunch',
-          timeLabel: '12:30',
-          aiComment: '야채가 풍부한 비빔밥이에요. 고추장을 줄이면 나트륨을 더 조절할 수 있어요.',
-        ),
-        _mealSamgyeopsalDinner.companion(
-          yesterday,
-          id: 'seed-diet-yesterday-dinner',
-        ),
-        _mealCakeLatteSnack.companion(
-          yesterday,
-          id: 'seed-diet-yesterday-snack',
-        ),
-        _mealGreekYogurtNuts.companion(
-          twoDaysAgo,
-          id: 'seed-diet-two-days-ago-breakfast',
-          timeLabel: '08:35',
-          aiComment: '그릭 요거트의 단백질과 견과류의 불포화지방을 고르게 섭취했어요.',
-        ),
-        _mealVegetableBibimbap.companion(
-          twoDaysAgo,
-          id: 'seed-diet-two-days-ago-lunch',
-          timeLabel: '12:20',
-          aiComment: '야채가 풍부한 비빔밥이에요. 고추장을 줄이면 나트륨을 더 조절할 수 있어요.',
-        ),
-        _mealSalmonBrownRice.companion(
-          twoDaysAgo,
-          id: 'seed-diet-two-days-ago-dinner',
-          timeLabel: '18:50',
-          aiComment: '연어의 지방과 현미밥의 복합 탄수화물 조합이 좋아요.',
-        ),
-        // 큐레이션 사흘 앞으로 한 달치를 더 채운다 — 날짜를 옮겨도 기록이
-        // 이어지도록(#671).
-        ..._historyDietEntries(now),
+        for (final FixtureDay day in days)
+          for (final FixtureMeal meal in day.meals)
+            DietEntriesCompanion.insert(
+              // 시연 중 화면에서 지목하는 행만 픽스처가 id 를 못 박아 둔다.
+              // 나머지는 날짜에서 만든다.
+              id: meal.rowId ?? 'seed-diet-${day.date}-${meal.mealType}',
+              date: day.date,
+              mealType: meal.mealType,
+              timeLabel: meal.timeLabel,
+              foodsJson: meal.foodsJson(),
+              totalCalories: meal.calories,
+              sodiumMg: Value(meal.sodiumMg),
+              sugarG: Value(meal.sugarG),
+              aiComment: Value(meal.aiComment),
+              photoAsset: Value(meal.photoAsset),
+            ),
       ]);
     });
 
-    // ---- Exercise sessions ----
-    // Per-day breakdown matches the prototype's WeeklyActivity stack:
-    // 월 40 (30+10), 화 60 (45+10+5), 수 50 (40+10),
-    // 목 65 (50+10+5), 금 55 (45+5+5), 토 80 (30+30+20), 일 0.
+    // ---- 운동 세션 ----
+    // **실제로 한** 운동만 쌓는다. 못 한 항목까지 넣으면 이행률은 67% 인데 주간
+    // 운동 시간은 100% 인 날이 나온다.
+    //
+    // 하루에 같은 종류가 둘일 수 있어(PT 날의 레그프레스·레그컬은 둘 다 근력)
+    // 종류로 합친다 — 주간 활동 그래프가 하루·종류당 한 칸을 그린다.
     await db.batch((Batch b) {
       b.insertAll(db.exerciseSessions, <ExerciseSessionsCompanion>[
-        // ---- Mon ----
-        ExerciseSessionsCompanion.insert(
-          id: 'seed-ex-mon-c',
-          weekStart: weekStart,
-          dayLabel: '월',
-          type: 'cardio',
-          minutes: 30,
-          calories: 225,
-        ),
-        ExerciseSessionsCompanion.insert(
-          id: 'seed-ex-mon-s',
-          weekStart: weekStart,
-          dayLabel: '월',
-          type: 'stretching',
-          minutes: 10,
-          calories: 30,
-        ),
-        // ---- Tue ----
-        ExerciseSessionsCompanion.insert(
-          id: 'seed-ex-tue-c',
-          weekStart: weekStart,
-          dayLabel: '화',
-          type: 'cardio',
-          minutes: 45,
-          calories: 337,
-        ),
-        ExerciseSessionsCompanion.insert(
-          id: 'seed-ex-tue-w',
-          weekStart: weekStart,
-          dayLabel: '화',
-          type: 'strength',
-          minutes: 10,
-          calories: 50,
-        ),
-        ExerciseSessionsCompanion.insert(
-          id: 'seed-ex-tue-s',
-          weekStart: weekStart,
-          dayLabel: '화',
-          type: 'stretching',
-          minutes: 5,
-          calories: 15,
-        ),
-        // ---- Wed ----
-        ExerciseSessionsCompanion.insert(
-          id: 'seed-ex-wed-c',
-          weekStart: weekStart,
-          dayLabel: '수',
-          type: 'cardio',
-          minutes: 40,
-          calories: 300,
-        ),
-        ExerciseSessionsCompanion.insert(
-          id: 'seed-ex-wed-s',
-          weekStart: weekStart,
-          dayLabel: '수',
-          type: 'stretching',
-          minutes: 10,
-          calories: 30,
-        ),
-        // ---- Thu ----
-        ExerciseSessionsCompanion.insert(
-          id: 'seed-ex-thu-c',
-          weekStart: weekStart,
-          dayLabel: '목',
-          type: 'cardio',
-          minutes: 50,
-          calories: 375,
-        ),
-        ExerciseSessionsCompanion.insert(
-          id: 'seed-ex-thu-w',
-          weekStart: weekStart,
-          dayLabel: '목',
-          type: 'strength',
-          minutes: 10,
-          calories: 50,
-        ),
-        ExerciseSessionsCompanion.insert(
-          id: 'seed-ex-thu-s',
-          weekStart: weekStart,
-          dayLabel: '목',
-          type: 'stretching',
-          minutes: 5,
-          calories: 15,
-        ),
-        // ---- Fri ----
-        ExerciseSessionsCompanion.insert(
-          id: 'seed-ex-fri-c',
-          weekStart: weekStart,
-          dayLabel: '금',
-          type: 'cardio',
-          minutes: 45,
-          calories: 337,
-        ),
-        ExerciseSessionsCompanion.insert(
-          id: 'seed-ex-fri-w',
-          weekStart: weekStart,
-          dayLabel: '금',
-          type: 'strength',
-          minutes: 5,
-          calories: 25,
-        ),
-        ExerciseSessionsCompanion.insert(
-          id: 'seed-ex-fri-s',
-          weekStart: weekStart,
-          dayLabel: '금',
-          type: 'stretching',
-          minutes: 5,
-          calories: 15,
-        ),
-        // ---- Sat ----
-        ExerciseSessionsCompanion.insert(
-          id: 'seed-ex-sat-c',
-          weekStart: weekStart,
-          dayLabel: '토',
-          type: 'cardio',
-          minutes: 30,
-          calories: 225,
-        ),
-        ExerciseSessionsCompanion.insert(
-          id: 'seed-ex-sat-w',
-          weekStart: weekStart,
-          dayLabel: '토',
-          type: 'strength',
-          minutes: 30,
-          calories: 150,
-        ),
-        ExerciseSessionsCompanion.insert(
-          id: 'seed-ex-sat-s',
-          weekStart: weekStart,
-          dayLabel: '토',
-          type: 'stretching',
-          minutes: 20,
-          calories: 60,
-        ),
-        // 지난 주들 — 운동 탭에서 주를 뒤로 넘겨도 기록이 이어지도록(#671).
-        ..._historyExerciseSessions(now),
+        for (final FixtureDay day in days)
+          for (final MapEntry<String, ({int minutes, int calories})> entry
+              in _byType(day.doneExercises).entries)
+            ExerciseSessionsCompanion.insert(
+              id: 'seed-ex-${day.date}-${entry.key}',
+              weekStart: day.weekStart,
+              dayLabel: day.dayLabel,
+              type: entry.key,
+              minutes: entry.value.minutes,
+              calories: entry.value.calories,
+            ),
       ]);
     });
 
@@ -422,525 +246,37 @@ Future<void> seedIfEmpty(AppDatabase db) async {
   // 노출한다.
   await db.putValue('dashboard_ai_advice', kDailyCombinedAdviceKey);
 
-  // 식단 탭의 하루 코치 문구. 시연에 쓰는 세 날짜만 문장을 정해 두고, 그 밖의
-  // 날짜는 인터셉터가 수치를 보고 만든 문구로 대신한다([kDietDayMessagesKey]).
+  // 식단 탭의 하루 코치 문구. 문장을 가진 날(픽스처의 큐레이션 사흘)만 넣고, 그
+  // 밖의 날짜는 인터셉터가 수치를 보고 만든 문구로 대신한다([kDietDayMessagesKey]).
   await db.putValue(
     kDietDayMessagesKey,
     jsonEncode(<String, String>{
-      today: '점심 짬뽕으로 오늘 나트륨 섭취가 많았어요. 저녁은 양념을 줄인 채소와 단백질 위주로 구성해 보세요.',
-      yesterday: '나트륨을 잘 조절했고 단백질도 고르게 섭취한 하루였어요.',
-      twoDaysAgo: '연어와 현미밥으로 탄단지 균형을 잘 맞췄어요.',
+      for (final FixtureDay day in days)
+        if (day.dayMessage.isNotEmpty) day.date: day.dayMessage,
     }),
   );
 
-  await db.putValue('seeded_v16', today);
+  await db.putValue('seeded_v17', today);
 }
 
-// ─────────────────────────────────────────────── 과거 기록 (데모 히스토리) ──
-
-/// 한 가지 음식. 화면이 읽는 키(`sodium_mg` 등)와 같은 이름을 쓴다.
-class _SeedFood {
-  const _SeedFood(
-    this.name, {
-    required this.calories,
-    required this.sodiumMg,
-    required this.sugarG,
-    required this.carbsG,
-    required this.proteinG,
-    required this.fatG,
-  });
-
-  final String name;
-  final int calories;
-  final int sodiumMg;
-  final double sugarG;
-  final double carbsG;
-  final double proteinG;
-  final double fatG;
-
-  Map<String, Object?> toJson() => <String, Object?>{
-    'name': name,
-    'calories': calories,
-    'sodium_mg': sodiumMg,
-    'sugar_g': sugarG,
-    'carbs_g': carbsG,
-    'protein_g': proteinG,
-    'fat_g': fatG,
-  };
-}
-
-/// 한 끼니 템플릿. 날짜만 갈아 끼우면 그날의 기록이 된다.
-class _SeedMeal {
-  const _SeedMeal({
-    required this.slug,
-    required this.mealType,
-    required this.timeLabel,
-    required this.foods,
-    required this.aiComment,
-    this.photoAsset = '',
-  });
-
-  final String slug;
-  final String mealType;
-  final String timeLabel;
-  final List<_SeedFood> foods;
-  final String aiComment;
-  final String photoAsset;
-
-  int get totalCalories =>
-      foods.fold<int>(0, (int a, _SeedFood f) => a + f.calories);
-  int get totalSodium =>
-      foods.fold<int>(0, (int a, _SeedFood f) => a + f.sodiumMg);
-  double get totalSugar =>
-      foods.fold<double>(0, (double a, _SeedFood f) => a + f.sugarG);
-
-  /// 이 끼니를 [date] 의 행으로 만든다.
-  ///
-  /// [id]·[timeLabel]·[aiComment] 를 덮어쓸 수 있다. 시연에 쓰는 큐레이션
-  /// 사흘은 고정 id(`seed-diet-lunch` 등)와 그날만의 코치 문구를 갖는데, **음식
-  /// 구성과 영양 수치는 히스토리와 똑같다.** 덮어쓰기를 두어 수치는 한 곳에만
-  /// 남기고 표현만 갈아 끼운다.
-  DietEntriesCompanion companion(
-    String date, {
-    String? id,
-    String? timeLabel,
-    String? aiComment,
-  }) => DietEntriesCompanion.insert(
-    id: id ?? 'seed-diet-$date-$slug',
-    date: date,
-    mealType: mealType,
-    timeLabel: timeLabel ?? this.timeLabel,
-    foodsJson: jsonEncode(<Map<String, Object?>>[
-      for (final _SeedFood f in foods) f.toJson(),
-    ]),
-    totalCalories: totalCalories,
-    sodiumMg: Value(totalSodium),
-    sugarG: Value(totalSugar),
-    aiComment: Value(aiComment ?? this.aiComment),
-    photoAsset: Value(photoAsset),
-  );
-}
-
-/// 여러 끼니에 함께 쓰이는 음식. 끼니 상수마다 다시 적으면 이 변경이 없애려는
-/// 중복이 그대로 남는다 — 한 곳에서만 고칠 수 있게 뽑아 둔다.
-const _SeedFood _foodDoenjangJjigae = _SeedFood(
-  '된장찌개',
-  calories: 300,
-  sodiumMg: 1300,
-  sugarG: 5,
-  carbsG: 18,
-  proteinG: 24,
-  fatG: 15,
-);
-
-const _SeedFood _foodRice = _SeedFood(
-  '밥',
-  calories: 310,
-  sodiumMg: 5,
-  sugarG: 0.7,
-  carbsG: 67,
-  proteinG: 6,
-  fatG: 2.5,
-);
-
-const _SeedFood _foodChickenSalad = _SeedFood(
-  '닭가슴살 샐러드',
-  calories: 315,
-  sodiumMg: 395,
-  sugarG: 10,
-  carbsG: 19,
-  proteinG: 34,
-  fatG: 11.1,
-);
-
-const _SeedMeal _mealOatmealBanana = _SeedMeal(
-  slug: 'breakfast',
-  mealType: 'breakfast',
-  timeLabel: '08:05',
-  photoAsset: 'assets/images/diet-oatmeal-banana.jpeg',
-  aiComment: '오트밀로 식이섬유를 챙긴 아침이에요.',
-  foods: <_SeedFood>[
-    _SeedFood(
-      '오트밀',
-      calories: 250,
-      sodiumMg: 100,
-      sugarG: 6,
-      carbsG: 42,
-      proteinG: 10,
-      fatG: 6,
-    ),
-    _SeedFood(
-      '바나나',
-      calories: 105,
-      sodiumMg: 1,
-      sugarG: 14,
-      carbsG: 27,
-      proteinG: 1.3,
-      fatG: 0.4,
-    ),
-  ],
-);
-
-const _SeedMeal _mealGreekYogurtNuts = _SeedMeal(
-  slug: 'breakfast',
-  mealType: 'breakfast',
-  timeLabel: '08:30',
-  photoAsset: 'assets/images/diet-greek-yogurt-nuts.jpeg',
-  aiComment: '단백질과 불포화지방을 고르게 섭취했어요.',
-  foods: <_SeedFood>[
-    _SeedFood(
-      '그릭 요거트',
-      calories: 170,
-      sodiumMg: 75,
-      sugarG: 7,
-      carbsG: 8,
-      proteinG: 18,
-      fatG: 8,
-    ),
-    _SeedFood(
-      '견과류',
-      calories: 150,
-      sodiumMg: 5,
-      sugarG: 2,
-      carbsG: 6,
-      proteinG: 5,
-      fatG: 13,
-    ),
-  ],
-);
-
-const _SeedMeal _mealScrambledEggStrawberry = _SeedMeal(
-  slug: 'breakfast',
-  mealType: 'breakfast',
-  timeLabel: '07:50',
-  photoAsset: 'assets/images/breakfast-scrambled-egg-strawberry.jpg',
-  aiComment: '달걀 단백질에 과일로 비타민을 더했어요.',
-  foods: <_SeedFood>[
-    _SeedFood(
-      '스크램블 에그',
-      calories: 185,
-      sodiumMg: 220,
-      sugarG: 0.8,
-      carbsG: 2,
-      proteinG: 13,
-      fatG: 14,
-    ),
-    _SeedFood(
-      '딸기',
-      calories: 32,
-      sodiumMg: 1,
-      sugarG: 5.5,
-      carbsG: 8,
-      proteinG: 0.5,
-      fatG: 0.5,
-    ),
-  ],
-);
-
-const List<_SeedMeal> _historyBreakfasts = <_SeedMeal>[
-  _mealOatmealBanana,
-  _mealGreekYogurtNuts,
-  _mealScrambledEggStrawberry,
-];
-
-const _SeedMeal _mealChickenSalad = _SeedMeal(
-  slug: 'lunch',
-  mealType: 'lunch',
-  timeLabel: '12:30',
-  photoAsset: 'assets/images/diet-chicken-salad.jpg',
-  aiComment: '닭가슴살과 채소로 단백질·식이섬유를 챙겼어요.',
-  foods: <_SeedFood>[_foodChickenSalad],
-);
-
-const _SeedMeal _mealVegetableBibimbap = _SeedMeal(
-  slug: 'lunch',
-  mealType: 'lunch',
-  timeLabel: '12:20',
-  photoAsset: 'assets/images/diet-vegetable-bibimbap.jpg',
-  aiComment: '야채가 풍부해요. 고추장을 줄이면 나트륨이 더 좋아져요.',
-  foods: <_SeedFood>[
-    _SeedFood(
-      '야채비빔밥',
-      calories: 610,
-      sodiumMg: 900,
-      sugarG: 12,
-      carbsG: 92,
-      proteinG: 20,
-      fatG: 16,
-    ),
-  ],
-);
-
-const _SeedMeal _mealJjamppong = _SeedMeal(
-  slug: 'lunch',
-  mealType: 'lunch',
-  timeLabel: '12:50',
-  photoAsset: 'assets/images/lunch-jjamppong.jpg',
-  aiComment: '국물 나트륨이 높은 날이에요. 국물은 남기는 편이 좋아요.',
-  foods: <_SeedFood>[
-    _SeedFood(
-      '짬뽕',
-      calories: 750,
-      sodiumMg: 3200,
-      sugarG: 8.5,
-      carbsG: 107,
-      proteinG: 29,
-      fatG: 22.5,
-    ),
-  ],
-);
-
-const _SeedMeal _mealDoenjangRiceLunch = _SeedMeal(
-  slug: 'lunch',
-  mealType: 'lunch',
-  timeLabel: '12:10',
-  photoAsset: 'assets/images/diet-doenjang-rice.jpeg',
-  aiComment: '집밥 한 상이에요. 찌개 국물만 조금 남겨 보세요.',
-  foods: <_SeedFood>[_foodDoenjangJjigae, _foodRice],
-);
-
-const List<_SeedMeal> _historyLunches = <_SeedMeal>[
-  _mealChickenSalad,
-  _mealVegetableBibimbap,
-  _mealJjamppong,
-  _mealDoenjangRiceLunch,
-];
-
-const _SeedMeal _mealSalmonBrownRice = _SeedMeal(
-  slug: 'dinner',
-  mealType: 'dinner',
-  timeLabel: '18:40',
-  photoAsset: 'assets/images/diet-salmon-brown-rice.jpeg',
-  aiComment: '연어의 지방과 현미밥의 복합 탄수화물 조합이 좋아요.',
-  foods: <_SeedFood>[
-    _SeedFood(
-      '연어구이',
-      calories: 395,
-      sodiumMg: 505,
-      sugarG: 9,
-      carbsG: 19,
-      proteinG: 35,
-      fatG: 19,
-    ),
-    _SeedFood(
-      '현미밥',
-      calories: 280,
-      sodiumMg: 5,
-      sugarG: 0,
-      carbsG: 58,
-      proteinG: 6,
-      fatG: 2,
-    ),
-  ],
-);
-
-const _SeedMeal _mealDoenjangRiceDinner = _SeedMeal(
-  slug: 'dinner',
-  mealType: 'dinner',
-  timeLabel: '19:10',
-  photoAsset: 'assets/images/diet-doenjang-rice.jpeg',
-  aiComment: '포만감은 좋지만 국물 나트륨이 높은 편이에요.',
-  foods: <_SeedFood>[_foodDoenjangJjigae, _foodRice],
-);
-
-const _SeedMeal _mealChickenSaladSweetPotato = _SeedMeal(
-  slug: 'dinner',
-  mealType: 'dinner',
-  timeLabel: '18:20',
-  photoAsset: 'assets/images/diet-chicken-salad.jpg',
-  aiComment: '가볍게 마무리한 저녁이에요.',
-  foods: <_SeedFood>[
-    _foodChickenSalad,
-    _SeedFood(
-      '고구마',
-      calories: 130,
-      sodiumMg: 20,
-      sugarG: 6.5,
-      carbsG: 30,
-      proteinG: 2,
-      fatG: 0.2,
-    ),
-  ],
-);
-
-const List<_SeedMeal> _historyDinners = <_SeedMeal>[
-  _mealSalmonBrownRice,
-  _mealDoenjangRiceDinner,
-  _mealChickenSaladSweetPotato,
-];
-
-const _SeedMeal _mealCoffeeNuts = _SeedMeal(
-  slug: 'snack',
-  mealType: 'snack',
-  timeLabel: '15:40',
-  photoAsset: 'assets/images/snack-coffee-nuts.jpg',
-  aiComment: '당류가 낮고 건강한 지방을 채운 간식이에요.',
-  foods: <_SeedFood>[
-    _SeedFood(
-      '아이스 아메리카노',
-      calories: 10,
-      sodiumMg: 5,
-      sugarG: 0,
-      carbsG: 2,
-      proteinG: 0.5,
-      fatG: 0,
-    ),
-    _SeedFood(
-      '견과류 한 봉',
-      calories: 90,
-      sodiumMg: 2,
-      sugarG: 3,
-      carbsG: 1,
-      proteinG: 2,
-      fatG: 8,
-    ),
-  ],
-);
-
-// ---- 약속이 있던 어제 ----------------------------------------------------
-//
-// 어제 하루만 칼로리·당류가 목표를 넘는다. 아침·점심은 평소대로 먹고 저녁에
-// 약속이 있어 고기와 디저트가 얹힌 하루다 — 아래 두 끼가 그 몫이다.
-
-const _SeedMeal _mealSamgyeopsalDinner = _SeedMeal(
-  slug: 'dinner',
-  mealType: 'dinner',
-  timeLabel: '19:30',
-  // 삼겹살 사진 에셋이 없어 가장 가까운 한식 상차림을 쓴다.
-  photoAsset: 'assets/images/diet-doenjang-rice.jpeg',
-  aiComment: '고기와 술이 함께여서 칼로리가 크게 올라갔어요. 다음 날은 가볍게 시작해 보세요.',
-  foods: <_SeedFood>[
-    _SeedFood(
-      '삼겹살 2인분',
-      calories: 620,
-      sodiumMg: 880,
-      sugarG: 1,
-      carbsG: 2,
-      proteinG: 42,
-      fatG: 50,
-    ),
-    _foodRice,
-    _SeedFood(
-      '소주 1병',
-      calories: 55,
-      sodiumMg: 0,
-      sugarG: 0,
-      carbsG: 0,
-      proteinG: 0,
-      fatG: 0,
-    ),
-  ],
-);
-
-const _SeedMeal _mealCakeLatteSnack = _SeedMeal(
-  slug: 'snack',
-  mealType: 'snack',
-  timeLabel: '21:10',
-  photoAsset: 'assets/images/snack-coffee-nuts.jpg',
-  aiComment: '디저트로 당류가 하루 목표를 넘었어요.',
-  foods: <_SeedFood>[
-    _SeedFood(
-      '초코 케이크 한 조각',
-      calories: 330,
-      sodiumMg: 280,
-      sugarG: 24,
-      carbsG: 42,
-      proteinG: 5,
-      fatG: 15,
-    ),
-    _SeedFood(
-      '카페라떼',
-      calories: 100,
-      sodiumMg: 95,
-      sugarG: 5.3,
-      carbsG: 10,
-      proteinG: 5,
-      fatG: 4,
-    ),
-  ],
-);
-
-/// 큐레이션 사흘 앞의 과거 식단. `offset` 은 오늘로부터의 일수(3 부터).
-///
-/// 날짜마다 조합을 돌려 값이 달라지게 한다 — 모든 날이 같으면 주간·월간 추이가
-/// 직선이 되어 기간 뷰가 아무것도 말해 주지 않는다. 7일마다 한 번은 저녁을
-/// 비우고(늦은 저녁 미기록), 11일마다 한 번은 하루를 통째로 비운다 — "기록이
-/// 없는 날"도 데모에 남아 있어야 그 빈 화면이 맞게 동작하는지 볼 수 있다.
-List<DietEntriesCompanion> _historyDietEntries(DateTime now) {
-  final entries = <DietEntriesCompanion>[];
-  for (int offset = 3; offset < 3 + kDemoDietHistoryDays; offset++) {
-    if (offset % 11 == 0) continue;
-    final String date = _fmtDate(now.subtract(Duration(days: offset)));
-    entries.add(
-      _historyBreakfasts[offset % _historyBreakfasts.length].companion(date),
+/// 운동을 종류별로 합친다 — {종류: (분, 칼로리)}. 픽스처 순서를 유지한다.
+Map<String, ({int minutes, int calories})> _byType(
+  List<FixtureExercise> exercises,
+) {
+  final Map<String, ({int minutes, int calories})> totals =
+      <String, ({int minutes, int calories})>{};
+  for (final FixtureExercise exercise in exercises) {
+    final ({int minutes, int calories}) prev =
+        totals[exercise.type] ?? (minutes: 0, calories: 0);
+    totals[exercise.type] = (
+      minutes: prev.minutes + exercise.minutes,
+      calories: prev.calories + exercise.calories,
     );
-    entries.add(
-      _historyLunches[offset % _historyLunches.length].companion(date),
-    );
-    if (offset % 7 != 6) {
-      entries.add(
-        _historyDinners[offset % _historyDinners.length].companion(date),
-      );
-    }
-    if (offset % 3 == 0) entries.add(_mealCoffeeNuts.companion(date));
   }
-  return entries;
-}
-
-/// 한 주의 운동 세션 한 벌. `minutes` 는 요일별 유산소·근력·스트레칭 분이다.
-const List<(String day, int cardio, int strength, int stretching)>
-_historyWeekPattern = <(String, int, int, int)>[
-  ('월', 30, 10, 5),
-  ('화', 40, 0, 10),
-  ('수', 0, 0, 0),
-  ('목', 35, 20, 5),
-  ('금', 45, 0, 10),
-  ('토', 25, 30, 15),
-  ('일', 20, 0, 10),
-];
-
-/// 지난 주들의 운동 세션. 주마다 강도를 조금씩 달리해(`scale`) 주간 비교가
-/// 의미를 갖게 한다. 이번 주는 큐레이션 값을 쓰므로 `weeksAgo` 는 1 부터다.
-List<ExerciseSessionsCompanion> _historyExerciseSessions(DateTime now) {
-  final sessions = <ExerciseSessionsCompanion>[];
-  final DateTime thisMonday = _mondayOfThisWeek(now);
-  for (int weeksAgo = 1; weeksAgo <= kDemoExerciseHistoryWeeks; weeksAgo++) {
-    final String weekStart = _fmtDate(
-      thisMonday.subtract(Duration(days: 7 * weeksAgo)),
-    );
-    // 오래된 주일수록 조금 적게 — 데모에서 "요즘 늘고 있다"로 읽힌다.
-    final double scale = 1 - (weeksAgo * 0.12);
-    for (final (String day, int cardio, int strength, int stretching)
-        in _historyWeekPattern) {
-      void add(String type, int minutes, int caloriesPerMin) {
-        final int scaled = (minutes * scale).round();
-        if (scaled <= 0) return;
-        sessions.add(
-          ExerciseSessionsCompanion.insert(
-            id: 'seed-ex-$weekStart-$day-$type',
-            weekStart: weekStart,
-            dayLabel: day,
-            type: type,
-            minutes: scaled,
-            calories: scaled * caloriesPerMin,
-          ),
-        );
-      }
-
-      add('cardio', cardio, 7);
-      add('strength', strength, 5);
-      add('stretching', stretching, 3);
-    }
-  }
-  return sessions;
+  return totals;
 }
 
 String _fmtDate(DateTime d) =>
     '${d.year.toString().padLeft(4, '0')}-'
     '${d.month.toString().padLeft(2, '0')}-'
     '${d.day.toString().padLeft(2, '0')}';
-
-DateTime _mondayOfThisWeek(DateTime now) {
-  final weekday = now.weekday; // 1 = Mon ... 7 = Sun
-  return DateTime(now.year, now.month, now.day - (weekday - 1));
-}

--- a/frontend/flutter/pubspec.lock
+++ b/frontend/flutter/pubspec.lock
@@ -249,6 +249,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
+  demo_fixture:
+    dependency: "direct main"
+    description:
+      path: "../../shared/demo_fixture"
+      relative: true
+    source: path
+    version: "1.0.0"
   dio:
     dependency: "direct main"
     description:

--- a/frontend/flutter/pubspec.yaml
+++ b/frontend/flutter/pubspec.yaml
@@ -33,6 +33,12 @@ dependencies:
   # incompatible with retrofit 4.9.2 (switch on Parser is non-exhaustive
   # for Parser.DartMappable), which blocks `build_runner build`.
 
+  # --- 데모 데이터 ---
+  # 김민수의 하루는 트레이너 앱·백엔드와 같은 픽스처에서 온다(#757). 두 앱을
+  # 나란히 놓고 시연하므로 각자 만들면 같은 날짜의 숫자가 어긋난다.
+  demo_fixture:
+    path: ../../shared/demo_fixture
+
   # --- Local persistence ---
   drift: ^2.20.3
   drift_flutter: ^0.2.4

--- a/frontend/flutter/test/core/network/local_api_interceptor_diet_demo_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_diet_demo_test.dart
@@ -11,8 +11,10 @@
 library;
 
 import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:demo_fixture/demo_fixture.dart';
 import 'package:dio/dio.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -28,6 +30,9 @@ String _dateString(DateTime d) =>
     '${d.day.toString().padLeft(2, '0')}';
 
 void main() {
+  // 시드가 공유 픽스처를 에셋에서 읽는다(#757) — rootBundle 을 쓰려면 바인딩이
+  // 먼저 서 있어야 한다.
+  TestWidgetsFlutterBinding.ensureInitialized();
   late AppDatabase db;
   late Dio dio;
 
@@ -76,14 +81,21 @@ void main() {
     });
 
     test('지난 날짜도 그 날짜의 문장을 쓴다', () async {
-      final yesterday = _dateString(
-        DateTime.now().subtract(const Duration(days: 1)),
-      );
+      final DateTime now = DateTime.now();
+      final yesterday = _dateString(now.subtract(const Duration(days: 1)));
       final res = await dio.get<Map<String, Object?>>(
         '/diet/days/$yesterday',
       );
 
-      expect(res.data!['ai_coach_message'], '나트륨을 잘 조절했고 단백질도 고르게 섭취한 하루였어요.');
+      // 문장은 픽스처가 갖고 있다 — 여기에 다시 적으면 두 벌이 되어 한쪽만 고쳤을 때
+      // 조용히 갈린다(#757).
+      final FixtureDay day = DemoFixture.parse(
+        File(
+          '../../shared/demo_fixture/assets/kim_minsu.json',
+        ).readAsStringSync(),
+      ).daysFor(now).firstWhere((FixtureDay d) => d.date == yesterday);
+      expect(day.dayMessage, isNotEmpty, reason: '어제는 큐레이션된 날이다');
+      expect(res.data!['ai_coach_message'], day.dayMessage);
     });
 
     test('끼니를 수정해도 코멘트와 사진이 남는다', () async {

--- a/frontend/flutter/test/core/network/local_api_interceptor_diet_demo_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_diet_demo_test.dart
@@ -30,9 +30,6 @@ String _dateString(DateTime d) =>
     '${d.day.toString().padLeft(2, '0')}';
 
 void main() {
-  // 시드가 공유 픽스처를 에셋에서 읽는다(#757) — rootBundle 을 쓰려면 바인딩이
-  // 먼저 서 있어야 한다.
-  TestWidgetsFlutterBinding.ensureInitialized();
   late AppDatabase db;
   late Dio dio;
 

--- a/frontend/flutter/test/core/network/local_api_smoke_test.dart
+++ b/frontend/flutter/test/core/network/local_api_smoke_test.dart
@@ -18,9 +18,6 @@ import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
 /// interceptor → JSON → fromJson factory. If any of these layers
 /// drift apart, this lights up first.
 void main() {
-  // 시드가 공유 픽스처를 에셋에서 읽는다(#757) — rootBundle 을 쓰려면 바인딩이
-  // 먼저 서 있어야 한다.
-  TestWidgetsFlutterBinding.ensureInitialized();
   late AppDatabase db;
   late Dio dio;
 

--- a/frontend/flutter/test/core/network/local_api_smoke_test.dart
+++ b/frontend/flutter/test/core/network/local_api_smoke_test.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+
+import 'package:demo_fixture/demo_fixture.dart';
 import 'package:dio/dio.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -15,6 +18,9 @@ import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
 /// interceptor → JSON → fromJson factory. If any of these layers
 /// drift apart, this lights up first.
 void main() {
+  // 시드가 공유 픽스처를 에셋에서 읽는다(#757) — rootBundle 을 쓰려면 바인딩이
+  // 먼저 서 있어야 한다.
+  TestWidgetsFlutterBinding.ensureInitialized();
   late AppDatabase db;
   late Dio dio;
 
@@ -66,9 +72,25 @@ void main() {
     final week = ExerciseWeek.fromJson(res.data!);
     expect(week.dailyMinutes.length, 7);
     expect(week.dayLabels, <String>['월', '화', '수', '목', '금', '토', '일']);
-    // v2 seed has multi-type rows per day so the stacked chart fills.
-    // Sum: 월 40 + 화 60 + 수 50 + 목 65 + 금 55 + 토 80 + 일 0 = 350.
-    expect(week.totalMinutes, 350);
+    // 합계는 픽스처가 정한다(#757). 여기 숫자를 적어 두면 요일마다 달라지는 값을
+    // 고정하게 되고(이번 주는 오늘까지만 시드된다), 픽스처를 고칠 때마다 깨진다.
+    final DateTime now = DateTime.now();
+    final String monday = _dateString(
+      DateTime(now.year, now.month, now.day - (now.weekday - 1)),
+    );
+    final int expectedMinutes = DemoFixture.parse(
+      File('../../shared/demo_fixture/assets/kim_minsu.json').readAsStringSync(),
+    ).daysFor(now).where((FixtureDay d) => d.weekStart == monday).fold<int>(
+      0,
+      (int sum, FixtureDay d) =>
+          sum +
+          d.doneExercises.fold<int>(
+            0,
+            (int m, FixtureExercise e) => m + e.minutes,
+          ),
+    );
+    expect(week.totalMinutes, expectedMinutes);
+    expect(expectedMinutes, greaterThan(0), reason: '이번 주 운동이 하나도 없으면 검증이 빈다');
     // 홈 '주간 추이' 차트가 데모 상수로 폴백하지 않도록 일별 칼로리도 내려준다.
     expect(week.dailyCalories.length, 7);
     expect(week.dailyCalories.reduce((a, b) => a + b), week.totalCalories);
@@ -124,9 +146,10 @@ void main() {
   });
 }
 
-String _daysAgoString(int days) {
-  final date = DateTime.now().subtract(Duration(days: days));
-  return '${date.year.toString().padLeft(4, '0')}-'
-      '${date.month.toString().padLeft(2, '0')}-'
-      '${date.day.toString().padLeft(2, '0')}';
-}
+String _daysAgoString(int days) =>
+    _dateString(DateTime.now().subtract(Duration(days: days)));
+
+String _dateString(DateTime date) =>
+    '${date.year.toString().padLeft(4, '0')}-'
+    '${date.month.toString().padLeft(2, '0')}-'
+    '${date.day.toString().padLeft(2, '0')}';

--- a/frontend/flutter/test/core/storage/seed_data_test.dart
+++ b/frontend/flutter/test/core/storage/seed_data_test.dart
@@ -174,6 +174,48 @@ void main() {
       );
     });
 
+    test('날짜별 값이 픽스처와 같다', () async {
+      // 트레이너 앱도 같은 픽스처를 읽으므로, 이 단정이 곧 "두 앱을 나란히 놓고 같은
+      // 날짜를 봐도 숫자가 같다"는 뜻이다(#757). 트레이너 쪽 짝은
+      // `flutter_trainer/test/core/storage/seed_data_test.dart` 에 있다.
+      await seedIfEmpty(db, fixture: _fixture);
+      final diet = await db.select(db.dietEntries).get();
+      final exercise = await db.select(db.exerciseSessions).get();
+
+      for (final FixtureDay day in _fixture.daysFor(DateTime.now())) {
+        final rows = diet.where((r) => r.date == day.date);
+        expect(
+          rows.fold<int>(0, (int sum, r) => sum + r.totalCalories),
+          day.calories,
+          reason: '${day.date} 칼로리',
+        );
+        expect(
+          rows.fold<int>(0, (int sum, r) => sum + r.sodiumMg),
+          day.sodiumMg,
+          reason: '${day.date} 나트륨',
+        );
+        expect(
+          rows.fold<double>(0, (double sum, r) => sum + r.sugarG),
+          closeTo(day.sugarG, 0.001),
+          reason: '${day.date} 당류',
+        );
+
+        // 운동은 **실제로 한** 항목만 쌓인다 — 이행률과 주간 운동 시간이 갈라지면
+        // 안 된다.
+        final int minutes = exercise
+            .where((r) => r.weekStart == day.weekStart && r.dayLabel == day.dayLabel)
+            .fold<int>(0, (int sum, r) => sum + r.minutes);
+        expect(
+          minutes,
+          day.doneExercises.fold<int>(
+            0,
+            (int sum, FixtureExercise e) => sum + e.minutes,
+          ),
+          reason: '${day.date} 운동 시간',
+        );
+      }
+    });
+
     test('지난 주 운동 세션도 시드된다', () async {
       await seedIfEmpty(db, fixture: _fixture);
       final exercise = await db.select(db.exerciseSessions).get();

--- a/frontend/flutter/test/core/storage/seed_data_test.dart
+++ b/frontend/flutter/test/core/storage/seed_data_test.dart
@@ -1,11 +1,22 @@
 import 'dart:convert';
+import 'dart:io';
 
+import 'package:demo_fixture/demo_fixture.dart';
 import 'package:drift/drift.dart' show Value;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:oncare/core/storage/app_database.dart';
 import 'package:oncare/core/storage/seed_data.dart';
+
+/// 시드가 읽는 것과 같은 픽스처. 테스트에서는 에셋 번들 대신 파일로 읽는다 — 번들이
+/// 준비됐는지에 기대지 않고 시드 자체만 본다.
+final DemoFixture _fixture = DemoFixture.parse(
+  File('../../shared/demo_fixture/assets/kim_minsu.json').readAsStringSync(),
+);
+
+/// 픽스처가 덮는 구간 밖의 offset. 그 앞으로는 기록이 없어야 한다.
+final int _beyondFixture = _fixture.historyWeeks * 7 + 5;
 
 String _todayString() {
   final now = DateTime.now();
@@ -34,7 +45,7 @@ void main() {
 
   group('seedIfEmpty', () {
     test('first run seeds diet/exercise/schedule with today\'s date', () async {
-      await seedIfEmpty(db);
+      await seedIfEmpty(db, fixture: _fixture);
 
       final today = _todayString();
       final diet = await db.select(db.dietEntries).get();
@@ -49,11 +60,18 @@ void main() {
       // 큐레이션 사흘 앞으로도 기록이 이어진다 — 날짜를 옮기면 대부분
       // 비어 있던 데모 문제(#671).
       expect(diet.where((r) => r.date == _daysAgoString(3)), isNotEmpty);
-      expect(diet.where((r) => r.date == _daysAgoString(30)), isNotEmpty);
+      // 한 달을 거슬러 올라가도 대부분의 날에 기록이 있다. "모든 날"이 아닌 이유는
+      // 픽스처가 기록 없는 날을 일부러 남겨 두기 때문이다.
+      final int loggedInLastMonth = <int>[
+        for (int offset = 3; offset < 33; offset++) offset,
+      ].where((int offset) {
+        return diet.any((r) => r.date == _daysAgoString(offset));
+      }).length;
+      expect(loggedInLastMonth, greaterThan(20));
       expect(
-        diet.where((r) => r.date == _daysAgoString(kDemoDietHistoryDays + 5)),
+        diet.where((r) => r.date == _daysAgoString(_beyondFixture)),
         isEmpty,
-        reason: '히스토리는 한 달치까지만 채운다',
+        reason: '픽스처가 덮는 구간(${_fixture.historyWeeks}주) 밖은 비어 있어야 한다',
       );
       final salmonDinner = diet.firstWhere(
         (row) => row.id == 'seed-diet-two-days-ago-dinner',
@@ -122,15 +140,18 @@ void main() {
         reason: 'exercise sessions for the current week must be seeded',
       );
 
-      expect(await db.readValue('seeded_v16'), today);
+      expect(await db.readValue('seeded_v17'), today);
     });
 
     test('과거 식단은 날짜마다 값이 달라 추이가 직선이 되지 않는다', () async {
-      await seedIfEmpty(db);
+      await seedIfEmpty(db, fixture: _fixture);
       final diet = await db.select(db.dietEntries).get();
 
+      // 픽스처가 덮는 구간 전체를 본다. 기록이 없는 날은 12주 안에 흩어져 있어서
+      // 최근 한 달만 보면 "전부 기록됨"으로 읽힌다.
+      final int span = _fixture.historyWeeks * 7;
       final Map<String, int> caloriesByDate = <String, int>{};
-      for (int offset = 3; offset < 3 + kDemoDietHistoryDays; offset++) {
+      for (int offset = 3; offset < span; offset++) {
         final String date = _daysAgoString(offset);
         final int kcal = diet
             .where((r) => r.date == date)
@@ -148,13 +169,13 @@ void main() {
       // 볼 수 있어야 한다.
       expect(
         caloriesByDate.length,
-        lessThan(kDemoDietHistoryDays),
+        lessThan(span - 3),
         reason: '기록 없는 날이 최소 하나는 남아야 한다',
       );
     });
 
     test('지난 주 운동 세션도 시드된다', () async {
-      await seedIfEmpty(db);
+      await seedIfEmpty(db, fixture: _fixture);
       final exercise = await db.select(db.exerciseSessions).get();
 
       final DateTime now = DateTime.now();
@@ -165,11 +186,7 @@ void main() {
       );
       final Set<String> weekStarts = exercise.map((r) => r.weekStart).toSet();
 
-      for (
-        int weeksAgo = 0;
-        weeksAgo <= kDemoExerciseHistoryWeeks;
-        weeksAgo++
-      ) {
+      for (int weeksAgo = 0; weeksAgo < _fixture.historyWeeks; weeksAgo++) {
         final DateTime monday = thisMonday.subtract(
           Duration(days: 7 * weeksAgo),
         );
@@ -185,7 +202,7 @@ void main() {
       // 수치를 템플릿 한 곳으로 모으면서(#677) 데모 화면의 문구·사진·시각이
       // 바뀌면 안 된다. 합계는 다른 테스트가 보므로 여기서는 표현만 못박는다.
       // 세 필드를 아홉 행 모두 검증한다 — 일부만 보면 나머지가 조용히 바뀐다.
-      await seedIfEmpty(db);
+      await seedIfEmpty(db, fixture: _fixture);
       final diet = await db.select(db.dietEntries).get();
       DietEntryRow row(String id) => diet.firstWhere((r) => r.id == id);
 
@@ -256,7 +273,7 @@ void main() {
       // companion() 의 id 는 선택 인자다. 큐레이션 호출에서 빠뜨리면
       // `seed-diet-2026-08-14-lunch` 같은 날짜 id 로 조용히 바뀌는데, 화면과
       // 테스트가 이 리터럴 id 로 행을 찾는다.
-      await seedIfEmpty(db);
+      await seedIfEmpty(db, fixture: _fixture);
       final diet = await db.select(db.dietEntries).get();
       final Set<String> ids = diet.map((r) => r.id).toSet();
 
@@ -292,7 +309,7 @@ void main() {
     test('같은 음식은 어느 날짜에 쓰이든 영양 수치가 하나다', () async {
       // #677 이 없애려는 상태: 큐레이션 쪽과 히스토리 쪽에 같은 음식의 수치가
       // 두 벌 존재해, 한쪽만 고치면 조용히 갈린다.
-      await seedIfEmpty(db);
+      await seedIfEmpty(db, fixture: _fixture);
       final diet = await db.select(db.dietEntries).get();
 
       final Map<String, Set<String>> fingerprintsByFood =
@@ -333,18 +350,21 @@ void main() {
         reason: '여러 날짜에 쓰이는 음식이 없으면 이 검증이 아무것도 지키지 못한다',
       );
       expect(
-        datesByFood['짬뽕']?.length ?? 0,
+        datesByFood['된장찌개']?.length ?? 0,
         greaterThan(1),
-        reason: '짬뽕은 오늘(큐레이션)과 히스토리 양쪽에 쓰인다',
+        reason: '된장찌개는 여러 날의 점심·저녁에 함께 쓰인다',
       );
+      // 짬뽕은 오늘 하루의 이야기다 — 한 끼로 하루 나트륨을 다 쓰는 끼니라
+      // 격자에 섞으면 그날의 나트륨÷칼로리가 현실에서 벗어난다.
+      expect(datesByFood['짬뽕'], <String>{_todayString()});
     });
 
     test('same-day re-run is a no-op (does not duplicate rows)', () async {
-      await seedIfEmpty(db);
+      await seedIfEmpty(db, fixture: _fixture);
       final dietBefore = await db.select(db.dietEntries).get();
       final exerciseBefore = await db.select(db.exerciseSessions).get();
 
-      await seedIfEmpty(db);
+      await seedIfEmpty(db, fixture: _fixture);
       final dietAfter = await db.select(db.dietEntries).get();
       final exerciseAfter = await db.select(db.exerciseSessions).get();
 
@@ -353,7 +373,7 @@ void main() {
     });
 
     test('diet seed has consistent realistic nutrition totals', () async {
-      await seedIfEmpty(db);
+      await seedIfEmpty(db, fixture: _fixture);
       final allDiet = await db.select(db.dietEntries).get();
       final diet = allDiet
           .where((entry) => entry.date == _todayString())
@@ -401,16 +421,16 @@ void main() {
 
     test('stale flag (different date) re-seeds with today', () async {
       // Pretend the seed last ran a week ago.
-      await seedIfEmpty(db);
-      await db.putValue('seeded_v16', '2020-01-01');
+      await seedIfEmpty(db, fixture: _fixture);
+      await db.putValue('seeded_v17', '2020-01-01');
 
-      await seedIfEmpty(db);
+      await seedIfEmpty(db, fixture: _fixture);
 
       final today = _todayString();
       final diet = await db.select(db.dietEntries).get();
       expect(diet, isNotEmpty);
       expect(diet.where((r) => r.date == today).length, 3);
-      expect(await db.readValue('seeded_v16'), today);
+      expect(await db.readValue('seeded_v17'), today);
     });
 
     test('legacy seeded_v2=true flag is migrated and cleared', () async {
@@ -433,11 +453,11 @@ void main() {
             ),
           );
 
-      await seedIfEmpty(db);
+      await seedIfEmpty(db, fixture: _fixture);
 
       // Legacy flag cleared, current flag set to today.
       expect(await db.readValue('seeded_v2'), isNull);
-      expect(await db.readValue('seeded_v16'), _todayString());
+      expect(await db.readValue('seeded_v17'), _todayString());
 
       // Stale seed-prefixed row was wiped and replaced with today's
       // seed batch.
@@ -465,10 +485,10 @@ void main() {
             ),
           );
 
-      await seedIfEmpty(db);
+      await seedIfEmpty(db, fixture: _fixture);
       // Force a re-seed by ageing the flag.
-      await db.putValue('seeded_v16', '2020-01-01');
-      await seedIfEmpty(db);
+      await db.putValue('seeded_v17', '2020-01-01');
+      await seedIfEmpty(db, fixture: _fixture);
 
       final diet = await db.select(db.dietEntries).get();
       expect(

--- a/frontend/flutter/test/features/dashboard/home_ai_advice_test.dart
+++ b/frontend/flutter/test/features/dashboard/home_ai_advice_test.dart
@@ -47,6 +47,9 @@ DashboardSummary _summary({String? adviceKey, String? sodiumWarning}) =>
 /// 보내, 홈이 그 값을 ARB 보다 우선하는 바람에 영어 로케일에서도 한국어가
 /// 나왔다(#435). 이제 둘 다 키만 싣고 문장은 ARB 가 갖는다.
 void main() {
+  // 시드가 공유 픽스처를 에셋에서 읽는다(#757) — rootBundle 을 쓰려면 바인딩이
+  // 먼저 서 있어야 한다.
+  TestWidgetsFlutterBinding.ensureInitialized();
   test('데모 mock 요약은 문구가 아니라 키를 싣는다', () async {
     final DashboardSummary summary = await MockDashboardRepository(
       FakeDietRepository(),

--- a/frontend/flutter/test/features/dashboard/home_ai_advice_test.dart
+++ b/frontend/flutter/test/features/dashboard/home_ai_advice_test.dart
@@ -47,9 +47,6 @@ DashboardSummary _summary({String? adviceKey, String? sodiumWarning}) =>
 /// 보내, 홈이 그 값을 ARB 보다 우선하는 바람에 영어 로케일에서도 한국어가
 /// 나왔다(#435). 이제 둘 다 키만 싣고 문장은 ARB 가 갖는다.
 void main() {
-  // 시드가 공유 픽스처를 에셋에서 읽는다(#757) — rootBundle 을 쓰려면 바인딩이
-  // 먼저 서 있어야 한다.
-  TestWidgetsFlutterBinding.ensureInitialized();
   test('데모 mock 요약은 문구가 아니라 키를 싣는다', () async {
     final DashboardSummary summary = await MockDashboardRepository(
       FakeDietRepository(),

--- a/frontend/flutter_trainer/lib/core/storage/seed_clients.dart
+++ b/frontend/flutter_trainer/lib/core/storage/seed_clients.dart
@@ -49,77 +49,30 @@ const List<_Client> _clients = <_Client>[
     lastTime: '18:18',
     threadHandled: true,
     active: true,
-    calories: 1067,
-    // 오늘은 짬뽕 한 그릇이 나트륨을 다 썼다(3200mg). 칼로리가 낮은 건 저녁을
-    // 아직 안 적었기 때문이고, 저 조합이 오늘 코칭 알림의 근거다.
+    // 김민수의 수치는 **여기에 없다.** 그는 사용자 앱의 데모 계정(`user-demo`)과
+    // 같은 사람이라 두 앱을 나란히 놓고 시연하는데, 각자 만들면 같은 날짜의 숫자가
+    // 어긋난다(#757). 하루 합계·요일별 계열·끼니·운동 이력은 공유 픽스처
+    // (`shared/demo_fixture`)가 정하고 `seed_data.dart` 가 그걸 읽어 넣는다.
     //
-    // 나머지 날은 나트륨 ÷ 칼로리가 1.0~1.5mg/kcal 안에 들어야 한다. 한식이
-    // 짜다 해도 900kcal 짜리 하루가 2,000mg 을 넘기려면 국물만 먹어야 한다 —
-    // 회원을 추가할 때 이 비율을 먼저 확인할 것.
-    //
-    // 이 배열은 요일에 붙는 평상시 값이다. **어제** 하루만 약속이 있어 칼로리·
-    // 당류가 목표를 넘는데, 그건 여기가 아니라 `seed_data.dart` 의 `_feastDay`
-    // 가 날짜로 덮어쓴다 — 어제가 무슨 요일인지는 데모를 여는 날마다 달라진다.
-    sodiumMg: 3428,
-    // Keep this aligned with the member app's current mock daily total.
-    sugarG: 17.8,
+    // 그래서 아래 필드는 비워 둔다 — 값을 남겨 두면 어느 쪽이 진짜인지 알 수 없고,
+    // 한쪽만 고쳤을 때 조용히 갈린다. 나머지 고객은 예전대로 이 파일이 정한다.
+    calories: 0,
+    sodiumMg: 0,
+    sugarG: 0,
     lastRoutine: '오늘',
-    weekCompletion: <int>[100, 67, 100, 0, 100, 67, 100],
-    sodiumWeek: <int>[2400, 2200, 1900, 2050, 2300, 1850, 3428],
-    caloriesWeek: <int>[1620, 1710, 1830, 1560, 1900, 1680, 1067],
-    sugarWeek: <double>[36.0, 41.5, 28.0, 45.5, 33.0, 38.5, 17.8],
-    diet: <_Meal>[
-      _Meal(
-        '아침',
-        '스크램블 에그, 딸기',
-        217,
-        221,
-        carbsG: 10,
-        proteinG: 13.5,
-        fatG: 14.5,
-      ),
-      _Meal('점심', '짬뽕', 750, 3200, carbsG: 107, proteinG: 29, fatG: 22.5),
-      _Meal(
-        '간식',
-        '아이스 아메리카노, 견과류 한 봉',
-        100,
-        7,
-        carbsG: 3,
-        proteinG: 2.5,
-        fatG: 8,
-      ),
-    ],
+    weekCompletion: <int>[],
+    sodiumWeek: <int>[],
+    caloriesWeek: <int>[],
+    sugarWeek: <double>[],
+    diet: <_Meal>[],
     aiRoutine: <_Routine>[
       _Routine('저강도 유산소 (걷기)', 30, '유산소', '혈압 안정에 효과적'),
       _Routine('하체 스트레칭', 15, '스트레칭', '혈액순환 개선'),
       _Routine('코어 강화', 10, '근력', '기초대사량 향상'),
     ],
-    history: <_History>[
-      _History(
-        dateLabel: '7/12 (오늘)',
-        label: 'PT 세션 · 트레이너 지도',
-        completionRate: 100,
-        exercises: <String>['레그프레스 3세트', '레그컬 3세트', '하체 스트레칭'],
-        clientFeedback: '무릎이 좀 당겼지만 트레이너님 덕분에 잘 마쳤어요 😊',
-        trainerNote: '무릎 가동범위 체크 필요. 다음 세션 중량 조절 예정.',
-      ),
-      _History(
-        dateLabel: '7/10',
-        label: 'AI 루틴 · 자율 운동',
-        completionRate: 67,
-        exercises: <String>['걷기 30분 ✓', '코어 강화 10분 ✓', '스트레칭 ✗ (생략)'],
-        clientFeedback: '스트레칭은 시간이 없어서 못 했어요',
-        trainerNote: '',
-      ),
-      _History(
-        dateLabel: '7/8',
-        label: 'AI 루틴 · 자율 운동',
-        completionRate: 100,
-        exercises: <String>['걷기 30분 ✓', '코어 강화 10분 ✓', '하체 스트레칭 15분 ✓'],
-        clientFeedback: '오늘은 다 했어요! 뿌듯해요 💪',
-        trainerNote: '',
-      ),
-    ],
+    // 운동 이력도 픽스처가 정한다. 예전에는 날짜 라벨이 `'7/12 (오늘)'` 로 박혀
+    // 있어 데모를 언제 열든 7월 12일이 "오늘"이었다.
+    history: <_History>[],
     // 김민수는 회원 앱 데모 사용자(user-demo)와 같은 사람이라, 이 스레드는
     // 두 앱에 같은 대화로 보여야 한다. 같은 목록이
     // `frontend/flutter/lib/features/member_coach/data/repositories/mock_member_coach_repository.dart`
@@ -129,10 +82,13 @@ const List<_Client> _clients = <_Client>[
     // **이미 진행 중인** 코칭의 한 토막이다. 김민수는 PT 12회차를 지난 회원이라
     // 첫 인사로 시작하면 앱의 다른 화면(운동 이력·AI 코치 카드)과 어긋난다.
     //
-    // 대화의 근거는 이 파일의 숫자에서 가져왔다 — 이행률 톱니형(화 67·목 0)이
-    // "화·목에 야근"이라는 답과 맞물린다. 반대로 요일별 나트륨 mg 은 인용하지
-    // 않는다: 회원 앱 데모의 주간 수치가 여기와 달라, 수치를 단정하면 둘 중
-    // 한 화면과 반드시 어긋난다(목표 2,000mg 만 인용).
+    // 대화의 근거는 픽스처의 숫자다 — 이번 주 이행률이 화·목에 떨어져 있고(화 50·
+    // 목 67), 그게 "화·목에 야근"이라는 답과 맞물린다. 픽스처의 주차별 이야기를
+    // 손볼 때 이 대화도 함께 읽을 것.
+    //
+    // 요일별 나트륨 mg 은 여전히 인용하지 않는다(목표 2,000mg 만 인용). 이제는 두
+    // 앱이 같은 수치를 보지만, 그 수치는 데모를 여는 요일에 따라 달라진다 —
+    // 대화에 숫자를 박으면 어떤 날에는 화면과 어긋난다.
     chat: <_Chat>[
       // 1일차.
       _Chat(

--- a/frontend/flutter_trainer/lib/core/storage/seed_data.dart
+++ b/frontend/flutter_trainer/lib/core/storage/seed_data.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:demo_fixture/demo_fixture.dart';
 import 'package:drift/drift.dart';
 
 import 'package:oncare_trainer/core/storage/app_database.dart';
@@ -25,6 +26,12 @@ part 'seed_clients.dart';
 /// - otherwise (first boot or date rolled over) → wipe every
 ///   `seed-`-prefixed row and re-insert, sliding the trainer's schedule
 ///   onto today so the 스케줄 탭 is never empty on a later calendar day.
+///
+/// 김민수(`seed-client-1`)의 하루는 이 파일이 만들지 않는다. 그는 사용자 앱의
+/// 데모 계정(`user-demo`)과 같은 사람이라 두 앱을 나란히 놓고 시연하는데, 예전에는
+/// 두 앱과 백엔드가 각자 알고리즘으로 그의 과거를 만들어서 같은 날짜의 숫자가 서로
+/// 달랐다(#757). 그의 식단·이행률·날짜별 이력은 공유 픽스처에서 오고, 나머지 고객은
+/// 아래 생성기(`_dailyMetrics`)가 그대로 만든다.
 ///
 /// The flag is `_v13` (was `_v12`): each weekday now gets its own routine
 /// so a week no longer repeats one workout (#754). `_v12` first carried that day's
@@ -56,12 +63,19 @@ part 'seed_clients.dart';
 /// the spread documented in `seed_clients.dart`. Note the schedule stays
 /// at six slots on purpose: fifteen clients on the books does not mean
 /// fifteen sessions in one day.
-Future<void> seedIfEmpty(AppDatabase db) async {
-  final today = ymd(DateTime.now());
+Future<void> seedIfEmpty(AppDatabase db, {DemoFixture? fixture}) async {
+  final now = DateTime.now();
+  final today = ymd(now);
   // 주간 계열을 요일 자리에 놓기 위한 오늘의 인덱스(월=0).
-  final todayIndex = DateTime.now().weekday - 1;
+  final todayIndex = now.weekday - 1;
 
-  if (await db.readValue('trainer_seeded_v15') == today) return;
+  if (await db.readValue('trainer_seeded_v16') == today) return;
+
+  // 김민수의 하루는 픽스처가 정한다 — 이 앱은 날짜에 붙여 저장하기만 한다(#757).
+  final _FixtureClient fixtureClient = _FixtureClient(
+    (fixture ?? DemoFixture.load()).daysFor(now),
+    todayIndex,
+  );
 
   // A fixed, ancient anchor for seed chat timestamps. Using a constant
   // (not DateTime.now()) keeps seed messages ordered before ANY reply
@@ -102,6 +116,9 @@ Future<void> seedIfEmpty(AppDatabase db) async {
 
     // ---- Re-insert clients + their nested data ----
     for (final client in _clients) {
+      // 김민수는 픽스처가 정한다. 나머지 고객은 이 파일의 값 그대로다.
+      final bool fromFixture = client.id == _fixtureClientId;
+
       await db
           .into(db.trainerClients)
           .insert(
@@ -113,42 +130,66 @@ Future<void> seedIfEmpty(AppDatabase db) async {
               lastMessage: client.lastMessage,
               lastTime: client.lastTime,
               active: Value(client.active),
-              caloriesToday: client.calories,
-              sodiumMg: client.sodiumMg,
-              sugarG: client.sugarG,
-              carbsG: Value(client.carbsG),
-              proteinG: Value(client.proteinG),
-              fatG: Value(client.fatG),
+              caloriesToday: fromFixture
+                  ? fixtureClient.today.calories
+                  : client.calories,
+              sodiumMg: fromFixture
+                  ? fixtureClient.today.sodiumMg
+                  : client.sodiumMg,
+              sugarG: fromFixture ? fixtureClient.today.sugarG : client.sugarG,
+              carbsG: Value(
+                fromFixture ? fixtureClient.carbsToday : client.carbsG,
+              ),
+              proteinG: Value(
+                fromFixture ? fixtureClient.proteinToday : client.proteinG,
+              ),
+              fatG: Value(fromFixture ? fixtureClient.fatToday : client.fatG),
               lastRoutine: client.lastRoutine,
               weekCompletionJson: jsonEncode(
-                _upToToday(client.weekCompletion, todayIndex),
+                fromFixture
+                    ? fixtureClient.completionWeek
+                    : _upToToday(client.weekCompletion, todayIndex),
               ),
               sodiumWeekJson: Value(
-                jsonEncode(_onWeekdays(client.sodiumWeek, todayIndex)),
+                jsonEncode(
+                  fromFixture
+                      ? fixtureClient.sodiumWeek
+                      : _onWeekdays(client.sodiumWeek, todayIndex),
+                ),
               ),
               caloriesWeekJson: Value(
-                jsonEncode(_onWeekdays(client.caloriesWeek, todayIndex)),
+                jsonEncode(
+                  fromFixture
+                      ? fixtureClient.caloriesWeek
+                      : _onWeekdays(client.caloriesWeek, todayIndex),
+                ),
               ),
               sugarWeekJson: Value(
-                jsonEncode(_onWeekdays(client.sugarWeek, todayIndex)),
+                jsonEncode(
+                  fromFixture
+                      ? fixtureClient.sugarWeek
+                      : _onWeekdays(client.sugarWeek, todayIndex),
+                ),
               ),
               sortOrder: Value(client.id),
             ),
           );
 
+      final List<_Meal> diet = fromFixture ? fixtureClient.diet : client.diet;
+
       await db.batch((Batch b) {
         b.insertAll(db.clientDietEntries, <ClientDietEntriesCompanion>[
-          for (var i = 0; i < client.diet.length; i++)
+          for (var i = 0; i < diet.length; i++)
             ClientDietEntriesCompanion.insert(
               id: 'seed-diet-${client.id}-$i',
               clientId: 'seed-client-${client.id}',
-              meal: client.diet[i].meal,
-              items: client.diet[i].items,
-              calories: client.diet[i].calories,
-              sodiumMg: client.diet[i].sodiumMg,
-              carbsG: Value(client.diet[i].carbsG),
-              proteinG: Value(client.diet[i].proteinG),
-              fatG: Value(client.diet[i].fatG),
+              meal: diet[i].meal,
+              items: diet[i].items,
+              calories: diet[i].calories,
+              sodiumMg: diet[i].sodiumMg,
+              carbsG: Value(diet[i].carbsG),
+              proteinG: Value(diet[i].proteinG),
+              fatG: Value(diet[i].fatG),
               sortOrder: Value(i),
             ),
         ]);
@@ -166,24 +207,29 @@ Future<void> seedIfEmpty(AppDatabase db) async {
             ),
         ]);
 
+        final List<_History> history = fromFixture
+            ? fixtureClient.history
+            : client.history;
         b.insertAll(db.clientRoutineHistory, <ClientRoutineHistoryCompanion>[
-          for (var i = 0; i < client.history.length; i++)
+          for (var i = 0; i < history.length; i++)
             ClientRoutineHistoryCompanion.insert(
               id: 'seed-history-${client.id}-$i',
               clientId: 'seed-client-${client.id}',
-              dateLabel: client.history[i].dateLabel,
-              label: client.history[i].label,
-              completionRate: client.history[i].completionRate,
-              exercisesJson: jsonEncode(client.history[i].exercises),
-              clientFeedback: Value(client.history[i].clientFeedback),
-              trainerNote: Value(client.history[i].trainerNote),
+              dateLabel: history[i].dateLabel,
+              label: history[i].label,
+              completionRate: history[i].completionRate,
+              exercisesJson: jsonEncode(history[i].exercises),
+              clientFeedback: Value(history[i].clientFeedback),
+              trainerNote: Value(history[i].trainerNote),
               sortOrder: Value(i),
             ),
         ]);
 
         b.insertAll(
           db.clientDailyMetrics,
-          _dailyMetrics(client, DateTime.now()).toList(growable: false),
+          fromFixture
+              ? fixtureClient.dailyMetrics().toList(growable: false)
+              : _dailyMetrics(client, now).toList(growable: false),
         );
 
         b.insertAll(db.clientChatMessages, <ClientChatMessagesCompanion>[
@@ -251,7 +297,7 @@ Future<void> seedIfEmpty(AppDatabase db) async {
     });
 
     // ---- Mark seeded (inside the txn so it commits atomically) ----
-    await db.putValue('trainer_seeded_v15', today);
+    await db.putValue('trainer_seeded_v16', today);
   });
 }
 
@@ -382,25 +428,122 @@ const List<double> _completionFactors = <double>[
 /// 기록이 드문 고객(휴면·첫 주)은 과거에도 드물게 남는다 — 과거 주만 갑자기
 /// 성실해지면 화면이 그 고객의 이야기와 어긋난다. 기록이 하나도 없는 고객은
 /// 과거에도 없다.
-/// 김민수의 **어제** 하루. 약속이 있어 칼로리·당류가 목표를 넘는다.
-///
-/// 요일이 아니라 날짜로 고른다 — 데모를 여는 날마다 어제의 요일이 달라지므로,
-/// 요일에 못 박으면 어떤 날에는 이번 주에 초과일이 하나도 없게 된다.
-///
-/// 같은 합계를 사용자앱 데모(`flutter/lib/core/storage/seed_data.dart` 의
-/// `_feastDay`)와 백엔드 시드(`seed_member_data.py`)가 함께 쓴다. 두 앱을
-/// 나란히 놓고 시연하므로 한쪽만 고치면 그 자리에서 티가 난다.
-const int _feastCalories = 2380;
-const int _feastSodiumMg = 2261;
-const double _feastSugarG = 63.0;
+/// 픽스처가 정하는 고객. 김민수(1) 하나다 — 그만 사용자 앱의 데모 계정과 같은
+/// 사람이라 두 앱의 숫자를 맞춰야 한다(#757). 나머지 고객은 이 파일이 만든다.
+const int _fixtureClientId = 1;
 
-/// 잔칫날을 가진 고객. 김민수(1) 하나다 — 로스터 전체가 같은 날 과식하면
-/// 화면이 복사본처럼 읽힌다.
-const int _feastClientId = 1;
+/// 픽스처가 말하는 김민수를, 이 앱의 테이블이 기대하는 모양으로 옮긴다.
+///
+/// 여기에 계산은 없다 — 합계도 이행률도 픽스처 쪽 모델이 이미 갖고 있고, 이 클래스는
+/// 그것을 요일 자리에 놓거나 행 모양으로 바꾸기만 한다.
+class _FixtureClient {
+  _FixtureClient(this.days, this.todayIndex)
+    : today = days.last,
+      _thisWeek = days.where((FixtureDay d) => d.weekStart == days.last.weekStart)
+          .toList(growable: false);
+
+  final List<FixtureDay> days;
+  final int todayIndex;
+  final FixtureDay today;
+  final List<FixtureDay> _thisWeek;
+
+  double get carbsToday => _sumToday((FixtureMeal m) => m.carbsG);
+  double get proteinToday => _sumToday((FixtureMeal m) => m.proteinG);
+  double get fatToday => _sumToday((FixtureMeal m) => m.fatG);
+
+  double _sumToday(double Function(FixtureMeal) pick) {
+    final double total = today.meals.fold<double>(
+      0,
+      (double sum, FixtureMeal m) => sum + pick(m),
+    );
+    return (total * 10).round() / 10;
+  }
+
+  /// 오늘 끼니. 트레이너 화면은 끼니 이름과 음식 목록을 한 줄로 읽는다.
+  List<_Meal> get diet => <_Meal>[
+    for (final FixtureMeal meal in today.meals)
+      _Meal(
+        _mealLabel(meal.mealType),
+        meal.foods.map((FixtureFood f) => f.name).join(', '),
+        meal.calories,
+        meal.sodiumMg,
+        carbsG: meal.carbsG,
+        proteinG: meal.proteinG,
+        fatG: meal.fatG,
+      ),
+  ];
+
+  /// 고객 상세의 최근 운동 이력. 가까운 날부터, 운동이 있던 날만.
+  List<_History> get history => <_History>[
+    for (final FixtureDay day in days.reversed.where(
+      (FixtureDay d) => d.exercises.isNotEmpty,
+    ).take(3))
+      _History(
+        dateLabel: _historyLabel(day),
+        label: day.routineLabel,
+        completionRate: day.completion,
+        exercises: <String>[
+          for (final FixtureExercise e in day.exercises) e.label,
+        ],
+        clientFeedback: day.clientFeedback,
+        trainerNote: day.trainerNote,
+      ),
+  ];
+
+  /// 날짜 라벨. 예전에는 `'7/12 (오늘)'` 처럼 박아 두어 날이 바뀌어도 그대로였다.
+  String _historyLabel(FixtureDay day) {
+    final DateTime date = DateTime.parse(day.date);
+    final String base = '${date.month}/${date.day}';
+    return day.date == today.date ? '$base (오늘)' : base;
+  }
+
+  List<int> get caloriesWeek => _week<int>(0, (FixtureDay d) => d.calories);
+  List<int> get sodiumWeek => _week<int>(0, (FixtureDay d) => d.sodiumMg);
+  List<double> get sugarWeek => _week<double>(0.0, (FixtureDay d) => d.sugarG);
+  List<int> get completionWeek => _week<int>(0, (FixtureDay d) => d.completion);
+
+  /// 이번 주 값을 월→일 자리에 놓는다. 아직 오지 않은 요일은 0 이다 — 넣으면 주간
+  /// 추이 그래프가 빈 날을 막대로 그리고 주 평균도 실제보다 높아진다(#752).
+  List<T> _week<T extends num>(T zero, T Function(FixtureDay) pick) {
+    final List<T> week = List<T>.filled(7, zero);
+    for (final FixtureDay day in _thisWeek) {
+      final int index = DateTime.parse(day.date).weekday - 1;
+      if (index <= todayIndex) week[index] = pick(day);
+    }
+    return week;
+  }
+
+  /// 날짜별 하루 집계. 기록이 아예 없는 날은 넣지 않는다.
+  Iterable<ClientDailyMetricsCompanion> dailyMetrics() sync* {
+    for (final FixtureDay day in days) {
+      if (!day.hasRecord) continue;
+      yield ClientDailyMetricsCompanion.insert(
+        clientId: 'seed-client-$_fixtureClientId',
+        date: day.date,
+        completion: Value(day.completion),
+        calories: Value(day.calories),
+        sodiumMg: Value(day.sodiumMg),
+        sugarG: Value(day.sugarG),
+        exercisesJson: Value(
+          jsonEncode(<String>[
+            for (final FixtureExercise e in day.exercises) e.label,
+          ]),
+        ),
+      );
+    }
+  }
+}
+
+/// 끼니 종류 → 화면에 쓰는 한국어 라벨.
+String _mealLabel(String mealType) => switch (mealType) {
+  'breakfast' => '아침',
+  'lunch' => '점심',
+  'dinner' => '저녁',
+  _ => '간식',
+};
 
 Iterable<ClientDailyMetricsCompanion> _dailyMetrics(_Client client, DateTime now) sync* {
   final today = DateTime(now.year, now.month, now.day);
-  final yesterday = today.subtract(const Duration(days: 1));
   final monday = today.subtract(Duration(days: today.weekday - 1));
   final todayIndex = today.weekday - 1;
 
@@ -421,14 +564,9 @@ Iterable<ClientDailyMetricsCompanion> _dailyMetrics(_Client client, DateTime now
     for (var day = 0; day < 7; day++) {
       final date = weekMonday.add(Duration(days: day));
       if (date.isAfter(today)) break;
-      final feast = client.id == _feastClientId && date == yesterday;
-      final cal = feast
-          ? _feastCalories
-          : _scaled(calories[day], calorieFactor);
-      final na = feast ? _feastSodiumMg : _scaled(sodium[day], sodiumFactor);
-      final sg = feast
-          ? _feastSugarG
-          : (day < sugar.length ? sugar[day] * sugarFactor : 0.0);
+      final cal = _scaled(calories[day], calorieFactor);
+      final na = _scaled(sodium[day], sodiumFactor);
+      final sg = day < sugar.length ? sugar[day] * sugarFactor : 0.0;
       final done = day < completion.length
           ? _scaled(completion[day], doneFactor).clamp(0, 100)
           : 0;

--- a/frontend/flutter_trainer/pubspec.lock
+++ b/frontend/flutter_trainer/pubspec.lock
@@ -177,6 +177,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.7"
+  demo_fixture:
+    dependency: "direct main"
+    description:
+      path: "../../shared/demo_fixture"
+      relative: true
+    source: path
+    version: "1.0.0"
   dio:
     dependency: "direct main"
     description:

--- a/frontend/flutter_trainer/pubspec.yaml
+++ b/frontend/flutter_trainer/pubspec.yaml
@@ -42,6 +42,13 @@ dependencies:
   # 보관한다. 기존 SharedPreferences 기반 SessionTokenStore 를 대체한다.
   flutter_secure_storage: ^9.2.2
 
+  # --- 데모 데이터 ---
+  # 김민수(seed-client-1)의 하루는 사용자 앱·백엔드와 같은 픽스처에서 온다(#757).
+  # 두 앱을 나란히 놓고 시연하므로 각자 만들면 같은 날짜의 숫자가 어긋난다.
+  # 나머지 고객은 이 앱의 생성기가 그대로 만든다.
+  demo_fixture:
+    path: ../../shared/demo_fixture
+
   # --- Local persistence ---
   # drift 시드/데모 및 기타 기능이 사용하는 앱 공용 prefs.
   shared_preferences: ^2.3.2

--- a/frontend/flutter_trainer/test/core/storage/seed_data_test.dart
+++ b/frontend/flutter_trainer/test/core/storage/seed_data_test.dart
@@ -1,10 +1,18 @@
 import 'dart:convert';
+import 'dart:io';
 
+import 'package:demo_fixture/demo_fixture.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:oncare_trainer/core/storage/app_database.dart';
 import 'package:oncare_trainer/core/storage/seed_data.dart';
+
+/// 시드가 읽는 것과 같은 픽스처. 사용자 앱 테스트도 같은 파일을 본다 — 두 앱의
+/// 단정이 같은 원본을 가리켜야 "같은 날짜, 같은 숫자"가 실제로 지켜진다(#757).
+final DemoFixture _fixture = DemoFixture.parse(
+  File('../../shared/demo_fixture/assets/kim_minsu.json').readAsStringSync(),
+);
 
 String _todayString() {
   final now = DateTime.now();
@@ -52,7 +60,7 @@ void main() {
       }
 
       expect(await db.select(db.clientChatMessages).get(), isNotEmpty);
-      expect(await db.readValue('trainer_seeded_v15'), _todayString());
+      expect(await db.readValue('trainer_seeded_v16'), _todayString());
     });
 
     test(
@@ -63,10 +71,44 @@ void main() {
         final minsu = await (db.select(
           db.trainerClients,
         )..where((c) => c.id.equals('seed-client-1'))).getSingle();
-        // frontend/flutter's current MockDietRepository daily total is 17.8g.
+        // 사용자 앱과 같은 픽스처에서 오는 값이다.
         expect(minsu.sugarG, 17.8);
       },
     );
+
+    test('김민수의 날짜별 값이 픽스처와 같다', () async {
+      // 사용자 앱도 같은 픽스처를 읽으므로, 이 단정이 곧 "두 앱을 나란히 놓고 같은
+      // 날짜를 봐도 숫자가 같다"는 뜻이다(#757).
+      await seedIfEmpty(db);
+
+      final Map<String, FixtureDay> byDate = <String, FixtureDay>{
+        for (final FixtureDay day in _fixture.daysFor(DateTime.now()))
+          day.date: day,
+      };
+
+      final rows =
+          await (db.select(db.clientDailyMetrics)
+                ..where((t) => t.clientId.equals('seed-client-1')))
+              .get();
+      expect(rows, isNotEmpty);
+      for (final row in rows) {
+        final FixtureDay day = byDate[row.date]!;
+        expect(row.calories, day.calories, reason: '${row.date} 칼로리');
+        expect(row.sodiumMg, day.sodiumMg, reason: '${row.date} 나트륨');
+        expect(row.sugarG, closeTo(day.sugarG, 0.001), reason: '${row.date} 당류');
+        expect(row.completion, day.completion, reason: '${row.date} 이행률');
+      }
+
+      // 기록이 없는 날은 행 자체가 없어야 한다 — 0 으로 채우면 주 평균이 내려간다.
+      final Set<String> seeded = rows.map((r) => r.date).toSet();
+      final Iterable<String> blank = byDate.values
+          .where((FixtureDay d) => !d.hasRecord)
+          .map((FixtureDay d) => d.date);
+      expect(blank, isNotEmpty, reason: '기록 없는 날이 픽스처에 있어야 이 검증이 뜻을 갖는다');
+      for (final String date in blank) {
+        expect(seeded, isNot(contains(date)), reason: '$date 는 기록이 없는 날이다');
+      }
+    });
 
     // The roster is a fixture for the *charts*, not just the list — its
     // whole point is that every state the console can render is reachable
@@ -240,13 +282,13 @@ void main() {
 
     test('stale flag (different date) re-seeds schedule onto today', () async {
       await seedIfEmpty(db);
-      await db.putValue('trainer_seeded_v15', '2020-01-01');
+      await db.putValue('trainer_seeded_v16', '2020-01-01');
 
       await seedIfEmpty(db);
 
       final schedule = await db.select(db.trainerScheduleEntries).get();
       expect(schedule.every((s) => s.date == _todayString()), isTrue);
-      expect(await db.readValue('trainer_seeded_v15'), _todayString());
+      expect(await db.readValue('trainer_seeded_v16'), _todayString());
     });
 
     test(
@@ -369,7 +411,7 @@ void main() {
         expect(week.length, 7);
         expect(week.any((v) => (v as num) > 0), isTrue);
 
-        expect(await db.readValue('trainer_seeded_v15'), today);
+        expect(await db.readValue('trainer_seeded_v16'), today);
       },
     );
 
@@ -391,7 +433,7 @@ void main() {
           );
 
       // Force a re-seed.
-      await db.putValue('trainer_seeded_v15', '2020-01-01');
+      await db.putValue('trainer_seeded_v16', '2020-01-01');
       await seedIfEmpty(db);
 
       final chat = await db.select(db.clientChatMessages).get();

--- a/frontend/flutter_trainer/test/features/clients/client_detail_workout_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_workout_test.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+
+import 'package:demo_fixture/demo_fixture.dart';
 import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -26,6 +29,48 @@ const Map<String, String> seedClientIds = <String, String>{
   '이지수': 'seed-client-2',
   '박성호': 'seed-client-3',
 };
+
+/// 김민수의 값은 시드가 아니라 공유 픽스처가 정한다(#757). 기대값을 여기에 적으면
+/// 픽스처와 두 벌이 되어 한쪽만 고쳤을 때 조용히 갈린다.
+final DemoFixture _fixture = DemoFixture.parse(
+  File('../../shared/demo_fixture/assets/kim_minsu.json').readAsStringSync(),
+);
+
+/// 운동 이력 맨 위 줄의 날짜 라벨. 오늘을 따라 움직인다.
+String _todayHistoryLabel() {
+  final DateTime now = DateTime.now();
+  return '${now.month}/${now.day} (오늘)';
+}
+
+/// 운동 이력 세 줄 안에서 김민수가 거른 항목의 이름. 화면은 ✓/✗ 표시를 떼고
+/// 취소선으로 보여 주므로 이름만 남는다.
+String _minsuSkippedExercise() {
+  final List<FixtureDay> recent = _fixture
+      .daysFor(DateTime.now())
+      .reversed
+      .where((FixtureDay d) => d.exercises.isNotEmpty)
+      .take(3)
+      .toList();
+  for (final FixtureDay day in recent) {
+    for (final FixtureExercise exercise in day.exercises) {
+      if (!exercise.done) return exercise.name;
+    }
+  }
+  throw StateError('최근 사흘에 거른 항목이 없다 — 취소선 렌더링을 볼 수 없다');
+}
+
+/// 김민수의 이번 주 요일별 이행률(월→일). 아직 오지 않은 요일은 0.
+List<int> _minsuCompletionWeek(DateTime now) {
+  final List<FixtureDay> days = _fixture.daysFor(now);
+  final String monday = days.last.weekStart;
+  final List<int> week = List<int>.filled(7, 0);
+  for (final FixtureDay day in days.where(
+    (FixtureDay d) => d.weekStart == monday,
+  )) {
+    week[DateTime.parse(day.date).weekday - 1] = day.completion;
+  }
+  return week;
+}
 
 /// Fails the first `watchHistory`; every other read still succeeds.
 class _HistoryFailsOnceRepository extends DriftClientRepository {
@@ -155,9 +200,12 @@ void main() {
         db,
       ).watchHistory('seed-client-1').first;
       expect(history.length, 3);
-      expect(history.first.dateLabel, '7/12 (오늘)');
+      // 날짜 라벨은 오늘을 따라 움직인다. 예전에는 `'7/12 (오늘)'` 로 박혀 있어
+      // 데모를 언제 열든 7월 12일이 "오늘"이었다(#757).
+      final DateTime now = DateTime.now();
+      expect(history.first.dateLabel, '${now.month}/${now.day} (오늘)');
       expect(history.first.completionRate, 100);
-      expect(history.first.exercises, contains('레그프레스 3세트'));
+      expect(history.first.exercises, contains('레그프레스 3세트 ✓'));
       expect(history.first.trainerNote, isNotEmpty);
       // Later entries have no trainer note (box hidden).
       expect(history[1].trainerNote, isEmpty);
@@ -262,11 +310,10 @@ void main() {
     ) async {
       await openWorkout(tester, '김민수');
 
-      // 김민수's seeded week is [100, 67, 100, 0, 100, 67, 100]. 아직 오지
-      // 않은 날은 물론, 기록이 없는 날(목요일 0)도 빼고 나눈다 — 주의 배지·
-      // 고객 검색·주간 리포트가 쓰는 규칙과 같아야 한 회원이 화면마다 다른
-      // 이행률로 보이지 않는다(#754).
-      const week = <int>[100, 67, 100, 0, 100, 67, 100];
+      // 아직 오지 않은 날은 물론, 기록이 없는 날(휴식인 수요일 0)도 빼고 나눈다 —
+      // 주의 배지·고객 검색·주간 리포트가 쓰는 규칙과 같아야 한 회원이 화면마다
+      // 다른 이행률로 보이지 않는다(#754).
+      final week = _minsuCompletionWeek(DateTime.now());
       final elapsed = elapsedWeekdays(DateTime.now());
       final logged = week.take(elapsed).where((rate) => rate > 0).toList();
       final expected = (logged.reduce((a, b) => a + b) / logged.length).round();
@@ -298,27 +345,29 @@ void main() {
       // History entries with feedback + note boxes. Lower list items are
       // built lazily — scroll each into view before asserting.
       await tester.scrollUntilVisible(
-        find.text('7/12 (오늘)'),
+        find.text(_todayHistoryLabel()),
         150,
         scrollable: detailScrollable('seed-client-1'),
       );
-      expect(find.text('7/12 (오늘)'), findsOneWidget);
+      expect(find.text(_todayHistoryLabel()), findsOneWidget);
       expect(find.text('100%'), findsWidgets);
       await tester.scrollUntilVisible(
         find.text('트레이너 메모'),
         150,
         scrollable: detailScrollable('seed-client-1'),
       );
-      expect(find.text('트레이너 메모'), findsOneWidget); // only 7/12 has one
+      expect(find.text('트레이너 메모'), findsOneWidget); // 오늘 것만 메모가 있다
       expect(find.text('무릎 가동범위 체크 필요. 다음 세션 중량 조절 예정.'), findsOneWidget);
       expect(find.text('고객 피드백'), findsWidgets);
       // A skipped exercise line renders (struck-through content present).
+      // 어느 항목을 걸렀는지는 픽스처가 정한다 — 이름을 여기 적으면 두 벌이 된다.
+      final String skipped = _minsuSkippedExercise();
       await tester.scrollUntilVisible(
-        find.text('스트레칭 (생략)'),
+        find.text(skipped),
         150,
         scrollable: detailScrollable('seed-client-1'),
       );
-      expect(find.text('스트레칭 (생략)'), findsOneWidget);
+      expect(find.text(skipped), findsOneWidget);
     });
 
     testWidgets('a failed 운동 기록 load does not take the routines with it', (
@@ -365,7 +414,7 @@ void main() {
       );
       await settle(tester);
       await tester.scrollUntilVisible(
-        find.text('7/12 (오늘)'),
+        find.text(_todayHistoryLabel()),
         150,
         scrollable: detailScrollable('seed-client-1'),
       );
@@ -374,7 +423,7 @@ void main() {
           container.read(clientRepositoryProvider)
               as _HistoryFailsOnceRepository;
       expect(repository.watchHistoryCalls, 2);
-      expect(find.text('7/12 (오늘)'), findsOneWidget);
+      expect(find.text(_todayHistoryLabel()), findsOneWidget);
     });
 
     testWidgets('배정 루틴 실패만 재시도해 다른 영역을 보존한다', (tester) async {

--- a/frontend/flutter_trainer/test/features/reports/reports_page_test.dart
+++ b/frontend/flutter_trainer/test/features/reports/reports_page_test.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+
+import 'package:demo_fixture/demo_fixture.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -39,6 +42,22 @@ class _SummaryFailsRepository implements ReportRepository {
     required DateTime weekStart,
     required String message,
   }) async {}
+}
+
+/// 이번 주 리포트의 요일 칸에 실제로 뜨는 김민수의 운동 이름 하나.
+///
+/// 값은 공유 픽스처가 갖고 있다(#757). 화면은 ✓/✗ 표시를 떼고 이름만 보여 준다.
+String _minsuExerciseThisWeek() {
+  final DemoFixture fixture = DemoFixture.parse(
+    File('../../shared/demo_fixture/assets/kim_minsu.json').readAsStringSync(),
+  );
+  final List<FixtureDay> days = fixture.daysFor(DateTime.now());
+  final String monday = days.last.weekStart;
+  for (final FixtureDay day in days.reversed) {
+    if (day.weekStart != monday) break;
+    if (day.exercises.isNotEmpty) return day.exercises.first.name;
+  }
+  throw StateError('이번 주에 운동한 날이 없다 — 요일 칸이 전부 비어 검증이 뜻을 잃는다');
 }
 
 class _ReportFailsOncePerKeyRepository implements ReportRepository {
@@ -527,7 +546,10 @@ void main() {
 
     // 요일 칸에는 운동 이름만 둔다 — 퍼센트는 바로 위 막대가 말하고,
     // 아직 오지 않은 날은 빈칸으로 둔다.
-    expect(find.text('벤치프레스 4세트'), findsWidgets);
+    //
+    // 목록의 첫 고객은 김민수라, 그의 운동 이름은 공유 픽스처가 정한다(#757).
+    // 이름을 여기 적으면 픽스처와 두 벌이 되어 한쪽만 고쳤을 때 조용히 갈린다.
+    expect(find.text(_minsuExerciseThisWeek()), findsWidgets);
   });
 
   testWidgets('요약 카드가 안내문 대신 이번 주 요약을 말한다 (#755)', (tester) async {

--- a/shared/demo_fixture/.gitignore
+++ b/shared/demo_fixture/.gitignore
@@ -1,0 +1,5 @@
+# Dart/Flutter 빌드 산출물. 이 패키지는 앱이 아니라 라이브러리라 lock 파일도
+# 커밋하지 않는다 — 버전은 이걸 쓰는 두 앱의 pubspec.lock 이 정한다.
+.dart_tool/
+build/
+pubspec.lock

--- a/shared/demo_fixture/analysis_options.yaml
+++ b/shared/demo_fixture/analysis_options.yaml
@@ -1,0 +1,8 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    # 두 앱과 같은 규칙 — 픽스처 모델은 양쪽에서 그대로 읽히므로 스타일이
+    # 갈라지면 옮겨 붙일 때마다 진단이 뜬다.
+    always_declare_return_types: true
+    prefer_final_locals: true

--- a/shared/demo_fixture/assets/kim_minsu.json
+++ b/shared/demo_fixture/assets/kim_minsu.json
@@ -596,7 +596,7 @@
               "type": "stretching",
               "minutes": 5,
               "calories": 15,
-              "done": true
+              "done": false
             }
           ],
           "meals": [
@@ -670,7 +670,7 @@
               "type": "stretching",
               "minutes": 15,
               "calories": 45,
-              "done": false
+              "done": true
             }
           ],
           "meals": [
@@ -2248,7 +2248,7 @@
               "type": "stretching",
               "minutes": 5,
               "calories": 15,
-              "done": true
+              "done": false
             }
           ],
           "meals": [
@@ -2322,7 +2322,7 @@
               "type": "stretching",
               "minutes": 15,
               "calories": 45,
-              "done": false
+              "done": true
             }
           ],
           "meals": [

--- a/shared/demo_fixture/assets/kim_minsu.json
+++ b/shared/demo_fixture/assets/kim_minsu.json
@@ -1,0 +1,3364 @@
+{
+  "version": 1,
+  "readme": "김민수 데모 데이터의 단일 원본. 사용자앱·트레이너웹·백엔드가 이 파일만 읽는다. 날짜는 상대값이다 — weeks[].weeksAgo 는 이번 주 월요일에서 몇 주 거슬러 올라가는지, days[].weekday 는 월(0)~일(6). recent[].offset 은 오늘로부터의 일수이고 주 격자 위를 덮는다. 이행률은 exercises[].done 개수에서 계산한다 — 퍼센트를 따로 적지 않는다.",
+  "member": {
+    "name": "김민수",
+    "userAppSeedId": "user-demo",
+    "trainerClientId": "seed-client-1"
+  },
+  "historyWeeks": 12,
+  "foods": {
+    "oatmeal": {
+      "name": "오트밀",
+      "calories": 250,
+      "sodiumMg": 100,
+      "sugarG": 6.0,
+      "carbsG": 42.0,
+      "proteinG": 10.0,
+      "fatG": 6.0
+    },
+    "banana": {
+      "name": "바나나",
+      "calories": 105,
+      "sodiumMg": 1,
+      "sugarG": 14.0,
+      "carbsG": 27.0,
+      "proteinG": 1.3,
+      "fatG": 0.4
+    },
+    "greek-yogurt": {
+      "name": "그릭 요거트",
+      "calories": 170,
+      "sodiumMg": 75,
+      "sugarG": 7.0,
+      "carbsG": 8.0,
+      "proteinG": 18.0,
+      "fatG": 8.0
+    },
+    "nuts": {
+      "name": "견과류",
+      "calories": 150,
+      "sodiumMg": 5,
+      "sugarG": 2.0,
+      "carbsG": 6.0,
+      "proteinG": 5.0,
+      "fatG": 13.0
+    },
+    "scrambled-egg": {
+      "name": "스크램블 에그",
+      "calories": 185,
+      "sodiumMg": 220,
+      "sugarG": 0.8,
+      "carbsG": 2.0,
+      "proteinG": 13.0,
+      "fatG": 14.0
+    },
+    "strawberry": {
+      "name": "딸기",
+      "calories": 32,
+      "sodiumMg": 1,
+      "sugarG": 5.5,
+      "carbsG": 8.0,
+      "proteinG": 0.5,
+      "fatG": 0.5
+    },
+    "chicken-salad": {
+      "name": "닭가슴살 샐러드",
+      "calories": 315,
+      "sodiumMg": 395,
+      "sugarG": 10.0,
+      "carbsG": 19.0,
+      "proteinG": 34.0,
+      "fatG": 11.1
+    },
+    "bibimbap": {
+      "name": "야채비빔밥",
+      "calories": 610,
+      "sodiumMg": 900,
+      "sugarG": 12.0,
+      "carbsG": 92.0,
+      "proteinG": 20.0,
+      "fatG": 16.0
+    },
+    "jjamppong": {
+      "name": "짬뽕",
+      "calories": 750,
+      "sodiumMg": 3200,
+      "sugarG": 8.5,
+      "carbsG": 107.0,
+      "proteinG": 29.0,
+      "fatG": 22.5
+    },
+    "doenjang-jjigae": {
+      "name": "된장찌개",
+      "calories": 300,
+      "sodiumMg": 1300,
+      "sugarG": 5.0,
+      "carbsG": 18.0,
+      "proteinG": 24.0,
+      "fatG": 15.0
+    },
+    "rice": {
+      "name": "밥",
+      "calories": 310,
+      "sodiumMg": 5,
+      "sugarG": 0.7,
+      "carbsG": 67.0,
+      "proteinG": 6.0,
+      "fatG": 2.5
+    },
+    "grilled-salmon": {
+      "name": "연어구이",
+      "calories": 395,
+      "sodiumMg": 505,
+      "sugarG": 9.0,
+      "carbsG": 19.0,
+      "proteinG": 35.0,
+      "fatG": 19.0
+    },
+    "brown-rice": {
+      "name": "현미밥",
+      "calories": 280,
+      "sodiumMg": 5,
+      "sugarG": 0.0,
+      "carbsG": 58.0,
+      "proteinG": 6.0,
+      "fatG": 2.0
+    },
+    "sweet-potato": {
+      "name": "고구마",
+      "calories": 130,
+      "sodiumMg": 20,
+      "sugarG": 6.5,
+      "carbsG": 30.0,
+      "proteinG": 2.0,
+      "fatG": 0.2
+    },
+    "iced-americano": {
+      "name": "아이스 아메리카노",
+      "calories": 10,
+      "sodiumMg": 5,
+      "sugarG": 0.0,
+      "carbsG": 2.0,
+      "proteinG": 0.5,
+      "fatG": 0.0
+    },
+    "nut-pack": {
+      "name": "견과류 한 봉",
+      "calories": 90,
+      "sodiumMg": 2,
+      "sugarG": 3.0,
+      "carbsG": 1.0,
+      "proteinG": 2.0,
+      "fatG": 8.0
+    },
+    "samgyeopsal": {
+      "name": "삼겹살 2인분",
+      "calories": 620,
+      "sodiumMg": 880,
+      "sugarG": 1.0,
+      "carbsG": 2.0,
+      "proteinG": 42.0,
+      "fatG": 50.0
+    },
+    "soju": {
+      "name": "소주 1병",
+      "calories": 55,
+      "sodiumMg": 0,
+      "sugarG": 0.0,
+      "carbsG": 0.0,
+      "proteinG": 0.0,
+      "fatG": 0.0
+    },
+    "choco-cake": {
+      "name": "초코 케이크 한 조각",
+      "calories": 330,
+      "sodiumMg": 280,
+      "sugarG": 24.0,
+      "carbsG": 42.0,
+      "proteinG": 5.0,
+      "fatG": 15.0
+    },
+    "cafe-latte": {
+      "name": "카페라떼",
+      "calories": 100,
+      "sodiumMg": 95,
+      "sugarG": 5.3,
+      "carbsG": 10.0,
+      "proteinG": 5.0,
+      "fatG": 4.0
+    }
+  },
+  "meals": {
+    "breakfast-oatmeal-banana": {
+      "mealType": "breakfast",
+      "timeLabel": "08:05",
+      "photoAsset": "assets/images/diet-oatmeal-banana.jpeg",
+      "aiComment": "오트밀로 식이섬유를 챙긴 아침이에요.",
+      "foods": [
+        "oatmeal",
+        "banana"
+      ]
+    },
+    "breakfast-greek-yogurt-nuts": {
+      "mealType": "breakfast",
+      "timeLabel": "08:30",
+      "photoAsset": "assets/images/diet-greek-yogurt-nuts.jpeg",
+      "aiComment": "단백질과 불포화지방을 고르게 섭취했어요.",
+      "foods": [
+        "greek-yogurt",
+        "nuts"
+      ]
+    },
+    "breakfast-egg-strawberry": {
+      "mealType": "breakfast",
+      "timeLabel": "07:50",
+      "photoAsset": "assets/images/breakfast-scrambled-egg-strawberry.jpg",
+      "aiComment": "달걀 단백질에 과일로 비타민을 더했어요.",
+      "foods": [
+        "scrambled-egg",
+        "strawberry"
+      ]
+    },
+    "lunch-chicken-salad": {
+      "mealType": "lunch",
+      "timeLabel": "12:30",
+      "photoAsset": "assets/images/diet-chicken-salad.jpg",
+      "aiComment": "닭가슴살과 채소로 단백질·식이섬유를 챙겼어요.",
+      "foods": [
+        "chicken-salad"
+      ]
+    },
+    "lunch-bibimbap": {
+      "mealType": "lunch",
+      "timeLabel": "12:20",
+      "photoAsset": "assets/images/diet-vegetable-bibimbap.jpg",
+      "aiComment": "야채가 풍부해요. 고추장을 줄이면 나트륨이 더 좋아져요.",
+      "foods": [
+        "bibimbap"
+      ]
+    },
+    "lunch-jjamppong": {
+      "mealType": "lunch",
+      "timeLabel": "12:50",
+      "photoAsset": "assets/images/lunch-jjamppong.jpg",
+      "aiComment": "국물 나트륨이 높은 날이에요. 국물은 남기는 편이 좋아요.",
+      "foods": [
+        "jjamppong"
+      ]
+    },
+    "lunch-doenjang-rice": {
+      "mealType": "lunch",
+      "timeLabel": "12:10",
+      "photoAsset": "assets/images/diet-doenjang-rice.jpeg",
+      "aiComment": "집밥 한 상이에요. 찌개 국물만 조금 남겨 보세요.",
+      "foods": [
+        "doenjang-jjigae",
+        "rice"
+      ]
+    },
+    "dinner-salmon-brown-rice": {
+      "mealType": "dinner",
+      "timeLabel": "18:40",
+      "photoAsset": "assets/images/diet-salmon-brown-rice.jpeg",
+      "aiComment": "연어의 지방과 현미밥의 복합 탄수화물 조합이 좋아요.",
+      "foods": [
+        "grilled-salmon",
+        "brown-rice"
+      ]
+    },
+    "dinner-doenjang-rice": {
+      "mealType": "dinner",
+      "timeLabel": "19:10",
+      "photoAsset": "assets/images/diet-doenjang-rice.jpeg",
+      "aiComment": "포만감은 좋지만 국물 나트륨이 높은 편이에요.",
+      "foods": [
+        "doenjang-jjigae",
+        "rice"
+      ]
+    },
+    "dinner-chicken-salad-sweet-potato": {
+      "mealType": "dinner",
+      "timeLabel": "18:20",
+      "photoAsset": "assets/images/diet-chicken-salad.jpg",
+      "aiComment": "가볍게 마무리한 저녁이에요.",
+      "foods": [
+        "chicken-salad",
+        "sweet-potato"
+      ]
+    },
+    "dinner-samgyeopsal": {
+      "mealType": "dinner",
+      "timeLabel": "19:30",
+      "photoAsset": "assets/images/diet-doenjang-rice.jpeg",
+      "aiComment": "고기와 술이 함께여서 칼로리가 크게 올라갔어요. 다음 날은 가볍게 시작해 보세요.",
+      "foods": [
+        "samgyeopsal",
+        "rice",
+        "soju"
+      ]
+    },
+    "snack-coffee-nuts": {
+      "mealType": "snack",
+      "timeLabel": "15:40",
+      "photoAsset": "assets/images/snack-coffee-nuts.jpg",
+      "aiComment": "당류가 낮고 건강한 지방을 채운 간식이에요.",
+      "foods": [
+        "iced-americano",
+        "nut-pack"
+      ]
+    },
+    "snack-cake-latte": {
+      "mealType": "snack",
+      "timeLabel": "21:10",
+      "photoAsset": "assets/images/snack-coffee-nuts.jpg",
+      "aiComment": "디저트로 당류가 하루 목표를 넘었어요.",
+      "foods": [
+        "choco-cake",
+        "cafe-latte"
+      ]
+    }
+  },
+  "recent": [
+    {
+      "offset": 0,
+      "label": "PT 세션 · 트레이너 지도",
+      "pt": true,
+      "clientFeedback": "무릎이 좀 당겼지만 트레이너님 덕분에 잘 마쳤어요 😊",
+      "trainerNote": "무릎 가동범위 체크 필요. 다음 세션 중량 조절 예정.",
+      "dayMessage": "점심 짬뽕으로 오늘 나트륨 섭취가 많았어요. 저녁은 양념을 줄인 채소와 단백질 위주로 구성해 보세요.",
+      "exercises": [
+        {
+          "name": "레그프레스 3세트",
+          "type": "strength",
+          "minutes": 25,
+          "calories": 125,
+          "done": true
+        },
+        {
+          "name": "레그컬 3세트",
+          "type": "strength",
+          "minutes": 20,
+          "calories": 100,
+          "done": true
+        },
+        {
+          "name": "하체 스트레칭 15분",
+          "type": "stretching",
+          "minutes": 15,
+          "calories": 45,
+          "done": true
+        }
+      ],
+      "meals": [
+        {
+          "meal": "breakfast-egg-strawberry",
+          "id": "seed-diet-breakfast",
+          "timeLabel": "08:20",
+          "aiComment": "단백질과 식이섬유의 깔끔한 조합으로, 소금 간과 기름만 조절하면 혈당과 혈압 모두 잡는 우수한 식단입니다."
+        },
+        {
+          "meal": "lunch-jjamppong",
+          "id": "seed-diet-lunch",
+          "timeLabel": "12:40",
+          "aiComment": "정제 면과 높은 나트륨으로 혈압·혈당 부담이 매우 크니, 국물은 남기고 야채 위주로 드시는 것이 좋습니다."
+        },
+        {
+          "meal": "snack-coffee-nuts",
+          "id": "seed-diet-snack",
+          "timeLabel": "15:30",
+          "aiComment": "당류와 칼로리가 낮고 견과류의 건강한 지방이 채워져 완벽한 간식입니다."
+        }
+      ]
+    },
+    {
+      "offset": 1,
+      "label": "AI 루틴 · 자율 운동",
+      "pt": false,
+      "clientFeedback": "스트레칭은 시간이 없어서 못 했어요",
+      "trainerNote": "",
+      "dayMessage": "약속이 있어 칼로리와 당류가 목표를 넘은 하루예요. 오늘은 가볍게 시작해 보세요.",
+      "exercises": [
+        {
+          "name": "저강도 유산소 (걷기) 30분",
+          "type": "cardio",
+          "minutes": 30,
+          "calories": 225,
+          "done": true
+        },
+        {
+          "name": "코어 강화 10분",
+          "type": "strength",
+          "minutes": 10,
+          "calories": 50,
+          "done": true
+        },
+        {
+          "name": "하체 스트레칭 15분",
+          "type": "stretching",
+          "minutes": 15,
+          "calories": 45,
+          "done": false
+        }
+      ],
+      "meals": [
+        {
+          "meal": "breakfast-oatmeal-banana",
+          "id": "seed-diet-yesterday-breakfast",
+          "timeLabel": "08:10",
+          "aiComment": "오트밀로 식이섬유를 챙겼어요. 바나나가 들어가 당류는 다소 높은 편이에요."
+        },
+        {
+          "meal": "lunch-bibimbap",
+          "id": "seed-diet-yesterday-lunch",
+          "timeLabel": "12:30",
+          "aiComment": "야채가 풍부한 비빔밥이에요. 고추장을 줄이면 나트륨을 더 조절할 수 있어요."
+        },
+        {
+          "meal": "dinner-samgyeopsal",
+          "id": "seed-diet-yesterday-dinner"
+        },
+        {
+          "meal": "snack-cake-latte",
+          "id": "seed-diet-yesterday-snack"
+        }
+      ]
+    },
+    {
+      "offset": 2,
+      "label": "AI 루틴 · 자율 운동",
+      "pt": false,
+      "clientFeedback": "오늘은 다 했어요! 뿌듯해요 💪",
+      "trainerNote": "",
+      "dayMessage": "연어와 현미밥으로 탄단지 균형을 잘 맞췄어요.",
+      "exercises": [
+        {
+          "name": "저강도 유산소 (걷기) 30분",
+          "type": "cardio",
+          "minutes": 30,
+          "calories": 225,
+          "done": true
+        },
+        {
+          "name": "코어 강화 10분",
+          "type": "strength",
+          "minutes": 10,
+          "calories": 50,
+          "done": true
+        },
+        {
+          "name": "하체 스트레칭 15분",
+          "type": "stretching",
+          "minutes": 15,
+          "calories": 45,
+          "done": true
+        }
+      ],
+      "meals": [
+        {
+          "meal": "breakfast-greek-yogurt-nuts",
+          "id": "seed-diet-two-days-ago-breakfast",
+          "timeLabel": "08:35",
+          "aiComment": "그릭 요거트의 단백질과 견과류의 불포화지방을 고르게 섭취했어요."
+        },
+        {
+          "meal": "lunch-bibimbap",
+          "id": "seed-diet-two-days-ago-lunch",
+          "timeLabel": "12:20",
+          "aiComment": "야채가 풍부한 비빔밥이에요. 고추장을 줄이면 나트륨을 더 조절할 수 있어요."
+        },
+        {
+          "meal": "dinner-salmon-brown-rice",
+          "id": "seed-diet-two-days-ago-dinner",
+          "timeLabel": "18:50",
+          "aiComment": "연어의 지방과 현미밥의 복합 탄수화물 조합이 좋아요."
+        }
+      ]
+    }
+  ],
+  "weeks": [
+    {
+      "weeksAgo": 0,
+      "note": "평소의 한 주 — 국물이 잦지만 기록은 성실하다.",
+      "days": [
+        {
+          "weekday": 0,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 30분",
+              "type": "cardio",
+              "minutes": 30,
+              "calories": 225,
+              "done": true
+            },
+            {
+              "name": "코어 강화 10분",
+              "type": "strength",
+              "minutes": 10,
+              "calories": 50,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 1,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 40분",
+              "type": "cardio",
+              "minutes": 40,
+              "calories": 300,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 2,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-doenjang-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 3,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 35분",
+              "type": "cardio",
+              "minutes": 35,
+              "calories": 262,
+              "done": true
+            },
+            {
+              "name": "코어 강화 20분",
+              "type": "strength",
+              "minutes": 20,
+              "calories": 100,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 4,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 45분",
+              "type": "cardio",
+              "minutes": 45,
+              "calories": 338,
+              "done": true
+            },
+            {
+              "name": "어깨 관절 보호 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-doenjang-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 5,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 25분",
+              "type": "cardio",
+              "minutes": 25,
+              "calories": 188,
+              "done": true
+            },
+            {
+              "name": "코어 강화 30분",
+              "type": "strength",
+              "minutes": 30,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 15분",
+              "type": "stretching",
+              "minutes": 15,
+              "calories": 45,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 6,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 20분",
+              "type": "cardio",
+              "minutes": 20,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "weeksAgo": 1,
+      "note": "가볍게 간 한 주 — 세 지표가 모두 목표 안에 든다.",
+      "days": [
+        {
+          "weekday": 0,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 30분",
+              "type": "cardio",
+              "minutes": 30,
+              "calories": 225,
+              "done": true
+            },
+            {
+              "name": "코어 강화 10분",
+              "type": "strength",
+              "minutes": 10,
+              "calories": 50,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 1,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 40분",
+              "type": "cardio",
+              "minutes": 40,
+              "calories": 300,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 2,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 3,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 35분",
+              "type": "cardio",
+              "minutes": 35,
+              "calories": 262,
+              "done": true
+            },
+            {
+              "name": "코어 강화 20분",
+              "type": "strength",
+              "minutes": 20,
+              "calories": 100,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 4,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 45분",
+              "type": "cardio",
+              "minutes": 45,
+              "calories": 338,
+              "done": true
+            },
+            {
+              "name": "어깨 관절 보호 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 5,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 25분",
+              "type": "cardio",
+              "minutes": 25,
+              "calories": 188,
+              "done": true
+            },
+            {
+              "name": "코어 강화 30분",
+              "type": "strength",
+              "minutes": 30,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 15분",
+              "type": "stretching",
+              "minutes": 15,
+              "calories": 45,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            }
+          ]
+        },
+        {
+          "weekday": 6,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 20분",
+              "type": "cardio",
+              "minutes": 20,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "weeksAgo": 2,
+      "note": "회식이 몰린 주 — 칼로리와 당류가 함께 목표를 넘는다.",
+      "days": [
+        {
+          "weekday": 0,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 30분",
+              "type": "cardio",
+              "minutes": 30,
+              "calories": 225,
+              "done": true
+            },
+            {
+              "name": "코어 강화 10분",
+              "type": "strength",
+              "minutes": 10,
+              "calories": 50,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-samgyeopsal"
+            },
+            {
+              "meal": "snack-cake-latte"
+            }
+          ]
+        },
+        {
+          "weekday": 1,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 40분",
+              "type": "cardio",
+              "minutes": 40,
+              "calories": 300,
+              "done": false
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-cake-latte"
+            }
+          ]
+        },
+        {
+          "weekday": 2,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-samgyeopsal"
+            }
+          ]
+        },
+        {
+          "weekday": 3,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 35분",
+              "type": "cardio",
+              "minutes": 35,
+              "calories": 262,
+              "done": true
+            },
+            {
+              "name": "코어 강화 20분",
+              "type": "strength",
+              "minutes": 20,
+              "calories": 100,
+              "done": false
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-doenjang-rice"
+            },
+            {
+              "meal": "snack-cake-latte"
+            }
+          ]
+        },
+        {
+          "weekday": 4,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 45분",
+              "type": "cardio",
+              "minutes": 45,
+              "calories": 338,
+              "done": true
+            },
+            {
+              "name": "어깨 관절 보호 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-samgyeopsal"
+            },
+            {
+              "meal": "snack-cake-latte"
+            }
+          ]
+        },
+        {
+          "weekday": 5,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 25분",
+              "type": "cardio",
+              "minutes": 25,
+              "calories": 188,
+              "done": true
+            },
+            {
+              "name": "코어 강화 30분",
+              "type": "strength",
+              "minutes": 30,
+              "calories": 150,
+              "done": false
+            },
+            {
+              "name": "하체 스트레칭 15분",
+              "type": "stretching",
+              "minutes": 15,
+              "calories": 45,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-cake-latte"
+            }
+          ]
+        },
+        {
+          "weekday": 6,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 20분",
+              "type": "cardio",
+              "minutes": 20,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "weeksAgo": 3,
+      "note": "코칭이 먹힌 주 — 국물을 줄여 나트륨이 목표 안으로 들어온다.",
+      "days": [
+        {
+          "weekday": 0,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 30분",
+              "type": "cardio",
+              "minutes": 30,
+              "calories": 225,
+              "done": true
+            },
+            {
+              "name": "코어 강화 10분",
+              "type": "strength",
+              "minutes": 10,
+              "calories": 50,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 1,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 40분",
+              "type": "cardio",
+              "minutes": 40,
+              "calories": 300,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 2,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 3,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 35분",
+              "type": "cardio",
+              "minutes": 35,
+              "calories": 262,
+              "done": true
+            },
+            {
+              "name": "코어 강화 20분",
+              "type": "strength",
+              "minutes": 20,
+              "calories": 100,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 4,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 45분",
+              "type": "cardio",
+              "minutes": 45,
+              "calories": 338,
+              "done": true
+            },
+            {
+              "name": "어깨 관절 보호 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 5,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 25분",
+              "type": "cardio",
+              "minutes": 25,
+              "calories": 188,
+              "done": true
+            },
+            {
+              "name": "코어 강화 30분",
+              "type": "strength",
+              "minutes": 30,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 15분",
+              "type": "stretching",
+              "minutes": 15,
+              "calories": 45,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 6,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 20분",
+              "type": "cardio",
+              "minutes": 20,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "weeksAgo": 4,
+      "note": "평범한 한 주 — 구내식당 국물이 나트륨을 밀어 올린다.",
+      "days": [
+        {
+          "weekday": 0,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 30분",
+              "type": "cardio",
+              "minutes": 30,
+              "calories": 225,
+              "done": true
+            },
+            {
+              "name": "코어 강화 10분",
+              "type": "strength",
+              "minutes": 10,
+              "calories": 50,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 1,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 40분",
+              "type": "cardio",
+              "minutes": 40,
+              "calories": 300,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-doenjang-rice"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 2,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            }
+          ]
+        },
+        {
+          "weekday": 3,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 35분",
+              "type": "cardio",
+              "minutes": 35,
+              "calories": 262,
+              "done": true
+            },
+            {
+              "name": "코어 강화 20분",
+              "type": "strength",
+              "minutes": 20,
+              "calories": 100,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 4,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 45분",
+              "type": "cardio",
+              "minutes": 45,
+              "calories": 338,
+              "done": true
+            },
+            {
+              "name": "어깨 관절 보호 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-doenjang-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 5,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 25분",
+              "type": "cardio",
+              "minutes": 25,
+              "calories": 188,
+              "done": true
+            },
+            {
+              "name": "코어 강화 30분",
+              "type": "strength",
+              "minutes": 30,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 15분",
+              "type": "stretching",
+              "minutes": 15,
+              "calories": 45,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 6,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 20분",
+              "type": "cardio",
+              "minutes": 20,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "weeksAgo": 5,
+      "note": "야근이 많던 주 — 늦은 저녁은 기록이 비어 있다.",
+      "days": [
+        {
+          "weekday": 0,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 30분",
+              "type": "cardio",
+              "minutes": 30,
+              "calories": 225,
+              "done": true
+            },
+            {
+              "name": "코어 강화 10분",
+              "type": "strength",
+              "minutes": 10,
+              "calories": 50,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 1,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 40분",
+              "type": "cardio",
+              "minutes": 40,
+              "calories": 300,
+              "done": false
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 2,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-doenjang-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 3,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 35분",
+              "type": "cardio",
+              "minutes": 35,
+              "calories": 262,
+              "done": true
+            },
+            {
+              "name": "코어 강화 20분",
+              "type": "strength",
+              "minutes": 20,
+              "calories": 100,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 4,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 45분",
+              "type": "cardio",
+              "minutes": 45,
+              "calories": 338,
+              "done": true
+            },
+            {
+              "name": "어깨 관절 보호 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 5,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 25분",
+              "type": "cardio",
+              "minutes": 25,
+              "calories": 188,
+              "done": true
+            },
+            {
+              "name": "코어 강화 30분",
+              "type": "strength",
+              "minutes": 30,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 15분",
+              "type": "stretching",
+              "minutes": 15,
+              "calories": 45,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            }
+          ]
+        },
+        {
+          "weekday": 6,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 20분",
+              "type": "cardio",
+              "minutes": 20,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "weeksAgo": 6,
+      "note": "기록을 막 시작한 주 — 아예 빠진 날이 있다.",
+      "days": [
+        {
+          "weekday": 0,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 30분",
+              "type": "cardio",
+              "minutes": 30,
+              "calories": 225,
+              "done": true
+            },
+            {
+              "name": "코어 강화 10분",
+              "type": "strength",
+              "minutes": 10,
+              "calories": 50,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-doenjang-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 1,
+          "exercises": [],
+          "meals": []
+        },
+        {
+          "weekday": 2,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 3,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 35분",
+              "type": "cardio",
+              "minutes": 35,
+              "calories": 262,
+              "done": true
+            },
+            {
+              "name": "코어 강화 20분",
+              "type": "strength",
+              "minutes": 20,
+              "calories": 100,
+              "done": false
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 4,
+          "exercises": [],
+          "meals": []
+        },
+        {
+          "weekday": 5,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 25분",
+              "type": "cardio",
+              "minutes": 25,
+              "calories": 188,
+              "done": true
+            },
+            {
+              "name": "코어 강화 30분",
+              "type": "strength",
+              "minutes": 30,
+              "calories": 150,
+              "done": false
+            },
+            {
+              "name": "하체 스트레칭 15분",
+              "type": "stretching",
+              "minutes": 15,
+              "calories": 45,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 6,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 20분",
+              "type": "cardio",
+              "minutes": 20,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "weeksAgo": 7,
+      "note": "평소의 한 주 — 국물이 잦지만 기록은 성실하다.",
+      "days": [
+        {
+          "weekday": 0,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 30분",
+              "type": "cardio",
+              "minutes": 30,
+              "calories": 225,
+              "done": true
+            },
+            {
+              "name": "코어 강화 10분",
+              "type": "strength",
+              "minutes": 10,
+              "calories": 50,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 1,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 40분",
+              "type": "cardio",
+              "minutes": 40,
+              "calories": 300,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 2,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-doenjang-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 3,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 35분",
+              "type": "cardio",
+              "minutes": 35,
+              "calories": 262,
+              "done": true
+            },
+            {
+              "name": "코어 강화 20분",
+              "type": "strength",
+              "minutes": 20,
+              "calories": 100,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 4,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 45분",
+              "type": "cardio",
+              "minutes": 45,
+              "calories": 338,
+              "done": true
+            },
+            {
+              "name": "어깨 관절 보호 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-doenjang-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 5,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 25분",
+              "type": "cardio",
+              "minutes": 25,
+              "calories": 188,
+              "done": true
+            },
+            {
+              "name": "코어 강화 30분",
+              "type": "strength",
+              "minutes": 30,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 15분",
+              "type": "stretching",
+              "minutes": 15,
+              "calories": 45,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 6,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 20분",
+              "type": "cardio",
+              "minutes": 20,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "weeksAgo": 8,
+      "note": "가볍게 간 한 주 — 세 지표가 모두 목표 안에 든다.",
+      "days": [
+        {
+          "weekday": 0,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 30분",
+              "type": "cardio",
+              "minutes": 30,
+              "calories": 225,
+              "done": true
+            },
+            {
+              "name": "코어 강화 10분",
+              "type": "strength",
+              "minutes": 10,
+              "calories": 50,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 1,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 40분",
+              "type": "cardio",
+              "minutes": 40,
+              "calories": 300,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 2,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 3,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 35분",
+              "type": "cardio",
+              "minutes": 35,
+              "calories": 262,
+              "done": true
+            },
+            {
+              "name": "코어 강화 20분",
+              "type": "strength",
+              "minutes": 20,
+              "calories": 100,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 4,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 45분",
+              "type": "cardio",
+              "minutes": 45,
+              "calories": 338,
+              "done": true
+            },
+            {
+              "name": "어깨 관절 보호 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 5,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 25분",
+              "type": "cardio",
+              "minutes": 25,
+              "calories": 188,
+              "done": true
+            },
+            {
+              "name": "코어 강화 30분",
+              "type": "strength",
+              "minutes": 30,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 15분",
+              "type": "stretching",
+              "minutes": 15,
+              "calories": 45,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            }
+          ]
+        },
+        {
+          "weekday": 6,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 20분",
+              "type": "cardio",
+              "minutes": 20,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "weeksAgo": 9,
+      "note": "회식이 몰린 주 — 칼로리와 당류가 함께 목표를 넘는다.",
+      "days": [
+        {
+          "weekday": 0,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 30분",
+              "type": "cardio",
+              "minutes": 30,
+              "calories": 225,
+              "done": true
+            },
+            {
+              "name": "코어 강화 10분",
+              "type": "strength",
+              "minutes": 10,
+              "calories": 50,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-samgyeopsal"
+            },
+            {
+              "meal": "snack-cake-latte"
+            }
+          ]
+        },
+        {
+          "weekday": 1,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 40분",
+              "type": "cardio",
+              "minutes": 40,
+              "calories": 300,
+              "done": false
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-cake-latte"
+            }
+          ]
+        },
+        {
+          "weekday": 2,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-samgyeopsal"
+            }
+          ]
+        },
+        {
+          "weekday": 3,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 35분",
+              "type": "cardio",
+              "minutes": 35,
+              "calories": 262,
+              "done": true
+            },
+            {
+              "name": "코어 강화 20분",
+              "type": "strength",
+              "minutes": 20,
+              "calories": 100,
+              "done": false
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-doenjang-rice"
+            },
+            {
+              "meal": "snack-cake-latte"
+            }
+          ]
+        },
+        {
+          "weekday": 4,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 45분",
+              "type": "cardio",
+              "minutes": 45,
+              "calories": 338,
+              "done": true
+            },
+            {
+              "name": "어깨 관절 보호 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-samgyeopsal"
+            },
+            {
+              "meal": "snack-cake-latte"
+            }
+          ]
+        },
+        {
+          "weekday": 5,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 25분",
+              "type": "cardio",
+              "minutes": 25,
+              "calories": 188,
+              "done": true
+            },
+            {
+              "name": "코어 강화 30분",
+              "type": "strength",
+              "minutes": 30,
+              "calories": 150,
+              "done": false
+            },
+            {
+              "name": "하체 스트레칭 15분",
+              "type": "stretching",
+              "minutes": 15,
+              "calories": 45,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-cake-latte"
+            }
+          ]
+        },
+        {
+          "weekday": 6,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 20분",
+              "type": "cardio",
+              "minutes": 20,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "weeksAgo": 10,
+      "note": "코칭이 먹힌 주 — 국물을 줄여 나트륨이 목표 안으로 들어온다.",
+      "days": [
+        {
+          "weekday": 0,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 30분",
+              "type": "cardio",
+              "minutes": 30,
+              "calories": 225,
+              "done": true
+            },
+            {
+              "name": "코어 강화 10분",
+              "type": "strength",
+              "minutes": 10,
+              "calories": 50,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 1,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 40분",
+              "type": "cardio",
+              "minutes": 40,
+              "calories": 300,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 2,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 3,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 35분",
+              "type": "cardio",
+              "minutes": 35,
+              "calories": 262,
+              "done": true
+            },
+            {
+              "name": "코어 강화 20분",
+              "type": "strength",
+              "minutes": 20,
+              "calories": 100,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 4,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 45분",
+              "type": "cardio",
+              "minutes": 45,
+              "calories": 338,
+              "done": true
+            },
+            {
+              "name": "어깨 관절 보호 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 5,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 25분",
+              "type": "cardio",
+              "minutes": 25,
+              "calories": 188,
+              "done": true
+            },
+            {
+              "name": "코어 강화 30분",
+              "type": "strength",
+              "minutes": 30,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 15분",
+              "type": "stretching",
+              "minutes": 15,
+              "calories": 45,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 6,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 20분",
+              "type": "cardio",
+              "minutes": 20,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "weeksAgo": 11,
+      "note": "평범한 한 주 — 구내식당 국물이 나트륨을 밀어 올린다.",
+      "days": [
+        {
+          "weekday": 0,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 30분",
+              "type": "cardio",
+              "minutes": 30,
+              "calories": 225,
+              "done": true
+            },
+            {
+              "name": "코어 강화 10분",
+              "type": "strength",
+              "minutes": 10,
+              "calories": 50,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 1,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 40분",
+              "type": "cardio",
+              "minutes": 40,
+              "calories": 300,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-doenjang-rice"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 2,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            }
+          ]
+        },
+        {
+          "weekday": 3,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 35분",
+              "type": "cardio",
+              "minutes": 35,
+              "calories": 262,
+              "done": true
+            },
+            {
+              "name": "코어 강화 20분",
+              "type": "strength",
+              "minutes": 20,
+              "calories": 100,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 5분",
+              "type": "stretching",
+              "minutes": 5,
+              "calories": 15,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 4,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 45분",
+              "type": "cardio",
+              "minutes": 45,
+              "calories": 338,
+              "done": true
+            },
+            {
+              "name": "어깨 관절 보호 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-egg-strawberry"
+            },
+            {
+              "meal": "lunch-bibimbap"
+            },
+            {
+              "meal": "dinner-doenjang-rice"
+            }
+          ]
+        },
+        {
+          "weekday": 5,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 25분",
+              "type": "cardio",
+              "minutes": 25,
+              "calories": 188,
+              "done": true
+            },
+            {
+              "name": "코어 강화 30분",
+              "type": "strength",
+              "minutes": 30,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 15분",
+              "type": "stretching",
+              "minutes": 15,
+              "calories": 45,
+              "done": true
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-greek-yogurt-nuts"
+            },
+            {
+              "meal": "lunch-doenjang-rice"
+            },
+            {
+              "meal": "dinner-chicken-salad-sweet-potato"
+            },
+            {
+              "meal": "snack-coffee-nuts"
+            }
+          ]
+        },
+        {
+          "weekday": 6,
+          "label": "AI 루틴 · 자율 운동",
+          "pt": false,
+          "exercises": [
+            {
+              "name": "저강도 유산소 (걷기) 20분",
+              "type": "cardio",
+              "minutes": 20,
+              "calories": 150,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": false
+            }
+          ],
+          "meals": [
+            {
+              "meal": "breakfast-oatmeal-banana"
+            },
+            {
+              "meal": "lunch-chicken-salad"
+            },
+            {
+              "meal": "dinner-salmon-brown-rice"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/shared/demo_fixture/lib/demo_fixture.dart
+++ b/shared/demo_fixture/lib/demo_fixture.dart
@@ -1,0 +1,356 @@
+/// 김민수 데모 데이터의 단일 원본을 읽는다.
+///
+/// 사용자앱(`user-demo`)과 트레이너앱(`seed-client-1`)은 같은 사람을 보여 준다.
+/// 예전에는 두 앱과 백엔드가 각자 알고리즘으로 그의 과거를 만들어서, 같은 날짜를
+/// 나란히 놓으면 숫자가 어긋났다(#757). 이제 셋 다 이 픽스처만 읽는다 — 여기에
+/// 계산은 없고, 픽스처에 적힌 값을 날짜에 붙이는 일만 한다.
+///
+/// **이행률은 저장하지 않는다.** `FixtureDay.completion` 은 그날 루틴 항목 중
+/// `done` 인 것의 비율이다. 퍼센트를 따로 적어 두면 화면의 "3개 중 2개 완료" 와
+/// 숫자가 갈라진다.
+library;
+
+import 'dart:convert';
+
+import 'package:flutter/services.dart' show AssetBundle, rootBundle;
+
+/// 픽스처 에셋의 키. 두 앱 모두 이 경로로 읽는다.
+const String kDemoFixtureAsset = 'packages/demo_fixture/assets/kim_minsu.json';
+
+/// 음식 한 가지.
+class FixtureFood {
+  const FixtureFood({
+    required this.name,
+    required this.calories,
+    required this.sodiumMg,
+    required this.sugarG,
+    required this.carbsG,
+    required this.proteinG,
+    required this.fatG,
+  });
+
+  factory FixtureFood.fromJson(Map<String, Object?> json) => FixtureFood(
+    name: json['name']! as String,
+    calories: (json['calories']! as num).toInt(),
+    sodiumMg: (json['sodiumMg']! as num).toInt(),
+    sugarG: (json['sugarG']! as num).toDouble(),
+    carbsG: (json['carbsG']! as num).toDouble(),
+    proteinG: (json['proteinG']! as num).toDouble(),
+    fatG: (json['fatG']! as num).toDouble(),
+  );
+
+  final String name;
+  final int calories;
+  final int sodiumMg;
+  final double sugarG;
+  final double carbsG;
+  final double proteinG;
+  final double fatG;
+
+  /// 화면·저장소가 읽는 키 이름 그대로. 세 곳이 같은 키를 쓴다.
+  Map<String, Object?> toJson() => <String, Object?>{
+    'name': name,
+    'calories': calories,
+    'sodium_mg': sodiumMg,
+    'sugar_g': sugarG,
+    'carbs_g': carbsG,
+    'protein_g': proteinG,
+    'fat_g': fatG,
+  };
+}
+
+/// 하루에 놓인 끼니 하나. 끼니 템플릿에 그날만의 id·시각·코멘트가 덮인 결과다.
+class FixtureMeal {
+  const FixtureMeal({
+    required this.slug,
+    required this.rowId,
+    required this.mealType,
+    required this.timeLabel,
+    required this.photoAsset,
+    required this.aiComment,
+    required this.foods,
+  });
+
+  /// 끼니 템플릿 이름(`lunch-jjamppong` 등).
+  final String slug;
+
+  /// 시연 중 화면에서 지목하는 행만 id 를 못 박는다. 나머지는 null 이고, 소비자가
+  /// 날짜로 id 를 만든다.
+  final String? rowId;
+
+  final String mealType;
+  final String timeLabel;
+  final String photoAsset;
+  final String aiComment;
+  final List<FixtureFood> foods;
+
+  int get calories =>
+      foods.fold<int>(0, (int sum, FixtureFood f) => sum + f.calories);
+  int get sodiumMg =>
+      foods.fold<int>(0, (int sum, FixtureFood f) => sum + f.sodiumMg);
+  double get sugarG => _round1(
+    foods.fold<double>(0, (double sum, FixtureFood f) => sum + f.sugarG),
+  );
+  double get carbsG => _round1(
+    foods.fold<double>(0, (double sum, FixtureFood f) => sum + f.carbsG),
+  );
+  double get proteinG => _round1(
+    foods.fold<double>(0, (double sum, FixtureFood f) => sum + f.proteinG),
+  );
+  double get fatG => _round1(
+    foods.fold<double>(0, (double sum, FixtureFood f) => sum + f.fatG),
+  );
+
+  String foodsJson() => jsonEncode(<Map<String, Object?>>[
+    for (final FixtureFood f in foods) f.toJson(),
+  ]);
+}
+
+/// 그날 루틴의 항목 하나.
+class FixtureExercise {
+  const FixtureExercise({
+    required this.name,
+    required this.type,
+    required this.minutes,
+    required this.calories,
+    required this.done,
+  });
+
+  factory FixtureExercise.fromJson(Map<String, Object?> json) =>
+      FixtureExercise(
+        name: json['name']! as String,
+        type: json['type']! as String,
+        minutes: (json['minutes']! as num).toInt(),
+        calories: (json['calories']! as num).toInt(),
+        done: json['done']! as bool,
+      );
+
+  final String name;
+
+  /// `cardio` | `strength` | `stretching`.
+  final String type;
+  final int minutes;
+  final int calories;
+  final bool done;
+
+  /// 트레이너 화면이 쓰는 표기. 이행률과 이 목록이 같은 자리에서 나오므로
+  /// "67%" 옆에 "3개 중 3개 완료" 가 놓이는 일이 없다(#754).
+  String get label => '$name ${done ? '✓' : '✗'}';
+}
+
+/// 픽스처가 말하는 하루.
+class FixtureDay {
+  const FixtureDay({
+    required this.date,
+    required this.weekStart,
+    required this.dayLabel,
+    required this.meals,
+    required this.exercises,
+    required this.routineLabel,
+    required this.isPt,
+    required this.clientFeedback,
+    required this.trainerNote,
+    required this.dayMessage,
+  });
+
+  /// `YYYY-MM-DD`.
+  final String date;
+
+  /// 그 주 월요일(`YYYY-MM-DD`). 운동은 주 단위로 조회된다.
+  final String weekStart;
+
+  /// 월~일 한 글자.
+  final String dayLabel;
+
+  final List<FixtureMeal> meals;
+  final List<FixtureExercise> exercises;
+
+  /// `PT 세션 · 트레이너 지도` 같은 종류 라벨.
+  final String routineLabel;
+  final bool isPt;
+  final String clientFeedback;
+  final String trainerNote;
+
+  /// 식단 탭의 하루 코치 문구. 큐레이션 사흘만 갖는다.
+  final String dayMessage;
+
+  bool get hasRecord => meals.isNotEmpty || exercises.isNotEmpty;
+
+  int get calories =>
+      meals.fold<int>(0, (int sum, FixtureMeal m) => sum + m.calories);
+  int get sodiumMg =>
+      meals.fold<int>(0, (int sum, FixtureMeal m) => sum + m.sodiumMg);
+  double get sugarG => _round1(
+    meals.fold<double>(0, (double sum, FixtureMeal m) => sum + m.sugarG),
+  );
+
+  /// 이행률(%) — 저장된 값이 아니라 `done` 개수에서 나온다. 루틴이 없는 날(휴식)은
+  /// 0 이다.
+  int get completion {
+    if (exercises.isEmpty) return 0;
+    final int done = exercises.where((FixtureExercise e) => e.done).length;
+    return (done * 100 / exercises.length).round();
+  }
+
+  /// 실제로 한 운동만. 사용자 앱의 주간 활동 그래프가 이걸 쌓는다.
+  List<FixtureExercise> get doneExercises =>
+      exercises.where((FixtureExercise e) => e.done).toList();
+}
+
+/// 픽스처 파일 한 벌.
+class DemoFixture {
+  DemoFixture._({
+    required this.memberName,
+    required this.userAppSeedId,
+    required this.trainerClientId,
+    required this.historyWeeks,
+    required Map<String, FixtureFood> foods,
+    required Map<String, Map<String, Object?>> meals,
+    required List<Map<String, Object?>> recent,
+    required List<Map<String, Object?>> weeks,
+  }) : _foods = foods,
+       _meals = meals,
+       _recent = recent,
+       _weeks = weeks;
+
+  /// 에셋에서 읽는다. 앱 부팅 경로에서 쓴다.
+  static Future<DemoFixture> load({AssetBundle? bundle}) async =>
+      DemoFixture.parse(
+        await (bundle ?? rootBundle).loadString(kDemoFixtureAsset),
+      );
+
+  /// 이미 읽어 둔 JSON 문자열에서 만든다. 테스트가 파일을 직접 읽어 넣을 때 쓴다.
+  factory DemoFixture.parse(String source) {
+    final Map<String, Object?> json =
+        jsonDecode(source) as Map<String, Object?>;
+    final Map<String, Object?> member = json['member']! as Map<String, Object?>;
+    return DemoFixture._(
+      memberName: member['name']! as String,
+      userAppSeedId: member['userAppSeedId']! as String,
+      trainerClientId: member['trainerClientId']! as String,
+      historyWeeks: (json['historyWeeks']! as num).toInt(),
+      foods: <String, FixtureFood>{
+        for (final MapEntry<String, Object?> e
+            in (json['foods']! as Map<String, Object?>).entries)
+          e.key: FixtureFood.fromJson(e.value! as Map<String, Object?>),
+      },
+      meals: <String, Map<String, Object?>>{
+        for (final MapEntry<String, Object?> e
+            in (json['meals']! as Map<String, Object?>).entries)
+          e.key: e.value! as Map<String, Object?>,
+      },
+      recent: <Map<String, Object?>>[
+        for (final Object? day in json['recent']! as List<Object?>)
+          day! as Map<String, Object?>,
+      ],
+      weeks: <Map<String, Object?>>[
+        for (final Object? week in json['weeks']! as List<Object?>)
+          week! as Map<String, Object?>,
+      ],
+    );
+  }
+
+  final String memberName;
+
+  /// 사용자 앱 데모 계정 id.
+  final String userAppSeedId;
+
+  /// 트레이너 앱에서 같은 사람을 가리키는 고객 id.
+  final String trainerClientId;
+
+  /// 픽스처가 덮는 주 수(이번 주 포함).
+  final int historyWeeks;
+
+  final Map<String, FixtureFood> _foods;
+  final Map<String, Map<String, Object?>> _meals;
+  final List<Map<String, Object?>> _recent;
+  final List<Map<String, Object?>> _weeks;
+
+  /// [now] 기준으로 날짜가 붙은 하루들을 오래된 → 오늘 순으로 돌려준다.
+  ///
+  /// 주 격자가 달력 주를 채우고, 최근 사흘(오늘·어제·그제)이 그 위를 덮는다.
+  /// 아직 오지 않은 요일은 넣지 않는다 — 넣으면 주간 추이 그래프가 빈 날을
+  /// 막대로 그리고 주 평균도 실제보다 높아진다(#752).
+  List<FixtureDay> daysFor(DateTime now) {
+    final DateTime today = DateTime(now.year, now.month, now.day);
+    final DateTime thisMonday = _addDays(today, -(today.weekday - 1));
+
+    final Map<String, FixtureDay> byDate = <String, FixtureDay>{};
+    for (final Map<String, Object?> week in _weeks) {
+      final int weeksAgo = (week['weeksAgo']! as num).toInt();
+      final DateTime weekMonday = _addDays(thisMonday, -7 * weeksAgo);
+      for (final Object? entry in week['days']! as List<Object?>) {
+        final Map<String, Object?> day = entry! as Map<String, Object?>;
+        final DateTime date = _addDays(
+          weekMonday,
+          (day['weekday']! as num).toInt(),
+        );
+        if (date.isAfter(today)) continue;
+        byDate[_ymd(date)] = _dayFrom(day, date);
+      }
+    }
+
+    for (final Map<String, Object?> day in _recent) {
+      final DateTime date = _addDays(today, -(day['offset']! as num).toInt());
+      byDate[_ymd(date)] = _dayFrom(day, date);
+    }
+
+    final List<String> dates = byDate.keys.toList()..sort();
+    return <FixtureDay>[for (final String date in dates) byDate[date]!];
+  }
+
+  FixtureDay _dayFrom(Map<String, Object?> day, DateTime date) {
+    final DateTime monday = _addDays(date, -(date.weekday - 1));
+    return FixtureDay(
+      date: _ymd(date),
+      weekStart: _ymd(monday),
+      dayLabel: _dayLabels[date.weekday - 1],
+      meals: <FixtureMeal>[
+        for (final Object? entry in day['meals']! as List<Object?>)
+          _mealFrom(entry! as Map<String, Object?>),
+      ],
+      exercises: <FixtureExercise>[
+        for (final Object? entry in day['exercises']! as List<Object?>)
+          FixtureExercise.fromJson(entry! as Map<String, Object?>),
+      ],
+      routineLabel: day['label'] as String? ?? '',
+      isPt: day['pt'] as bool? ?? false,
+      clientFeedback: day['clientFeedback'] as String? ?? '',
+      trainerNote: day['trainerNote'] as String? ?? '',
+      dayMessage: day['dayMessage'] as String? ?? '',
+    );
+  }
+
+  FixtureMeal _mealFrom(Map<String, Object?> entry) {
+    final String slug = entry['meal']! as String;
+    final Map<String, Object?> template = _meals[slug]!;
+    return FixtureMeal(
+      slug: slug,
+      rowId: entry['id'] as String?,
+      mealType: template['mealType']! as String,
+      timeLabel:
+          entry['timeLabel'] as String? ?? template['timeLabel']! as String,
+      photoAsset: template['photoAsset']! as String,
+      aiComment:
+          entry['aiComment'] as String? ?? template['aiComment']! as String,
+      foods: <FixtureFood>[
+        for (final Object? key in template['foods']! as List<Object?>)
+          _foods[key! as String]!,
+      ],
+    );
+  }
+}
+
+const List<String> _dayLabels = <String>['월', '화', '수', '목', '금', '토', '일'];
+
+/// 날짜만 더한다. `Duration(days:)` 은 서머타임이 있는 지역에서 하루가 23·25시간이
+/// 되는 날 날짜가 밀린다 — 데모가 그 날 하루치를 잃는다.
+DateTime _addDays(DateTime date, int days) =>
+    DateTime(date.year, date.month, date.day + days);
+
+String _ymd(DateTime d) =>
+    '${d.year.toString().padLeft(4, '0')}-'
+    '${d.month.toString().padLeft(2, '0')}-'
+    '${d.day.toString().padLeft(2, '0')}';
+
+double _round1(double value) => (value * 10).round() / 10;

--- a/shared/demo_fixture/lib/demo_fixture.dart
+++ b/shared/demo_fixture/lib/demo_fixture.dart
@@ -12,10 +12,7 @@ library;
 
 import 'dart:convert';
 
-import 'package:flutter/services.dart' show AssetBundle, rootBundle;
-
-/// 픽스처 에셋의 키. 두 앱 모두 이 경로로 읽는다.
-const String kDemoFixtureAsset = 'packages/demo_fixture/assets/kim_minsu.json';
+import 'package:demo_fixture/src/fixture_json.g.dart';
 
 /// 음식 한 가지.
 class FixtureFood {
@@ -213,13 +210,15 @@ class DemoFixture {
        _recent = recent,
        _weeks = weeks;
 
-  /// 에셋에서 읽는다. 앱 부팅 경로에서 쓴다.
-  static Future<DemoFixture> load({AssetBundle? bundle}) async =>
-      DemoFixture.parse(
-        await (bundle ?? rootBundle).loadString(kDemoFixtureAsset),
-      );
+  /// 앱에 심긴 픽스처. **동기**다.
+  ///
+  /// 에셋으로 두지 않는 이유: 에셋을 읽으려면 `rootBundle` 이 필요하고 그건 비동기라,
+  /// 가짜 비동기 안에서 도는 위젯 테스트가 펌프될 때까지 풀리지 않아 통째로 멈춘다.
+  /// 시드는 위젯 테스트의 부팅 경로에서도 불리므로 그 함정을 아예 없앤다.
+  factory DemoFixture.load() => DemoFixture.parse(kimMinsuFixtureJson);
 
-  /// 이미 읽어 둔 JSON 문자열에서 만든다. 테스트가 파일을 직접 읽어 넣을 때 쓴다.
+  /// 주어진 JSON 문자열에서 만든다. 테스트가 원본 파일을 직접 읽어 넣을 때 쓴다 —
+  /// 그래야 심긴 상수가 원본과 갈라졌는지도 함께 드러난다.
   factory DemoFixture.parse(String source) {
     final Map<String, Object?> json =
         jsonDecode(source) as Map<String, Object?>;

--- a/shared/demo_fixture/lib/src/fixture_json.g.dart
+++ b/shared/demo_fixture/lib/src/fixture_json.g.dart
@@ -1,3 +1,11 @@
+// GENERATED — 손으로 고치지 말 것.
+//
+// `python3 tool/gen_demo_fixture.py` 가
+// `shared/demo_fixture/assets/kim_minsu.json` 과 함께 만든다. 고칠 값은 그 JSON 에
+// 있고, 두 파일이 어긋나면 패키지 테스트가 잡는다.
+
+/// 김민수 데모 픽스처의 JSON 원문.
+const String kimMinsuFixtureJson = r'''
 {
   "version": 1,
   "readme": "김민수 데모 데이터의 단일 원본. 사용자앱·트레이너웹·백엔드가 이 파일만 읽는다. 날짜는 상대값이다 — weeks[].weeksAgo 는 이번 주 월요일에서 몇 주 거슬러 올라가는지, days[].weekday 는 월(0)~일(6). recent[].offset 은 오늘로부터의 일수이고 주 격자 위를 덮는다. 이행률은 exercises[].done 개수에서 계산한다 — 퍼센트를 따로 적지 않는다.",
@@ -3362,3 +3370,4 @@
     }
   ]
 }
+''';

--- a/shared/demo_fixture/pubspec.yaml
+++ b/shared/demo_fixture/pubspec.yaml
@@ -7,17 +7,9 @@ version: 1.0.0
 environment:
   sdk: ^3.10.0
 
-dependencies:
-  flutter:
-    sdk: flutter
-
+# Flutter 에 기대지 않는 순수 Dart 패키지다. 픽스처는 에셋이 아니라 생성된 Dart
+# 상수(`lib/src/fixture_json.g.dart`)로 들어 있어 읽기가 동기다 — 위젯 테스트의 가짜
+# 비동기 안에서 에셋을 기다리다 멈추는 일을 없앤다.
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
   flutter_lints: ^5.0.0
-
-flutter:
-  # 두 앱에서는 `packages/demo_fixture/assets/kim_minsu.json` 으로 읽힌다.
-  # 백엔드는 같은 파일을 경로로 직접 읽는다(`app/db/demo_fixture.py`).
-  assets:
-    - assets/kim_minsu.json
+  test: ^1.25.0

--- a/shared/demo_fixture/pubspec.yaml
+++ b/shared/demo_fixture/pubspec.yaml
@@ -1,0 +1,23 @@
+name: demo_fixture
+description: "김민수 데모 데이터의 단일 원본 — 사용자앱·트레이너웹·백엔드가 함께 읽는다."
+publish_to: 'none'
+version: 1.0.0
+
+# 사용자 앱(^3.10.0)과 트레이너 앱(^3.12.0) 양쪽이 쓰므로 더 낮은 쪽에 맞춘다.
+environment:
+  sdk: ^3.10.0
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^5.0.0
+
+flutter:
+  # 두 앱에서는 `packages/demo_fixture/assets/kim_minsu.json` 으로 읽힌다.
+  # 백엔드는 같은 파일을 경로로 직접 읽는다(`app/db/demo_fixture.py`).
+  assets:
+    - assets/kim_minsu.json

--- a/shared/demo_fixture/test/demo_fixture_test.dart
+++ b/shared/demo_fixture/test/demo_fixture_test.dart
@@ -1,15 +1,24 @@
 import 'dart:io';
 
 import 'package:demo_fixture/demo_fixture.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:demo_fixture/src/fixture_json.g.dart';
+import 'package:test/test.dart';
 
-/// 에셋 번들 없이 파일에서 바로 읽는다 — 이 패키지 테스트는 앱 부팅 경로가 아니라
-/// 픽스처 자체를 본다.
+/// 사람이 고치는 원본 파일. 앱이 쓰는 것은 여기서 생성된 Dart 상수다.
 DemoFixture _load() =>
     DemoFixture.parse(File('assets/kim_minsu.json').readAsStringSync());
 
 void main() {
   final DemoFixture fixture = _load();
+
+  test('앱에 심긴 상수가 원본 JSON 과 같다', () {
+    // 둘이 갈라지면 앱만 옛 값을 들고 다닌다. 맞추는 방법은 손이 아니라
+    // `python3 tool/gen_demo_fixture.py` 다.
+    expect(
+      kimMinsuFixtureJson.trim(),
+      File('assets/kim_minsu.json').readAsStringSync().trim(),
+    );
+  });
 
   test('오늘·어제 합계가 시연에서 말하는 값 그대로다', () {
     // 이 두 날은 두 앱을 나란히 놓고 화면에서 직접 읽는 값이다. 픽스처가 바뀌어도

--- a/shared/demo_fixture/test/demo_fixture_test.dart
+++ b/shared/demo_fixture/test/demo_fixture_test.dart
@@ -1,0 +1,105 @@
+import 'dart:io';
+
+import 'package:demo_fixture/demo_fixture.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// 에셋 번들 없이 파일에서 바로 읽는다 — 이 패키지 테스트는 앱 부팅 경로가 아니라
+/// 픽스처 자체를 본다.
+DemoFixture _load() =>
+    DemoFixture.parse(File('assets/kim_minsu.json').readAsStringSync());
+
+void main() {
+  final DemoFixture fixture = _load();
+
+  test('오늘·어제 합계가 시연에서 말하는 값 그대로다', () {
+    // 이 두 날은 두 앱을 나란히 놓고 화면에서 직접 읽는 값이다. 픽스처가 바뀌어도
+    // 이 합계는 유지되어야 한다 — 바꾸려면 이슈에 적힌 서사부터 다시 정한다.
+    final List<FixtureDay> days = fixture.daysFor(DateTime(2026, 8, 16));
+    final FixtureDay today = days.last;
+    final FixtureDay yesterday = days[days.length - 2];
+
+    expect(today.calories, 1067);
+    expect(today.sodiumMg, 3428);
+    expect(today.sugarG, 17.8);
+
+    expect(yesterday.calories, 2380);
+    expect(yesterday.sodiumMg, 2261);
+    expect(yesterday.sugarG, 63.0);
+  });
+
+  test('아직 오지 않은 날은 없다', () {
+    // 주중에 열어도 이번 주 남은 요일이 채워지면 주 평균이 실제보다 높아진다(#752).
+    for (final DateTime now in <DateTime>[
+      DateTime(2026, 8, 10), // 월
+      DateTime(2026, 8, 13), // 목
+      DateTime(2026, 8, 16), // 일
+    ]) {
+      final List<FixtureDay> days = fixture.daysFor(now);
+      final String today =
+          '${now.year}-${now.month.toString().padLeft(2, '0')}-'
+          '${now.day.toString().padLeft(2, '0')}';
+      expect(days.last.date, today, reason: '마지막 날은 항상 오늘이어야 한다');
+      expect(
+        days.where((FixtureDay d) => d.date.compareTo(today) > 0),
+        isEmpty,
+      );
+    }
+  });
+
+  test('12주를 빈틈없이 덮는다', () {
+    final List<FixtureDay> days = fixture.daysFor(DateTime(2026, 8, 16));
+    expect(fixture.historyWeeks, 12);
+    // 일요일에 열면 12주가 꽉 찬다(84일). 날짜가 하루도 겹치지 않아야 한다.
+    expect(days.length, 84);
+    expect(days.map((FixtureDay d) => d.date).toSet().length, 84);
+  });
+
+  test('이행률은 루틴 항목에서 나온다 — 목록과 퍼센트가 갈라지지 않는다', () {
+    for (final FixtureDay day in fixture.daysFor(DateTime(2026, 8, 16))) {
+      if (day.exercises.isEmpty) {
+        expect(day.completion, 0, reason: '${day.date}: 휴식일은 0');
+        continue;
+      }
+      final int done = day.exercises.where((FixtureExercise e) => e.done).length;
+      expect(day.completion, (done * 100 / day.exercises.length).round());
+      expect(day.doneExercises.length, done);
+    }
+  });
+
+  test('끼니 합계는 음식 합계와 같다', () {
+    for (final FixtureDay day in fixture.daysFor(DateTime(2026, 8, 16))) {
+      for (final FixtureMeal meal in day.meals) {
+        int calories = 0;
+        int sodium = 0;
+        for (final FixtureFood food in meal.foods) {
+          calories += food.calories;
+          sodium += food.sodiumMg;
+        }
+        expect(meal.calories, calories, reason: '${day.date} ${meal.slug}');
+        expect(meal.sodiumMg, sodium, reason: '${day.date} ${meal.slug}');
+      }
+    }
+  });
+
+  test('기록이 없는 날이 남아 있다', () {
+    // 빈 화면이 맞게 동작하는지 시연에서 볼 수 있어야 한다.
+    final List<FixtureDay> days = fixture.daysFor(DateTime(2026, 8, 16));
+    expect(days.where((FixtureDay d) => !d.hasRecord), isNotEmpty);
+  });
+
+  test('주가 바뀌어도 하루가 사라지지 않는다', () {
+    // 서머타임이 있는 지역에서 `Duration(days:)` 로 날짜를 옮기면 하루가 밀린다.
+    // 픽스처는 날짜 연산만 쓰므로 어느 날에 열어도 연속이어야 한다.
+    final List<FixtureDay> days = fixture.daysFor(DateTime(2026, 3, 29));
+    final List<String> dates = days.map((FixtureDay d) => d.date).toList();
+    for (int i = 1; i < dates.length; i++) {
+      final DateTime prev = DateTime.parse(dates[i - 1]);
+      final DateTime cur = DateTime.parse(dates[i]);
+      expect(
+        cur.difference(prev).inDays,
+        1,
+        reason: '${dates[i - 1]} → ${dates[i]} 사이가 비었다',
+      );
+    }
+  });
+}

--- a/tool/gen_demo_fixture.py
+++ b/tool/gen_demo_fixture.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 _ROOT = Path(__file__).resolve().parents[1]
 
-#: 픽스처 원본. 두 Flutter 앱이 `packages/demo_fixture/…` 로 읽는다.
+#: 픽스처 원본. 사람이 읽고 고치는 파일이다.
 OUT = _ROOT / "shared/demo_fixture/assets/kim_minsu.json"
 
 #: 백엔드가 읽는 같은 파일. 내용은 [OUT] 과 **바이트까지 같아야 한다**
@@ -32,6 +32,14 @@ OUT = _ROOT / "shared/demo_fixture/assets/kim_minsu.json"
 #: 건 배포 워크플로를 건드리는 일이라 여기서 하지 않는다. 대신 이 스크립트가 두
 #: 곳에 함께 써서 손으로 맞출 일을 없앤다.
 OUT_BACKEND = _ROOT / "backend/app/db/demo_fixture_data.json"
+
+#: 두 Flutter 앱이 읽는 같은 내용. 에셋이 아니라 **Dart 상수**로 심는다.
+#:
+#: 에셋으로 두면 읽는 데 `rootBundle` 이 필요하고 그건 비동기다. 위젯 테스트는 가짜
+#: 비동기 안에서 도는데, 거기서 에셋을 기다리면 펌프될 때까지 풀리지 않아 테스트가
+#: 통째로 멈춘다 — 26초에 끝나던 파일이 10분을 넘겨도 끝나지 않았다. 상수로 두면
+#: 읽기가 동기라 그 함정이 없고, 새 테스트를 쓰는 사람이 밟을 일도 없다.
+OUT_DART = _ROOT / "shared/demo_fixture/lib/src/fixture_json.g.dart"
 
 HISTORY_WEEKS = 12
 
@@ -202,7 +210,10 @@ WEEK_STORIES: list[tuple[str, list[list[str | None] | None], dict[int, int]]] = 
             [B_EGG, L_DOE, D_SAL, S_NUT],
             [B_YOG, L_DOE, D_SLM, None],
         ],
-        {1: 1, 5: 1},
+        # 화·목이 낮다. 트레이너 스레드에서 김민수가 "화요일이랑 목요일이 야근이
+        # 많아요" 라고 답하는데, 이행률이 그 요일에 떨어져 있지 않으면 대화가 화면의
+        # 숫자와 어긋난다(`seed_clients.dart` 의 chat).
+        {1: 1, 3: 1},
     ),
     (
         "가볍게 간 한 주 — 세 지표가 모두 목표 안에 든다.",
@@ -481,12 +492,31 @@ def build() -> dict:
     }
 
 
+_DART_HEADER = '''// GENERATED — 손으로 고치지 말 것.
+//
+// `python3 tool/gen_demo_fixture.py` 가
+// `shared/demo_fixture/assets/kim_minsu.json` 과 함께 만든다. 고칠 값은 그 JSON 에
+// 있고, 두 파일이 어긋나면 패키지 테스트가 잡는다.
+
+/// 김민수 데모 픽스처의 JSON 원문.
+const String kimMinsuFixtureJson = r\'\'\'
+'''
+
+
 def main() -> None:
     payload = json.dumps(build(), ensure_ascii=False, indent=2) + "\n"
     for path in (OUT, OUT_BACKEND):
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(payload, encoding="utf-8")
         print(f"wrote {path}")
+
+    # raw 문자열(r''')로 감싼다 — JSON 에 백슬래시 이스케이프가 들어와도 Dart 가 다시
+    # 해석하지 않는다. JSON 은 작은따옴표 세 개를 만들 수 없어(문자열 값은 큰따옴표로
+    # 이스케이프된다) 구분자와 부딪히지 않는다.
+    assert "'''" not in payload, "픽스처에 ''' 이 들어가면 raw 문자열이 깨진다"
+    OUT_DART.parent.mkdir(parents=True, exist_ok=True)
+    OUT_DART.write_text(_DART_HEADER + payload + "''';\n", encoding="utf-8")
+    print(f"wrote {OUT_DART}")
 
 
 if __name__ == "__main__":

--- a/tool/gen_demo_fixture.py
+++ b/tool/gen_demo_fixture.py
@@ -1,0 +1,493 @@
+#!/usr/bin/env python3
+"""김민수 데모 픽스처(`shared/demo_fixture/assets/kim_minsu.json`)를 만든다.
+
+픽스처는 **결과물이 원본**이다 — 사용자앱·트레이너웹·백엔드는 이 JSON 을 읽기만
+하고 아무것도 계산하지 않는다. 이 스크립트는 그 JSON 을 처음 짜 넣기 위한
+도구이고, 이후 값을 손보고 싶으면 JSON 을 직접 고쳐도 된다. 다시 돌리면 손댄
+내용이 날아가므로, 규칙 자체를 바꿀 때만 쓴다.
+
+    python3 tool/gen_demo_fixture.py
+
+날짜는 절대 날짜로 적지 않는다. 달력 주 격자(`weeks`: 몇 주 전 × 요일)가 12주를
+채우고, 최근 사흘(`recent`: 오늘·어제·그제)만 큐레이션이 그 위를 덮는다. 주 격자를
+쓰는 이유는 리포트·추이 그래프가 달력 주로 묶기 때문이다 — 오늘로부터의 일수만으로
+적으면 "회식이 몰린 주" 같은 이야기가 두 주에 걸쳐 잘린다.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+
+#: 픽스처 원본. 두 Flutter 앱이 `packages/demo_fixture/…` 로 읽는다.
+OUT = _ROOT / "shared/demo_fixture/assets/kim_minsu.json"
+
+#: 백엔드가 읽는 같은 파일. 내용은 [OUT] 과 **바이트까지 같아야 한다**
+#: (`backend/tests/test_demo_fixture.py` 가 검사한다).
+#:
+#: 왜 복사본이 있나: 백엔드 이미지는 `docker build .` 을 `backend/` 에서 돌려서
+#: 빌드 컨텍스트 밖(`shared/`)의 파일을 담을 수 없다. 컨텍스트를 레포 루트로 올리는
+#: 건 배포 워크플로를 건드리는 일이라 여기서 하지 않는다. 대신 이 스크립트가 두
+#: 곳에 함께 써서 손으로 맞출 일을 없앤다.
+OUT_BACKEND = _ROOT / "backend/app/db/demo_fixture_data.json"
+
+HISTORY_WEEKS = 12
+
+# ── 음식 ───────────────────────────────────────────────────────────────────
+# (이름, 칼로리, 나트륨mg, 당류g, 탄수g, 단백g, 지방g)
+FOODS: dict[str, tuple[str, int, int, float, float, float, float]] = {
+    "oatmeal": ("오트밀", 250, 100, 6, 42, 10, 6),
+    "banana": ("바나나", 105, 1, 14, 27, 1.3, 0.4),
+    "greek-yogurt": ("그릭 요거트", 170, 75, 7, 8, 18, 8),
+    "nuts": ("견과류", 150, 5, 2, 6, 5, 13),
+    "scrambled-egg": ("스크램블 에그", 185, 220, 0.8, 2, 13, 14),
+    "strawberry": ("딸기", 32, 1, 5.5, 8, 0.5, 0.5),
+    "chicken-salad": ("닭가슴살 샐러드", 315, 395, 10, 19, 34, 11.1),
+    "bibimbap": ("야채비빔밥", 610, 900, 12, 92, 20, 16),
+    "jjamppong": ("짬뽕", 750, 3200, 8.5, 107, 29, 22.5),
+    "doenjang-jjigae": ("된장찌개", 300, 1300, 5, 18, 24, 15),
+    "rice": ("밥", 310, 5, 0.7, 67, 6, 2.5),
+    "grilled-salmon": ("연어구이", 395, 505, 9, 19, 35, 19),
+    "brown-rice": ("현미밥", 280, 5, 0, 58, 6, 2),
+    "sweet-potato": ("고구마", 130, 20, 6.5, 30, 2, 0.2),
+    "iced-americano": ("아이스 아메리카노", 10, 5, 0, 2, 0.5, 0),
+    "nut-pack": ("견과류 한 봉", 90, 2, 3, 1, 2, 8),
+    "samgyeopsal": ("삼겹살 2인분", 620, 880, 1, 2, 42, 50),
+    "soju": ("소주 1병", 55, 0, 0, 0, 0, 0),
+    "choco-cake": ("초코 케이크 한 조각", 330, 280, 24, 42, 5, 15),
+    "cafe-latte": ("카페라떼", 100, 95, 5.3, 10, 5, 4),
+}
+
+# ── 끼니 ───────────────────────────────────────────────────────────────────
+# (끼니종류, 시각, 사진, AI 코멘트, 음식들)
+#
+# 사진 에셋이 없는 끼니는 가장 가까운 한식 상차림을 재사용한다. 삼겹살·디저트가
+# 그렇다 — 에셋이 생기면 여기만 고치면 세 곳이 함께 따라온다.
+MEALS: dict[str, tuple[str, str, str, str, list[str]]] = {
+    "breakfast-oatmeal-banana": (
+        "breakfast", "08:05", "assets/images/diet-oatmeal-banana.jpeg",
+        "오트밀로 식이섬유를 챙긴 아침이에요.",
+        ["oatmeal", "banana"],
+    ),
+    "breakfast-greek-yogurt-nuts": (
+        "breakfast", "08:30", "assets/images/diet-greek-yogurt-nuts.jpeg",
+        "단백질과 불포화지방을 고르게 섭취했어요.",
+        ["greek-yogurt", "nuts"],
+    ),
+    "breakfast-egg-strawberry": (
+        "breakfast", "07:50", "assets/images/breakfast-scrambled-egg-strawberry.jpg",
+        "달걀 단백질에 과일로 비타민을 더했어요.",
+        ["scrambled-egg", "strawberry"],
+    ),
+    "lunch-chicken-salad": (
+        "lunch", "12:30", "assets/images/diet-chicken-salad.jpg",
+        "닭가슴살과 채소로 단백질·식이섬유를 챙겼어요.",
+        ["chicken-salad"],
+    ),
+    "lunch-bibimbap": (
+        "lunch", "12:20", "assets/images/diet-vegetable-bibimbap.jpg",
+        "야채가 풍부해요. 고추장을 줄이면 나트륨이 더 좋아져요.",
+        ["bibimbap"],
+    ),
+    "lunch-jjamppong": (
+        "lunch", "12:50", "assets/images/lunch-jjamppong.jpg",
+        "국물 나트륨이 높은 날이에요. 국물은 남기는 편이 좋아요.",
+        ["jjamppong"],
+    ),
+    "lunch-doenjang-rice": (
+        "lunch", "12:10", "assets/images/diet-doenjang-rice.jpeg",
+        "집밥 한 상이에요. 찌개 국물만 조금 남겨 보세요.",
+        ["doenjang-jjigae", "rice"],
+    ),
+    "dinner-salmon-brown-rice": (
+        "dinner", "18:40", "assets/images/diet-salmon-brown-rice.jpeg",
+        "연어의 지방과 현미밥의 복합 탄수화물 조합이 좋아요.",
+        ["grilled-salmon", "brown-rice"],
+    ),
+    "dinner-doenjang-rice": (
+        "dinner", "19:10", "assets/images/diet-doenjang-rice.jpeg",
+        "포만감은 좋지만 국물 나트륨이 높은 편이에요.",
+        ["doenjang-jjigae", "rice"],
+    ),
+    "dinner-chicken-salad-sweet-potato": (
+        "dinner", "18:20", "assets/images/diet-chicken-salad.jpg",
+        "가볍게 마무리한 저녁이에요.",
+        ["chicken-salad", "sweet-potato"],
+    ),
+    "dinner-samgyeopsal": (
+        "dinner", "19:30", "assets/images/diet-doenjang-rice.jpeg",
+        "고기와 술이 함께여서 칼로리가 크게 올라갔어요. 다음 날은 가볍게 시작해 보세요.",
+        ["samgyeopsal", "rice", "soju"],
+    ),
+    "snack-coffee-nuts": (
+        "snack", "15:40", "assets/images/snack-coffee-nuts.jpg",
+        "당류가 낮고 건강한 지방을 채운 간식이에요.",
+        ["iced-americano", "nut-pack"],
+    ),
+    "snack-cake-latte": (
+        "snack", "21:10", "assets/images/snack-coffee-nuts.jpg",
+        "디저트로 당류가 하루 목표를 넘었어요.",
+        ["choco-cake", "cafe-latte"],
+    ),
+}
+
+# ── 요일별 루틴 ────────────────────────────────────────────────────────────
+# 이행률은 여기 항목의 `done` 개수에서 나온다 — 퍼센트를 따로 적으면 화면의
+# "3개 중 2개 완료" 와 숫자가 갈라진다(#754).
+#
+# (이름, 종류, 분, 칼로리). 수요일은 휴식이라 항목이 없다 — 사용자앱의 주간
+# 활동 그래프와 백엔드 시드가 이미 쓰던 리듬이다.
+ROUTINE: dict[int, list[tuple[str, str, int]]] = {
+    0: [("저강도 유산소 (걷기) 30분", "cardio", 30),
+        ("코어 강화 10분", "strength", 10),
+        ("하체 스트레칭 5분", "stretching", 5)],
+    1: [("저강도 유산소 (걷기) 40분", "cardio", 40),
+        ("하체 스트레칭 10분", "stretching", 10)],
+    2: [],
+    3: [("저강도 유산소 (걷기) 35분", "cardio", 35),
+        ("코어 강화 20분", "strength", 20),
+        ("하체 스트레칭 5분", "stretching", 5)],
+    4: [("저강도 유산소 (걷기) 45분", "cardio", 45),
+        ("어깨 관절 보호 스트레칭 10분", "stretching", 10)],
+    5: [("저강도 유산소 (걷기) 25분", "cardio", 25),
+        ("코어 강화 30분", "strength", 30),
+        ("하체 스트레칭 15분", "stretching", 15)],
+    6: [("저강도 유산소 (걷기) 20분", "cardio", 20),
+        ("하체 스트레칭 10분", "stretching", 10)],
+}
+
+#: 분당 칼로리. 종류마다 다르다 — 걷기와 스트레칭을 같은 값으로 두면 주간 활동
+#: 그래프의 스택이 실제 운동 강도와 어긋난다.
+KCAL_PER_MIN = {"cardio": 7.5, "strength": 5, "stretching": 3}
+
+# ── 주별 이야기 ────────────────────────────────────────────────────────────
+# 12주를 7가지 주로 돌려 채운다. 예전에는 주마다 계수 하나를 곱해 흔들었는데,
+# 그러면 12주 내내 나트륨은 늘 초과하고 칼로리는 늘 목표 안이었다. 사람은 그렇게
+# 살지 않는다 — 회식이 몰린 주는 칼로리도 당류도 같이 넘고, 코칭이 먹힌 주는
+# 나트륨이 목표 안으로 들어온다. 그래서 계수가 아니라 **그 주에 뭘 먹었는지** 로
+# 적는다.
+#
+# 값은 요일(월→일)마다 (아침, 점심, 저녁, 간식). None 은 그 끼니를 기록하지 않은
+# 것이고, 요일 전체가 None 이면 하루를 통째로 비운다 — "기록이 없는 날" 도 데모에
+# 남아 있어야 그 빈 화면이 맞게 동작하는지 볼 수 있다.
+B_OAT, B_YOG, B_EGG = (
+    "breakfast-oatmeal-banana",
+    "breakfast-greek-yogurt-nuts",
+    "breakfast-egg-strawberry",
+)
+# 짬뽕(3,200mg)은 **오늘 하루**에만 쓴다. 한 끼로 하루 나트륨을 다 쓰는 끼니라,
+# 격자에 섞으면 그날의 나트륨÷칼로리가 2 를 넘어 `seed_clients.dart` 가 지키라고
+# 적어 둔 1.0~1.5 를 깬다. 오늘의 예외라는 점이 코칭 알림의 근거이기도 하다.
+L_SAL, L_BIB, L_JJA, L_DOE = (
+    "lunch-chicken-salad", "lunch-bibimbap", "lunch-jjamppong", "lunch-doenjang-rice",
+)
+D_SLM, D_DOE, D_SAL, D_SAM = (
+    "dinner-salmon-brown-rice", "dinner-doenjang-rice",
+    "dinner-chicken-salad-sweet-potato", "dinner-samgyeopsal",
+)
+S_NUT, S_CAK = "snack-coffee-nuts", "snack-cake-latte"
+
+WEEK_STORIES: list[tuple[str, list[list[str | None] | None], dict[int, int]]] = [
+    # (한 줄 설명, 요일별 끼니, 요일별로 못 한 루틴 항목 수)
+    (
+        "평소의 한 주 — 국물이 잦지만 기록은 성실하다.",
+        [
+            [B_YOG, L_SAL, D_SLM, None],
+            [B_OAT, L_DOE, D_SAL, S_NUT],
+            [B_EGG, L_BIB, D_DOE, None],
+            [B_YOG, L_SAL, D_SLM, S_NUT],
+            [B_OAT, L_BIB, D_DOE, None],
+            [B_EGG, L_DOE, D_SAL, S_NUT],
+            [B_YOG, L_DOE, D_SLM, None],
+        ],
+        {1: 1, 5: 1},
+    ),
+    (
+        "가볍게 간 한 주 — 세 지표가 모두 목표 안에 든다.",
+        [
+            [B_YOG, L_SAL, D_SLM, None],
+            [B_YOG, L_SAL, D_SAL, S_NUT],
+            [B_OAT, L_BIB, D_SLM, None],
+            [B_EGG, L_SAL, D_SAL, S_NUT],
+            [B_YOG, L_BIB, D_SLM, None],
+            [B_OAT, L_SAL, D_SAL, None],
+            [B_EGG, L_SAL, D_SLM, S_NUT],
+        ],
+        {},
+    ),
+    (
+        "회식이 몰린 주 — 칼로리와 당류가 함께 목표를 넘는다.",
+        [
+            [B_OAT, L_DOE, D_SAM, S_CAK],
+            [B_EGG, L_DOE, D_SAL, S_CAK],
+            [B_YOG, L_BIB, D_SAM, None],
+            [B_OAT, L_BIB, D_DOE, S_CAK],
+            [B_EGG, L_DOE, D_SAM, S_CAK],
+            [B_OAT, L_BIB, D_SAL, S_CAK],
+            [B_YOG, L_SAL, D_SLM, None],
+        ],
+        {1: 2, 3: 2, 4: 1, 5: 2},
+    ),
+    (
+        "코칭이 먹힌 주 — 국물을 줄여 나트륨이 목표 안으로 들어온다.",
+        [
+            [B_YOG, L_SAL, D_SLM, None],
+            [B_OAT, L_SAL, D_SAL, S_NUT],
+            [B_EGG, L_SAL, D_SLM, None],
+            [B_YOG, L_BIB, D_SAL, S_NUT],
+            [B_OAT, L_SAL, D_SLM, None],
+            [B_EGG, L_SAL, D_SAL, S_NUT],
+            [B_YOG, L_SAL, D_SLM, None],
+        ],
+        {5: 1},
+    ),
+    (
+        "평범한 한 주 — 구내식당 국물이 나트륨을 밀어 올린다.",
+        [
+            [B_OAT, L_DOE, D_SLM, None],
+            [B_EGG, L_BIB, D_DOE, S_NUT],
+            [B_YOG, L_DOE, D_SAL, None],
+            [B_OAT, L_DOE, D_SLM, S_NUT],
+            [B_EGG, L_BIB, D_DOE, None],
+            [B_YOG, L_DOE, D_SAL, S_NUT],
+            [B_OAT, L_SAL, D_SLM, None],
+        ],
+        {1: 1, 6: 1},
+    ),
+    (
+        "야근이 많던 주 — 늦은 저녁은 기록이 비어 있다.",
+        [
+            [B_YOG, L_DOE, D_SLM, None],
+            [B_OAT, L_DOE, None, S_NUT],
+            [B_EGG, L_BIB, D_DOE, None],
+            [B_YOG, L_DOE, None, S_NUT],
+            [B_OAT, L_SAL, D_SLM, None],
+            [B_EGG, L_BIB, D_SAL, None],
+            [B_YOG, L_SAL, D_SLM, S_NUT],
+        ],
+        {1: 2, 3: 1, 4: 1},
+    ),
+    (
+        "기록을 막 시작한 주 — 아예 빠진 날이 있다.",
+        [
+            [B_OAT, L_BIB, D_DOE, None],
+            None,
+            [B_EGG, L_DOE, D_SLM, None],
+            [B_YOG, L_DOE, None, None],
+            None,
+            [B_OAT, L_BIB, D_SAL, S_NUT],
+            [B_EGG, L_SAL, D_SLM, None],
+        ],
+        {0: 1, 1: 1, 3: 2, 4: 1, 5: 2, 6: 1},
+    ),
+]
+
+# ── 큐레이션 사흘 ──────────────────────────────────────────────────────────
+# 시연에 쓰는 오늘·어제·그제. 주 격자 위를 덮는다.
+#
+# 어제는 약속이 있던 날 — 하루 합이 2,380kcal · 2,261mg · 63.0g 으로 칼로리와
+# 당류가 목표(2,000kcal · 50g)를 넘는다. 목표선과 초과 색이 실제로 동작하는지
+# 시연에서 눈으로 확인하려면 넘긴 날이 하나는 있어야 하고, **어제**여야 데모를
+# 여는 날이 언제든 항상 화면에 들어온다. 오늘은 점심 짬뽕 한 그릇이 나트륨을 다
+# 쓴 하루다(3,428mg) — 오늘 코칭 알림의 근거가 그 조합이다.
+#
+# `id` 를 못 박은 끼니는 시연 중 화면에서 지목하는 행이라 값이 고정이어야 한다.
+RECENT: list[dict] = [
+    {
+        "offset": 0,
+        "label": "PT 세션 · 트레이너 지도",
+        "pt": True,
+        "clientFeedback": "무릎이 좀 당겼지만 트레이너님 덕분에 잘 마쳤어요 😊",
+        "trainerNote": "무릎 가동범위 체크 필요. 다음 세션 중량 조절 예정.",
+        "dayMessage": "점심 짬뽕으로 오늘 나트륨 섭취가 많았어요. 저녁은 양념을 줄인 채소와 단백질 위주로 구성해 보세요.",
+        "exercises": [
+            ("레그프레스 3세트", "strength", 25, True),
+            ("레그컬 3세트", "strength", 20, True),
+            ("하체 스트레칭 15분", "stretching", 15, True),
+        ],
+        "meals": [
+            (B_EGG, "seed-diet-breakfast", "08:20",
+             "단백질과 식이섬유의 깔끔한 조합으로, 소금 간과 기름만 조절하면 혈당과 혈압 모두 잡는 우수한 식단입니다."),
+            (L_JJA, "seed-diet-lunch", "12:40",
+             "정제 면과 높은 나트륨으로 혈압·혈당 부담이 매우 크니, 국물은 남기고 야채 위주로 드시는 것이 좋습니다."),
+            (S_NUT, "seed-diet-snack", "15:30",
+             "당류와 칼로리가 낮고 견과류의 건강한 지방이 채워져 완벽한 간식입니다."),
+        ],
+    },
+    {
+        "offset": 1,
+        "label": "AI 루틴 · 자율 운동",
+        "pt": False,
+        "clientFeedback": "스트레칭은 시간이 없어서 못 했어요",
+        "trainerNote": "",
+        "dayMessage": "약속이 있어 칼로리와 당류가 목표를 넘은 하루예요. 오늘은 가볍게 시작해 보세요.",
+        "exercises": [
+            ("저강도 유산소 (걷기) 30분", "cardio", 30, True),
+            ("코어 강화 10분", "strength", 10, True),
+            ("하체 스트레칭 15분", "stretching", 15, False),
+        ],
+        "meals": [
+            (B_OAT, "seed-diet-yesterday-breakfast", "08:10",
+             "오트밀로 식이섬유를 챙겼어요. 바나나가 들어가 당류는 다소 높은 편이에요."),
+            (L_BIB, "seed-diet-yesterday-lunch", "12:30",
+             "야채가 풍부한 비빔밥이에요. 고추장을 줄이면 나트륨을 더 조절할 수 있어요."),
+            (D_SAM, "seed-diet-yesterday-dinner", None, None),
+            (S_CAK, "seed-diet-yesterday-snack", None, None),
+        ],
+    },
+    {
+        "offset": 2,
+        "label": "AI 루틴 · 자율 운동",
+        "pt": False,
+        "clientFeedback": "오늘은 다 했어요! 뿌듯해요 💪",
+        "trainerNote": "",
+        "dayMessage": "연어와 현미밥으로 탄단지 균형을 잘 맞췄어요.",
+        "exercises": [
+            ("저강도 유산소 (걷기) 30분", "cardio", 30, True),
+            ("코어 강화 10분", "strength", 10, True),
+            ("하체 스트레칭 15분", "stretching", 15, True),
+        ],
+        "meals": [
+            (B_YOG, "seed-diet-two-days-ago-breakfast", "08:35",
+             "그릭 요거트의 단백질과 견과류의 불포화지방을 고르게 섭취했어요."),
+            (L_BIB, "seed-diet-two-days-ago-lunch", "12:20",
+             "야채가 풍부한 비빔밥이에요. 고추장을 줄이면 나트륨을 더 조절할 수 있어요."),
+            (D_SLM, "seed-diet-two-days-ago-dinner", "18:50",
+             "연어의 지방과 현미밥의 복합 탄수화물 조합이 좋아요."),
+        ],
+    },
+]
+
+
+def _round1(value: float) -> float:
+    """당류·탄단지는 소수 한 자리. 부동소수 찌꺼기가 JSON 에 남지 않게 자른다."""
+    return round(value + 0.0, 1)
+
+
+def _meal_entry(
+    meal_id: str,
+    *,
+    row_id: str | None = None,
+    time_label: str | None = None,
+    ai_comment: str | None = None,
+) -> dict:
+    entry: dict = {"meal": meal_id}
+    if row_id:
+        entry["id"] = row_id
+    if time_label:
+        entry["timeLabel"] = time_label
+    if ai_comment:
+        entry["aiComment"] = ai_comment
+    return entry
+
+
+def _exercise(name: str, kind: str, minutes: int, done: bool) -> dict:
+    return {
+        "name": name,
+        "type": kind,
+        "minutes": minutes,
+        "calories": round(minutes * KCAL_PER_MIN[kind]),
+        "done": done,
+    }
+
+
+def _grid_day(weekday: int, plan: list[str | None], skipped: int) -> dict:
+    routine = ROUTINE[weekday]
+    kept = len(routine) - skipped
+    return {
+        "weekday": weekday,
+        "label": "AI 루틴 · 자율 운동",
+        "pt": False,
+        "exercises": [
+            _exercise(name, kind, minutes, index < kept)
+            for index, (name, kind, minutes) in enumerate(routine)
+        ],
+        "meals": [_meal_entry(meal) for meal in plan if meal is not None],
+    }
+
+
+def build() -> dict:
+    weeks = []
+    for index in range(HISTORY_WEEKS):
+        note, plans, skips = WEEK_STORIES[index % len(WEEK_STORIES)]
+        days = []
+        for weekday in range(7):
+            plan = plans[weekday]
+            if plan is None:
+                # 기록이 아예 없는 날. 루틴도 남기지 않는다 — 식단만 비고 운동만
+                # 남으면 그날 화면이 반쪽으로 읽힌다.
+                days.append({"weekday": weekday, "exercises": [], "meals": []})
+                continue
+            days.append(_grid_day(weekday, plan, skips.get(weekday, 0)))
+        weeks.append({"weeksAgo": index, "note": note, "days": days})
+
+    recent = []
+    for day in RECENT:
+        recent.append({
+            "offset": day["offset"],
+            "label": day["label"],
+            "pt": day["pt"],
+            "clientFeedback": day["clientFeedback"],
+            "trainerNote": day["trainerNote"],
+            "dayMessage": day["dayMessage"],
+            "exercises": [_exercise(*item) for item in day["exercises"]],
+            "meals": [
+                _meal_entry(meal, row_id=row_id, time_label=time_label, ai_comment=comment)
+                for meal, row_id, time_label, comment in day["meals"]
+            ],
+        })
+
+    return {
+        "version": 1,
+        "readme": (
+            "김민수 데모 데이터의 단일 원본. 사용자앱·트레이너웹·백엔드가 이 파일만 "
+            "읽는다. 날짜는 상대값이다 — weeks[].weeksAgo 는 이번 주 월요일에서 몇 주 "
+            "거슬러 올라가는지, days[].weekday 는 월(0)~일(6). recent[].offset 은 "
+            "오늘로부터의 일수이고 주 격자 위를 덮는다. 이행률은 exercises[].done "
+            "개수에서 계산한다 — 퍼센트를 따로 적지 않는다."
+        ),
+        "member": {
+            "name": "김민수",
+            "userAppSeedId": "user-demo",
+            "trainerClientId": "seed-client-1",
+        },
+        "historyWeeks": HISTORY_WEEKS,
+        "foods": {
+            key: {
+                "name": name,
+                "calories": calories,
+                "sodiumMg": sodium,
+                "sugarG": _round1(sugar),
+                "carbsG": _round1(carbs),
+                "proteinG": _round1(protein),
+                "fatG": _round1(fat),
+            }
+            for key, (name, calories, sodium, sugar, carbs, protein, fat) in FOODS.items()
+        },
+        "meals": {
+            key: {
+                "mealType": meal_type,
+                "timeLabel": time_label,
+                "photoAsset": photo,
+                "aiComment": comment,
+                "foods": foods,
+            }
+            for key, (meal_type, time_label, photo, comment, foods) in MEALS.items()
+        },
+        "recent": recent,
+        "weeks": weeks,
+    }
+
+
+def main() -> None:
+    payload = json.dumps(build(), ensure_ascii=False, indent=2) + "\n"
+    for path in (OUT, OUT_BACKEND):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(payload, encoding="utf-8")
+        print(f"wrote {path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #757

## Summary

김민수는 사용자앱의 `user-demo` 와 트레이너앱의 `seed-client-1` 이 같은 사람인데, 그의 과거를 **세 곳이 각자 만들고 있었습니다**. 사용자앱은 끼니 풀을 `offset % 풀길이` 로 돌리고, 트레이너웹은 요일 배열에 주 계수를 곱하고, 백엔드는 나트륨 배열에 또 다른 계수를 곱했습니다. 계수 값 자체는 세 곳에 같은 숫자로 복사돼 있었지만 **곱해지는 대상이 달라서** 결과가 맞지 않았고, 오늘과 어제만 세 곳에 손으로 같은 값을 박아 두고 있었습니다.

합쳐야 하는 것은 저장소가 아니라 숫자 한 벌입니다. 하루치 픽스처 한 벌을 두고 세 곳이 그것만 읽습니다.

## Changes

**공유 픽스처 (`shared/demo_fixture`)**

- 픽스처 JSON 과, 두 Flutter 앱이 함께 쓰는 모델·로더를 담은 Dart 패키지입니다. 백엔드는 같은 내용을 `app/db/demo_fixture.py` 로 읽습니다.
- **날짜는 상대값**입니다. 달력 주 격자(몇 주 전 × 요일)가 12주를 채우고, 최근 사흘(오늘·어제·그제) 큐레이션이 그 위를 덮습니다. 절대 날짜로 적으면 하루만 지나도 데모가 빕니다. 오늘로부터의 일수만으로 적지 않은 이유는 리포트·추이가 달력 주로 묶기 때문입니다 — 그러면 "회식이 몰린 주" 같은 이야기가 두 주에 걸쳐 잘립니다.
- **식단은 끼니 단위**로 적습니다. 하루 합계가 자동으로 따라오므로 끼니 화면과 일별 집계가 구조적으로 어긋날 수 없습니다.
- **운동은 날짜별 루틴 항목과 수행 여부**로 적고, 이행률은 거기서 계산합니다. 퍼센트를 따로 적으면 화면의 "3개 중 2개 완료" 와 숫자가 갈라집니다(#754).
- 주마다 계수 하나를 곱하던 것을 **그 주에 뭘 먹었는지**로 바꿨습니다. 예전에는 12주 내내 나트륨은 늘 초과하고 칼로리는 늘 목표 안이라, 목표선도 색도 지표마다 한쪽 경우만 보여 줬습니다.

**세 소비자**

- 백엔드 시드는 김민수에 한해 픽스처를 읽습니다. 나머지 회원은 기존 생성기 그대로입니다.
- 사용자앱·트레이너웹도 같습니다. 트레이너 로스터의 나머지 12명은 건드리지 않았습니다.
- 트레이너 `seed_clients.dart` 에서 김민수의 수치를 비웠습니다. 값을 남겨 두면 어느 쪽이 진짜인지 알 수 없고, 한쪽만 고쳤을 때 조용히 갈립니다.

**픽스처는 에셋이 아니라 생성된 Dart 상수로 읽습니다.** 에셋은 `rootBundle` 이 필요해 비동기인데, 위젯 테스트는 가짜 비동기 안에서 돌기 때문에 거기서 에셋을 기다리면 펌프될 때까지 풀리지 않습니다 — 26초에 끝나던 테스트 파일이 10분을 넘겨도 끝나지 않았습니다. 상수로 두면 읽기가 동기라 그 함정이 없고, 새 테스트를 쓰는 사람이 밟을 일도 없습니다.

## Verification

테스트 통과와 "세 저장소의 값이 같다"는 다른 얘기라, 세 곳에 실제로 시드를 깔고 저장된 값을 뽑아 대조했습니다.

```
날짜 수 — 사용자앱 82, 트레이너 82, 백엔드 82
날짜 집합 동일: True
불일치 0건 (칼로리·나트륨·당류·운동분·이행률)
```

84일 중 82일인 것은 픽스처가 "기록이 없는 날" 을 일부러 남겨 두기 때문이고, 그 이틀은 세 곳 모두 행이 없습니다. 오늘 1,067kcal · 3,428mg · 17.8g 과 어제 2,380 · 2,261 · 63.0 은 이슈에 적힌 그대로 유지됩니다.

대조 중 결함 하나를 찾아 고쳤습니다. 개인 RAG 문서는 행 id 로 그 기록을 가리키는데 적재는 추가만 합니다. 픽스처를 다시 깔며 행을 지우면 문서만 남아 **옛 수치를 말하고**, 코치가 같은 날짜에 새 값과 옛 값을 함께 인용하게 됩니다. 실제 DB 에 고아 문서가 남아 있었습니다.

## Notes

숫자 말고 달라지는 것들입니다.

- **한 번 재시드됩니다.** 사용자앱 `seeded_v17`, 트레이너앱 `trainer_seeded_v16`, 백엔드는 김민수 행에 `seed-fix-` 접두사. 사용자가 직접 넣은 데이터(비-`seed-` id)는 그대로 살아남습니다.
- 백엔드의 김민수 시드는 append-only 에서 **날짜가 넘어가면 다시 까는** 방식으로 바뀝니다. 픽스처가 상대 날짜라 전체가 하루씩 미끄러져야 합니다. 다른 회원은 예전 방식 그대로입니다.
- 운동 이력 날짜 라벨이 오늘을 따라 움직입니다. 예전에는 `7/12 (오늘)` 로 박혀 있어 데모를 언제 열든 7월 12일이 "오늘" 이었습니다.
- 운동 항목에 ✓/✗ 가 일관되게 붙습니다. PT 날만 표시가 없어 이행률과 목록이 다른 말을 했습니다.
- 어제 하루 코치 문구를 그날 수치와 맞는 문장으로 바꿨습니다. 예전 문구는 "나트륨을 잘 조절했다" 였는데 실제로는 칼로리·당류가 목표를 넘긴 날입니다.
- 사용자앱의 과거 식단이 30일에서 12주로, 운동이 4주에서 12주로 늘어 다른 두 곳과 같아집니다.
- 휴식일이 수요일로 통일됩니다. 트레이너만 목요일이 0 이었습니다.
- 짬뽕은 오늘 하루의 이야기로 한정했습니다. 한 끼로 하루 나트륨을 다 쓰는 끼니라 격자에 섞으면 그날의 나트륨÷칼로리가 2 를 넘어, `seed_clients.dart` 가 지키라고 적어 둔 1.0~1.5 를 깹니다.
- 화면·API·리포지토리·프로바이더 코드는 건드리지 않았습니다. 런타임 변경은 시드 계층뿐입니다.

세 CI 의 path 필터에 `shared/demo_fixture/**` 를 넣었습니다 — 픽스처만 바뀌어도 세 곳이 함께 돌아야 합니다. 픽스처 자체의 불변식(큐레이션 합계·이행률 산출·앱에 심긴 상수가 원본 JSON 과 같은지)은 앱 테스트가 보지 않으므로 사용자 앱 CI 에서 한 번 돌립니다.

**남은 것**: 이슈 Notes 의 사진 에셋 정리입니다. 삼겹살·디저트 이미지가 없어 어제 저녁·간식이 한식 상차림 사진을 재사용합니다. 에셋이 생기면 픽스처 한 곳만 고치면 세 곳이 함께 따라옵니다.
