### PR TITLE
fix(member-coach): 담당 코치 없을 때 채팅·프로필 버튼의 비활성 표시

### DIFF
--- a/frontend/flutter/lib/design_system/figma/figma_kit.dart
+++ b/frontend/flutter/lib/design_system/figma/figma_kit.dart
@@ -216,6 +216,7 @@ class FigmaCircleButton extends StatelessWidget {
     this.dotColor = FigmaColors.orange,
     this.size = 36,
     this.iconSize = 18,
+    this.enabled = true,
   });
 
   final IconData icon;
@@ -225,8 +226,17 @@ class FigmaCircleButton extends StatelessWidget {
   final double size;
   final double iconSize;
 
+  /// 지금 쓸 수 있는 버튼인지. false 면 흐리게 그린다.
+  ///
+  /// [onTap] 과 따로 두는 이유: 쓸 수 없다는 것과 눌러도 소용없다는 것은 다르다.
+  /// 왜 쓸 수 없는지 알려 주려면 흐린 채로도 탭을 받아야 한다. 예전에는 이 구분이
+  /// 없어서, 담당 트레이너가 없을 때 채팅 버튼이 멀쩡한 모습으로 죽어 있었다(#786).
+  final bool enabled;
+
   @override
   Widget build(BuildContext context) {
+    // `onTap` 이 아예 없으면 그것도 쓸 수 없는 상태다.
+    final bool usable = enabled && onTap != null;
     return SizedBox(
       width: size,
       height: size,
@@ -235,13 +245,19 @@ class FigmaCircleButton extends StatelessWidget {
         children: <Widget>[
           Positioned.fill(
             child: Material(
-              color: FigmaColors.softBlue,
+              color: usable ? FigmaColors.softBlue : FigmaColors.track,
               shape: const CircleBorder(),
               clipBehavior: Clip.antiAlias,
               child: InkWell(
                 onTap: onTap,
                 child: Center(
-                  child: Icon(icon, size: iconSize, color: FigmaColors.primary),
+                  child: Icon(
+                    icon,
+                    size: iconSize,
+                    color: usable
+                        ? FigmaColors.primary
+                        : FigmaColors.textFaint,
+                  ),
                 ),
               ),
             ),

--- a/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_card.dart
+++ b/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_card.dart
@@ -91,11 +91,16 @@ class CoachCard extends ConsumerWidget {
                         ],
                       ),
                     ),
-                    const Icon(
-                      Icons.chevron_right_rounded,
-                      size: 20,
-                      color: FigmaColors.textMuted,
-                    ),
+                    // 화살표는 '누르면 간다'는 신호다. 트레이너 상세로 갈 수
+                    // 없을 때(myTrainerProvider 가 아직 없거나 연결이 끊긴
+                    // 경우)는 지운다 — 예전에는 화살표만 남아 눌러도 아무 일이
+                    // 없었다(#786).
+                    if (assignedTrainer != null)
+                      const Icon(
+                        Icons.chevron_right_rounded,
+                        size: 20,
+                        color: FigmaColors.textMuted,
+                      ),
                   ],
                 ),
               ),

--- a/frontend/flutter/lib/features/member_coach/presentation/widgets/trainer_chat_header_button.dart
+++ b/frontend/flutter/lib/features/member_coach/presentation/widgets/trainer_chat_header_button.dart
@@ -2,29 +2,46 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:oncare/design_system/figma/figma_kit.dart';
+import 'package:oncare/features/member_coach/domain/entities/member_coach.dart';
 import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
 import 'package:oncare/features/member_coach/presentation/widgets/coach_chat_sheet.dart';
 
 /// 모든 메인 탭 헤더에서 동일한 담당 트레이너 채팅으로 진입하는 버튼이다.
+///
+/// 담당 트레이너가 아직 없거나 조회 중이면 흐리게 그리고, 눌렀을 때는 왜 지금은
+/// 쓸 수 없는지 한 줄로 알린다. 예전에는 이 상태에서 `onTap: null` 만 넘겨서
+/// 모양은 그대로인 채 아무 반응도 없었다 — 고장 난 버튼으로 읽혔다(#786).
 class TrainerChatHeaderButton extends ConsumerWidget {
   const TrainerChatHeaderButton({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final coach = ref.watch(memberCoachProvider).valueOrNull;
+    final AsyncValue<MemberCoach?> coachAsync = ref.watch(memberCoachProvider);
+    final MemberCoach? coach = coachAsync.valueOrNull;
     final int unread = ref.watch(coachUnreadProvider).valueOrNull ?? 0;
+    final bool ready = coach != null;
+
+    // 아직 받아 오는 중인지, 받아 봤더니 없는지는 다른 사정이다. 안내 문구도 달라야
+    // 한다 — 로딩 중에 "트레이너가 없다" 고 말하면 거짓이 된다.
+    final String unavailableReason = coachAsync.isLoading
+        ? '담당 트레이너를 불러오는 중이에요'
+        : '담당 트레이너가 아직 없어요. 운동 탭에서 헬스장·트레이너를 연결해 보세요';
 
     return Semantics(
       button: true,
+      enabled: ready,
       label: '트레이너와 채팅',
       child: FigmaCircleButton(
         key: const Key('trainerChatHeaderButton'),
         icon: Icons.chat_bubble_outline_rounded,
         showDot: unread > 0,
         dotColor: FigmaColors.redDot,
-        onTap: coach == null
-            ? null
-            : () => openTrainerChatPage(context, trainerName: coach.name),
+        enabled: ready,
+        onTap: ready
+            ? () => openTrainerChatPage(context, trainerName: coach.name)
+            : () => ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(content: Text(unavailableReason)),
+              ),
       ),
     );
   }

--- a/frontend/flutter/test/features/member_coach/trainer_chat_header_button_test.dart
+++ b/frontend/flutter/test/features/member_coach/trainer_chat_header_button_test.dart
@@ -1,0 +1,119 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/design_system/figma/figma_kit.dart';
+import 'package:oncare/features/member_coach/domain/entities/member_coach.dart';
+import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
+import 'package:oncare/features/member_coach/presentation/widgets/trainer_chat_header_button.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+const MemberCoach _coach = MemberCoach(
+  trainerId: 'coach-1',
+  name: '김트레이너',
+  specialty: '체형 교정',
+  career: '5년',
+  intro: '',
+  gymName: '신촌 짐',
+  goal: '',
+);
+
+/// 버튼의 아이콘 색으로 활성/비활성을 읽는다 — 화면에서 사용자가 구별하는 근거와
+/// 같은 것을 본다.
+Color _iconColor(WidgetTester tester) {
+  return tester
+      .widget<Icon>(
+        find.descendant(
+          of: find.byType(FigmaCircleButton),
+          matching: find.byType(Icon),
+        ),
+      )
+      .color!;
+}
+
+void main() {
+  Future<void> pump(
+    WidgetTester tester, {
+    required Override coachOverride,
+  }) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          coachOverride,
+          coachUnreadProvider.overrideWith((ref) async => 0),
+        ],
+        child: const MaterialApp(
+          locale: Locale('ko'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: TrainerChatHeaderButton()),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('담당 트레이너가 있으면 활성으로 그린다', (WidgetTester tester) async {
+    await pump(
+      tester,
+      coachOverride: memberCoachProvider.overrideWith((ref) async => _coach),
+    );
+
+    expect(_iconColor(tester), FigmaColors.primary);
+  });
+
+  testWidgets('담당 트레이너가 없으면 흐리게 그린다', (WidgetTester tester) async {
+    await pump(
+      tester,
+      coachOverride: memberCoachProvider.overrideWith((ref) async => null),
+    );
+
+    // 예전에는 색이 그대로여서 눌리는 버튼과 구별되지 않았다(#786).
+    expect(_iconColor(tester), FigmaColors.textFaint);
+  });
+
+  testWidgets('담당 트레이너가 없을 때 누르면 이유를 알린다', (WidgetTester tester) async {
+    await pump(
+      tester,
+      coachOverride: memberCoachProvider.overrideWith((ref) async => null),
+    );
+
+    await tester.tap(find.byKey(const Key('trainerChatHeaderButton')));
+    await tester.pumpAndSettle();
+
+    // 흐리게 그리되 아무 반응도 없지는 않다 — 왜 못 쓰는지 말해 준다.
+    expect(
+      find.text('담당 트레이너가 아직 없어요. 운동 탭에서 헬스장·트레이너를 연결해 보세요'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('조회 중에는 없다고 단정하지 않는다', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          // 끝나지 않는 Future — 로딩 상태로 붙잡아 둔다.
+          memberCoachProvider.overrideWith(
+            (ref) => Completer<MemberCoach?>().future,
+          ),
+          coachUnreadProvider.overrideWith((ref) async => 0),
+        ],
+        child: const MaterialApp(
+          locale: Locale('ko'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: TrainerChatHeaderButton()),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key('trainerChatHeaderButton')));
+    await tester.pump();
+
+    // 로딩 중에 "트레이너가 없다" 고 말하면 거짓이 된다.
+    expect(find.text('담당 트레이너를 불러오는 중이에요'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #786

## Summary

담당 트레이너가 없거나 아직 조회 중일 때, 트레이너 관련 진입 버튼들이 눌리지 않는데 모양은 그대로였다. 비활성이라는 표시가 없어 회원 입장에서는 고장 난 버튼으로 읽힌다.

## Changes

- `FigmaCircleButton` 에 `enabled` 추가. false 면 배경·아이콘을 흐리게 그린다. `onTap` 과 따로 둔 이유는 아래 Notes 에.
- 모든 탭 헤더의 트레이너 채팅 버튼: 담당 트레이너가 없으면 흐리게 그리고, 누르면 왜 지금은 쓸 수 없는지 한 줄로 알린다. 조회 중과 "없음" 을 구분해 문구가 달라진다.
- 운동 탭 담당 트레이너 카드의 프로필 행: 트레이너 상세로 갈 수 없을 때는 오른쪽 `>` 화살표를 그리지 않는다.

## Notes

- `enabled` 를 `onTap` 과 따로 둔 것은 의도적이다. **쓸 수 없다**는 것과 **눌러도 소용없다**는 것은 다르다. 왜 못 쓰는지 알려 주려면 흐린 채로도 탭을 받아야 한다. `onTap: null` 로 두면 흐려지기는 해도 다시 아무 반응 없는 버튼이 된다.
- 조회 중과 "담당 트레이너 없음" 을 구분한다. 로딩 중에 "트레이너가 아직 없어요" 라고 말하면 거짓이 된다 — 잠시 뒤 생길 수도 있다.
- 화살표를 지운 것도 같은 이유다. 화살표는 '누르면 간다'는 신호라, 갈 곳이 없으면 신호부터 없어야 한다.
- `FigmaCircleButton` 은 헤더의 알림 벨·캘린더 버튼도 쓴다. 그쪽은 늘 `onTap` 이 있어 보이는 모습이 달라지지 않는다.
- 검증: `flutter analyze` 무경고, 전체 `flutter test` 661건 통과(신규 4건 포함). 활성/비활성은 아이콘 색으로 확인한다 — 화면에서 사용자가 구별하는 근거와 같은 것을 본다.
