### PR TITLE
fix(ci): 연속 병합 시 main 검증 실행 취소 방지

### DIFF
--- a/.github/workflows/trainer-ci.yml
+++ b/.github/workflows/trainer-ci.yml
@@ -23,7 +23,13 @@ permissions:
 
 concurrency:
   group: trainer-ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # PR 실행만 취소한다. 같은 브랜치에 새 커밋이 오면 옛 실행은 볼 값이 없다.
+  #
+  # main 은 다르다. `github.ref` 가 병합마다 똑같이 `refs/heads/main` 이라,
+  # 연달아 병합하면 앞선 검증이 취소된다 — 병합 뒤 검증이 안전망인데 빠르게
+  # 병합할수록 그 안전망이 꺼진다. 2026-08-16 에 실제로 네 커밋이 검증되지
+  # 않은 채 지나갔고, 다섯 번째에서야 깨진 것이 드러났다(#807).
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   analyze-and-test:

--- a/.github/workflows/user-app-ci.yml
+++ b/.github/workflows/user-app-ci.yml
@@ -24,7 +24,13 @@ permissions:
 
 concurrency:
   group: user-app-ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # PR 실행만 취소한다. 같은 브랜치에 새 커밋이 오면 옛 실행은 볼 값이 없다.
+  #
+  # main 은 다르다. `github.ref` 가 병합마다 똑같이 `refs/heads/main` 이라,
+  # 연달아 병합하면 앞선 검증이 취소된다 — 병합 뒤 검증이 안전망인데 빠르게
+  # 병합할수록 그 안전망이 꺼진다. 2026-08-16 에 실제로 네 커밋이 검증되지
+  # 않은 채 지나갔고, 다섯 번째에서야 깨진 것이 드러났다(#807).
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   analyze-and-test:


### PR DESCRIPTION
#807 의 두 항목 중 **Problem 2** 를 다룬다. Problem 1(병합 전 최신 main 재검사)은 저장소 설정이라 이 PR 로 닫지 않는다.

## Summary

`concurrency` 그룹이 `github.ref` 로 묶여 있어 `push: main` 에도 취소가 걸렸다. 병합이 연달아 들어오면 ref 가 모두 `refs/heads/main` 이라 앞선 검증이 취소된다 — 병합 뒤 검증이 안전망인데, 빠르게 병합할수록 그 안전망이 스스로 꺼졌다.

## Changes

- `cancel-in-progress` 를 PR 실행으로만 좁혔다(`user-app-ci.yml`, `trainer-ci.yml`).

## Notes

- PR 실행은 지금처럼 취소한다. 같은 브랜치에 새 커밋이 오면 옛 실행은 볼 값이 없다.
- 실제 기록에서 네 커밋(`e7581ce0`·`fa8c95e7`·`e36959f1`·`b9ebf502`)이 검증되지 않은 채 지나갔고, 다섯 번째(`afd096b8`)에서야 실패가 드러났다. 그 실패조차 다음 병합이 곧 들어왔다면 취소됐을 수 있다.
- `backend-ci.yml` 에는 `concurrency` 블록이 없어 이 문제가 없다. 손대지 않았다.
- 워크플로 변경이라 이 PR 자체로는 동작을 확인할 수 없다. 병합 뒤 `main` 에 연속 push 가 생기는 시점에 실행이 남는지로 확인한다.
