### PR TITLE
fix(schedule): 일정 추가 날짜·시간 입력의 형식 검증과 피커 도입

### DIFF
--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -10,6 +10,7 @@ import 'package:oncare/core/demo/demo_ai_advice.dart';
 import 'package:oncare/core/storage/app_database.dart';
 import 'package:oncare/core/storage/seed_data.dart' show kDietDayMessagesKey;
 import 'package:oncare/features/diet/domain/entities/meal_recommendation.dart';
+import 'package:oncare/features/schedule/domain/schedule_format.dart';
 
 /// A drift-backed dummy backend. Intercepts dio requests and serves
 /// them out of the local SQLite database so the app can run as a
@@ -1087,6 +1088,10 @@ class LocalApiInterceptor extends Interceptor {
 
   /// POST /schedule/events — persist a new event to drift so it shows up in
   /// GET /schedule/events and the dashboard's "오늘의 일정" for that date.
+  ///
+  /// 형식 검사는 [isScheduleDate]·[isScheduleTime] 이 맡는다 — FastAPI
+  /// (`app/api/v1/schedule.py`) 와 같은 계약이라 데모와 실서버의 답이 갈리지
+  /// 않는다.
   Future<Response<Object?>> _scheduleCreate(RequestOptions options) async {
     final body = _jsonBody(options);
     final date = (body['date'] as String? ?? '').trim();
@@ -1094,7 +1099,16 @@ class LocalApiInterceptor extends Interceptor {
     if (date.isEmpty || title.isEmpty) {
       return _badRequest(options, 'date and title are required');
     }
+    // 형식을 여기서도 막는다. 조회는 `YYYY-MM-DD` 를 전제해 거르므로, 계약을
+    // 벗어난 값을 받아 두면 저장은 성공했는데 어디에도 보이지 않는 일정이
+    // 남는다(#785). FastAPI 는 이미 같은 검사를 한다 — 데모도 같게 답한다.
+    if (!isScheduleDate(date)) {
+      return _badRequest(options, 'date must be YYYY-MM-DD');
+    }
     final time = (body['time'] as String? ?? '').trim();
+    if (!isScheduleTime(time)) {
+      return _badRequest(options, 'time must be HH:mm or empty');
+    }
     final category = (body['category'] as String? ?? 'other').trim();
     final (emoji, colorHex) = _scheduleStyle(category);
     final id = 'evt-${DateTime.now().microsecondsSinceEpoch}';

--- a/frontend/flutter/lib/features/schedule/domain/schedule_format.dart
+++ b/frontend/flutter/lib/features/schedule/domain/schedule_format.dart
@@ -1,0 +1,36 @@
+/// 일정 계약 형식 — 날짜 `YYYY-MM-DD`, 시간 `HH:mm`(또는 빈 문자열).
+///
+/// 검사를 한곳에 모아 두는 이유: 이 형식은 저장할 때만 쓰는 것이 아니라
+/// **조회할 때 전제**가 된다. 달 조회는 `YYYY-MM-` 로 시작하는지 보고, 캘린더는
+/// 날짜의 마지막 조각을 숫자로 읽는다. 그래서 형식을 벗어난 값이 한 번 저장되면
+/// 그 일정은 어디에도 나타나지 않는다(#785).
+///
+/// FastAPI 쪽 같은 검사는 `backend/app/api/v1/schedule.py` 에 있다. 두 곳이
+/// 갈리면 데모와 실서버가 다르게 답하므로 규칙을 함께 유지한다.
+library;
+
+final RegExp _ymd = RegExp(r'^\d{4}-\d{2}-\d{2}$');
+final RegExp _hhmm = RegExp(r'^\d{2}:\d{2}$');
+
+/// `YYYY-MM-DD` 이면서 달력상 실제로 있는 날인지.
+///
+/// 형식만 보면 `2026-02-30`·`2026-13-01` 이 통과한다. `DateTime.parse` 는 월·일
+/// 범위를 넘긴 값을 다음 달로 굴려 버리므로(2026-02-30 → 3월 2일), 파싱한 결과가
+/// 넣은 값과 같은지까지 확인해야 한다.
+bool isScheduleDate(String value) {
+  if (!_ymd.hasMatch(value)) return false;
+  final DateTime? parsed = DateTime.tryParse(value);
+  if (parsed == null) return false;
+  return parsed.year == int.parse(value.substring(0, 4)) &&
+      parsed.month == int.parse(value.substring(5, 7)) &&
+      parsed.day == int.parse(value.substring(8, 10));
+}
+
+/// `HH:mm`(24시간) 이거나 빈 문자열인지. 시간은 선택 항목이라 빈 값을 허용한다.
+bool isScheduleTime(String value) {
+  if (value.isEmpty) return true;
+  if (!_hhmm.hasMatch(value)) return false;
+  final int hour = int.parse(value.substring(0, 2));
+  final int minute = int.parse(value.substring(3, 5));
+  return hour < 24 && minute < 60;
+}

--- a/frontend/flutter/lib/shared/widgets/modals/add_event_dialog.dart
+++ b/frontend/flutter/lib/shared/widgets/modals/add_event_dialog.dart
@@ -26,12 +26,17 @@ Future<void> showAddEventDialog(BuildContext context) {
   );
 }
 
-String _todayString() {
-  final now = DateTime.now();
-  final mm = now.month.toString().padLeft(2, '0');
-  final dd = now.day.toString().padLeft(2, '0');
-  return '${now.year}-$mm-$dd';
-}
+/// 서버 계약 형식(`YYYY-MM-DD`). 화면에는 로케일 형식으로 보여 주고, 나갈 때만
+/// 이 형식으로 바꾼다 — 사용자가 형식을 맞출 일이 없어야 한다.
+String wireDate(DateTime d) =>
+    '${d.year.toString().padLeft(4, '0')}-'
+    '${d.month.toString().padLeft(2, '0')}-'
+    '${d.day.toString().padLeft(2, '0')}';
+
+/// 서버 계약 형식(`HH:mm`, 24시간). 시드 일정도 같은 형식이다.
+String wireTime(TimeOfDay t) =>
+    '${t.hour.toString().padLeft(2, '0')}:'
+    '${t.minute.toString().padLeft(2, '0')}';
 
 class _AddEventDialog extends ConsumerStatefulWidget {
   const _AddEventDialog();
@@ -41,30 +46,49 @@ class _AddEventDialog extends ConsumerStatefulWidget {
 
 class _AddEventDialogState extends ConsumerState<_AddEventDialog> {
   final TextEditingController _title = TextEditingController();
-  late final TextEditingController _date = TextEditingController(
-    text: _todayString(),
-  );
-  final TextEditingController _time = TextEditingController();
+
+  /// 날짜는 늘 값이 있다(기본 오늘). 피커로만 고르므로 형식이 어긋날 수 없다.
+  DateTime _date = DateTime.now();
+
+  /// 시간은 선택 항목이다 — 서버 계약에서도 빈 문자열을 허용한다.
+  TimeOfDay? _time;
+
   String _category = _categoryMap.keys.first;
   bool _saving = false;
 
   @override
   void dispose() {
     _title.dispose();
-    _date.dispose();
-    _time.dispose();
     super.dispose();
+  }
+
+  Future<void> _pickDate() async {
+    final DateTime now = DateTime.now();
+    final DateTime? picked = await showDatePicker(
+      context: context,
+      initialDate: _date,
+      // 지난 일정도 기록할 수 있어야 하고, 앞으로도 넉넉히 잡을 수 있어야 한다.
+      firstDate: DateTime(now.year - 1),
+      lastDate: DateTime(now.year + 2, 12, 31),
+    );
+    if (picked != null) setState(() => _date = picked);
+  }
+
+  Future<void> _pickTime() async {
+    final TimeOfDay? picked = await showTimePicker(
+      context: context,
+      initialTime: _time ?? TimeOfDay.now(),
+    );
+    if (picked != null) setState(() => _time = picked);
   }
 
   Future<void> _submit() async {
     if (_saving) return;
     final messenger = ScaffoldMessenger.of(context);
     final title = _title.text.trim();
-    final date = _date.text.trim();
-    if (title.isEmpty || date.isEmpty) {
-      messenger.showSnackBar(
-        const SnackBar(content: Text('제목과 날짜를 입력해 주세요')),
-      );
+    // 날짜는 피커가 늘 채우므로 제목만 확인하면 된다.
+    if (title.isEmpty) {
+      messenger.showSnackBar(const SnackBar(content: Text('일정 제목을 입력해 주세요')));
       return;
     }
     setState(() => _saving = true);
@@ -72,8 +96,8 @@ class _AddEventDialogState extends ConsumerState<_AddEventDialog> {
       await ref
           .read(scheduleRepositoryProvider)
           .createEvent(
-            date: date,
-            time: _time.text.trim(),
+            date: wireDate(_date),
+            time: _time == null ? '' : wireTime(_time!),
             title: title,
             category: _categoryMap[_category] ?? ScheduleCategory.other,
           );
@@ -136,9 +160,34 @@ class _AddEventDialogState extends ConsumerState<_AddEventDialog> {
               const SizedBox(height: AppSpacing.md),
               AppInput(controller: _title, label: '일정 제목', hint: '예: 병원 정기검진'),
               const SizedBox(height: AppSpacing.sm),
-              AppInput(controller: _date, label: '날짜', hint: '2026-05-14'),
+              // 날짜·시간은 직접 칠 수 없다. 예전에는 자유 입력이라 `2026/05/14`
+              // 처럼 계약을 벗어난 값이 저장되고, 조회는 `YYYY-MM-DD` 를 전제해
+              // 걸러 내서 넣은 일정이 어디에도 보이지 않았다(#785).
+              _PickerField(
+                key: const Key('addEventDate'),
+                label: '날짜',
+                value: MaterialLocalizations.of(context).formatMediumDate(_date),
+                icon: Icons.calendar_today_outlined,
+                onTap: _saving ? null : _pickDate,
+              ),
               const SizedBox(height: AppSpacing.sm),
-              AppInput(controller: _time, label: '시간', hint: '10:00'),
+              _PickerField(
+                key: const Key('addEventTime'),
+                label: '시간',
+                // 시간은 선택이라 비워 둘 수 있다. 비었다는 것을 값 자리에서
+                // 그대로 말해 준다.
+                value: _time == null
+                    ? '시간 없음'
+                    : MaterialLocalizations.of(
+                        context,
+                      ).formatTimeOfDay(_time!),
+                muted: _time == null,
+                icon: Icons.schedule_outlined,
+                onTap: _saving ? null : _pickTime,
+                onClear: _time == null || _saving
+                    ? null
+                    : () => setState(() => _time = null),
+              ),
               const SizedBox(height: AppSpacing.sm),
               Container(
                 padding: const EdgeInsets.symmetric(
@@ -172,6 +221,87 @@ class _AddEventDialogState extends ConsumerState<_AddEventDialog> {
               ),
             ],
           ),
+        ),
+      ),
+    );
+  }
+}
+
+/// 눌러서 고르는 값 한 칸. [AppInput] 과 같은 테두리·라벨을 쓰되 글자를 직접
+/// 칠 수는 없다 — 형식이 어긋난 값이 애초에 만들어지지 않게 하는 것이 목적이다.
+class _PickerField extends StatelessWidget {
+  const _PickerField({
+    required this.label,
+    required this.value,
+    required this.icon,
+    required this.onTap,
+    this.onClear,
+    this.muted = false,
+    super.key,
+  });
+
+  final String label;
+  final String value;
+  final IconData icon;
+
+  /// null 이면 저장 중이라 잠긴 상태다.
+  final VoidCallback? onTap;
+
+  /// 지울 수 있는 값(시간)일 때만 준다.
+  final VoidCallback? onClear;
+
+  /// 값이 비어 있음을 알리는 자리표시일 때 흐리게 그린다.
+  final bool muted;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return InkWell(
+      onTap: onTap,
+      borderRadius: const BorderRadius.all(AppRadius.md),
+      child: InputDecorator(
+        decoration: InputDecoration(
+          labelText: label,
+          border: const OutlineInputBorder(
+            borderRadius: BorderRadius.all(AppRadius.md),
+          ),
+        ),
+        child: Row(
+          children: <Widget>[
+            Icon(icon, size: 18, color: AppColors.mutedForeground),
+            const SizedBox(width: AppSpacing.sm),
+            Expanded(
+              child: Text(
+                value,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: muted
+                      ? AppColors.mutedForeground
+                      : AppColors.foreground,
+                ),
+              ),
+            ),
+            if (onClear != null)
+              // 시각적 아이콘은 16 이지만 탭 영역은 접근성 최소치를 지킨다.
+              Semantics(
+                button: true,
+                label: '$label 지우기',
+                child: InkWell(
+                  onTap: onClear,
+                  customBorder: const CircleBorder(),
+                  child: const SizedBox(
+                    width: 44,
+                    height: 44,
+                    child: Icon(
+                      Icons.close,
+                      size: 16,
+                      color: AppColors.mutedForeground,
+                    ),
+                  ),
+                ),
+              ),
+          ],
         ),
       ),
     );

--- a/frontend/flutter/test/features/schedule/schedule_format_test.dart
+++ b/frontend/flutter/test/features/schedule/schedule_format_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/schedule/domain/schedule_format.dart';
+
+void main() {
+  group('isScheduleDate', () {
+    test('계약 형식의 실제 날짜만 받는다', () {
+      expect(isScheduleDate('2026-08-16'), isTrue);
+      expect(isScheduleDate('2024-02-29'), isTrue); // 윤년
+    });
+
+    test('형식이 어긋난 값을 막는다', () {
+      // 예전에 저장까지 통과하던 값들이다 — 저장은 되고 조회에서 걸러져
+      // 어디에도 보이지 않는 일정이 됐다(#785).
+      expect(isScheduleDate('2026/08/16'), isFalse);
+      expect(isScheduleDate('8월 16일'), isFalse);
+      expect(isScheduleDate('2026-8-16'), isFalse);
+      expect(isScheduleDate('20260816'), isFalse);
+      expect(isScheduleDate(''), isFalse);
+    });
+
+    test('달력에 없는 날을 막는다', () {
+      // 형식만 보면 통과한다. DateTime.parse 는 이런 값을 다음 달로 굴리므로
+      // 파싱 결과까지 비교해야 걸러진다.
+      expect(isScheduleDate('2026-02-30'), isFalse);
+      expect(isScheduleDate('2026-13-01'), isFalse);
+      expect(isScheduleDate('2026-02-29'), isFalse); // 평년
+      expect(isScheduleDate('2026-04-31'), isFalse);
+    });
+  });
+
+  group('isScheduleTime', () {
+    test('빈 값과 HH:mm 을 받는다', () {
+      expect(isScheduleTime(''), isTrue); // 시간은 선택 항목
+      expect(isScheduleTime('09:00'), isTrue);
+      expect(isScheduleTime('23:59'), isTrue);
+    });
+
+    test('형식이 어긋나거나 범위를 넘긴 값을 막는다', () {
+      expect(isScheduleTime('9:00'), isFalse);
+      expect(isScheduleTime('오전 9시'), isFalse);
+      expect(isScheduleTime('24:00'), isFalse);
+      expect(isScheduleTime('10:60'), isFalse);
+    });
+  });
+}

--- a/frontend/flutter/test/shared/add_event_dialog_test.dart
+++ b/frontend/flutter/test/shared/add_event_dialog_test.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/schedule/domain/entities/schedule_event.dart';
+import 'package:oncare/features/schedule/domain/repositories/schedule_repository.dart';
+import 'package:oncare/features/schedule/domain/schedule_format.dart';
+import 'package:oncare/features/schedule/presentation/controllers/schedule_controller.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+import 'package:oncare/shared/widgets/modals/add_event_dialog.dart';
+
+/// 저장된 값을 그대로 붙잡아 둔다 — 다이얼로그가 서버에 무엇을 보내는지가
+/// 이 테스트의 관심사다.
+class _CapturingRepository implements ScheduleRepository {
+  String? date;
+  String? time;
+  String? title;
+
+  @override
+  Future<ScheduleEvent> createEvent({
+    required String date,
+    required String title,
+    String time = '',
+    ScheduleCategory category = ScheduleCategory.other,
+  }) async {
+    this.date = date;
+    this.time = time;
+    this.title = title;
+    return ScheduleEvent(
+      id: 'evt-1',
+      date: date,
+      time: time,
+      title: title,
+      category: category,
+    );
+  }
+
+  @override
+  Future<List<ScheduleEvent>> fetchByDate(String date) async =>
+      const <ScheduleEvent>[];
+
+  @override
+  Future<List<ScheduleEvent>> fetchByMonth(String month) async =>
+      const <ScheduleEvent>[];
+}
+
+void main() {
+  late _CapturingRepository repo;
+
+  Future<void> openDialog(WidgetTester tester) async {
+    // 실제 폰 크기로 잡는다. 시간 피커는 다이얼로그라서 열릴 때의 MediaQuery 를
+    // 그대로 쓰는데, `setSurfaceSize` 는 한 번 정착(settle)한 뒤에야 반영되어
+    // 피커가 이전 크기로 그려진다. `view` 는 첫 프레임부터 적용된다.
+    tester.view.physicalSize = const Size(390 * 3, 844 * 3);
+    tester.view.devicePixelRatio = 3.0;
+    addTearDown(tester.view.reset);
+    repo = _CapturingRepository();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          scheduleRepositoryProvider.overrideWithValue(repo),
+        ],
+        child: MaterialApp(
+          locale: const Locale('ko'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) => TextButton(
+                onPressed: () => showAddEventDialog(context),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('날짜·시간을 직접 칠 수 없다', (WidgetTester tester) async {
+    await openDialog(tester);
+
+    // 예전에는 세 칸 모두 자유 입력이라 계약을 벗어난 값이 그대로 나갔다(#785).
+    // 이제 편집 가능한 칸은 제목 하나뿐이다.
+    expect(find.byType(TextField), findsOneWidget);
+    expect(find.byKey(const Key('addEventDate')), findsOneWidget);
+    expect(find.byKey(const Key('addEventTime')), findsOneWidget);
+  });
+
+  testWidgets('저장하면 계약 형식으로 나간다', (WidgetTester tester) async {
+    await openDialog(tester);
+
+    await tester.enterText(find.byType(TextField), '병원 정기검진');
+    await tester.tap(find.text('추가하기'));
+    await tester.pumpAndSettle();
+
+    expect(repo.title, '병원 정기검진');
+    // 형식을 직접 비교하지 않고 계약 검사기에 물어본다 — 저장 경로와 조회
+    // 경로가 같은 규칙을 쓰는지가 핵심이다.
+    expect(isScheduleDate(repo.date!), isTrue);
+    expect(isScheduleTime(repo.time!), isTrue);
+    // 시간은 고르지 않았으므로 빈 값이다(계약이 허용한다).
+    expect(repo.time, '');
+  });
+
+  testWidgets('제목이 비면 저장하지 않고 알린다', (WidgetTester tester) async {
+    await openDialog(tester);
+
+    await tester.tap(find.text('추가하기'));
+    await tester.pumpAndSettle();
+
+    expect(repo.title, isNull);
+    expect(find.text('일정 제목을 입력해 주세요'), findsOneWidget);
+  });
+
+  testWidgets('시간을 고르면 HH:mm 으로 나가고 지울 수 있다', (WidgetTester tester) async {
+    await openDialog(tester);
+    await tester.enterText(find.byType(TextField), '운동');
+
+    await tester.tap(find.byKey(const Key('addEventTime')));
+    await tester.pumpAndSettle();
+    // 다이얼에서 특정 시각을 집기는 어렵고 이 테스트의 관심사도 아니다. 확인만
+    // 눌러 초기값(현재 시각)을 그대로 받고, 그 값이 계약 형식으로 나가는지를 본다.
+    await tester.tap(find.widgetWithText(TextButton, '확인'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('추가하기'));
+    await tester.pumpAndSettle();
+
+    expect(isScheduleTime(repo.time!), isTrue);
+    expect(repo.time, isNot(''));
+  });
+}


### PR DESCRIPTION
Closes #785

## Summary

일정 추가에서 날짜·시간을 직접 칠 수 없게 한다. 계약을 벗어난 값이 애초에 만들어지지 않는 것이 검증 문구를 붙이는 것보다 확실하다.

문제는 저장이 아니라 저장과 조회의 어긋남이었다. 저장은 형식을 보지 않고 받았고, 조회는 `YYYY-MM-DD` 를 전제해 걸렀다(달 조회는 `YYYY-MM-` prefix, 캘린더는 날짜 마지막 조각을 숫자로 읽음). 그래서 `2026/08/16` 같은 값은 저장에 성공하고도 어디에도 나타나지 않았다.

## Changes

- 날짜는 `showDatePicker`, 시간은 `showTimePicker` 로만 받는다. 화면에는 로케일 형식으로 보여 주고(`8월 16일 (일)`), 나갈 때만 계약 형식(`YYYY-MM-DD` / `HH:mm`)으로 바꾼다.
- 시간은 계약상 빈 값을 허용하므로 선택 항목으로 두고, 고른 뒤 지울 수 있게 했다. 비어 있을 때는 값 자리에 그대로 "시간 없음" 이라고 적는다.
- 검증 로직을 `features/schedule/domain/schedule_format.dart` 로 모았다. 형식뿐 아니라 달력상 실제로 있는 날인지까지 본다 — `DateTime.parse` 는 `2026-02-30` 을 3월 2일로 굴려 버려서, 파싱 결과를 넣은 값과 비교해야 걸러진다.
- 데모 경로(`LocalApiInterceptor`)도 같은 검사를 하고 400 으로 돌려준다.

## Notes

- FastAPI(`backend/app/api/v1/schedule.py`)는 이미 같은 검증을 하고 있었다. 그래서 실서버 경로는 원래 잘못된 값을 막고 있었고, 앱이 그 실패를 일반 오류로만 보여 줬다. 이번 변경으로 데모와 실서버의 답이 같아진다.
- 백엔드 검증과 앱 검증이 두 곳에 생겼다. 계약이 바뀌면 함께 고쳐야 하므로 양쪽 주석에 서로를 적어 뒀다.
- 검증: `flutter analyze` 무경고, 전체 `flutter test` 666건 통과(신규 13건 포함).

### 작업 중 확인한 것

시간 피커가 좁은 화면에서 확인 버튼이 잘리는 것처럼 보여 실기기 폭(320~430)에서 따로 확인했다. 잘리지 않는다 — 진단 하니스가 `setSurfaceSize` 반영 전에 크기를 읽어 생긴 착시였다(`setSurfaceSize` 는 한 번 정착한 뒤 반영된다). 새 테스트는 첫 프레임부터 적용되는 `tester.view` 를 쓴다.
