### PR TITLE
feat(trainer): 확인 필요 고객 배지의 당류 추가와 우선순위 기준

### DIFF
--- a/frontend/flutter_trainer/lib/features/dashboard/data/ai_coaching_summary_repository.dart
+++ b/frontend/flutter_trainer/lib/features/dashboard/data/ai_coaching_summary_repository.dart
@@ -92,6 +92,8 @@ class DemoAiCoachingSummaryRepository implements AiCoachingSummaryRepository {
         ? RuleCoachingSignal.sodium
         : switch (entry.primary) {
             ClientAlert.sodiumOver => RuleCoachingSignal.sodium,
+            // 당류도 식단 신호다 — 코칭 문구는 나트륨과 같은 갈래를 탄다.
+            ClientAlert.sugarOver => RuleCoachingSignal.sodium,
             ClientAlert.lowCompletion => RuleCoachingSignal.lowCompletion,
             ClientAlert.unanswered => RuleCoachingSignal.unanswered,
           };

--- a/frontend/flutter_trainer/lib/features/dashboard/domain/dashboard_summary.dart
+++ b/frontend/flutter_trainer/lib/features/dashboard/domain/dashboard_summary.dart
@@ -3,7 +3,7 @@ import 'package:oncare_trainer/shared/models/trainer_client.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 
 export 'package:oncare_trainer/shared/models/client_alerts.dart'
-    show AttentionClient, ClientAlert, lowCompletionThreshold;
+    show AttentionClient, ClientAlert, alertSeverity, lowCompletionThreshold;
 
 /// Weekday labels for the 주간 이행률 chart, in the current locale.
 /// [TrainerClient.weekCompletion] is indexed 월→일, matching
@@ -113,15 +113,21 @@ DashboardSummary buildDashboardSummary({
     }
   }
 
-  // Most urgent alert type first; within a type, keep the incoming
-  // (coaching-priority) order. `List.sort` is not stable in Dart, so the
-  // original position is the explicit tiebreaker.
+  // 목표를 가장 크게 벗어난 회원부터. 예전에는 신호 **종류** 순으로 묶었는데,
+  // 카드가 다섯 행만 보여 주다 보니 첫 종류가 카드를 통째로 차지했다 — 배지를
+  // 회원별로 고르게 만들어도 화면은 여전히 한 가지 말만 했다(#767).
+  //
+  // 동점이면 들어온 순서를 지킨다. `List.sort` 는 안정 정렬이 아니라 원래
+  // 위치를 명시적 타이브레이커로 둔다.
   final order = <String, int>{
     for (var i = 0; i < clients.length; i++) clients[i].id: i,
   };
   attention.sort((a, b) {
-    final byAlert = a.primary.index.compareTo(b.primary.index);
-    if (byAlert != 0) return byAlert;
+    final bySeverity = alertSeverity(
+      b.client,
+      b.primary,
+    ).compareTo(alertSeverity(a.client, a.primary));
+    if (bySeverity != 0) return bySeverity;
     return (order[a.client.id] ?? 0).compareTo(order[b.client.id] ?? 0);
   });
 

--- a/frontend/flutter_trainer/lib/features/dashboard/presentation/pages/dashboard_page.dart
+++ b/frontend/flutter_trainer/lib/features/dashboard/presentation/pages/dashboard_page.dart
@@ -223,11 +223,13 @@ class _TaskRow extends StatelessWidget {
     final tone = switch (alert) {
       ClientAlert.unanswered => AppColors.primary,
       ClientAlert.sodiumOver => AppColors.overTarget,
+      ClientAlert.sugarOver => AppColors.overTarget,
       ClientAlert.lowCompletion => AppColors.warning,
     };
     final type = switch (alert) {
       ClientAlert.unanswered => l.dashTaskReply,
       ClientAlert.sodiumOver => l.dashTaskDiet,
+      ClientAlert.sugarOver => l.dashTaskDiet,
       ClientAlert.lowCompletion => l.dashTaskWorkout,
     };
     return Padding(

--- a/frontend/flutter_trainer/lib/features/dashboard/presentation/widgets/attention_card.dart
+++ b/frontend/flutter_trainer/lib/features/dashboard/presentation/widgets/attention_card.dart
@@ -32,6 +32,7 @@ class AttentionCard extends StatelessWidget {
   static String sectionFor(ClientAlert alert) => switch (alert) {
     ClientAlert.unanswered => 'chat',
     ClientAlert.sodiumOver => 'diet',
+    ClientAlert.sugarOver => 'diet',
     ClientAlert.lowCompletion => 'workout',
   };
 

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
@@ -3392,6 +3392,12 @@ abstract class AppLocalizations {
   /// **'Sodium over'**
   String get alertSodiumOver;
 
+  /// No description provided for @alertSugarOver.
+  ///
+  /// In en, this message translates to:
+  /// **'Sugar over target'**
+  String get alertSugarOver;
+
   /// No description provided for @alertLowCompletion.
   ///
   /// In en, this message translates to:

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
@@ -1909,6 +1909,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get alertSodiumOver => 'Sodium over';
 
   @override
+  String get alertSugarOver => 'Sugar over target';
+
+  @override
   String get alertLowCompletion => 'Low completion';
 
   @override

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
@@ -1852,6 +1852,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get alertSodiumOver => '나트륨 초과';
 
   @override
+  String get alertSugarOver => '당류 초과';
+
+  @override
   String get alertLowCompletion => '이행률 저조';
 
   @override

--- a/frontend/flutter_trainer/lib/l10n/app_en.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_en.arb
@@ -1152,6 +1152,7 @@
   "unknownMember": "Unknown member",
   "filterAll": "All",
   "alertSodiumOver": "Sodium over",
+  "alertSugarOver": "Sugar over target",
   "alertLowCompletion": "Low completion",
   "alertAwaitingReply": "Awaiting reply",
   "clientLastRoutine": "Last routine",

--- a/frontend/flutter_trainer/lib/l10n/app_ko.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_ko.arb
@@ -576,6 +576,7 @@
   "unknownMember": "알 수 없는 고객",
   "filterAll": "전체",
   "alertSodiumOver": "나트륨 초과",
+  "alertSugarOver": "당류 초과",
   "alertLowCompletion": "이행률 저조",
   "alertAwaitingReply": "답장 대기",
   "clientLastRoutine": "마지막 루틴",

--- a/frontend/flutter_trainer/lib/shared/models/client_alerts.dart
+++ b/frontend/flutter_trainer/lib/shared/models/client_alerts.dart
@@ -15,6 +15,13 @@ enum ClientAlert {
   /// Today's sodium is over the daily target.
   sodiumOver,
 
+  /// Today's sugar is over the daily target.
+  ///
+  /// 나트륨과 나란히 둔다 — 둘 다 식단 신호이고, "적을수록 낫다" 가 모든
+  /// 회원에게 성립한다. 칼로리는 그렇지 않아 배지로 두지 않는다: 벌크업
+  /// 회원에게 칼로리 초과는 잘한 것이다(#767).
+  sugarOver,
+
   /// This week's routine completion is low.
   lowCompletion,
 
@@ -28,6 +35,7 @@ enum ClientAlert {
   /// Badge text shown next to the client's name, in the current locale. (#501)
   String label(AppLocalizations l) => switch (this) {
     ClientAlert.sodiumOver => l.alertSodiumOver,
+    ClientAlert.sugarOver => l.alertSugarOver,
     ClientAlert.lowCompletion => l.alertLowCompletion,
     ClientAlert.unanswered => l.alertAwaitingReply,
   };
@@ -62,11 +70,44 @@ class AttentionClient {
 /// This is the full picture — what the 오늘 챙길 고객 list and the client
 /// detail header show. For the 주의 고객 *count* use [healthAlertsFor].
 List<ClientAlert> alertsFor(TrainerClient client, {int unread = 0}) {
+  // 건강 신호는 **그 회원에게 얼마나 나쁜지** 로 줄 세운다. 지표 종류의 고정
+  // 순서로 두면 나트륨이 1mg 만 넘어도 이행률 36% 를 덮어, 배지가 늘 같은 말을
+  // 한다(#767). 배지는 첫 신호 하나뿐이라 그 자리를 가장 급한 것에 준다.
+  final health =
+      <ClientAlert>[
+        if (client.sodiumOverBudget) ClientAlert.sodiumOver,
+        if (client.sugarOverBudget) ClientAlert.sugarOver,
+        if (isLowCompletion(client)) ClientAlert.lowCompletion,
+      ]..sort(
+        (a, b) => alertSeverity(client, b).compareTo(alertSeverity(client, a)),
+      );
+
   return <ClientAlert>[
-    if (client.sodiumOverBudget) ClientAlert.sodiumOver,
-    if (isLowCompletion(client)) ClientAlert.lowCompletion,
+    ...health,
+    // 답장 대기는 늘 마지막이다. 트레이너 자신의 받은편지함이지 회원의 건강
+    // 신호가 아니고, `답장 필요` 카운터가 이미 그 수를 보여 준다.
     if (unread > 0) ClientAlert.unanswered,
   ];
+}
+
+/// [alert] 가 [client] 에게 얼마나 나쁜지. 1 을 넘을수록 나쁘다.
+///
+/// 세 지표를 **같은 저울** 에 올린다. 나트륨·당류는 `값 ÷ 목표` 로 1 을 넘고,
+/// 이행률은 낮을수록 나쁘니 뒤집어 `기준선 ÷ 실제` 로 둔다. 그래야 "나트륨을
+/// 조금 넘긴 회원" 과 "이행률이 절반인 회원" 중 누가 더 급한지 견줄 수 있다.
+///
+/// 답장 대기는 0 이다 — 건강 신호가 아니라 견줄 저울이 없고, 늘 마지막이다.
+double alertSeverity(TrainerClient client, ClientAlert alert) => switch (alert) {
+  ClientAlert.sodiumOver => client.sodiumMg / sodiumTargetMg,
+  ClientAlert.sugarOver => client.sugarG / sugarTargetG,
+  ClientAlert.lowCompletion => _completionRatio(client),
+  ClientAlert.unanswered => 0,
+};
+
+double _completionRatio(TrainerClient client) {
+  final mean = recordedCompletionMean(client);
+  if (mean == null || mean <= 0) return double.infinity;
+  return lowCompletionThreshold / mean;
 }
 
 /// The subset of [alertsFor] that comes from the member's health data.

--- a/frontend/flutter_trainer/lib/shared/widgets/alert_badge.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/alert_badge.dart
@@ -16,6 +16,8 @@ import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 Color alertColor(ClientAlert alert) => switch (alert) {
   ClientAlert.unanswered => AppColors.primary,
   ClientAlert.sodiumOver => AppColors.overTarget,
+  // 회원 앱이 당류 초과를 빨갛게 보여 준다 — 같은 사실을 같은 세기로.
+  ClientAlert.sugarOver => AppColors.overTarget,
   ClientAlert.lowCompletion => AppColors.warning,
 };
 

--- a/frontend/flutter_trainer/test/features/dashboard/dashboard_page_test.dart
+++ b/frontend/flutter_trainer/test/features/dashboard/dashboard_page_test.dart
@@ -169,7 +169,10 @@ void main() {
       await openDashboard(tester);
 
       expect(find.text('AI 코칭 요약'), findsOneWidget);
-      expect(find.textContaining('김민수 고객'), findsWidgets);
+      // 머리말은 1순위 회원의 이름을 부른다. 그게 누구인지는 그날의 수치가
+      // 정하므로(#767 이후 초과 폭 순) 이름을 박지 않는다 — 박아 두면 시드가
+      // 조금만 움직여도 깨지고, 정작 검증하려는 건 "이름을 부른다" 는 것이다.
+      expect(find.textContaining('고객을 먼저 확인하고'), findsWidgets);
       expect(find.text('오늘 운동 중심'), findsWidgets);
       expect(find.textContaining('중강도 걷기'), findsWidgets);
       expect(find.text('판단 근거'), findsWidgets);

--- a/frontend/flutter_trainer/test/features/dashboard/dashboard_summary_test.dart
+++ b/frontend/flutter_trainer/test/features/dashboard/dashboard_summary_test.dart
@@ -78,10 +78,30 @@ void main() {
       expect(summary.healthAttentionCount, 1);
     });
 
-    test('within one alert type the incoming (priority) order is kept', () {
+    test('목표를 더 크게 벗어난 회원이 앞에 온다 (#767)', () {
+      // 카드는 다섯 행만 보여 준다. 신호 종류로 묶어 정렬하면 첫 종류가 카드를
+      // 통째로 차지해, 배지를 회원별로 고르게 만들어도 화면은 한 가지 말만
+      // 한다. 종류가 아니라 초과 폭으로 줄 세운다.
       final summary = buildDashboardSummary(
         clients: <TrainerClient>[
-          makeClient(id: 'first', sodiumMg: 2100),
+          makeClient(id: 'mild-sodium', sodiumMg: 2100),
+          makeClient(id: 'bad-workout', weekCompletion: List<int>.filled(7, 25)),
+        ],
+        unread: const <String, int>{},
+      );
+
+      expect(summary.attention.map((a) => a.client.id), <String>[
+        'bad-workout',
+        'mild-sodium',
+      ]);
+    });
+
+    test('초과 폭이 같으면 들어온 순서를 지킨다', () {
+      // `List.sort` 는 안정 정렬이 아니다 — 동점의 순서가 실행마다 달라지면
+      // 대시보드가 새로고침마다 다르게 보인다.
+      final summary = buildDashboardSummary(
+        clients: <TrainerClient>[
+          makeClient(id: 'first', sodiumMg: 2400),
           makeClient(id: 'second', sodiumMg: 2400),
         ],
         unread: const <String, int>{},
@@ -91,6 +111,49 @@ void main() {
         'first',
         'second',
       ]);
+    });
+
+    test('배지는 그 회원에게 가장 나쁜 신호다 (#767)', () {
+      // 나트륨은 목표를 겨우 넘었고 이행률은 절반 아래다. 지표 종류의 고정
+      // 순서로 고르면 배지가 '나트륨 초과' 가 되어, 트레이너가 정작 급한
+      // 것을 놓친다.
+      final summary = buildDashboardSummary(
+        clients: <TrainerClient>[
+          makeClient(
+            id: 'worse-workout',
+            sodiumMg: 2010,
+            weekCompletion: List<int>.filled(7, 30),
+          ),
+        ],
+        unread: const <String, int>{},
+      );
+
+      expect(summary.attention.single.primary, ClientAlert.lowCompletion);
+      // 나트륨도 여전히 신호로 남는다 — 배지 자리를 내줬을 뿐이다.
+      expect(summary.attention.single.alerts, contains(ClientAlert.sodiumOver));
+    });
+
+    test('당류 초과도 배지가 된다 (#767)', () {
+      // `sugarOverBudget` 은 모델에 있었지만 아무도 읽지 않아, 당류만 넘긴
+      // 회원은 목록에 아예 오르지 못했다.
+      final summary = buildDashboardSummary(
+        clients: <TrainerClient>[makeClient(id: 'sweet', sugarG: 80)],
+        unread: const <String, int>{},
+      );
+
+      expect(summary.attention.single.primary, ClientAlert.sugarOver);
+      expect(summary.healthAttentionCount, 1);
+    });
+
+    test('식단 신호 둘 중에서도 더 많이 넘긴 쪽이 배지다 (#767)', () {
+      final summary = buildDashboardSummary(
+        clients: <TrainerClient>[
+          makeClient(id: 'sugar-worse', sodiumMg: 2100, sugarG: 90),
+        ],
+        unread: const <String, int>{},
+      );
+
+      expect(summary.attention.single.primary, ClientAlert.sugarOver);
     });
 
     test('a healthy roster raises nothing', () {


### PR DESCRIPTION
Closes #767

## Summary

대시보드의 `확인 필요 고객` 이 거의 전부 **나트륨 초과** 로 떴습니다. 데모 화면이 한 가지 이야기만 반복했습니다.

시드 숫자가 아니라 두 가지가 원인이었습니다.

## Changes

### 당류 초과를 신호로 세웠습니다

`TrainerClient.sugarOverBudget` 은 모델에 **이미 있었지만 아무도 읽지 않았습니다.** 당류만 넘긴 회원은 목록에 오르지도 못했습니다.

**칼로리는 신호로 두지 않았습니다.** 증감의 방향이 회원마다 뒤집힙니다 — 벌크업 회원에게 칼로리 초과는 잘한 것입니다. 나트륨·당류는 "적을수록 낫다" 가 모든 회원에게 성립합니다(#755 에서 요약 카드의 두 번째 지표를 나트륨으로 둔 것과 같은 이유).

### 배지와 목록을 "목표를 벗어난 폭" 으로 줄 세웁니다

둘 다 신호 **종류** 의 고정 순서를 따르고 있었습니다.

- 배지는 회원의 첫 신호 하나뿐인데, 나트륨이 1mg 만 넘어도 이행률 36% 를 덮었습니다.
- 카드는 다섯 행만 보여 주는데 종류로 묶어 정렬하니 첫 종류가 카드를 통째로 차지했습니다. 배지만 고쳐서는 화면이 바뀌지 않았습니다.

세 지표를 같은 저울에 올리려고 이행률은 뒤집었습니다 — 나트륨·당류는 `값 ÷ 목표`, 이행률은 `기준선 ÷ 실제`. 그래야 "나트륨을 조금 넘긴 회원" 과 "이행률이 절반인 회원" 중 누가 더 급한지 견줄 수 있습니다. 답장 대기는 0 이라 늘 마지막입니다 — 트레이너 자신의 받은편지함이지 회원의 건강 신호가 아니고, `답장 필요` 카운터가 이미 그 수를 보여 줍니다.

## Result

**시드는 한 줄도 바꾸지 않았습니다.**

| 배지 | 이전 | 이후 |
|---|---|---|
| 나트륨 초과 | 8명 | 5명 |
| 당류 초과 | 0명 (신호 없음) | 2명 |
| 이행률 저조 | 1명 (7명이 나트륨에 덮임) | 2명 |

카드에 보이는 다섯 줄:

| | 회원 | 배지 | 초과 폭 |
|---|---|---|---|
| 1 | 류태경 | 당류 초과 | 1.82 |
| 2 | 문가영 | 이행률 저조 | 1.82 |
| 3 | 김민수 | 나트륨 초과 | 1.71 |
| 4 | 배준혁 | 이행률 저조 | 1.67 |
| 5 | 오세라 | 당류 초과 | 1.64 |

배준혁이 이 변경을 잘 보여 줍니다 — 이행률 36% 인데 나트륨이 2,280mg 이라 지금까지 `나트륨 초과` 로 보였습니다. 초과 폭으로 재면 이행률(1.67)이 나트륨(1.14)을 앞서, 트레이너가 볼 이유가 실제로 가장 급한 것이 됩니다.

## Notes

**고객 탭 목록에는 배지를 넣지 않았습니다.** 고객 카드는 이미 각 행에 칼로리·나트륨·당류 수치를 보여 주고 목표를 넘긴 것을 빨갛게 칠합니다. 배지를 얹으면 `나트륨 초과` 와 `2,400mg`(빨강)이 한 행에서 같은 말을 두 번 합니다. 그 파일에는 "고객 로스터는 의도적으로 채팅 미리보기나 알림 배지를 노출하지 않는다" 는 설계 의도가 주석으로 남아 있습니다 — 메시지 탭과 역할을 가르려는 결정입니다.

새 신호를 추가하자 컴파일러가 처리해야 할 자리 다섯을 전부 잡아 줬습니다(배지 색, 대시보드 할 일 색·문구, 고객 상세 이동 경로, AI 코칭 신호 갈래). 당류는 식단 신호라 나트륨과 같은 갈래를 탑니다.

시드 수치 자체의 정리는 #768 에서 다룹니다 — #757(공유 픽스처)과 같은 파일이라 그쪽 다음입니다.

## Tests

- 배지가 그 회원에게 가장 나쁜 신호인지 / 당류만 넘겨도 목록에 오르는지 / 식단 신호 둘 중 더 많이 넘긴 쪽이 배지인지
- 정렬 계약을 "초과 폭 순, 동점이면 로스터 순서" 로 옮기고, 동점 안정성은 따로 남겼습니다 — `List.sort` 가 안정 정렬이 아니라 대시보드가 새로고침마다 달라질 수 있습니다.
- AI 요약 머리말이 부르는 이름을 박아 두고 있었습니다. 그 자리는 그날 수치가 정하므로 "이름을 부른다" 만 검증합니다.

로컬: `flutter analyze` 무경고, 트레이너 639 테스트 통과.
