### PR TITLE
fix(e2e): assert the new slot after reopening the sheet

### DIFF
--- a/frontend/flutter_trainer/test_e2e/reservation_trainer_test.dart
+++ b/frontend/flutter_trainer/test_e2e/reservation_trainer_test.dart
@@ -96,7 +96,14 @@ void main() {
         // 재빌드될 때 스크롤 위치가 초기화되어 바닥에 닿기 전에 훑기가 끝난다.
         // 다시 열면 목록을 새로 받아오므로, 확인하려는 계약("연 자리가 슬롯 목록에
         // 보인다")은 그대로 두고 타이밍 의존만 걷어낼 수 있다.
-        await tester.tap(find.byIcon(Icons.close));
+        // 닫기 아이콘은 시트 안에서만 찾는다. 트리 전체를 뒤지면 같은 화면에 다른
+        // 닫기 컨트롤이 붙는 순간 여러 개가 잡혀 깨진다.
+        await tester.tap(
+          find.descendant(
+            of: find.byType(ReservationSlotsSheet),
+            matching: find.byIcon(Icons.close),
+          ),
+        );
         await pumpUntilAbsent(
           tester,
           find.byType(ReservationSlotsSheet),

--- a/frontend/flutter_trainer/test_e2e/reservation_trainer_test.dart
+++ b/frontend/flutter_trainer/test_e2e/reservation_trainer_test.dart
@@ -91,6 +91,24 @@ void main() {
         );
         expect(created['is_closed'], isFalse);
 
+        // 시트를 닫았다 다시 연다. 생성 직후의 목록을 그대로 훑으면 결과가 흔들린다 —
+        // 자리가 쌓여 목록이 길어지면 새 자리는 맨 아래에 붙는데, 갱신으로 리스트가
+        // 재빌드될 때 스크롤 위치가 초기화되어 바닥에 닿기 전에 훑기가 끝난다.
+        // 다시 열면 목록을 새로 받아오므로, 확인하려는 계약("연 자리가 슬롯 목록에
+        // 보인다")은 그대로 두고 타이밍 의존만 걷어낼 수 있다.
+        await tester.tap(find.byIcon(Icons.close));
+        await pumpUntilAbsent(
+          tester,
+          find.byType(ReservationSlotsSheet),
+          step: '슬롯 시트 닫힘',
+        );
+        await tester.tap(find.byKey(const ValueKey<String>('schedule-open-slots')));
+        await pumpUntil(
+          tester,
+          find.byKey(const ValueKey<String>('slot-create')),
+          step: '예약 슬롯 시트 재진입',
+        );
+
         await pumpUntilVisibleInList(
           tester,
           find.byKey(ValueKey<String>('slot-row-${created['id']}')),


### PR DESCRIPTION
## Summary

* 예약 E2E 의 `create-slot` 단계가 자리가 쌓이면 실패합니다. 슬롯은 서버에 정상 생성되는데 시트 목록에서 그 행을 찾지 못합니다.
* 생성 직후의 목록을 그대로 훑는 방식이 원인입니다. 시트를 닫았다 다시 열어 새로 받아온 목록에서 확인하도록 고칩니다.
* **이 수정은 원래 #678 에 있었는데 머지 과정에서 누락됐습니다.** 로컬 브랜치를 정리하다 발견해 되살립니다.

---

## Changes

### ✨ Features

* 없음

### 🔧 Improvements

* `create-slot` 단계가 슬롯 목록을 확인하기 전에 시트를 닫았다 다시 엽니다.

### 🎨 UI/UX

* 없음 — 테스트만 바뀝니다.

### 📝 Docs

* 없음

### 🐛 Fixes

* 자리가 누적된 환경에서 `create-slot` 이 실패하던 문제를 고칩니다.

---

## Commits

1. `1ebe9776` fix(e2e): 슬롯 목록 확인을 시트 재진입 뒤로 옮긴다

---

## Notes

* **왜 누락됐는지.** #678 은 리베이스 전 커밋(`ee770f26`)으로 머지됐습니다. 그 뒤 로컬에서 리베이스하고 이 수정을 올렸는데, force-push 가 권한 정책에 막혀 원격에 반영되지 못한 채 PR 이 머지됐습니다. 같은 시점의 다른 두 수정(시드 정오 고정, 헬스체크 `/v1/healthz`)은 들어갔고 이것만 빠졌습니다.
* **무엇이 문제였나.** 자리가 쌓여 목록이 길어지면 새 자리는 맨 아래에 붙습니다. 그런데 갱신으로 리스트가 재빌드될 때 스크롤 위치가 초기화되어, 훑기가 바닥에 닿기 전에 끝납니다. 실제로 **앞선 실행이 만든 자리는 목록에 보이는데 방금 만든 자리만 보이지 않는** 상태가 됐습니다.
* 검증하려는 계약("연 자리가 슬롯 목록에 보인다")은 그대로 두고 타이밍 의존만 걷어냈습니다.

---

## Test Plan

* [x] 기능 정상 동작 확인
* [ ] 예외 케이스 확인
* [ ] UI 확인
* [x] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. `cd backend && docker compose up -d` 로 백엔드를 띄웁니다.
2. `bash tool/run_reservation_e2e.sh` 로 `create-slot` 이 통과하는지 확인합니다.
3. 같은 명령을 여러 번 반복해 자리가 쌓인 뒤에도 통과하는지 확인합니다.

---

## Related Issues

관련: #637, #678

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 슬롯 생성 후 슬롯 목록을 다시 열 때 서버의 최신 목록을 불러오도록 개선했습니다.
  * 새로 생성된 슬롯이 목록에 정상적으로 표시되는 흐름을 유지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->