### PR TITLE
fix(my): 라우터 테스트의 appConfigProvider 미주입으로 인한 main 실패

### DIFF
--- a/frontend/flutter/test/features/my_health/my_find_trainer_target_test.dart
+++ b/frontend/flutter/test/features/my_health/my_find_trainer_target_test.dart
@@ -43,6 +43,10 @@ void main() {
     await tester.pumpWidget(
       ProviderScope(
         overrides: <Override>[
+          // 라우터를 세우면 MainShell 도 함께 그려진다. 그 안의 Oni 배지가
+          // appConfigProvider 를 읽으므로 여기서 넘겨야 한다 — 없으면
+          // 'must be overridden in ProviderScope' 로 화면이 아예 뜨지 않는다(#805).
+          appConfigProvider.overrideWithValue(_config),
           // 헬스장은 연결돼 있고 담당 트레이너만 없는 상태 — 이 버튼이 뜨는 조건.
           myGymProvider.overrideWith((ref) async => _gym),
           myTrainerProvider.overrideWith((ref) async => null),


### PR DESCRIPTION
Closes #805

## Summary

`main` 의 사용자앱 테스트가 깨져 있다. #800 과 #804 는 각각 CI 를 통과했지만 합쳐진 뒤 실패한다.

## Changes

- 라우터 테스트의 `ProviderScope` 에 `appConfigProvider` 를 넘긴다. 그 파일에 이미 있던 `_config` 를 쓴다.

## Notes

- 원인: #800 이 `MainShell` 에서 `coachingBadgeCountProvider` 를 watch 하게 했고, 그 provider 가 `appConfigProvider` 를 읽는다. #804 의 테스트는 실제 라우터를 세워 `MainShell` 을 함께 그리므로 이제 그 provider 가 필요하다.
- 어느 PR 의 잘못도 아니다. CI 가 병합 결과가 아니라 PR head 를 검사하기 때문에 둘 다 초록이었다. 같은 종류의 사고는 앞으로도 날 수 있다 — 병합 직전 재검사(merge queue 또는 `Require branches to be up to date`)가 있으면 걸린다. 지금 범위 밖이라 이 PR 에서는 다루지 않는다.
- 검증: `flutter analyze` 무경고, 전체 `flutter test` 696건 통과.
