### PR TITLE
fix(dashboard): Oni FAB 알림 배지 고정값 해소

### DIFF
--- a/frontend/flutter/lib/app/router/main_shell.dart
+++ b/frontend/flutter/lib/app/router/main_shell.dart
@@ -109,7 +109,9 @@ class _MainShellState extends ConsumerState<MainShell>
       body: navigationShell,
       floatingActionButton: OniFab(
         key: const Key('coachingFab'),
-        onTap: () => showCoachingSheet(context),
+        // 배지는 시트가 실제로 보여 줄 카드 수를 따른다. 열어서 확인하면 내려간다.
+        badgeCount: ref.watch(coachingBadgeCountProvider),
+        onTap: () => showCoachingSheet(context, ref: ref),
       ),
       bottomNavigationBar: SizedBox(
         height: barHeight + lift + effectiveBottomPadding,

--- a/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
@@ -66,15 +66,17 @@ class DashboardContent extends StatelessWidget {
             // 지역적으로 얻는다 — 헤더 전체를 다시 그리지 않는다.
             Consumer(
               builder: (BuildContext context, WidgetRef ref, Widget? _) =>
-FigmaTabHeader(
-                  title: 'On - Care',
-                  leading: const HeartLogo(),
-                  trailingAction: const TrainerChatHeaderButton(),
-                  onBell: onNotificationTap,
-                  bellHasUnread:
-                      (ref.watch(notificationUnreadProvider).valueOrNull ?? 0) > 0,
-                  onCalendar: onCalendarTap,
-                ),
+                  FigmaTabHeader(
+                    title: 'On - Care',
+                    leading: const HeartLogo(),
+                    trailingAction: const TrainerChatHeaderButton(),
+                    onBell: onNotificationTap,
+                    bellHasUnread:
+                        (ref.watch(notificationUnreadProvider).valueOrNull ??
+                            0) >
+                        0,
+                    onCalendar: onCalendarTap,
+                  ),
             ),
             const SizedBox(height: 8),
             Consumer(
@@ -90,7 +92,9 @@ FigmaTabHeader(
                           ),
                       data: (DashboardSummary summary) => _DashboardData(
                         summary: summary,
-                        onCoachingTap: () => showCoachingSheet(context),
+                        // 홈 배너로 열어도 같은 시트다 — 배지도 같이 내려간다.
+                        onCoachingTap: () =>
+                            showCoachingSheet(context, ref: ref),
                         onDietTap: () => context.go(AppRoutes.diet),
                         onExerciseTap: () => context.go(AppRoutes.exercise),
                       ),
@@ -1134,8 +1138,6 @@ const List<double> _demoExerciseWeekCalories = <double>[
   330,
   520,
 ];
-
-
 
 /// 오늘 요일 인덱스(0=월 … 6=일). 고정 라벨 배열 `_weekDayLabels` 와 함께 써서
 /// 주간 차트의 '오늘' 배지·라이브 값을 실제 요일 칸에 배치하고, 오늘 이후(미래)

--- a/frontend/flutter/lib/shared/widgets/coaching_sheet.dart
+++ b/frontend/flutter/lib/shared/widgets/coaching_sheet.dart
@@ -13,7 +13,12 @@ import 'package:oncare/gen/l10n/app_localizations.dart';
 /// "AI 건강 도우미" bottom sheet — the daily coaching digest opened from the
 /// floating Oni button and the Home coaching banner. Its CTA hands off to the
 /// AI chat. Mirrors the Figma `CoachingSheet`.
-Future<void> showCoachingSheet(BuildContext context) {
+Future<void> showCoachingSheet(BuildContext context, {WidgetRef? ref}) {
+  // 열어서 봤으면 배지를 내린다. 읽을 것이 없는데도 남는 숫자는 알림 벨의
+  // 미읽음 점과 같은 종류의 거짓말이다(#788).
+  ref?.read(coachingSeenCountProvider.notifier).state = ref.read(
+    coachingSuggestionCountProvider,
+  );
   return showModalBottomSheet<void>(
     context: context,
     isScrollControlled: true,
@@ -22,6 +27,41 @@ Future<void> showCoachingSheet(BuildContext context) {
     builder: (BuildContext ctx) => const _CoachingSheet(),
   );
 }
+
+/// 실제 제안을 받지 못했을 때 시트가 대신 그리는 기본 카드 수.
+///
+/// [_cardsOf] 의 길이와 같아야 한다 — 배지 숫자와 시트에 실제로 보이는 카드 수가
+/// 어긋나면 배지가 다시 거짓말을 한다. 위젯 테스트가 두 값을 맞춰 둔다.
+const int kCoachFallbackCardCount = 2;
+
+/// 지금 코칭 시트가 보여 줄 카드 수. 배지와 시트가 같은 규칙을 읽는다.
+final coachingSuggestionCountProvider = Provider<int>((ref) {
+  if (ref.watch(appConfigProvider).useMockApi) return kCoachFallbackCardCount;
+  final List<AiSuggestion>? live = ref
+      .watch(aiCoachStateProvider)
+      .asData
+      ?.value
+      .suggestions;
+  // 로딩·에러·빈 응답이면 시트가 기본 카드로 떨어지므로 수도 그것을 따른다.
+  return (live == null || live.isEmpty) ? kCoachFallbackCardCount : live.length;
+}, name: 'coachingSuggestionCount');
+
+/// 마지막으로 시트를 열어 확인한 카드 수.
+///
+/// 배지는 이 값을 넘는 만큼만 뜬다. 새 제안이 늘면 다시 뜨고, 다 본 뒤에는
+/// 사라진다. 앱을 다시 켜면 초기화된다 — 코칭 카드는 하루 단위 요약이라
+/// 영구 저장까지 할 만한 상태가 아니다.
+final coachingSeenCountProvider = StateProvider<int>(
+  (ref) => 0,
+  name: 'coachingSeenCount',
+);
+
+/// 플로팅 버튼에 띄울 배지 숫자. 볼 것이 없으면 0.
+final coachingBadgeCountProvider = Provider<int>((ref) {
+  final int count = ref.watch(coachingSuggestionCountProvider);
+  final int seen = ref.watch(coachingSeenCountProvider);
+  return count > seen ? count - seen : 0;
+}, name: 'coachingBadgeCount');
 
 class _CoachCard {
   const _CoachCard({

--- a/frontend/flutter/lib/shared/widgets/oni_fab.dart
+++ b/frontend/flutter/lib/shared/widgets/oni_fab.dart
@@ -5,8 +5,12 @@ import 'package:oncare/design_system/figma/figma_kit.dart';
 /// The floating "Oni" assistant button shown on every main tab. Taps open the
 /// coaching sheet. A red badge shows the number of pending suggestions.
 /// Mirrors the Figma FAB.
+///
+/// [badgeCount] 기본값은 0 이다. 예전에는 2 로 두고 부르는 쪽이 값을 넘기지 않아,
+/// 제안 수와 무관하게 늘 '2' 가 떠 있었다 — 다 읽어도 사라지지 않았다(#788).
+/// 셀 수 없을 때는 배지를 아예 그리지 않는 편이 상수보다 정직하다.
 class OniFab extends StatelessWidget {
-  const OniFab({super.key, required this.onTap, this.badgeCount = 2});
+  const OniFab({super.key, required this.onTap, this.badgeCount = 0});
 
   final VoidCallback onTap;
   final int badgeCount;

--- a/frontend/flutter/test/shared/coaching_badge_test.dart
+++ b/frontend/flutter/test/shared/coaching_badge_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/features/ai_coach/domain/entities/ai_coach_state.dart';
+import 'package:oncare/features/ai_coach/presentation/controllers/ai_coach_controller.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+import 'package:oncare/shared/widgets/coaching_sheet.dart';
+
+const AppConfig _mock = AppConfig(
+  environment: Environment.dev,
+  apiBaseUrl: 'https://dev.api.test',
+  useMockApi: true,
+);
+
+const AppConfig _real = AppConfig(
+  environment: Environment.dev,
+  apiBaseUrl: 'https://dev.api.test',
+  useMockApi: false,
+);
+
+AiSuggestion _suggestion(String title) =>
+    AiSuggestion(title: title, body: '본문', tag: AiSuggestionTag.diet);
+
+void main() {
+  group('배지 숫자', () {
+    test('목업 모드는 기본 카드 수를 따른다', () {
+      final ProviderContainer c = ProviderContainer(
+        overrides: <Override>[appConfigProvider.overrideWithValue(_mock)],
+      );
+      addTearDown(c.dispose);
+
+      expect(c.read(coachingSuggestionCountProvider), kCoachFallbackCardCount);
+      expect(c.read(coachingBadgeCountProvider), kCoachFallbackCardCount);
+    });
+
+    test('실 제안이 오면 그 개수를 따른다', () async {
+      final ProviderContainer c = ProviderContainer(
+        overrides: <Override>[
+          appConfigProvider.overrideWithValue(_real),
+          aiCoachStateProvider.overrideWith(
+            (ref) async => AiCoachState(
+              greeting: '',
+              suggestions: <AiSuggestion>[
+                _suggestion('하나'),
+                _suggestion('둘'),
+                _suggestion('셋'),
+              ],
+            ),
+          ),
+        ],
+      );
+      addTearDown(c.dispose);
+      await c.read(aiCoachStateProvider.future);
+
+      // 예전에는 무엇이 오든 늘 2 였다(#788).
+      expect(c.read(coachingSuggestionCountProvider), 3);
+    });
+
+    test('빈 응답이면 시트가 기본 카드로 떨어지므로 수도 그것을 따른다', () async {
+      final ProviderContainer c = ProviderContainer(
+        overrides: <Override>[
+          appConfigProvider.overrideWithValue(_real),
+          aiCoachStateProvider.overrideWith(
+            (ref) async => const AiCoachState(
+              greeting: '',
+              suggestions: <AiSuggestion>[],
+            ),
+          ),
+        ],
+      );
+      addTearDown(c.dispose);
+      await c.read(aiCoachStateProvider.future);
+
+      expect(c.read(coachingSuggestionCountProvider), kCoachFallbackCardCount);
+    });
+
+    test('다 보면 배지가 내려가고, 새 제안이 오면 그만큼 다시 뜬다', () {
+      final ProviderContainer c = ProviderContainer(
+        overrides: <Override>[appConfigProvider.overrideWithValue(_mock)],
+      );
+      addTearDown(c.dispose);
+
+      c.read(coachingSeenCountProvider.notifier).state = c.read(
+        coachingSuggestionCountProvider,
+      );
+      expect(c.read(coachingBadgeCountProvider), 0);
+
+      // 본 것보다 제안이 줄어도 음수가 되지 않는다.
+      c.read(coachingSeenCountProvider.notifier).state = 99;
+      expect(c.read(coachingBadgeCountProvider), 0);
+    });
+  });
+
+  testWidgets('시트에 실제로 그려지는 카드 수가 기본 카드 수와 같다', (WidgetTester tester) async {
+    // 배지 숫자와 시트 내용이 어긋나면 배지가 다시 거짓말을 한다. 상수와 실제
+    // 렌더 결과를 여기서 맞춰 둔다.
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[appConfigProvider.overrideWithValue(_mock)],
+        child: MaterialApp(
+          locale: const Locale('ko'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) => TextButton(
+                onPressed: () => showCoachingSheet(context),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    // 구분선까지 세지 않도록 카드 위젯만 센다.
+    expect(
+      find.byWidgetPredicate(
+        (Widget w) => w.runtimeType.toString() == '_CoachCardTile',
+      ),
+      findsNWidgets(kCoachFallbackCardCount),
+    );
+  });
+}


### PR DESCRIPTION
Closes #788

## Summary

Oni 플로팅 버튼의 빨간 배지가 늘 `2` 였다. `OniFab.badgeCount` 기본값이 `2` 인데 `MainShell` 이 값을 넘기지 않아, 실제 제안 수와 무관하게 상수가 떠 있었다. 코칭 시트를 열어 다 읽어도 사라지지 않았다.

## Changes

- 배지가 **코칭 시트가 실제로 보여 줄 카드 수**를 따른다. 시트와 배지가 같은 provider(`coachingSuggestionCountProvider`)를 읽어 두 숫자가 갈리지 않는다.
- 시트를 열면 그 수를 '본 것'으로 기록하고 배지가 내려간다. 새 제안이 늘면 그만큼 다시 뜬다. 홈 배너로 열어도 같다.
- `OniFab.badgeCount` 기본값을 `0` 으로. 셀 수 없을 때는 배지를 그리지 않는 편이 상수보다 정직하다.

## Notes

- 데모/목업 모드에서는 시트가 기본 카드 2장을 그리므로 배지도 2로 시작한다. 우연히 예전 값과 같지만, 이제는 **시트 내용에서 나온 수**라 실 모드에서 제안이 3개면 3으로 뜬다.
- 상수(`kCoachFallbackCardCount`)와 시트가 실제로 그리는 카드 수가 어긋나면 배지가 다시 거짓말을 한다. 두 값을 맞추는 위젯 테스트를 함께 뒀다 — 상수만 검사하면 시트 내용이 바뀌었을 때 놓친다.
- '본 것' 상태는 앱을 다시 켜면 초기화된다. 코칭 카드는 하루 단위 요약이라 영구 저장까지 할 성질이 아니라고 봤다. 유지가 필요하면 별도 이슈로 뗀다.
- 알림 벨의 미읽음 점(`bellHasUnread`)이 서버 상태를 보도록 고친 것과 같은 종류의 문제였다.
- 검증: `flutter analyze` 무경고, 전체 `flutter test` 662건 통과(신규 5건 포함).
