### PR TITLE
fix(my): 트레이너 찾기 버튼의 이동 대상 불일치

### DIFF
--- a/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
@@ -900,7 +900,11 @@ class _TrainerGymSection extends ConsumerWidget {
                   onRemoveTrainer: trainer == null
                       ? null
                       : () => _removeTrainer(context, ref, gym, trainer),
-                  onFindTrainer: onFindGym,
+                  // 헬스장은 이미 연결돼 있고 트레이너만 없는 상태다. 헬스장을
+                  // 찾는 화면이 아니라 **그 헬스장의 소속 트레이너**로 보낸다 —
+                  // 예전에는 라벨이 '트레이너 찾기'인데 헬스장 탭으로 갔다(#793).
+                  onFindTrainer: () =>
+                      context.push(AppRoutes.gymDetailPath(gym.id)),
                 ),
         ),
       ],

--- a/frontend/flutter/test/features/my_health/my_find_trainer_target_test.dart
+++ b/frontend/flutter/test/features/my_health/my_find_trainer_target_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:oncare/app/router/app_router.dart';
+import 'package:oncare/app/router/routes.dart';
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/features/exercise/domain/entities/gym.dart';
+import 'package:oncare/features/exercise/domain/entities/trainer.dart';
+import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
+import 'package:oncare/features/my_health/data/repositories/mock_my_health_repository.dart';
+import 'package:oncare/features/my_health/presentation/controllers/my_health_controller.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+const Gym _gym = Gym(
+  id: 'gym-mine',
+  name: '내 헬스장',
+  address: '서울시 서대문구 신촌로 1',
+  distanceKm: 0.4,
+  rating: 4.6,
+  tags: <String>['PT'],
+);
+
+const AppConfig _config = AppConfig(
+  environment: Environment.dev,
+  apiBaseUrl: 'https://dev.api.test',
+  useMockApi: true,
+);
+
+void main() {
+  testWidgets('담당 트레이너가 없으면 그 헬스장의 소속 트레이너로 보낸다 (#793)', (
+    WidgetTester tester,
+  ) async {
+    tester.view.physicalSize = const Size(390 * 3, 844 * 3);
+    tester.view.devicePixelRatio = 3.0;
+    addTearDown(tester.view.reset);
+
+    final GoRouter router = buildAppRouter(config: _config);
+    addTearDown(router.dispose);
+    router.go(AppRoutes.myHealth);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          // 헬스장은 연결돼 있고 담당 트레이너만 없는 상태 — 이 버튼이 뜨는 조건.
+          myGymProvider.overrideWith((ref) async => _gym),
+          myTrainerProvider.overrideWith((ref) async => null),
+          gymTrainersProvider(
+            _gym.id,
+          ).overrideWith((ref) async => const <Trainer>[]),
+          myHealthRepositoryProvider.overrideWithValue(
+            const MockMyHealthRepository(),
+          ),
+        ],
+        child: MaterialApp.router(
+          routerConfig: router,
+          locale: const Locale('ko'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final AppLocalizations l = AppLocalizations.of(
+      tester.element(find.byType(Scaffold).first),
+    );
+    final Finder findTrainer = find.text(l.exFindTrainer);
+    await tester.scrollUntilVisible(
+      findTrainer,
+      200,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.tap(findTrainer);
+    await tester.pumpAndSettle();
+
+    // 예전에는 라벨이 '트레이너 찾기'인데 헬스장을 찾는 운동 탭으로 갔다.
+    //
+    // `currentConfiguration.uri` 가 아니라 마지막 match 를 본다 — 셸 브랜치 위에
+    // push 하면 uri 는 브랜치 위치(`/my-health`)로 남고, 실제로 올라간 화면은
+    // match 목록의 끝에 있다.
+    expect(
+      router.routerDelegate.currentConfiguration.matches.last.matchedLocation,
+      AppRoutes.gymDetailPath(_gym.id),
+    );
+  });
+}


### PR DESCRIPTION
Closes #793

## Summary

MY 탭 '내 트레이너 · 헬스장' 카드에서 담당 트레이너가 없을 때 뜨는 **'트레이너 찾기'** 가 트레이너 목록이 아니라 운동 탭 헬스장 화면으로 갔다.

이 버튼이 뜨는 조건은 **헬스장은 이미 연결돼 있고 트레이너만 없는** 상태다. 그런데 헬스장을 찾는 화면으로 보내니, 이미 한 일을 다시 하라는 셈이었다.

## Changes

- 연결된 그 헬스장의 상세로 보낸다. 소속 트레이너 목록과 상담 신청이 있는 자리다.

## Notes

- 트레이너 목록(`AppRoutes.trainers`) 대신 헬스장 상세를 고른 이유: 이미 연결된 헬스장이 있으므로 **그 헬스장 소속** 트레이너가 먼저 보여야 한다. 전체 목록으로 보내면 연결된 헬스장과 무관한 트레이너까지 섞인다.
- 회귀 테스트는 라우터를 세우고 실제로 눌러 도착 라우트를 확인한다. `currentConfiguration.uri` 가 아니라 마지막 match 를 보는데, 셸 브랜치 위에 `push` 하면 uri 는 브랜치 위치(`/my-health`)로 남고 실제로 올라간 화면은 match 목록 끝에 있기 때문이다.
- 이 테스트가 옛 동작을 잡는지 확인했다 — 변경을 되돌리고 돌려 `/exercise` 로 실패하는 것을 보고 복구했다.
- 검증: `flutter analyze` 무경고, 전체 `flutter test` 658건 통과.
