### PR TITLE
feat(program): AI 개인운동 제안의 검토·승인 상태와 API 추가

### DIFF
--- a/backend/app/api/v1/trainer.py
+++ b/backend/app/api/v1/trainer.py
@@ -47,6 +47,7 @@ from app.schemas.trainer_api import (
     ReportSendRequest, ReportSummaryOut,
     RoutineAssignRequest, RoutineOut, RoutineHistoryOut,
     RoutineFeedbackRequest,
+    RoutineSuggestionApproveRequest, RoutineSuggestionCreateRequest,
     ProgramAssignRequest,
     RoutineOptionsOut, RoutineOptionsRequest, RoutineUpdateRequest,
     ScheduleCompleteRequest, ScheduleCreateRequest, ScheduleProgramRegisterOut,
@@ -573,6 +574,107 @@ def trainer_assign_routine(
         type_=payload.type, reason=payload.reason, source=payload.source,
         client_request_id=payload.client_request_id,
     )
+
+
+# ---- AI 개인운동 제안 검토 (#790) ----
+
+@router.get(
+    "/trainer/clients/{member_id}/routine-suggestions",
+    response_model=list[RoutineOut],
+)
+def trainer_routine_suggestions(
+    member_id: str,
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> list[RoutineOut]:
+    """검토를 기다리는 AI 개인운동 제안 목록.
+
+    배정 목록(`GET .../routines`)과 나눠 둔다 — 배정은 이미 회원이 보는 것이고
+    제안은 아직 아무에게도 닿지 않은 것이라, 한 목록에 섞이면 어느 쪽이 회원에게
+    갔는지 알 수 없다.
+    """
+    _require_client(db, trainer.id, member_id)
+    return trainer_service.list_routine_suggestions(db, trainer.id, member_id)
+
+
+@router.post(
+    "/trainer/clients/{member_id}/routine-suggestions",
+    response_model=RoutineOut,
+    status_code=201,
+)
+def trainer_create_routine_suggestion(
+    member_id: str,
+    payload: RoutineSuggestionCreateRequest,
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> RoutineOut:
+    """AI 개인운동 후보를 검토 대기로 등록한다. 회원에게는 아직 보이지 않는다."""
+    _require_client(db, trainer.id, member_id)
+    if not payload.name.strip():
+        raise HTTPException(status_code=400, detail="운동 이름이 필요합니다.")
+    return trainer_service.create_routine_suggestion(
+        db,
+        trainer.id,
+        member_id,
+        name=payload.name.strip(),
+        minutes=payload.minutes,
+        type_=payload.type,
+        reason=payload.reason,
+        client_request_id=payload.client_request_id,
+    )
+
+
+@router.post(
+    "/trainer/routine-suggestions/{suggestion_id}/approve",
+    response_model=RoutineOut,
+)
+def trainer_approve_routine_suggestion(
+    suggestion_id: str,
+    payload: RoutineSuggestionApproveRequest,
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> RoutineOut:
+    """제안을 승인해 회원에게 배정한다. 준 필드가 있으면 고쳐서 승인한다."""
+    fields = payload.model_dump(exclude_unset=True)
+    name = fields.get("name")
+    if name is not None and not name.strip():
+        raise HTTPException(status_code=400, detail="운동 이름이 필요합니다.")
+    try:
+        return trainer_service.approve_routine_suggestion(
+            db,
+            trainer.id,
+            suggestion_id,
+            name=name.strip() if name is not None else None,
+            minutes=fields.get("minutes"),
+            type_=fields.get("type"),
+            reason=fields.get("reason"),
+        )
+    except trainer_service.RoutineNotFound as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except trainer_service.RoutineAlreadyReviewed as exc:
+        # 두 번 눌렀거나 다른 창에서 이미 처리한 경우다. 404 로 뭉개면 트레이너가
+        # "사라졌다" 로 읽는데, 실제로는 이미 반영돼 있다.
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+
+@router.post(
+    "/trainer/routine-suggestions/{suggestion_id}/dismiss",
+    response_model=RoutineOut,
+)
+def trainer_dismiss_routine_suggestion(
+    suggestion_id: str,
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> RoutineOut:
+    """제안을 추천하지 않기로 한다. 회원 배정도 알림도 만들지 않는다."""
+    try:
+        return trainer_service.dismiss_routine_suggestion(
+            db, trainer.id, suggestion_id
+        )
+    except trainer_service.RoutineNotFound as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except trainer_service.RoutineAlreadyReviewed as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 
 @router.post(

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -796,6 +796,20 @@ class TrainerRoutine(Base):
     type: Mapped[str] = mapped_column(String(20))  # 유산소|근력|스트레칭
     reason: Mapped[str] = mapped_column(String(200), default="")
     source: Mapped[str] = mapped_column(String(20), default="ai")  # ai|trainer
+    #: 검토 상태 — approved(회원에게 노출) | pending(트레이너 검토 대기) |
+    #: dismissed(추천하지 않기로 함).
+    #:
+    #: 기본이 approved 인 것이 하위 호환의 핵심이다. 지금까지의 배정은 모두
+    #: 트레이너가 보낸 것이므로 그대로 회원에게 보여야 한다. AI 가 만든 후보만
+    #: pending 으로 들어와 승인 전까지 회원 조회에서 빠진다.
+    status: Mapped[str] = mapped_column(String(20), default="approved", index=True)
+    #: 트레이너가 승인/거절한 시각. pending 인 동안은 비어 있다.
+    reviewed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    #: 검토한 트레이너 id. 배정 트레이너와 같지만, 나중에 대리 검토가 생겨도
+    #: 누가 판단했는지는 남아야 한다.
+    reviewed_by: Mapped[str | None] = mapped_column(String(64), nullable=True)
     #: 여러 세션을 한 프로그램으로 묶는 이름. 단일 루틴 배정은 빈 문자열이다.
     program_name: Mapped[str] = mapped_column(String(100), default="")
     #: 이 루틴이 어느 세션인가. 세션이 하나뿐이면 비어 있다.

--- a/backend/app/schemas/trainer_api.py
+++ b/backend/app/schemas/trainer_api.py
@@ -303,6 +303,33 @@ class RoutineAssignRequest(BaseModel):
     client_request_id: str | None = Field(default=None, max_length=64)
 
 
+class RoutineSuggestionCreateRequest(BaseModel):
+    """AI 개인운동 후보 등록. 검토 대기 상태로만 만들어진다.
+
+    승인 전에는 회원에게 닿지 않으므로 알림도 나가지 않는다.
+    """
+
+    name: str = Field(min_length=1, max_length=100)
+    minutes: int = Field(ge=0, le=600)
+    type: RoutineType
+    reason: str = Field(default="", max_length=200)
+    #: 재전송 중복 생성 방지용 멱등키. 배정(`AssignRoutineRequest`)과 같은 규약이다.
+    client_request_id: str | None = Field(default=None, max_length=64)
+
+
+class RoutineSuggestionApproveRequest(PartialUpdate):
+    """제안 승인. 필드를 주면 그것으로 고쳐서 승인한다(수정 후 추천).
+
+    아무 필드도 주지 않으면 그대로 승인이다. `RoutineUpdateRequest` 와 같은 이유로
+    명시적 null 은 422 다 — 이름·시간을 '지우는 것'은 기능이 아니다.
+    """
+
+    name: str | None = Field(default=None, min_length=1, max_length=100)
+    minutes: int | None = Field(default=None, ge=0, le=600)
+    type: RoutineType | None = None
+    reason: str | None = Field(default=None, max_length=200)
+
+
 class RoutineUpdateRequest(PartialUpdate):
     """루틴 부분 수정. 보낸 필드만 반영한다. (#504)
 

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -783,6 +783,16 @@ def delete_trainer_account(db: Session, trainer: User) -> None:
     db.commit()
 
 
+#: 배정 행의 검토 상태. AI 후보는 pending 으로 들어와 트레이너 판단을 기다린다.
+#:
+#: 기본이 approved 인 이유는 하위 호환이다 — 이 값이 생기기 전의 배정은 모두
+#: 트레이너가 보낸 것이므로 그대로 회원에게 보여야 한다.
+ROUTINE_APPROVED = "approved"
+ROUTINE_PENDING = "pending"
+ROUTINE_DISMISSED = "dismissed"
+ROUTINE_STATUSES = frozenset({ROUTINE_APPROVED, ROUTINE_PENDING, ROUTINE_DISMISSED})
+
+
 def build_routines(db: Session, member_id: str, trainer_id: str) -> list[RoutineOut]:
     """이 트레이너가 회원에게 배정한 루틴(정렬순).
 
@@ -791,7 +801,14 @@ def build_routines(db: Session, member_id: str, trainer_id: str) -> list[Routine
     """
     rows = db.scalars(
         select(TrainerRoutine)
-        .where(TrainerRoutine.trainer_id == trainer_id, TrainerRoutine.member_id == member_id)
+        .where(
+            TrainerRoutine.trainer_id == trainer_id,
+            TrainerRoutine.member_id == member_id,
+            # 검토를 기다리는 후보와 거절된 후보는 '배정된 루틴'이 아니다.
+            # 회원 화면은 물론 트레이너의 배정 목록에도 섞이면 안 된다 —
+            # 검토는 전용 목록(list_routine_suggestions)에서 한다(#790).
+            TrainerRoutine.status == ROUTINE_APPROVED,
+        )
         .order_by(TrainerRoutine.sort_order, TrainerRoutine.created_at)
     ).all()
     routine_ids = [row.id for row in rows]
@@ -908,6 +925,166 @@ _ROUTINE_EXERCISE_TYPES = {
 }
 
 
+
+# ─────────────────────────────────── AI 개인운동 제안 검토 ───────────────────
+
+class RoutineAlreadyReviewed(Exception):
+    """이미 승인/거절된 제안을 다시 검토하려 했다."""
+
+
+def create_routine_suggestion(
+    db: Session,
+    trainer_id: str,
+    member_id: str,
+    *,
+    name: str,
+    minutes: int,
+    type_: str,
+    reason: str,
+    client_request_id: str | None = None,
+) -> RoutineOut:
+    """AI 개인운동 후보를 검토 대기(pending) 로 만든다.
+
+    [assign_routine] 과 나눠 둔 이유: 배정은 회원에게 곧바로 닿는 행동이고 알림도
+    나가지만, 후보는 아직 아무에게도 닿지 않는다. 알림은 승인 시점에 나간다 —
+    트레이너가 보지도 않은 운동으로 회원이 먼저 알림을 받으면 안 된다(#790).
+    """
+    if client_request_id:
+        existing = find_routine_by_client_request(
+            db, trainer_id, member_id, client_request_id
+        )
+        if existing is not None:
+            return _routine_out(existing)
+
+    max_order = db.scalar(
+        select(func.max(TrainerRoutine.sort_order)).where(
+            TrainerRoutine.trainer_id == trainer_id,
+            TrainerRoutine.member_id == member_id,
+        )
+    )
+    rt = TrainerRoutine(
+        id=f"rt-{uuid.uuid4().hex[:12]}",
+        trainer_id=trainer_id,
+        member_id=member_id,
+        name=name,
+        minutes=minutes,
+        type=type_,
+        reason=reason,
+        source="ai",
+        status=ROUTINE_PENDING,
+        sort_order=(max_order or 0) + 1,
+        client_request_id=client_request_id,
+        created_at=clock.now(),
+    )
+    db.add(rt)
+    try:
+        db.flush()
+    except IntegrityError:
+        db.rollback()
+        if client_request_id:
+            existing = find_routine_by_client_request(
+                db, trainer_id, member_id, client_request_id
+            )
+            if existing is not None:
+                return _routine_out(existing)
+        raise
+    db.commit()
+    db.refresh(rt)
+    return _routine_out(rt)
+
+
+def list_routine_suggestions(
+    db: Session, trainer_id: str, member_id: str
+) -> list[RoutineOut]:
+    """검토를 기다리는 AI 개인운동 제안. 승인·거절한 것은 빠진다."""
+    rows = db.scalars(
+        select(TrainerRoutine)
+        .where(
+            TrainerRoutine.trainer_id == trainer_id,
+            TrainerRoutine.member_id == member_id,
+            TrainerRoutine.status == ROUTINE_PENDING,
+        )
+        .order_by(TrainerRoutine.sort_order, TrainerRoutine.created_at)
+    ).all()
+    return [_routine_out(row) for row in rows]
+
+
+def _pending_suggestion(
+    db: Session, trainer_id: str, suggestion_id: str
+) -> TrainerRoutine:
+    """검토할 수 있는 제안 하나. 남의 것·없는 것은 [RoutineNotFound].
+
+    이미 처리된 제안은 [RoutineAlreadyReviewed] 로 나눈다 — 없는 것과 같은 답을
+    주면, 두 번 눌렀을 때 트레이너가 "사라졌다" 로 읽는다. 실제로는 이미 반영됐다.
+    """
+    row = db.scalar(
+        select(TrainerRoutine).where(
+            TrainerRoutine.id == suggestion_id,
+            TrainerRoutine.trainer_id == trainer_id,
+        )
+    )
+    if row is None:
+        raise RoutineNotFound("제안을 찾을 수 없습니다.")
+    if row.status != ROUTINE_PENDING:
+        raise RoutineAlreadyReviewed("이미 검토한 제안입니다.")
+    return row
+
+
+def approve_routine_suggestion(
+    db: Session,
+    trainer_id: str,
+    suggestion_id: str,
+    *,
+    name: str | None = None,
+    minutes: int | None = None,
+    type_: str | None = None,
+    reason: str | None = None,
+) -> RoutineOut:
+    """제안을 승인해 회원에게 배정한다. 준 값이 있으면 그것으로 고쳐서 승인한다.
+
+    새 행을 만들지 않고 이 행의 상태를 바꾼다. 후보와 배정이 같은 행이라
+    회원 조회·완료 처리·프로그램 묶음이 지금 쓰는 경로를 그대로 지난다.
+    """
+    row = _pending_suggestion(db, trainer_id, suggestion_id)
+    if name is not None:
+        row.name = name
+    if minutes is not None:
+        row.minutes = minutes
+    if type_ is not None:
+        row.type = type_
+    if reason is not None:
+        row.reason = reason
+    row.status = ROUTINE_APPROVED
+    row.reviewed_at = clock.now()
+    row.reviewed_by = trainer_id
+
+    # 알림은 여기서 나간다 — 회원이 볼 수 있게 된 시점이 곧 알릴 시점이다.
+    notification_service.queue(
+        db,
+        member_id=row.member_id,
+        kind=notification_service.EXERCISE,
+        category=notification_service.MEMBER_ROUTINE,
+        title="새 운동 루틴이 배정되었어요",
+        body=f"{row.name} · {row.minutes}분",
+    )
+    db.commit()
+    db.refresh(row)
+    return _routine_out(row)
+
+
+def dismiss_routine_suggestion(
+    db: Session, trainer_id: str, suggestion_id: str
+) -> RoutineOut:
+    """제안을 추천하지 않기로 한다. 회원 배정도 알림도 만들지 않는다."""
+    row = _pending_suggestion(db, trainer_id, suggestion_id)
+    row.status = ROUTINE_DISMISSED
+    row.reviewed_at = clock.now()
+    row.reviewed_by = trainer_id
+    db.commit()
+    db.refresh(row)
+    return _routine_out(row)
+
+
 def complete_assigned_routine(
     db: Session,
     trainer_id: str,
@@ -924,6 +1101,10 @@ def complete_assigned_routine(
     모은다. 이름은 스냅샷이라 이후 배정 수정·철회에 흔들리지 않는다.
     """
     routine = _owned_routine(db, trainer_id, member_id, routine_id)
+    # 승인되지 않은 후보는 회원에게 보이지도 않는다. id 를 알아내 직접 호출해도
+    # 완료로 넘어가지 않게 여기서 막는다 — 조회만 거르면 경로가 하나 남는다(#790).
+    if routine.status != ROUTINE_APPROVED:
+        raise RoutineNotFound("루틴을 찾을 수 없습니다.")
     existing = db.scalar(
         select(ExerciseSession).where(
             ExerciseSession.assigned_routine_id == routine_id

--- a/backend/migrations/versions/0040_routine_review_status.py
+++ b/backend/migrations/versions/0040_routine_review_status.py
@@ -1,0 +1,60 @@
+"""Give an assigned routine a review status so AI suggestions wait for the trainer.
+
+AI 가 만든 개인운동 후보가 곧바로 회원에게 배정되면, 트레이너가 알고 있는
+부상·회복 상태가 반영되지 않은 운동이 회원 화면에 뜬다. 배정 행에 검토 상태를
+두어 승인 전에는 회원 조회에서 빠지게 한다.
+
+기존 행은 모두 `approved` 로 채운다 — 지금까지 배정된 루틴은 이미 트레이너가
+보낸 것이므로, 이 마이그레이션 뒤에도 회원 화면이 달라지지 않는다.
+
+Revision ID: 0040_routine_review_status
+Revises: 0039_program_sessions
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0040_routine_review_status"
+down_revision: str | Sequence[str] | None = "0039_program_sessions"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # server_default 를 둬야 이미 있는 행이 NOT NULL 을 만족한다. 기본값을
+    # `approved` 로 잡는 것이 하위 호환의 핵심이다 — 예전 배정은 전부 승인된
+    # 것으로 읽혀야 회원 화면이 그대로다.
+    op.add_column(
+        "trainer_routines",
+        sa.Column(
+            "status",
+            sa.String(length=20),
+            nullable=False,
+            server_default="approved",
+        ),
+    )
+    op.add_column(
+        "trainer_routines",
+        sa.Column("reviewed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "trainer_routines",
+        sa.Column("reviewed_by", sa.String(length=64), nullable=True),
+    )
+    # 회원 조회는 status 로 거른다. 트레이너·회원 조합에 이미 인덱스가 있으므로
+    # 상태만 따로 걸어 두면 검토 대기 목록 조회가 전체 스캔으로 떨어지지 않는다.
+    op.create_index(
+        "ix_trainer_routines_status",
+        "trainer_routines",
+        ["status"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_trainer_routines_status", table_name="trainer_routines")
+    op.drop_column("trainer_routines", "reviewed_by")
+    op.drop_column("trainer_routines", "reviewed_at")
+    op.drop_column("trainer_routines", "status")

--- a/backend/migrations/versions/0042_routine_review_status.py
+++ b/backend/migrations/versions/0042_routine_review_status.py
@@ -7,8 +7,8 @@ AI 가 만든 개인운동 후보가 곧바로 회원에게 배정되면, 트레
 기존 행은 모두 `approved` 로 채운다 — 지금까지 배정된 루틴은 이미 트레이너가
 보낸 것이므로, 이 마이그레이션 뒤에도 회원 화면이 달라지지 않는다.
 
-Revision ID: 0040_routine_review_status
-Revises: 0039_program_sessions
+Revision ID: 0042_routine_review_status
+Revises: 0041_schedule_program_sent
 """
 from __future__ import annotations
 
@@ -17,8 +17,8 @@ from collections.abc import Sequence
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "0040_routine_review_status"
-down_revision: str | Sequence[str] | None = "0039_program_sessions"
+revision: str = "0042_routine_review_status"
+down_revision: str | Sequence[str] | None = "0041_schedule_program_sent"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/tests/test_routine_suggestion_review.py
+++ b/backend/tests/test_routine_suggestion_review.py
@@ -1,0 +1,235 @@
+"""AI 개인운동 제안의 검토·승인·거절. (#790) DB 필요.
+
+핵심 계약은 하나다 — **트레이너가 승인하기 전에는 회원에게 닿지 않는다.**
+AI 가 만든 후보가 곧바로 배정되면, 트레이너가 알고 있는 부상·회복 상태가
+반영되지 않은 운동이 회원 화면에 뜬다.
+"""
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+
+def _trainer_token(client) -> str:
+    return client.post(
+        "/v1/auth/login",
+        data={"username": "trainer@oncare.com", "password": "oncare123"},
+    ).json()["access_token"]
+
+
+def _member_token(client) -> str:
+    return client.post(
+        "/v1/auth/login",
+        data={"username": "jisu@oncare.com", "password": "oncare123"},
+    ).json()["access_token"]
+
+
+def _h(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+MEMBER = "user-jisu"
+
+
+@pytest.fixture()
+def suggestion(client):
+    """검토 대기 제안 하나. 테스트가 끝나면 지운다."""
+    token = _trainer_token(client)
+    created = client.post(
+        f"/v1/trainer/clients/{MEMBER}/routine-suggestions",
+        headers=_h(token),
+        json={
+            "name": f"어깨 스트레칭 {uuid4().hex[:6]}",
+            "minutes": 8,
+            "type": "스트레칭",
+            "reason": "최근 PT 피드백 반영",
+        },
+    )
+    assert created.status_code == 201, created.text
+    row = created.json()
+    yield token, row
+    client.delete(
+        f"/v1/trainer/clients/{MEMBER}/routines/{row['id']}", headers=_h(token)
+    )
+
+
+def test_pending_suggestion_is_invisible_to_the_member(client, suggestion):
+    _, row = suggestion
+
+    mine = client.get("/v1/me/coach/routines", headers=_h(_member_token(client)))
+
+    assert mine.status_code == 200, mine.text
+    assert row["id"] not in {r["id"] for r in mine.json()}
+
+
+def test_pending_suggestion_is_not_in_the_assigned_list(client, suggestion):
+    token, row = suggestion
+
+    assigned = client.get(
+        f"/v1/trainer/clients/{MEMBER}/routines", headers=_h(token)
+    )
+
+    # 배정 목록은 '이미 회원이 보는 것'이다. 아직 검토 전인 후보가 섞이면
+    # 어느 쪽이 회원에게 갔는지 알 수 없다.
+    assert row["id"] not in {r["id"] for r in assigned.json()}
+
+
+def test_suggestion_shows_up_in_the_review_list(client, suggestion):
+    token, row = suggestion
+
+    pending = client.get(
+        f"/v1/trainer/clients/{MEMBER}/routine-suggestions", headers=_h(token)
+    )
+
+    assert row["id"] in {r["id"] for r in pending.json()}
+
+
+def test_approve_makes_it_visible_to_the_member(client, suggestion):
+    token, row = suggestion
+
+    approved = client.post(
+        f"/v1/trainer/routine-suggestions/{row['id']}/approve",
+        headers=_h(token),
+        json={},
+    )
+    assert approved.status_code == 200, approved.text
+
+    mine = client.get("/v1/me/coach/routines", headers=_h(_member_token(client)))
+    assert row["id"] in {r["id"] for r in mine.json()}
+
+
+def test_approve_with_edits_saves_the_edited_values(client, suggestion):
+    token, row = suggestion
+
+    approved = client.post(
+        f"/v1/trainer/routine-suggestions/{row['id']}/approve",
+        headers=_h(token),
+        json={"minutes": 10, "reason": "오른쪽 어깨 통증 시 중단"},
+    )
+
+    assert approved.status_code == 200, approved.text
+    body = approved.json()
+    assert body["minutes"] == 10
+    assert body["reason"] == "오른쪽 어깨 통증 시 중단"
+    # 주지 않은 값은 그대로다.
+    assert body["name"] == row["name"]
+
+
+def test_dismiss_keeps_it_away_from_the_member(client, suggestion):
+    token, row = suggestion
+
+    dismissed = client.post(
+        f"/v1/trainer/routine-suggestions/{row['id']}/dismiss", headers=_h(token)
+    )
+    assert dismissed.status_code == 200, dismissed.text
+
+    mine = client.get("/v1/me/coach/routines", headers=_h(_member_token(client)))
+    assert row["id"] not in {r["id"] for r in mine.json()}
+    pending = client.get(
+        f"/v1/trainer/clients/{MEMBER}/routine-suggestions", headers=_h(token)
+    )
+    assert row["id"] not in {r["id"] for r in pending.json()}
+
+
+def test_second_review_is_rejected_rather_than_silently_repeated(client, suggestion):
+    token, row = suggestion
+
+    first = client.post(
+        f"/v1/trainer/routine-suggestions/{row['id']}/approve",
+        headers=_h(token),
+        json={},
+    )
+    assert first.status_code == 200
+
+    second = client.post(
+        f"/v1/trainer/routine-suggestions/{row['id']}/approve",
+        headers=_h(token),
+        json={},
+    )
+
+    # 404 로 뭉개면 트레이너가 "사라졌다" 로 읽는다. 실제로는 이미 반영돼 있다.
+    assert second.status_code == 409, second.text
+
+
+def test_dismissed_suggestion_cannot_be_approved_afterwards(client, suggestion):
+    token, row = suggestion
+
+    client.post(
+        f"/v1/trainer/routine-suggestions/{row['id']}/dismiss", headers=_h(token)
+    )
+    late = client.post(
+        f"/v1/trainer/routine-suggestions/{row['id']}/approve",
+        headers=_h(token),
+        json={},
+    )
+
+    assert late.status_code == 409, late.text
+
+
+def test_member_cannot_complete_a_pending_suggestion(client, suggestion):
+    _, row = suggestion
+
+    done = client.post(
+        f"/v1/me/coach/routines/{row['id']}/complete",
+        headers=_h(_member_token(client)),
+        json={"minutes": 8, "intensity": "light", "member_note": ""},
+    )
+
+    # 조회에서만 거르면 id 를 알아낸 호출이 한 경로 남는다.
+    assert done.status_code == 404, done.text
+
+
+def test_same_client_request_id_does_not_create_two_suggestions(client):
+    token = _trainer_token(client)
+    key = uuid4().hex
+    payload = {
+        "name": f"저강도 걷기 {key[:6]}",
+        "minutes": 20,
+        "type": "유산소",
+        "reason": "회복",
+        "client_request_id": key,
+    }
+
+    first = client.post(
+        f"/v1/trainer/clients/{MEMBER}/routine-suggestions",
+        headers=_h(token),
+        json=payload,
+    )
+    second = client.post(
+        f"/v1/trainer/clients/{MEMBER}/routine-suggestions",
+        headers=_h(token),
+        json=payload,
+    )
+
+    assert first.status_code == 201, first.text
+    assert second.json()["id"] == first.json()["id"]
+
+    client.delete(
+        f"/v1/trainer/clients/{MEMBER}/routines/{first.json()['id']}",
+        headers=_h(token),
+    )
+
+
+def test_existing_assignments_stay_visible(client):
+    """상태 칼럼이 생겨도 예전처럼 배정한 루틴은 그대로 회원에게 간다."""
+    token = _trainer_token(client)
+    created = client.post(
+        f"/v1/trainer/clients/{MEMBER}/routines",
+        headers=_h(token),
+        json={
+            "name": f"직접 배정 {uuid4().hex[:6]}",
+            "minutes": 30,
+            "type": "근력",
+            "reason": "직접 배정",
+        },
+    )
+    assert created.status_code == 201, created.text
+    row = created.json()
+
+    mine = client.get("/v1/me/coach/routines", headers=_h(_member_token(client)))
+    assert row["id"] in {r["id"] for r in mine.json()}
+
+    client.delete(
+        f"/v1/trainer/clients/{MEMBER}/routines/{row['id']}", headers=_h(token)
+    )


### PR DESCRIPTION
#790 의 `### Backend / Domain` 체크리스트를 처리한다. 트레이너 웹 UI 와 회원 앱 화면은 이 PR 범위 밖이다(사유는 #790 댓글).

## Summary

AI 가 만든 개인운동 후보가 곧바로 회원에게 배정되면, 트레이너가 아는 부상·회복 상태가 반영되지 않은 운동이 회원 화면에 뜬다. 배정 행에 검토 상태를 두어 **승인 전에는 회원에게 닿지 않게** 한다.

## Changes

- `trainer_routines.status` 추가: `approved` | `pending` | `dismissed` (+ `reviewed_at`, `reviewed_by`).
- 회원 조회(`GET /me/coach/routines`)와 트레이너 배정 목록은 `approved` 만 본다.
- 검토 API 추가
  - `GET  /trainer/clients/{member_id}/routine-suggestions` — 검토 대기 목록
  - `POST /trainer/clients/{member_id}/routine-suggestions` — 후보 등록(pending)
  - `POST /trainer/routine-suggestions/{id}/approve` — 승인(필드를 주면 수정 후 승인)
  - `POST /trainer/routine-suggestions/{id}/dismiss` — 추천 안 함
- 마이그레이션 `0040_routine_review_status`.

## Notes

- **하위 호환**: 기본값이 `approved` 다. 이 칼럼이 생기기 전의 배정은 모두 트레이너가 보낸 것이므로 그대로 회원에게 보여야 한다. 마이그레이션 뒤 회원 화면이 달라지지 않는 것을 테스트로 못박았다.
- **후보와 배정을 같은 행으로 둔 이유.** 별도 suggestion 테이블을 만들면 `exercises_json`·프로그램 묶음·완료 연결·멱등키를 전부 다시 만들어야 한다. 상태 하나를 더하면 회원 조회·완료 처리가 지금 경로를 그대로 지난다. #790 의 "기존 모델에 자연스럽게 추가할 수 있다면 기존 구조를 확장한다" 를 따랐다.
  - 다만 #790 본문은 `AI suggestion → approve → 기존 routine assignment 생성` 이라는 그림도 함께 제시한다. 이 PR 은 행을 새로 만드는 대신 **상태를 바꾼다.** 회원 입장에서 "승인 전에는 배정이 존재하지 않는다" 는 계약은 같지만 구현이 다르므로, 다르게 가야 한다면 알려주세요 — 바꾸는 비용은 지금이 가장 싸다.
- **노출 차단을 두 곳에 걸었다.** 조회에서 거르고, 완료 호출(`POST /me/coach/routines/{id}/complete`)도 막는다. 조회만 거르면 id 를 알아낸 호출이 한 경로 남는다.
- **재검토는 409 다.** 404 로 뭉개면 두 번 눌렀을 때 트레이너가 "사라졌다" 로 읽는데, 실제로는 이미 반영돼 있다.
- **AI 후보의 자동 생성(스케줄러)은 범위 밖이다.** 지금은 등록 API 로 후보가 들어온다. 기존 `trainer_routine_options_service`(LLM + 규칙 폴백)를 재사용해 주기적으로 채우는 것은 트레이너 웹 UI 와 함께 붙이는 편이 자연스럽다.
- 검증: 백엔드 전체 `pytest` 868건 통과(신규 11건 포함).

### 로컬 테스트 DB 참고

테스트 DB 는 alembic 이 아니라 `create_all` 로 만들어져 이력이 없다. 이미 만들어 둔 로컬 DB 가 있다면 칼럼을 직접 맞춰야 한다(CI 는 매번 새 DB 라 해당 없음).

```sql
ALTER TABLE trainer_routines ADD COLUMN IF NOT EXISTS status VARCHAR(20) NOT NULL DEFAULT 'approved';
ALTER TABLE trainer_routines ADD COLUMN IF NOT EXISTS reviewed_at TIMESTAMPTZ NULL;
ALTER TABLE trainer_routines ADD COLUMN IF NOT EXISTS reviewed_by VARCHAR(64) NULL;
CREATE INDEX IF NOT EXISTS ix_trainer_routines_status ON trainer_routines (status);
```
