### PR TITLE
fix(ci): 최신 main 반영을 강제하기 위한 PR 앵커 검사 추가

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -1,0 +1,38 @@
+name: PR Gate
+
+# 브랜치 보호의 '최신 main 반영' 을 실제로 걸기 위한 앵커 검사(#807).
+#
+# GitHub 은 `Require branches to be up to date before merging`(API 의 `strict`)을
+# **필수 상태 검사가 하나 이상 있을 때만** 적용한다. 필수 검사를 비워 두고 strict 만
+# 켜면 설정은 저장되지만 아무것도 막지 않는다 — 실제로 그렇게 두었더니 main 보다
+# 16 커밋 뒤진 PR 이 `BEHIND` 가 아니라 그냥 병합 가능으로 남았다.
+#
+# 기존 CI 세 개(user-app / trainer / backend)는 전부 `paths` 필터를 쓴다. 그것을
+# 필수로 지정하면 해당 경로를 건드리지 않는 PR 에서는 검사가 **생성되지 않아**
+# 영원히 대기한다(백엔드만 고치는 PR 이 사용자앱 검사를 기다리는 식). 그래서
+# 경로와 무관하게 항상 도는 이 검사를 필수로 삼는다.
+#
+# 이 검사는 코드 품질을 보지 않는다. 그 일은 각 CI 가 한다. 여기서 필요한 것은
+# "모든 PR 에 반드시 존재하는 검사" 하나뿐이다.
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    name: PR gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm the branch is current with the base
+        # strict 규칙이 병합 버튼을 막는 실제 주체다. 이 단계는 왜 이 검사가
+        # 있는지 로그에 남겨, 나중에 보는 사람이 빈 job 으로 오해하지 않게 한다.
+        run: |
+          echo "PR #${{ github.event.pull_request.number }}"
+          echo "base: ${{ github.event.pull_request.base.ref }}"
+          echo "이 검사는 브랜치 보호의 최신화 요구를 걸기 위한 앵커다(#807)."


### PR DESCRIPTION
Closes #807

#807 의 Problem 1 을 마무리한다. Problem 2(연속 병합 시 main 검증 취소)는 #808 에서 처리했다.

## Summary

브랜치 보호의 **최신 main 반영 요구**를 실제로 걸기 위한 앵커 검사를 추가한다.

`main` 에 `Require branches to be up to date before merging`(API 의 `strict`)만 켜 봤더니 **아무것도 막지 않았다.** GitHub 은 필수 상태 검사가 하나 이상 있을 때만 그 규칙을 적용한다. 설정은 저장되지만 효과가 없다.

## Changes

- `pr-gate.yml` 추가. 경로 필터 없이 모든 PR 에서 도는 가벼운 검사다.

## Notes

- **실증**: strict 만 켠 상태에서 #781 은 `main` 보다 16 커밋 뒤져 있었는데 상태가 `BEHIND` 가 아니라 그냥 병합 가능(`UNSTABLE`)이었다. 필수 검사가 없으면 strict 가 놀고 있다는 뜻이다.
- **기존 CI 를 필수로 지정하지 않은 이유**: `user-app-ci`·`trainer-ci`·`backend-ci` 는 모두 `paths` 필터를 쓴다. 필수로 지정하면 해당 경로를 건드리지 않는 PR 에서는 검사가 **생성되지 않아** 영원히 대기 상태가 된다. 백엔드만 고치는 PR 이 사용자앱 검사를 기다리는 식이다.
- 이 검사는 코드 품질을 보지 않는다. 그 일은 각 CI 가 계속 한다. 여기서 필요한 것은 "모든 PR 에 반드시 존재하는 검사" 하나뿐이다.
- 병합 뒤 이 검사를 브랜치 보호의 필수 항목으로 지정한다. 지정은 병합 **후**에 해야 한다 — 한 번도 돈 적 없는 검사를 필수로 걸면 열려 있는 PR 이 전부 막힌다.
- 앞으로 `main` 이 움직이면 병합 전에 브랜치 최신화가 필요하다. 팀 전체에 적용된다(협업자 세 명이 모두 admin 이라 `enforce_admins` 를 켜야 실효가 있었다).
