### PR TITLE
fix(my): 건강 목표 조회 실패 시 기본값 노출과 덮어쓰기 방지

### DIFF
--- a/frontend/flutter/lib/features/my_health/presentation/widgets/my_flows.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/widgets/my_flows.dart
@@ -211,6 +211,66 @@ class _Avatar extends StatelessWidget {
 }
 
 /// Spinner shown inside a sheet while `profileProvider` is loading.
+/// 프로필을 못 읽었을 때의 화면.
+///
+/// 예전에는 빈 [UserProfile] 로 폼을 그렸다. 화면만 보면 조회 성공과 구별되지
+/// 않아, 기본값이 내 설정인 것처럼 보이고 그대로 저장하면 서버에 있던 실제 값이
+/// 기본값으로 덮였다(#789). 읽지 못했으면 읽지 못했다고 말하고, 저장 자체를
+/// 막는 것이 맞다.
+class _LoadFailed extends StatelessWidget {
+  const _LoadFailed({required this.onRetry});
+
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations l = AppLocalizations.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 40, horizontal: 16),
+      child: Column(
+        children: <Widget>[
+          const Icon(
+            Icons.cloud_off_rounded,
+            size: 32,
+            color: FigmaColors.textMuted,
+          ),
+          const SizedBox(height: 12),
+          const Text(
+            '설정을 불러오지 못했어요',
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: 15,
+              fontWeight: FontWeight.w700,
+              color: FigmaColors.ink,
+            ),
+          ),
+          const SizedBox(height: 6),
+          const Text(
+            '지금 저장하면 기존 설정이 지워질 수 있어 편집을 잠갔어요.',
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: 13.5,
+              height: 1.4,
+              color: AppColors.mutedForeground,
+            ),
+          ),
+          const SizedBox(height: 16),
+          OutlinedButton(
+            key: const Key('mySettingsRetry'),
+            onPressed: onRetry,
+            style: OutlinedButton.styleFrom(
+              foregroundColor: FigmaColors.primary,
+              side: BorderSide(color: FigmaColors.primaryA(0.4)),
+              minimumSize: const Size(48, 44),
+            ),
+            child: Text(l.actionRetry),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 class _SheetLoader extends StatelessWidget {
   const _SheetLoader();
 
@@ -304,9 +364,11 @@ class ProfileSettingsPage extends ConsumerWidget {
       data: (UserProfile p) => _ProfileForm(initial: p),
       loading: () =>
           _shell(context, l.myProfileTitle, const <Widget>[_SheetLoader()]),
-      error: (_, _) => const _ProfileForm(
-        initial: UserProfile(id: '', name: '', email: ''),
-      ),
+      // 건강 목표와 같은 이유로 폼을 그리지 않는다 — 빈 프로필을 저장하면
+      // 이름·연락처가 지워진다(#789).
+      error: (_, _) => _shell(context, l.myProfileTitle, <Widget>[
+        _LoadFailed(onRetry: () => ref.invalidate(profileProvider)),
+      ]),
     );
   }
 }
@@ -466,9 +528,9 @@ class HealthGoalsPage extends ConsumerWidget {
     return profile.when(
       data: (UserProfile p) => _GoalsForm(initial: p),
       loading: () => _shell(context, '건강 목표', const <Widget>[_SheetLoader()]),
-      error: (_, _) => const _GoalsForm(
-        initial: UserProfile(id: '', name: '', email: ''),
-      ),
+      error: (_, _) => _shell(context, '건강 목표', <Widget>[
+        _LoadFailed(onRetry: () => ref.invalidate(profileProvider)),
+      ]),
     );
   }
 }

--- a/frontend/flutter/test/features/my_health/settings_load_failure_test.dart
+++ b/frontend/flutter/test/features/my_health/settings_load_failure_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/account/domain/entities/user_profile.dart';
+import 'package:oncare/features/account/presentation/controllers/account_controller.dart';
+import 'package:oncare/features/my_health/presentation/widgets/my_flows.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+/// 조회에 실패한 프로필. `AsyncError` 로 넣어 화면의 error 분기를 태운다.
+class _FailingProfile extends ProfileController {
+  @override
+  Future<UserProfile> build() async => throw Exception('network down');
+}
+
+void main() {
+  Future<void> pump(WidgetTester tester, Widget page) async {
+    tester.view.physicalSize = const Size(390 * 3, 844 * 3);
+    tester.view.devicePixelRatio = 3.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[profileProvider.overrideWith(_FailingProfile.new)],
+        child: MaterialApp(
+          locale: const Locale('ko'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: page,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('건강 목표는 조회에 실패하면 폼 대신 사정을 알린다', (WidgetTester tester) async {
+    await pump(tester, const HealthGoalsPage());
+
+    // 예전에는 빈 프로필로 폼을 그려, 기본값이 내 목표인 것처럼 보이고 그대로
+    // 저장하면 서버의 실제 목표가 덮였다(#789).
+    expect(find.text('설정을 불러오지 못했어요'), findsOneWidget);
+    expect(find.byKey(const Key('mySettingsRetry')), findsOneWidget);
+    // 저장 버튼이 없어야 덮어쓸 방법도 없다.
+    expect(find.text('저장'), findsNothing);
+    expect(find.byType(TextField), findsNothing);
+  });
+
+  testWidgets('프로필 설정도 같은 이유로 폼을 열지 않는다', (WidgetTester tester) async {
+    await pump(tester, const ProfileSettingsPage());
+
+    expect(find.text('설정을 불러오지 못했어요'), findsOneWidget);
+    expect(find.byType(TextField), findsNothing);
+  });
+}


### PR DESCRIPTION
Closes #789

## Summary

MY > 건강 목표가 프로필 조회에 실패해도 실패했다고 알리지 않고 **기본값이 채워진 폼**을 보여 줬다. 화면만 보면 조회 성공과 구별되지 않아, 기본값이 내 목표인 것처럼 보이고 그대로 저장하면 서버에 있던 실제 목표가 기본값으로 덮였다.

## Changes

- 조회에 실패하면 폼 대신 사정을 알리고 다시 시도만 남긴다. 폼을 그리지 않으니 덮어쓸 방법 자체가 없어진다.
- 프로필 설정 화면도 같은 모양이라 함께 고쳤다.

## Notes

- 프로필 설정을 함께 고친 이유: `error:` 분기에서 빈 `UserProfile` 로 폼을 그리는 **같은 한 줄**이었다. 여기서는 이름·연락처가 지워진다. 한쪽만 고치면 남은 쪽이 그대로 같은 사고를 낸다.
- 안내 문구에 "지금 저장하면 기존 설정이 지워질 수 있어 편집을 잠갔어요" 를 넣었다. 편집이 막힌 이유를 말하지 않으면 그것대로 고장으로 읽힌다.
- **이슈 본문의 마지막 항목은 해당 없음이다.** "숫자 칸에 파싱 불가능한 값을 넣고 저장하면 조용히 무시된다" 고 적었는데, 목표 입력칸은 이미 `_digitsOnly` 포맷터를 쓰고 있어 문자를 칠 수 없다. 남는 경우는 칸을 **비우는** 것뿐이고, 그때 `null` 이 가는 것은 "이 항목은 안 바꿈" 이라는 부분 수정 계약대로다. 별도 처리를 넣지 않았다.
- 검증: `flutter analyze` 무경고, 전체 `flutter test` 659건 통과(신규 2건 포함).
