### PR TITLE
fix(exercise): 운동 탭 좁은 화면 넘침 해소

### DIFF
--- a/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
@@ -154,12 +154,19 @@ class _SubTabs extends StatelessWidget {
                 color: on ? FigmaColors.primary : FigmaColors.textMuted,
               ),
               const SizedBox(width: 6),
-              Text(
-                label,
-                style: TextStyle(
-                  fontSize: 15,
-                  fontWeight: FontWeight.w700,
-                  color: on ? FigmaColors.ink : AppColors.mutedForeground,
+              // 라벨은 남는 폭 안에서 접힌다. 아이콘·라벨 둘 다 고정 폭이면
+              // 320px 에서 탭 두 개가 화면을 넘겼다 — 영어(`Exercise log`)는
+              // 기본 배율에서도 넘친다(#766). 아이콘은 접지 않는다.
+              Flexible(
+                child: Text(
+                  label,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w700,
+                    color: on ? FigmaColors.ink : AppColors.mutedForeground,
+                  ),
                 ),
               ),
             ],
@@ -394,12 +401,18 @@ class _ExerciseWeekStrip extends StatelessWidget {
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: <Widget>[
-                Text(
-                  l.dietWeekLabel(center.month, _weekOfMonth(center)),
-                  style: const TextStyle(
-                    fontSize: 13.5,
-                    fontWeight: FontWeight.w600,
-                    color: AppColors.mutedForeground,
+                // 영어의 주 라벨은 한국어보다 훨씬 길다. 고정 폭으로 두면
+                // 좁은 화면에서 오늘 버튼을 밀어내며 넘친다(#766).
+                Flexible(
+                  child: Text(
+                    l.dietWeekLabel(center.month, _weekOfMonth(center)),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      fontSize: 13.5,
+                      fontWeight: FontWeight.w600,
+                      color: AppColors.mutedForeground,
+                    ),
                   ),
                 ),
                 if (showTodayButton)
@@ -437,13 +450,17 @@ class _ExerciseWeekStrip extends StatelessWidget {
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: <Widget>[
+                    // 셀마다 제 크기를 요구하면 일곱의 합이 화면을 넘는다 —
+                    // 영어 요일 라벨(Mon/Tue)이 한글 한 글자보다 넓다(#766).
                     for (final DateTime d in days)
-                      _WeekDay(
-                        day: d,
-                        label: _weekday(l, d.weekday),
-                        isToday: d == today,
-                        isSelected: d == selected,
-                        onTap: () => onSelect(d),
+                      Expanded(
+                        child: _WeekDay(
+                          day: d,
+                          label: _weekday(l, d.weekday),
+                          isToday: d == today,
+                          isSelected: d == selected,
+                          onTap: () => onSelect(d),
+                        ),
                       ),
                   ],
                 ),
@@ -708,12 +725,18 @@ class _WeekDay extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
-          Text(
-            label,
-            style: TextStyle(
-              fontSize: 12,
-              fontWeight: FontWeight.w600,
-              color: labelColor,
+          // 말줄임이 아니라 축소다. 'Mon' 이 'M…' 이 되면 무슨 요일인지가
+          // 사라진다 — 좁아도 읽을 수 있어야 한다(#766).
+          FittedBox(
+            fit: BoxFit.scaleDown,
+            child: Text(
+              label,
+              maxLines: 1,
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+                color: labelColor,
+              ),
             ),
           ),
           const SizedBox(height: 3),
@@ -987,21 +1010,33 @@ class _ActivityStatusState extends State<_ActivityStatus> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
+        // 식단 탭 `영양 요약` 의 같은 줄과 같은 구조로 둔다(#761) — 남는 폭은
+        // 제목과 토글 **사이**로 가고, 둘 다 좁아지면 접힌다. `Spacer` 로 밀면
+        // 정렬은 맞지만 접힐 자리가 없어 320px 에서 줄이 넘쳤다(#766).
         Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: <Widget>[
-            Text(
-              l.exActivityTitle,
-              style: const TextStyle(
-                fontSize: 15,
-                fontWeight: FontWeight.w700,
-                color: FigmaColors.ink,
+            Flexible(
+              child: Padding(
+                padding: const EdgeInsets.only(right: 8),
+                child: Text(
+                  l.exActivityTitle,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w700,
+                    color: FigmaColors.ink,
+                  ),
+                ),
               ),
             ),
-            const Spacer(),
-            _PeriodToggle(
-              active: _period,
-              labels: <String>[l.exToday, l.exThisWeek, l.exThisMonth],
-              onChanged: (int i) => setState(() => _period = i),
+            Flexible(
+              child: _PeriodToggle(
+                active: _period,
+                labels: <String>[l.exToday, l.exThisWeek, l.exThisMonth],
+                onChanged: (int i) => setState(() => _period = i),
+              ),
             ),
           ],
         ),
@@ -1268,6 +1303,8 @@ class _PeriodToggle extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
+      // 줄 오른쪽 끝에 붙었는지를 테스트가 잴 수 있어야 한다(#766).
+      key: const ValueKey<String>('exercise-period-toggle'),
       padding: const EdgeInsets.all(3),
       decoration: BoxDecoration(
         color: FigmaColors.statBg,
@@ -1276,28 +1313,37 @@ class _PeriodToggle extends StatelessWidget {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
+          // 좁은 화면·큰 글자 배율에서는 세 탭의 최소 폭 합이 남는 폭보다
+          // 커진다. 접히게 두어야 줄이 넘치지 않는다 — 식단 탭의 같은 토글과
+          // 같은 처리다(#739, #766). 보통 폭에서는 최소 폭 그대로라 모양이 같다.
           for (int i = 0; i < labels.length; i++)
-            GestureDetector(
-              onTap: () => onChanged(i),
-              behavior: HitTestBehavior.opaque,
-              child: AnimatedContainer(
-                duration: const Duration(milliseconds: 160),
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 12,
-                  vertical: 5,
-                ),
-                decoration: BoxDecoration(
-                  color: active == i ? FigmaColors.primary : Colors.transparent,
-                  borderRadius: BorderRadius.circular(999),
-                ),
-                child: Text(
-                  labels[i],
-                  style: TextStyle(
-                    fontSize: 12.5,
-                    fontWeight: FontWeight.w700,
+            Flexible(
+              child: GestureDetector(
+                onTap: () => onChanged(i),
+                behavior: HitTestBehavior.opaque,
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 160),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 5,
+                  ),
+                  decoration: BoxDecoration(
                     color: active == i
-                        ? Colors.white
-                        : AppColors.mutedForeground,
+                        ? FigmaColors.primary
+                        : Colors.transparent,
+                    borderRadius: BorderRadius.circular(999),
+                  ),
+                  child: Text(
+                    labels[i],
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontSize: 12.5,
+                      fontWeight: FontWeight.w700,
+                      color: active == i
+                          ? Colors.white
+                          : AppColors.mutedForeground,
+                    ),
                   ),
                 ),
               ),
@@ -1447,13 +1493,15 @@ class _ActivityChart extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 6),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.center,
+          // 범례 셋은 좁아지면 다음 줄로 넘긴다. 한 줄에 붙여 두면 320px 에서
+          // 넘쳤고, 라벨을 줄이면 무슨 색이 무엇인지가 사라진다(#766).
+          Wrap(
+            alignment: WrapAlignment.center,
+            spacing: 16,
+            runSpacing: 6,
             children: <Widget>[
               _Legend(color: FigmaColors.primary, label: l.exTypeCardio),
-              const SizedBox(width: 16),
               _Legend(color: const Color(0xFF1B6FA8), label: l.exTypeStrength),
-              const SizedBox(width: 16),
               _Legend(
                 color: const Color(0xFFD4EEF8),
                 label: l.exTypeStretching,
@@ -1473,7 +1521,9 @@ class _Legend extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // `Wrap` 안에서는 가로 제약이 없다 — 제 폭만 차지해야 줄바꿈이 계산된다.
     return Row(
+      mainAxisSize: MainAxisSize.min,
       children: <Widget>[
         Container(
           width: 10,
@@ -1484,12 +1534,16 @@ class _Legend extends StatelessWidget {
           ),
         ),
         const SizedBox(width: 6),
-        Text(
-          label,
-          style: const TextStyle(
-            fontSize: 12,
-            fontWeight: FontWeight.w500,
-            color: AppColors.mutedForeground,
+        // 배율이 크면 범례 하나가 한 줄보다 넓어진다. 그때는 라벨 안에서
+        // 줄을 바꾼다(#766).
+        Flexible(
+          child: Text(
+            label,
+            style: const TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w500,
+              color: AppColors.mutedForeground,
+            ),
           ),
         ),
       ],
@@ -1967,25 +2021,34 @@ class _DemoPtLogCard extends StatelessWidget {
                 color: FigmaColors.primary,
               ),
               SizedBox(width: 6),
-              Text(
-                '오늘 완료한 PT',
-                style: TextStyle(
-                  fontSize: 15,
-                  fontWeight: FontWeight.w800,
-                  color: FigmaColors.ink,
+              // 큰 글자 배율에서 제목이 카드를 넘겼다(#766).
+              Flexible(
+                child: Text(
+                  '오늘 완료한 PT',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w800,
+                    color: FigmaColors.ink,
+                  ),
                 ),
               ),
             ],
           ),
           const SizedBox(height: 10),
-          const Row(
+          // 칩 둘은 좁아지면 다음 줄로 넘긴다. 한 줄에 붙여 두면 320px 기본
+          // 배율에서도 카드를 크게 넘겼고, 칩 글자를 줄이면 몇 회차인지·몇 시
+          // 수업인지가 사라진다(#766).
+          const Wrap(
+            spacing: 6,
+            runSpacing: 6,
             children: <Widget>[
               _MetaChip(
                 icon: Icons.check_circle,
                 text: '18:00 수업 완료',
                 color: FigmaColors.statusGreen,
               ),
-              SizedBox(width: 6),
               _MetaChip(icon: Icons.person_outline, text: '김트레이너와 12회차'),
             ],
           ),
@@ -1996,22 +2059,33 @@ class _DemoPtLogCard extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.fromLTRB(10, 3, 0, 3),
               child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: <Widget>[
-                  Container(
-                    width: 6,
-                    height: 6,
-                    decoration: const BoxDecoration(
-                      color: FigmaColors.primary,
-                      shape: BoxShape.circle,
+                  Padding(
+                    // 항목이 두 줄로 접히면 점이 가운데로 뜬다. 첫 줄 높이에
+                    // 맞춰 위쪽에 고정한다.
+                    padding: const EdgeInsets.only(top: 7),
+                    child: Container(
+                      width: 6,
+                      height: 6,
+                      decoration: const BoxDecoration(
+                        color: FigmaColors.primary,
+                        shape: BoxShape.circle,
+                      ),
                     ),
                   ),
                   const SizedBox(width: 8),
-                  Text(
-                    it,
-                    style: const TextStyle(
-                      fontSize: 14,
-                      fontWeight: FontWeight.w500,
-                      color: AppColors.foreground,
+                  // 말줄임이 아니라 줄바꿈이다. `벤치프레스 40kg · 4세트` 가
+                  // `벤치프레스 40k…` 가 되면 몇 세트인지가 사라진다 — 접혀도
+                  // 뜻이 남아야 한다(#766).
+                  Expanded(
+                    child: Text(
+                      it,
+                      style: const TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w500,
+                        color: AppColors.foreground,
+                      ),
                     ),
                   ),
                 ],
@@ -2113,12 +2187,16 @@ class _MetaChip extends StatelessWidget {
         children: <Widget>[
           Icon(icon, size: 11, color: color),
           const SizedBox(width: 4),
-          Text(
-            text,
-            style: TextStyle(
-              fontSize: 12,
-              fontWeight: FontWeight.w700,
-              color: color,
+          // 배율 1.6 이상에서는 칩 하나가 카드보다 넓어진다. 그때는 칩 안에서
+          // 줄을 바꾼다 — 말줄임하면 몇 시 수업인지·몇 회차인지가 사라진다(#766).
+          Flexible(
+            child: Text(
+              text,
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w700,
+                color: color,
+              ),
             ),
           ),
         ],

--- a/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_card.dart
+++ b/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_card.dart
@@ -170,12 +170,17 @@ class AiRecommendedExerciseCard extends ConsumerWidget {
             children: <Widget>[
               Icon(Icons.auto_awesome, size: 16, color: FigmaColors.primary),
               SizedBox(width: 6),
-              Text(
-                'AI 맞춤 운동',
-                style: TextStyle(
-                  fontSize: 15,
-                  fontWeight: FontWeight.w800,
-                  color: FigmaColors.ink,
+              // 큰 글자 배율에서 제목이 카드를 넘겼다(#766).
+              Flexible(
+                child: Text(
+                  'AI 맞춤 운동',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w800,
+                    color: FigmaColors.ink,
+                  ),
                 ),
               ),
             ],
@@ -329,47 +334,61 @@ class _RecommendedExerciseRowState
                 ),
               ),
               const SizedBox(width: 8),
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: <Widget>[
-                  Text(
-                    '${routine.type} · '
-                    '${routine.completedMinutes ?? routine.minutes}분',
-                    style: const TextStyle(
-                      fontSize: 12.5,
-                      fontWeight: FontWeight.w700,
-                      color: FigmaColors.primary,
-                    ),
-                  ),
-                  const SizedBox(height: 4),
-                  if (routine.completed)
-                    const Row(
-                      children: <Widget>[
-                        Icon(Icons.check_circle, size: 16, color: Colors.green),
-                        SizedBox(width: 4),
-                        Text('수행 완료'),
-                      ],
-                    )
-                  else
-                    SizedBox(
-                      height: 30,
-                      child: OutlinedButton(
-                        key: Key('completeRoutine-${routine.id}'),
-                        onPressed: _saving ? null : _complete,
-                        style: OutlinedButton.styleFrom(
-                          padding: const EdgeInsets.symmetric(horizontal: 10),
-                        ),
-                        child: _saving
-                            ? const SizedBox.square(
-                                dimension: 14,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
-                                ),
-                              )
-                            : const Text('수행 완료'),
+              // 오른쪽 묶음도 접힌다. 고정 폭으로 두면 큰 글자 배율에서
+              // 운동 이름 쪽을 다 밀어낸 뒤에도 줄이 넘쳤다(#766).
+              Flexible(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: <Widget>[
+                    Text(
+                      '${routine.type} · '
+                      '${routine.completedMinutes ?? routine.minutes}분',
+                      textAlign: TextAlign.end,
+                      style: const TextStyle(
+                        fontSize: 12.5,
+                        fontWeight: FontWeight.w700,
+                        color: FigmaColors.primary,
                       ),
                     ),
-                ],
+                    const SizedBox(height: 4),
+                    if (routine.completed)
+                      const Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: <Widget>[
+                          Icon(
+                            Icons.check_circle,
+                            size: 16,
+                            color: Colors.green,
+                          ),
+                          SizedBox(width: 4),
+                          Flexible(child: Text('수행 완료')),
+                        ],
+                      )
+                    else
+                      SizedBox(
+                        height: 30,
+                        child: OutlinedButton(
+                          key: Key('completeRoutine-${routine.id}'),
+                          onPressed: _saving ? null : _complete,
+                          style: OutlinedButton.styleFrom(
+                            padding: const EdgeInsets.symmetric(horizontal: 10),
+                          ),
+                          child: _saving
+                              ? const SizedBox.square(
+                                  dimension: 14,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                  ),
+                                )
+                              : const Text(
+                                  '수행 완료',
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                        ),
+                      ),
+                  ],
+                ),
               ),
             ],
           ),
@@ -548,12 +567,18 @@ class _ChatButton extends StatelessWidget {
                 color: FigmaColors.primary,
               ),
               const SizedBox(width: 8),
-              const Text(
-                '트레이너와 채팅',
-                style: TextStyle(
-                  fontSize: 14,
-                  fontWeight: FontWeight.w700,
-                  color: FigmaColors.primary,
+              // 큰 글자 배율에서 라벨이 버튼을 넘겼다. 안 읽은 개수 배지는
+              // 접지 않는다 — 몇 건인지가 이 버튼을 누를 이유다(#766).
+              const Flexible(
+                child: Text(
+                  '트레이너와 채팅',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w700,
+                    color: FigmaColors.primary,
+                  ),
                 ),
               ),
               if (unread > 0) ...<Widget>[

--- a/frontend/flutter/test/features/exercise/exercise_narrow_layout_test.dart
+++ b/frontend/flutter/test/features/exercise/exercise_narrow_layout_test.dart
@@ -1,0 +1,146 @@
+/// 좁은 화면·큰 글자 배율에서 운동 탭이 넘치지 않는지 (#766).
+///
+/// 320px 는 아이폰 SE 1세대·구형 안드로이드의 논리 폭이고, 배율 2.0 은 접근성
+/// 설정의 상한에 가깝다. 예전에는 이 조건에서 상단 탭·날짜 스트립·기간 토글·
+/// 그래프 범례·PT 카드의 칩과 운동 항목이 각각 넘쳐, 글자가 잘리거나 노랑·검정
+/// 줄무늬가 그려졌다.
+///
+/// **한국어와 영어를 모두 검증한다.** 영어는 라벨이 훨씬 길어(`This month` vs
+/// `이번 달`) 기본 배율에서도 넘쳤다 — 식단 탭에서 en 만 따로 새던 일(#743)을
+/// 여기서 되풀이하지 않으려고 처음부터 두 로케일을 함께 돈다.
+///
+/// 높이를 넉넉히 두는 이유는 `ListView` 가 보이는 자식만 만들기 때문이다 —
+/// 짧은 화면에서는 아래쪽 카드가 아예 그려지지 않아 검증 대상이 사라진다.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/features/account/data/repositories/mock_account_repository.dart';
+import 'package:oncare/features/account/domain/entities/user_profile.dart';
+import 'package:oncare/features/account/presentation/controllers/account_controller.dart';
+import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
+import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
+import 'package:oncare/features/exercise/presentation/pages/exercise_page.dart';
+import 'package:oncare/features/member_coach/data/repositories/mock_member_coach_repository.dart';
+import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+void main() {
+  const ExerciseWeek week = ExerciseWeek(
+    sessions: <ExerciseSession>[],
+    dailyMinutes: <double>[60, 45, 70, 30, 55, 40, 65],
+    dailyCalories: <double>[300, 220, 350, 150, 270, 200, 320],
+    cardioMinutes: <double>[30, 20, 35, 15, 25, 20, 30],
+    strengthMinutes: <double>[20, 15, 25, 10, 20, 12, 25],
+    stretchingMinutes: <double>[10, 10, 10, 5, 10, 8, 10],
+    dayLabels: <String>['월', '화', '수', '목', '금', '토', '일'],
+    totalMinutes: 365,
+    totalCalories: 1810,
+    streakDays: 7,
+    aiCoachMessage: '꾸준히 운동해 보세요.',
+  );
+
+  Future<void> pumpExercise(
+    WidgetTester tester, {
+    required String lang,
+    required Size size,
+  }) async {
+    await tester.binding.setSurfaceSize(size);
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          appConfigProvider.overrideWithValue(
+            const AppConfig(
+              environment: Environment.dev,
+              apiBaseUrl: 'https://example.test',
+              useMockApi: true,
+            ),
+          ),
+          accountRepositoryProvider.overrideWithValue(
+            MockAccountRepository(
+              profile: const UserProfile(
+                id: 'member',
+                name: '테스트',
+                email: 'member@example.com',
+              ),
+            ),
+          ),
+          exerciseWeekProvider.overrideWith((ref) async => week),
+          memberCoachRepositoryProvider.overrideWithValue(
+            MockMemberCoachRepository(),
+          ),
+        ],
+        child: MaterialApp(
+          locale: Locale(lang),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const ExercisePage(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  group('운동 탭 좁은 화면 레이아웃 (#766)', () {
+    for (final String lang in <String>['ko', 'en']) {
+      for (final double scale in <double>[1.0, 1.3, 1.6, 2.0]) {
+        testWidgets('폭 320 · $lang · 글자 배율 $scale 에서 넘치지 않는다', (
+          WidgetTester tester,
+        ) async {
+          tester.platformDispatcher.textScaleFactorTestValue = scale;
+          addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
+
+          await pumpExercise(
+            tester,
+            lang: lang,
+            // 높이는 카드가 모두 그려질 만큼 — 배율 2.0 에서도 아래쪽 PT 카드가
+            // 화면에 들어와야 그 줄들이 검증된다.
+            size: const Size(320, 6000),
+          );
+
+          // overflow 는 렌더링 예외로 보고된다. 예외 없이 그려졌다면 넘친
+          // 곳이 없다는 뜻이다.
+          expect(tester.takeException(), isNull);
+          expect(find.byType(ExercisePage), findsOneWidget);
+        });
+      }
+    }
+
+    testWidgets('기간 토글은 좁아지면 접히고, 넓으면 줄 오른쪽 끝에 붙는다', (
+      WidgetTester tester,
+    ) async {
+      // 넘침을 막으려고 토글을 `Flexible` 로 접히게 두었다. 그 과정에서 `Spacer`
+      // 를 걷어냈으므로, 넓은 폭에서 토글이 오른쪽 끝을 지키는지도 함께 본다 —
+      // 식단 탭에서 같은 자리가 가운데로 밀렸던 적이 있다(#761).
+      await pumpExercise(tester, lang: 'ko', size: const Size(800, 3000));
+
+      final AppLocalizations l = AppLocalizations.of(
+        tester.element(find.byType(ExercisePage)),
+      );
+      final Finder row = find
+          .ancestor(
+            of: find.text(l.exActivityTitle),
+            matching: find.byType(Row),
+          )
+          .first;
+      final Finder toggle = find.byKey(
+        const ValueKey<String>('exercise-period-toggle'),
+      );
+      expect(toggle, findsOneWidget);
+
+      expect(
+        tester.getRect(toggle).right,
+        moreOrLessEquals(tester.getRect(row).right, epsilon: 0.5),
+      );
+      // 제목은 여전히 줄 왼쪽에 있다 — 둘이 가운데로 몰리지 않는다.
+      expect(
+        tester.getRect(find.text(l.exActivityTitle)).left,
+        moreOrLessEquals(tester.getRect(row).left, epsilon: 0.5),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #766

## Summary

운동 탭(`ExercisePage`)이 320px 에서 넘치던 자리를 모두 고칩니다. 식단 탭에서 #739·#743·#760 으로 했던 일의 운동 탭 판입니다.

폭 320 에서 잰 overflow 건수:

| 배율 | ko before → after | en before → after |
|---|---|---|
| 1.0 | 4 → **0** | 7 → **0** |
| 1.3 | 6 → **0** | 9 → **0** |
| 1.6 | 10 → **0** | 12 → **0** |
| 2.0 | 14 → **0** | 16 → **0** |

## Changes

접는 방법은 자리마다 다릅니다 — **접혀도 뜻이 남는가**를 기준으로 골랐습니다.

| 자리 | 방법 |
|---|---|
| 상단 탭(`운동 기록`·`헬스장`) 라벨 | `Flexible` + 말줄임 |
| 주 라벨 + `오늘` 버튼 | 주 라벨만 접힘. 버튼은 늘 눌려야 한다 |
| 날짜 스트립 요일 일곱 | 셀마다 `Expanded`, 요일 글자는 `FittedBox` 로 축소 — `Mon` 이 `M…` 이 되면 안 된다 |
| `운동 현황` 제목 + 기간 토글 | 식단 `영양 요약` 과 같은 구조로 통일(`spaceBetween` + 양쪽 `Flexible`), 토글 탭도 접히게 |
| 그래프 범례 셋 | `Wrap` 으로 다음 줄에 넘김 |
| PT 카드 제목·칩 | 제목은 말줄임, 칩 둘은 `Wrap`, 칩 안 글자는 줄바꿈 |
| 운동 항목(`벤치프레스 40kg · 4세트`) | 줄바꿈. 말줄임하면 몇 세트인지가 사라진다 |
| `CoachCard` 제목·루틴 줄·채팅 버튼 | 같은 화면에서 함께 넘쳐 함께 고침 |

## Notes

- **`운동 현황` 줄의 정렬은 원래 정상이었습니다.** #761 이 식단 탭에서 고친 '끝 요소가 가운데에 뜨는' 문제는 여기 없었고(`Spacer` 가 유일한 flex 자식이라 남는 폭을 전부 흡수), 이 PR 은 넘침만 다룹니다. 다만 접히게 만들며 `Spacer` 를 걷어냈으므로, 넓은 폭에서 토글이 오른쪽 끝을 지키는지 테스트로 고정했습니다.
- `CoachCard` 는 운동 탭 밖에서도 쓰이지만, 바꾼 것은 접힘 규칙뿐이라 넓은 화면 모양은 그대로입니다.

## Tests

- `test/features/exercise/exercise_narrow_layout_test.dart` 추가 — 폭 320 × 배율 1.0·1.3·1.6·2.0 을 **ko·en 두 로케일**로 돕니다. 식단 쪽은 en 이 빠져 있어 나중에 #743 으로 다시 다뤄야 했는데, 여기서는 처음부터 함께 넣었습니다.
- 같은 파일에 기간 토글의 오른쪽 끝 좌표를 재는 검증을 함께 뒀습니다.
- `flutter test` 전체 통과.
