### PR TITLE
fix(exercise): 사용자앱 운동 주간 기록의 공유 픽스처 연결

### DIFF
--- a/frontend/flutter/lib/features/exercise/data/repositories/mock_exercise_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/mock_exercise_repository.dart
@@ -1,24 +1,30 @@
+import 'package:demo_fixture/demo_fixture.dart';
+
 import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
 import 'package:oncare/features/exercise/domain/repositories/exercise_repository.dart';
 
-/// In-memory stateful mock for demo mode (`useMockApi`). Seeds the
-/// "상황 1: 오늘 PT 받은 날" scenario as a **4-day streak ending today**, then
-/// keeps add/update/delete in memory for the app session so the weekly
-/// summary·chart·count reflect edits made through the app (issue #294).
+/// In-memory stateful mock for demo mode (`useMockApi`). The week it starts
+/// from is **김민수의 공유 픽스처**(`shared/demo_fixture`)이고, 그 위에서
+/// add/update/delete 를 앱 세션 동안 메모리로 이어받아 주간 요약·차트·횟수가
+/// 앱에서 한 편집을 그대로 따라간다(#294).
 ///
-/// The seed is anchored to the real weekday (via [_todayIdx]) so the home
-/// 운동 카드와 운동 탭이 같은 '오늘'을 가리킨다. [_sessions] is the single
-/// source of truth: per-day minutes, the stacked-chart series
-/// (유산소/근력/스트레칭), per-day calories, and the weekly totals are all
-/// derived from it in [_buildWeek], keeping the invariant
-/// `daily == cardio + strength + stretching` for every day.
+/// 픽스처를 읽는 이유: 예전에는 이 목업이 "오늘 + 직전 3일" 을 스스로 박아
+/// 넣어서, 같은 사람인데 트레이너웹은 6회·사용자앱은 4회로 갈렸다(#771).
+/// 식단·홈 요약은 이미 픽스처 하나를 보고 있었고 운동만 빠져 있었다(#757).
+///
+/// [_sessions] is the single source of truth for the live week: per-day
+/// minutes, the stacked-chart series (유산소/근력/스트레칭), per-day calories,
+/// and the weekly totals are all derived from it in [_buildWeek], keeping the
+/// invariant `daily == cardio + strength + stretching` for every day.
 class MockExerciseRepository implements ExerciseRepository {
   /// [today] defaults to the real date; tests inject a fixed date so the
-  /// date-relative seed stays deterministic.
-  MockExerciseRepository({DateTime? today})
+  /// date-relative fixture stays deterministic. [fixture] defaults to the
+  /// bundled 김민수 픽스처.
+  MockExerciseRepository({DateTime? today, DemoFixture? fixture})
     : _today = _dateOnly(today ?? DateTime.now()),
-      _todayIdx = (today ?? DateTime.now()).weekday - 1 {
-    _sessions.addAll(_seed(_todayIdx));
+      _todayIdx = (today ?? DateTime.now()).weekday - 1,
+      _fixture = fixture ?? DemoFixture.load() {
+    _sessions.addAll(_sessionsForWeek(0));
     _totalCalories = _sessions.fold<int>(
       0,
       (int acc, ExerciseSession s) => acc + s.calories,
@@ -28,8 +34,10 @@ class MockExerciseRepository implements ExerciseRepository {
   /// Today's weekday index (0 = Mon … 6 = Sun).
   final int _todayIdx;
 
-  /// 자정으로 자른 오늘. 지난 주 조회가 몇 주 전인지 세는 기준이다.
+  /// 자정으로 자른 오늘. 픽스처의 상대 날짜를 실제 날짜로 붙이는 기준이다.
   final DateTime _today;
+
+  final DemoFixture _fixture;
 
   static DateTime _dateOnly(DateTime d) => DateTime(d.year, d.month, d.day);
 
@@ -45,55 +53,68 @@ class MockExerciseRepository implements ExerciseRepository {
   static const String _aiCoachMessage =
       '12회차 PT 완료! 코치님이 강조하신 어깨 회전근개 스트레칭과 마무리 유산소로 완벽히 정리해보세요.';
 
-  /// Seeds 오늘 + 직전 3일(4일 연속)을 실제 요일에 맞춰 채운다. offset 0 = 오늘
-  /// (12회차 PT·근력 중심), 1..3 = 직전 날(유산소/근력/스트레칭 혼합). 주 시작
-  /// (월) 이전으로 넘어가는 offset 은 이번 주 뷰 밖이라 생략한다.
-  static List<ExerciseSession> _seed(int todayIdx) {
-    const Map<int, List<(ExerciseType, int, int)>> plans =
-        <int, List<(ExerciseType, int, int)>>{
-          0: <(ExerciseType, int, int)>[(ExerciseType.strength, 50, 520)],
-          1: <(ExerciseType, int, int)>[
-            (ExerciseType.cardio, 45, 328),
-            (ExerciseType.strength, 10, 73),
-            (ExerciseType.stretching, 5, 37),
-          ],
-          2: <(ExerciseType, int, int)>[
-            (ExerciseType.cardio, 45, 315),
-            (ExerciseType.strength, 5, 36),
-            (ExerciseType.stretching, 5, 36),
-          ],
-          3: <(ExerciseType, int, int)>[
-            (ExerciseType.cardio, 30, 225),
-            (ExerciseType.strength, 10, 70),
-            (ExerciseType.stretching, 5, 35),
-          ],
-        };
+  /// [weeksAgo] 주 전의 세션. 픽스처가 **실제로 한** 운동만 갖고 있으므로 못 한
+  /// 항목은 여기에 없다 — 이행률 67% 인 날의 주간 시간이 100% 로 잡히지 않는다.
+  ///
+  /// 하루에 같은 종류가 둘일 수 있어(PT 날의 레그프레스·레그컬은 둘 다 근력)
+  /// 종류로 합친다. 주간 활동 그래프가 하루·종류당 한 칸을 그리는 규칙이고,
+  /// 사용자앱의 drift 시드(`seed_data.dart`)도 같은 규칙으로 쌓는다.
+  List<ExerciseSession> _sessionsForWeek(int weeksAgo) {
+    final String weekStart = _ymd(
+      _addDays(_today, -(_todayIdx + 7 * weeksAgo)),
+    );
     final List<ExerciseSession> out = <ExerciseSession>[];
-    for (final int offset in <int>[3, 2, 1, 0]) {
-      final int wi = todayIdx - offset;
-      if (wi < 0) continue; // 주 시작(월) 이전은 이번 주 뷰 밖.
-      final String label = _dayLabels[wi];
-      final bool isToday = offset == 0;
-      int k = 0;
-      for (final (ExerciseType type, int min, int kcal) in plans[offset]!) {
+    for (final FixtureDay day in _fixture.daysFor(_today).where(
+      (FixtureDay d) => d.weekStart == weekStart,
+    )) {
+      final Map<ExerciseType, List<FixtureExercise>> byType =
+          <ExerciseType, List<FixtureExercise>>{};
+      for (final FixtureExercise e in day.doneExercises) {
+        byType.putIfAbsent(_typeOf(e), () => <FixtureExercise>[]).add(e);
+      }
+      for (final MapEntry<ExerciseType, List<FixtureExercise>> entry
+          in byType.entries) {
         out.add(
           ExerciseSession(
-            id: isToday ? 's-today' : 's-d$offset-${k++}',
-            dayLabel: label,
-            dateLabel: isToday ? '오늘' : '$label요일',
-            timeLabel: isToday ? '18:00' : null,
-            type: type,
-            minutes: min,
-            calories: kcal,
-            items: isToday
-                ? const <String>['벤치프레스 40kg 4세트', '덤벨 숄더프레스 10kg 4세트']
-                : const <String>[],
+            id: 'seed-ex-${day.date}-${entry.key.name}',
+            dayLabel: day.dayLabel,
+            dateLabel: _dateLabel(day.date),
+            // PT 날만 시각이 있다. 자율 운동은 픽스처가 시각을 갖지 않는다.
+            timeLabel: day.isPt ? '18:00' : null,
+            type: entry.key,
+            minutes: entry.value.fold<int>(
+              0,
+              (int sum, FixtureExercise e) => sum + e.minutes,
+            ),
+            calories: entry.value.fold<int>(
+              0,
+              (int sum, FixtureExercise e) => sum + e.calories,
+            ),
+            items: <String>[
+              for (final FixtureExercise e in entry.value) e.name,
+            ],
           ),
         );
       }
     }
+    // 최근 요일이 위로 — 프로토타입의 오늘 / 어제 / 그 이전 묶음이 위에서
+    // 아래로 읽힌다.
+    out.sort(
+      (ExerciseSession a, ExerciseSession b) =>
+          _dayLabels.indexOf(b.dayLabel) - _dayLabels.indexOf(a.dayLabel),
+    );
     return out;
   }
+
+  /// 픽스처의 종류 문자열(`cardio`|`strength`|`stretching`) → [ExerciseType].
+  ExerciseType _typeOf(FixtureExercise e) => switch (e.type) {
+    'cardio' => ExerciseType.cardio,
+    'walking' => ExerciseType.walking,
+    'strength' => ExerciseType.strength,
+    'stretching' => ExerciseType.stretching,
+    'yoga' => ExerciseType.yoga,
+    _ => ExerciseType.other,
+  };
 
   final List<ExerciseSession> _sessions = <ExerciseSession>[];
 
@@ -119,68 +140,38 @@ class MockExerciseRepository implements ExerciseRepository {
 
   /// [weekStart] 가 이번 주에서 몇 주 전인지. 이번 주면 0.
   int _weeksAgo(DateTime weekStart) {
-    final DateTime thisMonday = _today.subtract(Duration(days: _todayIdx));
+    final DateTime thisMonday = _addDays(_today, -_todayIdx);
     final int days = thisMonday.difference(_dateOnly(weekStart)).inDays;
     return days <= 0 ? 0 : (days / 7).round();
   }
 
-  /// 지난 주의 기록. 주마다 조금씩 다른 값이라야 주간 비교가 뜻을 갖는다 —
-  /// 오래된 주일수록 조금 적게(요즘 늘고 있다), 그리고 주마다 쉬는 날이 하루씩
-  /// 밀린다. 인메모리 CRUD 는 이번 주에만 적용되므로 여기서는 파생값만 만든다.
-  ExerciseWeek _pastWeek(int weeksAgo) {
-    const List<(ExerciseType, int, int)> dayPlan = <(ExerciseType, int, int)>[
-      (ExerciseType.cardio, 35, 260),
-      (ExerciseType.strength, 15, 105),
-      (ExerciseType.stretching, 10, 40),
-    ];
-    final double scale = (1 - weeksAgo * 0.1).clamp(0.4, 1.0);
-    final int restDay = weeksAgo % 7; // 주마다 쉬는 요일이 하나씩 밀린다.
-    final List<ExerciseSession> sessions = <ExerciseSession>[];
-    for (int i = 0; i < _dayLabels.length; i++) {
-      if (i == restDay) continue;
-      int k = 0;
-      for (final (ExerciseType type, int min, int kcal) in dayPlan) {
-        // 요일마다 종목 구성이 조금씩 달라지도록 한 종목씩 건너뛴다.
-        if ((i + k) % 3 == 2) {
-          k++;
-          continue;
-        }
-        final int minutes = (min * scale).round();
-        if (minutes <= 0) {
-          k++;
-          continue;
-        }
-        sessions.add(
-          ExerciseSession(
-            id: 'past-$weeksAgo-$i-${k++}',
-            dayLabel: _dayLabels[i],
-            dateLabel: _dateLabel(weeksAgo, i),
-            type: type,
-            minutes: minutes,
-            calories: (kcal * scale).round(),
-          ),
-        );
-      }
-    }
-    return _weekFrom(
-      sessions,
-      aiCoachMessage: '지난 기록이에요. 이번 주와 견줘 보면 흐름이 보여요.',
-    );
+  /// 지난 주의 기록. 이번 주와 같은 픽스처에서 오므로 주간 비교가 실제 기록
+  /// 끼리의 비교다. 픽스처가 덮는 주(`historyWeeks`)를 넘어가면 빈 주다 —
+  /// 없는 기록을 지어내면 트레이너웹과 다시 갈린다.
+  ///
+  /// 인메모리 CRUD 는 이번 주에만 적용된다.
+  ExerciseWeek _pastWeek(int weeksAgo) => _weekFrom(
+    _sessionsForWeek(weeksAgo),
+    aiCoachMessage: '지난 기록이에요. 이번 주와 견줘 보면 흐름이 보여요.',
+  );
+
+  /// 세션 카드 위의 날짜 라벨. LocalApiInterceptor·FastAPI 와 같은 규칙이라
+  /// 목업으로 보던 화면과 실 경로로 보는 화면의 문구가 같다.
+  String _dateLabel(String date) {
+    final DateTime parsed = DateTime.parse(date);
+    final int diff = _today.difference(_dateOnly(parsed)).inDays;
+    if (diff == 0) return '오늘';
+    if (diff == 1) return '어제';
+    return '${parsed.month}월 ${parsed.day}일';
   }
 
-  /// 지난 주 어느 요일의 "M월 D일" 라벨.
-  String _dateLabel(int weeksAgo, int dayIdx) {
-    final DateTime monday = _today.subtract(
-      Duration(days: _todayIdx + 7 * weeksAgo),
-    );
-    // Duration 이 아니라 날짜 성분으로 더한다(서머타임 안전).
-    final DateTime date = DateTime(
-      monday.year,
-      monday.month,
-      monday.day + dayIdx,
-    );
-    return '${date.month}월 ${date.day}일';
-  }
+  static DateTime _addDays(DateTime d, int days) =>
+      DateTime(d.year, d.month, d.day + days);
+
+  static String _ymd(DateTime d) =>
+      '${d.year.toString().padLeft(4, '0')}-'
+      '${d.month.toString().padLeft(2, '0')}-'
+      '${d.day.toString().padLeft(2, '0')}';
 
   @override
   Future<ExerciseSession> addSession({

--- a/frontend/flutter/test/features/exercise/exercise_controller_test.dart
+++ b/frontend/flutter/test/features/exercise/exercise_controller_test.dart
@@ -11,8 +11,9 @@ void main() {
       overrides: <Override>[
         // Production repo is DioExerciseRepository (needs dio + db);
         // unit test only needs the React-shaped in-memory mock.
-        // Inject a fixed Friday so the date-relative seed (오늘 + 직전 3일)
-        // is deterministic: 활성일 화·수·목·금 → 210분 / 1,675kcal / 연속 4일.
+        // 고정 금요일을 주입해 날짜에 상대적인 시드를 결정적으로 만든다.
+        // 값이 픽스처와 맞는지는 mock_exercise_repository_test 가 본다 —
+        // 여기에 숫자를 또 적으면 픽스처와 세 벌이 된다.
         exerciseRepositoryProvider.overrideWithValue(
           MockExerciseRepository(today: DateTime(2024, 1, 5)),
         ),
@@ -22,9 +23,9 @@ void main() {
     final week = await container.read(exerciseWeekProvider.future);
     expect(week.dailyMinutes.length, 7);
     expect(week.dayLabels.length, 7);
-    expect(week.totalMinutes, 210);
-    expect(week.totalCalories, 1675);
-    expect(week.streakDays, 4);
+    expect(week.totalMinutes, greaterThan(0));
+    expect(week.totalCalories, greaterThan(0));
+    expect(week.streakDays, greaterThan(0));
     expect(week.aiCoachMessage, isNotEmpty);
     expect(week.sessions, isNotEmpty);
     // Stacked-chart series should line up with the bar chart x-axis.

--- a/frontend/flutter/test/features/exercise/mock_exercise_repository_test.dart
+++ b/frontend/flutter/test/features/exercise/mock_exercise_repository_test.dart
@@ -1,44 +1,123 @@
+import 'dart:io';
+
+import 'package:demo_fixture/demo_fixture.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:oncare/features/exercise/data/repositories/mock_exercise_repository.dart';
 import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
 
-void main() {
-  // 시드는 '오늘 + 직전 3일(4일 연속)'을 실제 요일에 맞춰 채운다. 결정적 검증을
-  // 위해 고정 금요일(2024-01-05, weekday=금 → index 4)을 주입한다.
-  // 활성일: 화(index1)·수(2)·목(3)·금/오늘(4).
-  final DateTime friday = DateTime(2024, 1, 5);
-  MockExerciseRepository repo() => MockExerciseRepository(today: friday);
+/// 기대값은 여기에 적지 않고 **원본 픽스처 파일**에서 뽑는다. 숫자를 적어 두면
+/// 픽스처와 두 벌이 되어, 한쪽만 고쳤을 때 조용히 갈린다(#757).
+///
+/// 앱에 심긴 상수(`kimMinsuFixtureJson`)가 아니라 원본 파일을 읽는 이유: 목업은
+/// 심긴 상수를 쓰므로, 둘이 어긋나면 이 테스트가 그것까지 잡는다.
+final DemoFixture _fixture = DemoFixture.parse(
+  File('../../shared/demo_fixture/assets/kim_minsu.json').readAsStringSync(),
+);
 
-  group('MockExerciseRepository seeds a real-date 4-day streak (#294)', () {
-    test('seed totals reflect 오늘 + 직전 3일', () async {
-      final ExerciseWeek w = await repo().fetchThisWeek();
-      // 화3 + 수3 + 목3 + 금1(오늘 PT) = 10 세션.
-      expect(w.sessions.length, 10);
-      expect(w.workoutCount, 4); // 활성 일수 화·수·목·금
-      expect(w.streakDays, 4);
-      expect(w.totalMinutes, 210); // 45 + 55 + 60 + 50
-      expect(w.totalCalories, 1675); // 330 + 387 + 438 + 520
-      // 요일별(월..일) 분: 월0 화45 수55 목60 금50 토0 일0.
-      expect(w.dailyMinutes, <double>[0, 45, 55, 60, 50, 0, 0]);
-      // 요일별 칼로리.
-      expect(w.dailyCalories, <double>[0, 330, 387, 438, 520, 0, 0]);
+/// 시드는 날짜에 상대적이라 오늘이 언제냐에 따라 값이 달라진다. 결정적 검증을
+/// 위해 고정 금요일(2024-01-05, weekday=금 → index 4)을 주입한다.
+final DateTime _friday = DateTime(2024, 1, 5);
+
+MockExerciseRepository _repo({DateTime? today}) =>
+    MockExerciseRepository(today: today ?? _friday);
+
+String _ymd(DateTime d) =>
+    '${d.year.toString().padLeft(4, '0')}-'
+    '${d.month.toString().padLeft(2, '0')}-'
+    '${d.day.toString().padLeft(2, '0')}';
+
+/// [today] 기준 [weeksAgo] 주 전의 픽스처 하루들.
+List<FixtureDay> _weekDays(DateTime today, {int weeksAgo = 0}) {
+  final DateTime monday = DateTime(
+    today.year,
+    today.month,
+    today.day - (today.weekday - 1) - 7 * weeksAgo,
+  );
+  return _fixture
+      .daysFor(today)
+      .where((FixtureDay d) => d.weekStart == _ymd(monday))
+      .toList();
+}
+
+/// 그 주의 요일별(월→일) **한** 운동 분.
+List<double> _minutesByWeekday(DateTime today, {int weeksAgo = 0}) {
+  final List<double> out = List<double>.filled(7, 0);
+  for (final FixtureDay day in _weekDays(today, weeksAgo: weeksAgo)) {
+    out[DateTime.parse(day.date).weekday - 1] = day.doneExercises
+        .fold<int>(0, (int sum, FixtureExercise e) => sum + e.minutes)
+        .toDouble();
+  }
+  return out;
+}
+
+void main() {
+  group('이번 주는 공유 픽스처에서 온다 (#771)', () {
+    test('세션·시간·칼로리가 픽스처의 한 운동과 같다', () async {
+      final ExerciseWeek w = await _repo().fetchThisWeek();
+      final List<FixtureDay> days = _weekDays(_friday);
+
+      // 세션은 하루·종류당 하나로 합쳐진다(PT 날의 레그프레스·레그컬은 둘 다
+      // 근력이라 한 줄). 주간 활동 그래프가 그 규칙으로 칸을 그린다.
+      final int expectedSessions = days.fold<int>(
+        0,
+        (int sum, FixtureDay d) =>
+            sum + d.doneExercises.map((FixtureExercise e) => e.type).toSet().length,
+      );
+      expect(w.sessions.length, expectedSessions);
+      expect(w.dailyMinutes, _minutesByWeekday(_friday));
+      expect(
+        w.totalMinutes,
+        days.fold<int>(
+          0,
+          (int sum, FixtureDay d) =>
+              sum +
+              d.doneExercises.fold<int>(
+                0,
+                (int s, FixtureExercise e) => s + e.minutes,
+              ),
+        ),
+      );
+      expect(
+        w.totalCalories,
+        days.fold<int>(
+          0,
+          (int sum, FixtureDay d) =>
+              sum +
+              d.doneExercises.fold<int>(
+                0,
+                (int s, FixtureExercise e) => s + e.calories,
+              ),
+        ),
+      );
+      expect(w.streakDays, longestActiveStreak(w.dailyMinutes));
     });
 
-    test('월요일이면 직전 3일이 이전 주로 빠져 오늘 1건만 남는다', () async {
-      // 월요일(2024-01-01, weekday=월 → index 0)을 주입하면 offset 1..3의
-      // wi(= -1..-3)가 모두 음수라 _seed 가 건너뛰고, 오늘 PT 1건만 시드된다.
-      final ExerciseWeek w =
-          await MockExerciseRepository(today: DateTime(2024)) // 2024-01-01(월)
-              .fetchThisWeek();
-      expect(w.sessions.length, 1);
+    test('운동 일수는 트레이너웹의 이행률 기록일과 같은 날을 센다', () async {
+      // 트레이너웹은 같은 픽스처에서 나온 일별 이행률이 0 보다 큰 날을 센다.
+      // 두 앱이 같은 사람을 다른 횟수로 말하지 않으려면 이 둘이 같아야 한다 —
+      // 예전에는 목업이 '오늘 + 직전 3일'을 스스로 박아 6회 vs 4회로 갈렸다.
+      final ExerciseWeek w = await _repo().fetchThisWeek();
+      final int loggedDays = _weekDays(
+        _friday,
+      ).where((FixtureDay d) => d.completion > 0).length;
+
+      expect(loggedDays, greaterThan(0), reason: '픽스처에 이번 주 기록이 없다');
+      expect(w.workoutCount, loggedDays);
+    });
+
+    test('주 시작 전으로 넘어가는 날은 이번 주 뷰에 들어오지 않는다', () async {
+      // 월요일(2024-01-01)이면 이번 주에 남는 날은 오늘 하루뿐이다.
+      final DateTime monday = DateTime(2024);
+      final ExerciseWeek w = await _repo(today: monday).fetchThisWeek();
+
+      expect(w.dailyMinutes, _minutesByWeekday(monday));
+      expect(w.dailyMinutes.skip(1), everyElement(0.0));
       expect(w.workoutCount, 1);
-      expect(w.streakDays, 1);
-      expect(w.dailyMinutes, <double>[50, 0, 0, 0, 0, 0, 0]);
     });
 
     test('daily == cardio + strength + stretching for every day', () async {
-      final ExerciseWeek w = await repo().fetchThisWeek();
+      final ExerciseWeek w = await _repo().fetchThisWeek();
       for (int i = 0; i < w.dailyMinutes.length; i++) {
         expect(
           w.cardioMinutes[i] + w.strengthMinutes[i] + w.stretchingMinutes[i],
@@ -47,82 +126,119 @@ void main() {
         );
       }
     });
+
+    test('오늘 기록에는 오늘 라벨과 픽스처의 종목 이름이 붙는다', () async {
+      final ExerciseWeek w = await _repo().fetchThisWeek();
+      final FixtureDay today = _weekDays(_friday).last;
+      final Iterable<ExerciseSession> todaySessions = w.sessions.where(
+        (ExerciseSession s) => s.dateLabel == '오늘',
+      );
+
+      expect(todaySessions, isNotEmpty);
+      expect(
+        todaySessions.expand((ExerciseSession s) => s.items).toSet(),
+        today.doneExercises.map((FixtureExercise e) => e.name).toSet(),
+      );
+    });
   });
 
   group('CRUD keeps derived totals/chart in memory (#294)', () {
     test('addSession persists and updates totals/chart/count', () async {
-      final MockExerciseRepository r = repo();
-      expect((await r.fetchThisWeek()).sessions.length, 10);
+      final MockExerciseRepository r = _repo();
+      final ExerciseWeek before = await r.fetchThisWeek();
+      // 아직 기록이 없는 요일을 골라 새 활성일이 하나 느는 것을 본다.
+      final int restDay = before.dailyMinutes.indexOf(0);
+      expect(restDay, greaterThanOrEqualTo(0), reason: '이번 주가 이미 꽉 찼다');
 
       final ExerciseSession added = await r.addSession(
         type: ExerciseType.cardio,
         minutes: 30,
         calories: 200,
-        dayLabel: '월', // 휴식일 → 새 활성일
+        dayLabel: before.dayLabels[restDay],
       );
 
       final ExerciseWeek after = await r.fetchThisWeek();
-      expect(after.sessions.length, 11);
+      expect(after.sessions.length, before.sessions.length + 1);
       expect(
         after.sessions.map((ExerciseSession s) => s.id),
         contains(added.id),
       );
-      expect(after.totalMinutes, 240);
-      expect(after.totalCalories, 1875);
-      expect(after.dailyMinutes[0], 30);
-      expect(after.dailyCalories[0], 200);
-      expect(after.cardioMinutes[0], 30);
-      expect(after.workoutCount, 5);
+      expect(after.totalMinutes, before.totalMinutes + 30);
+      expect(after.totalCalories, before.totalCalories + 200);
+      expect(after.dailyMinutes[restDay], 30);
+      expect(after.dailyCalories[restDay], 200);
+      expect(after.cardioMinutes[restDay], 30);
+      expect(after.workoutCount, before.workoutCount + 1);
     });
 
     test('deleteSession removes it and restores the totals', () async {
-      final MockExerciseRepository r = repo();
-      // s-d1-0 = 목요일 유산소 45분/328kcal.
-      await r.deleteSession('s-d1-0');
+      final MockExerciseRepository r = _repo();
+      final ExerciseWeek before = await r.fetchThisWeek();
+      final ExerciseSession target = before.sessions.firstWhere(
+        (ExerciseSession s) => s.type == ExerciseType.cardio,
+      );
+      final int day = before.dayLabels.indexOf(target.dayLabel);
+
+      await r.deleteSession(target.id!);
 
       final ExerciseWeek after = await r.fetchThisWeek();
-      expect(after.sessions.length, 9);
+      expect(after.sessions.length, before.sessions.length - 1);
       expect(
         after.sessions.map((ExerciseSession s) => s.id),
-        isNot(contains('s-d1-0')),
+        isNot(contains(target.id)),
       );
-      expect(after.totalMinutes, 210 - 45);
-      expect(after.totalCalories, 1675 - 328);
-      expect(after.dailyMinutes[3], 15); // 목: 근력10 + 스트레칭5
-      expect(after.cardioMinutes[3], 0);
+      expect(after.totalMinutes, before.totalMinutes - target.minutes);
+      expect(after.totalCalories, before.totalCalories - target.calories);
+      expect(
+        after.dailyMinutes[day],
+        before.dailyMinutes[day] - target.minutes,
+      );
+      expect(
+        after.cardioMinutes[day],
+        before.cardioMinutes[day] - target.minutes,
+      );
     });
 
     test('deleting an unknown id is a no-op', () async {
-      final MockExerciseRepository r = repo();
+      final MockExerciseRepository r = _repo();
+      final ExerciseWeek before = await r.fetchThisWeek();
       await r.deleteSession('does-not-exist');
       final ExerciseWeek after = await r.fetchThisWeek();
-      expect(after.sessions.length, 10);
-      expect(after.totalMinutes, 210);
+      expect(after.sessions.length, before.sessions.length);
+      expect(after.totalMinutes, before.totalMinutes);
     });
 
     test('updateSession edits a session and re-derives totals', () async {
-      final MockExerciseRepository r = repo();
-      // 오늘 PT(s-today) 근력 50분/520kcal → 80분/700kcal.
+      final MockExerciseRepository r = _repo();
+      final ExerciseWeek before = await r.fetchThisWeek();
+      final ExerciseSession target = before.sessions.firstWhere(
+        (ExerciseSession s) => s.type == ExerciseType.strength,
+      );
+      final int day = before.dayLabels.indexOf(target.dayLabel);
+
       await r.updateSession(
-        id: 's-today',
+        id: target.id!,
         type: ExerciseType.strength,
-        minutes: 80,
-        calories: 700,
-        dayLabel: '금',
+        minutes: target.minutes + 30,
+        calories: target.calories + 180,
+        dayLabel: target.dayLabel,
       );
 
       final ExerciseWeek after = await r.fetchThisWeek();
-      expect(after.sessions.length, 10); // 개수 불변
-      expect(after.totalMinutes, 210 - 50 + 80);
-      expect(after.totalCalories, 1675 - 520 + 700);
-      expect(after.strengthMinutes[4], 80);
-      expect(after.dailyMinutes[4], 80);
+      expect(after.sessions.length, before.sessions.length); // 개수 불변
+      expect(after.totalMinutes, before.totalMinutes + 30);
+      expect(after.totalCalories, before.totalCalories + 180);
+      expect(
+        after.strengthMinutes[day],
+        before.strengthMinutes[day] + 30,
+      );
+      expect(after.dailyMinutes[day], before.dailyMinutes[day] + 30);
     });
   });
 
   group('fetchWeek 로 지난 주를 조회한다 (#671)', () {
     test('이번 주 월요일을 주면 fetchThisWeek 과 같다', () async {
-      final MockExerciseRepository r = repo();
+      final MockExerciseRepository r = _repo();
       // 2024-01-05 는 금요일 → 그 주 월요일은 2024-01-01.
       final ExerciseWeek week = await r.fetchWeek(DateTime(2024));
       final ExerciseWeek current = await r.fetchThisWeek();
@@ -130,11 +246,12 @@ void main() {
       expect(week.totalMinutes, current.totalMinutes);
     });
 
-    test('지난 주는 값이 있고, 이번 주와 다르다', () async {
-      final MockExerciseRepository r = repo();
+    test('지난 주도 같은 픽스처에서 오고, 이번 주와 다르다', () async {
+      final MockExerciseRepository r = _repo();
       final ExerciseWeek last = await r.fetchWeek(DateTime(2023, 12, 25));
       final ExerciseWeek current = await r.fetchThisWeek();
 
+      expect(last.dailyMinutes, _minutesByWeekday(_friday, weeksAgo: 1));
       expect(last.totalMinutes, greaterThan(0));
       expect(last.sessions, isNotEmpty);
       expect(
@@ -161,11 +278,20 @@ void main() {
       );
     });
 
-    test('오래된 주일수록 운동량이 줄어든다', () async {
-      final MockExerciseRepository r = repo();
-      final ExerciseWeek oneWeekAgo = await r.fetchWeek(DateTime(2023, 12, 25));
-      final ExerciseWeek fourWeeksAgo = await r.fetchWeek(DateTime(2023, 12, 4));
-      expect(fourWeeksAgo.totalMinutes, lessThan(oneWeekAgo.totalMinutes));
+    test('픽스처가 덮지 않는 옛 주는 빈 주다', () async {
+      // 없는 기록을 지어내면 트레이너웹과 다시 갈린다. 화면은 빈 주를
+      // "기록이 없어요" 로 그린다.
+      final MockExerciseRepository r = _repo();
+      final DateTime tooOld = DateTime(
+        2024,
+        1,
+        1 - 7 * (_fixture.historyWeeks + 1),
+      );
+      final ExerciseWeek week = await r.fetchWeek(tooOld);
+
+      expect(week.sessions, isEmpty);
+      expect(week.totalMinutes, 0);
+      expect(week.dailyMinutes, everyElement(0.0));
     });
   });
 }


### PR DESCRIPTION
Closes #771

## Summary

데모 모드에서 사용자앱의 운동 주간 기록을 김민수 공유 픽스처에 연결합니다. 같은 사람의 이번 주 운동 일수가 트레이너웹은 6회, 사용자앱은 4회로 갈리던 원인이었습니다.

원인은 계산 규칙이 아니라 원본이었습니다. `MockExerciseRepository` 가 "오늘 + 직전 3일" 을 스스로 박아 넣고 있었고, 데모 모드에서는 `exerciseRepositoryProvider` 가 Dio 를 타지 않아 픽스처로 시드된 로컬 API 경로에 닿지 않았습니다. 식단·홈 요약은 #757 에서 픽스처로 옮겼고 운동만 그 이관에서 빠져 있었습니다.

## Changes

- 이번 주·지난 주 세션을 `DemoFixture` 에서 만듭니다. 하루·종류당 한 세션으로 합치고(PT 날의 레그프레스·레그컬은 둘 다 근력) **실제로 한** 운동만 쌓아, 사용자앱 drift 시드가 쓰는 규칙과 같은 값이 나옵니다
- 픽스처의 종목 이름이 세션 항목으로 들어가고, 날짜 라벨은 `LocalApiInterceptor`·FastAPI 와 같은 오늘/어제/`M월 D일` 규칙을 씁니다
- 픽스처가 덮지 않는 옛 주는 빈 주입니다. 없는 기록을 지어내면 트레이너웹과 다시 갈립니다
- 테스트 기대값을 원본 픽스처 파일(`shared/demo_fixture/assets/kim_minsu.json`)에서 뽑도록 바꾸고, **운동 일수가 트레이너웹이 세는 날(이행률 > 0 인 날)과 같은지** 보는 회귀 테스트를 추가했습니다

## Notes

- 인메모리 CRUD(#294)는 그대로입니다. 시연 중 앱에서 추가·수정·삭제한 값이 주간 요약·차트·횟수에 계속 반영됩니다
- 실 백엔드 연동 경로(`DioExerciseRepository`)는 건드리지 않았습니다. 데모 모드 한정 변경입니다
- `flutter analyze` 무이슈, 사용자앱 테스트 657건 통과
- 웹 데모로 확인: 홈 주간 운동 카드가 `운동 일수 6 /3일`, 운동 추이 막대의 수요일이 휴식으로 비어 픽스처와 일치합니다
