### PR TITLE
fix(ai-coach): 헤더 더보기·입력창 추가 버튼 무동작 해소

### DIFF
--- a/frontend/flutter/lib/features/ai_coach/presentation/pages/ai_coach_page.dart
+++ b/frontend/flutter/lib/features/ai_coach/presentation/pages/ai_coach_page.dart
@@ -201,7 +201,12 @@ class _AICoachPageState extends ConsumerState<AICoachPage> {
               ],
             ),
           ),
-          _circle(Icons.more_horiz, () {}),
+          // 뒤로 버튼과 같은 폭의 빈 자리. 오른쪽에 놓을 동작이 아직 없어서
+          // 두는 것이지, 누를 것이 있는 자리가 아니다 — 예전에는 여기 '⋯'
+          // 버튼이 있었는데 콜백이 비어 있어 눌러도 아무 일이 없었다(#783).
+          // 대화 초기화 같은 메뉴를 붙이려면 서버에 저장된 대화를 지우는
+          // 경로(`GET /ai-coach/messages` 의 짝)가 먼저 필요하다.
+          const SizedBox(width: 36),
         ],
       ),
     );
@@ -414,24 +419,11 @@ class _AICoachPageState extends ConsumerState<AICoachPage> {
         ),
         child: Row(
           children: <Widget>[
-            Container(
-              width: 32,
-              height: 32,
-              decoration: BoxDecoration(
-                color: Colors.white,
-                shape: BoxShape.circle,
-                border: Border.all(
-                  color: FigmaColors.primaryA(0.25),
-                  width: 1.5,
-                ),
-              ),
-              child: const Icon(
-                Icons.add,
-                size: 16,
-                color: FigmaColors.primary,
-              ),
-            ),
-            const SizedBox(width: 8),
+            // 예전에는 여기 '+' 원형이 있었다. 제스처 위젯이 없는 순수
+            // Container 라서 첨부 버튼처럼 보이기만 하고 눌리지 않았다(#783).
+            // 붙일 동작(사진·기록 첨부)이 생기면 그때 실제 버튼으로 되살린다.
+            // 원형이 빠진 만큼 글자가 테두리에 붙어서, 최소한의 여백만 남긴다.
+            const SizedBox(width: 6),
             Expanded(
               child: TextField(
                 controller: _controller,

--- a/frontend/flutter/test/features/ai_coach/ai_coach_page_test.dart
+++ b/frontend/flutter/test/features/ai_coach/ai_coach_page_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/ai_coach/domain/entities/ai_coach_state.dart';
+import 'package:oncare/features/ai_coach/domain/entities/chat_message.dart';
+import 'package:oncare/features/ai_coach/domain/repositories/ai_coach_repository.dart';
+import 'package:oncare/features/ai_coach/presentation/controllers/ai_coach_controller.dart';
+import 'package:oncare/features/ai_coach/presentation/pages/ai_coach_page.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+/// 화면만 그리면 되므로 대화는 비워 둔다.
+class _QuietRepository implements AiCoachRepository {
+  const _QuietRepository();
+
+  @override
+  Future<AiCoachState> fetchState() async =>
+      const AiCoachState(greeting: '', suggestions: <AiSuggestion>[]);
+
+  @override
+  Future<List<ChatMessage>> fetchHistory() async => const <ChatMessage>[];
+
+  @override
+  Future<ChatMessage> sendMessage({
+    required String message,
+    required List<ChatMessage> history,
+  }) async => const ChatMessage(role: ChatRole.coach, content: '네');
+}
+
+void main() {
+  Future<void> pumpPage(WidgetTester tester) async {
+    await tester.binding.setSurfaceSize(const Size(390, 844));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          aiCoachRepositoryProvider.overrideWithValue(const _QuietRepository()),
+        ],
+        child: const MaterialApp(
+          locale: Locale('ko'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: AICoachPage(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  // 두 아이콘 모두 예전에는 눌리는 것처럼 보이면서 아무 동작이 없었다(#783).
+  // 다시 그려 넣는다면 그때는 실제 동작을 달아야 하므로, 아이콘이 있다는 것
+  // 자체를 실패로 잡는다.
+  testWidgets('헤더에 동작 없는 더보기 버튼을 그리지 않는다', (WidgetTester tester) async {
+    await pumpPage(tester);
+
+    expect(find.byIcon(Icons.more_horiz), findsNothing);
+  });
+
+  testWidgets('입력창에 동작 없는 추가 버튼을 그리지 않는다', (WidgetTester tester) async {
+    await pumpPage(tester);
+
+    // 보내기 버튼을 함께 확인한다 — 입력창이 그려지지도 않았는데 findsNothing
+    // 이라 통과하는 빈 검사가 되지 않도록.
+    expect(find.byIcon(Icons.arrow_upward), findsOneWidget);
+    expect(find.byIcon(Icons.add), findsNothing);
+  });
+
+  testWidgets('살아 있는 버튼은 그대로 남는다', (WidgetTester tester) async {
+    await pumpPage(tester);
+
+    // 죽은 버튼을 지우면서 뒤로 가기까지 함께 지우는 실수를 막는다.
+    expect(find.byIcon(Icons.chevron_left), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #783

## Summary

AI 코치 화면에서 눌러도 아무 일이 없던 버튼 두 개를 없앤다. 붙일 동작이 아직 없으므로 연결이 아니라 제거를 골랐다 — 누를 수 있어 보이는데 반응이 없는 상태가 가장 나쁘다.

## Changes

- 헤더 오른쪽 `⋯` 제거. 콜백이 빈 함수라 `InkWell` 리플만 나오고 아무 일도 없었다. 자리에는 뒤로 버튼과 같은 폭(36)의 빈 공간을 남겨 가운데 제목이 그대로 가운데에 놓이게 했다.
- 입력창 왼쪽 `+` 원형 제거. 제스처 위젯이 전혀 없는 `Container` 라 첨부 버튼처럼 보이기만 했다. 원형이 빠진 만큼 글자가 테두리에 붙어서 최소한의 여백만 남겼다.
- 두 아이콘이 다시 들어오면 실패하는 회귀 테스트 추가.

## Notes

- 대화 초기화 같은 실제 메뉴를 `⋯` 자리에 붙이려면 서버에 저장된 대화를 지우는 경로가 먼저 필요하다. 지금은 `GET /ai-coach/messages` 만 있어 이 PR 범위 밖으로 둔다.
- 회귀 테스트는 사라진 아이콘만 보지 않는다. 뒤로 버튼과 보내기 버튼이 그대로 있는 것도 함께 확인해, 화면이 아예 안 그려져서 통과하는 빈 검사가 되지 않게 했다.
- 검증: `flutter analyze` 무경고, 전체 `flutter test` 660건 통과. 화면은 위젯 테스트로 실제 페이지를 띄워 렌더 결과를 확인했다(제목 가운데 정렬·입력줄 간격 유지).
