### PR TITLE
feat(exercise): AI 조언과 추천 개인운동을 하나의 AI 코칭으로 통합

### DIFF
--- a/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
@@ -312,31 +312,31 @@ class _RecordTabState extends ConsumerState<_RecordTab> {
               ),
             ),
             const SizedBox(height: 20),
-            // 2) AI 피드백
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 24),
-              child: _ExerciseFeedback(message: week.aiCoachMessage),
-            ),
-            const SizedBox(height: 20),
-            // 3) 운동 현황 (오늘 / 이번 주 / 이번 달)
+            // 2) 운동 현황 (오늘 / 이번 주 / 이번 달)
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 24),
               child: _ActivityStatus(week: week),
             ),
             const SizedBox(height: 20),
-            // 4) 운동 현황에 이어 담당 트레이너와 직접 추천 운동을 확인한다.
-            const CoachCard(),
-            // 5) 오늘 완료한 PT 일지 (트레이너 연동)
+            // 3) 오늘 완료한 PT 일지 (트레이너 피드백 포함)
             const Padding(
               padding: EdgeInsets.symmetric(horizontal: 24),
               child: _PtLogCard(),
             ),
             const SizedBox(height: 20),
-            // 6) 건강 기록과 PT 피드백 기반 AI 맞춤 개인운동
-            const Padding(
-              padding: EdgeInsets.symmetric(horizontal: 24),
-              child: AiRecommendedExerciseCard(),
+            // 4) AI 코칭 — 코칭 포인트와 추천 개인운동.
+            //
+            // PT 피드백 바로 다음에 둔다. `오늘 PT 에서 받은 피드백 → 그래서
+            // 어떤 관리가 필요한지 → 어떤 개인운동을 하면 되는지` 가 한 흐름으로
+            // 읽혀야 한다. 예전에는 조언이 맨 위, 추천 운동이 맨 아래라 그 사이를
+            // 회원이 직접 이어 붙여야 했다(#782).
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: AiCoachingCard(coachingPoint: week.aiCoachMessage),
             ),
+            const SizedBox(height: 20),
+            // 5) 담당 트레이너 — 관계와 소통만. 추천 운동은 AI 코칭에 모였다.
+            const CoachCard(),
           ],
         ],
       ),
@@ -1751,58 +1751,6 @@ class _StackedBarPainter extends CustomPainter {
       oldDelegate.todayIndex != todayIndex ||
       oldDelegate.todayLabel != todayLabel ||
       oldDelegate.progress != progress;
-}
-
-class _ExerciseFeedback extends StatelessWidget {
-  const _ExerciseFeedback({required this.message});
-
-  final String message;
-
-  @override
-  Widget build(BuildContext context) {
-    final AppLocalizations l = AppLocalizations.of(context);
-    if (message.trim().isEmpty) return const SizedBox.shrink();
-    return Container(
-      padding: const EdgeInsets.all(14),
-      decoration: BoxDecoration(
-        color: FigmaColors.softBlue,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: FigmaColors.primaryA(0.15)),
-      ),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          const OniAvatar(size: 40),
-          const SizedBox(width: 12),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Text(
-                  l.exAiFeedback,
-                  style: const TextStyle(
-                    fontSize: 13.5,
-                    fontWeight: FontWeight.w700,
-                    color: FigmaColors.primary,
-                  ),
-                ),
-                const SizedBox(height: 2),
-                Text(
-                  message,
-                  style: const TextStyle(
-                    fontSize: 13.5,
-                    height: 1.5,
-                    fontWeight: FontWeight.w500,
-                    color: FigmaColors.ink,
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ],
-      ),
-    );
-  }
 }
 
 // ───────────────────────────────────── 오늘 완료한 PT 일지 ──

--- a/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_card.dart
+++ b/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_card.dart
@@ -11,7 +11,12 @@ import 'package:oncare/features/member_coach/domain/entities/member_coach.dart';
 import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
 import 'package:oncare/features/member_coach/presentation/widgets/coach_chat_sheet.dart';
 
-/// 담당 트레이너 정보와 트레이너가 직접 추천한 개인운동을 표시한다.
+/// 담당 트레이너 관계와 소통만 담는다 — 이름·전문 분야·프로필 이동·채팅.
+///
+/// 추천 개인운동은 여기 있지 않다. 트레이너 추천이든 AI 추천이든 회원에게는
+/// "지금 무엇을 하면 되는가" 라는 한 가지 질문이라, [AiCoachingCard] 의
+/// `추천 개인운동` 한 곳에 모았다(#782). 예전에는 이 카드와 AI 카드가 화면
+/// 두 곳에 나뉘어 있어 둘의 관계와 우선순위를 회원이 다시 해석해야 했다.
 class CoachCard extends ConsumerWidget {
   const CoachCard({super.key});
 
@@ -24,10 +29,6 @@ class CoachCard extends ConsumerWidget {
     // 여러 명이 있으므로 헬스장 id 로는 한 명을 특정할 수 없다.
     final assignedTrainer = ref.watch(myTrainerProvider).valueOrNull;
 
-    final List<CoachRoutine> trainerRoutines =
-        (ref.watch(coachRoutinesProvider).valueOrNull ?? const <CoachRoutine>[])
-            .where((CoachRoutine routine) => routine.isTrainerRecommended)
-            .toList();
     final unread = ref.watch(coachUnreadProvider).valueOrNull ?? 0;
 
     return Padding(
@@ -106,38 +107,6 @@ class CoachCard extends ConsumerWidget {
               ),
             ),
             const SizedBox(height: 14),
-            const Text(
-              '트레이너 추천 추가 개인운동',
-              style: TextStyle(
-                fontSize: 14,
-                fontWeight: FontWeight.w700,
-                color: FigmaColors.ink,
-              ),
-            ),
-            const SizedBox(height: 10),
-            if (trainerRoutines.isEmpty)
-              const Text(
-                '아직 트레이너가 추천한 개인운동이 없어요',
-                style: TextStyle(
-                  fontSize: 13.5,
-                  color: AppColors.mutedForeground,
-                ),
-              )
-            else
-              for (final (int index, CoachRoutine routine)
-                  in trainerRoutines.indexed) ...<Widget>[
-                // 여러 세션짜리 프로그램은 첫 세션 위에 프로그램 이름을 한 번
-                // 얹는다 — 세션 카드가 어디에 묶이는지 보이지 않으면 그냥
-                // 낱개 루틴 여러 개로 읽힌다(#709).
-                if (routine.programName.isNotEmpty &&
-                    (index == 0 ||
-                        trainerRoutines[index - 1].programName !=
-                            routine.programName))
-                  _ProgramHeading(name: routine.programName),
-                _RecommendedExerciseRow(routine: routine),
-                const SizedBox(height: 8),
-              ],
-            const SizedBox(height: 6),
             _ChatButton(
               unread: unread,
               onTap: () =>
@@ -150,18 +119,37 @@ class CoachCard extends ConsumerWidget {
   }
 }
 
-/// 건강 기록과 PT 피드백을 바탕으로 생성된 AI 추천 개인운동만 표시한다.
-class AiRecommendedExerciseCard extends ConsumerWidget {
-  const AiRecommendedExerciseCard({super.key});
+/// 운동 탭의 `AI 코칭` — 코칭 포인트와 추천 개인운동을 한 흐름으로 보여준다.
+///
+/// 예전에는 `AI 맞춤 조언`(텍스트)과 `AI 맞춤 운동`(카드)이 화면 위아래로 멀리
+/// 떨어져 있고 그 사이에 운동 현황·트레이너 카드가 끼어 있었다. 둘은 같은
+/// 기록에서 나온 같은 판단인데, 회원은 "왜 이 운동인지" 를 다시 이어 붙여야
+/// 했다(#782).
+///
+/// 추천 개인운동은 `추가 운동` 이 아니라 **PT 와 다음 PT 사이에 스스로 하는
+/// 운동**이다. 그래서 추천할 것이 없는 날은 빈 카드를 만들지 않고 코칭 포인트만
+/// 남긴다 — AI 가 매번 운동을 억지로 만들어 낼 이유가 없다.
+class AiCoachingCard extends ConsumerWidget {
+  const AiCoachingCard({required this.coachingPoint, super.key});
+
+  /// 이번 코칭 포인트. 운동 주간 데이터의 `aiCoachMessage` 가 그대로 들어온다.
+  final String coachingPoint;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final List<CoachRoutine> aiRoutines =
-        (ref.watch(coachRoutinesProvider).valueOrNull ?? const <CoachRoutine>[])
-            .where((CoachRoutine routine) => routine.isAiRecommended)
-            .toList();
+    // 트레이너 추천과 AI 추천을 한 목록으로 합친다. 회원에게는 "지금 무엇을
+    // 하면 되는가" 라는 한 가지 질문이고, 누가 정했는지는 각 줄의 출처가 말한다.
+    final List<CoachRoutine> routines =
+        ref.watch(coachRoutinesProvider).valueOrNull ?? const <CoachRoutine>[];
+    final MemberCoach? coach = ref.watch(memberCoachProvider).valueOrNull;
+    final String point = coachingPoint.trim();
+
+    // 코칭 포인트도 추천도 없으면 카드 자체를 그리지 않는다. 빈 카드는 자리만
+    // 차지하고 아무것도 알려 주지 않는다.
+    if (point.isEmpty && routines.isEmpty) return const SizedBox.shrink();
 
     return Container(
+      key: const Key('aiCoachingCard'),
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
         color: Colors.white,
@@ -178,7 +166,7 @@ class AiRecommendedExerciseCard extends ConsumerWidget {
               // 큰 글자 배율에서 제목이 카드를 넘겼다(#766).
               Flexible(
                 child: Text(
-                  'AI 맞춤 운동',
+                  'AI 코칭',
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                   style: TextStyle(
@@ -190,37 +178,90 @@ class AiRecommendedExerciseCard extends ConsumerWidget {
               ),
             ],
           ),
-          const SizedBox(height: 6),
-          const Text(
-            '나의 건강 기록과 트레이너 PT 피드백을 바탕으로 AI가 추천한 개인운동이에요',
-            style: TextStyle(
-              fontSize: 12.5,
-              height: 1.4,
-              color: AppColors.mutedForeground,
-            ),
-          ),
-          const SizedBox(height: 12),
-          if (aiRoutines.isEmpty)
+          if (point.isNotEmpty) ...<Widget>[
+            const SizedBox(height: 12),
             const Text(
-              '현재 추천할 수 있는 AI 맞춤 운동이 없어요',
+              '이번 코칭 포인트',
               style: TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+                color: FigmaColors.primary,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              point,
+              style: const TextStyle(
                 fontSize: 13.5,
+                height: 1.5,
+                fontWeight: FontWeight.w500,
+                color: FigmaColors.ink,
+              ),
+            ),
+          ],
+          if (routines.isNotEmpty) ...<Widget>[
+            const SizedBox(height: 14),
+            const Text(
+              '추천 개인운동',
+              style: TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+                color: FigmaColors.primary,
+              ),
+            ),
+            const SizedBox(height: 4),
+            const Text(
+              'PT 와 다음 PT 사이에 스스로 하는 운동이에요',
+              style: TextStyle(
+                fontSize: 12.5,
+                height: 1.4,
                 color: AppColors.mutedForeground,
               ),
-            )
-          else
-            for (final CoachRoutine routine in aiRoutines) ...<Widget>[
-              _RecommendedExerciseRow(routine: routine),
+            ),
+            const SizedBox(height: 10),
+            for (final (int index, CoachRoutine routine)
+                in routines.indexed) ...<Widget>[
+              // 여러 세션짜리 프로그램은 첫 세션 위에 프로그램 이름을 한 번
+              // 얹는다 — 세션 카드가 어디에 묶이는지 보이지 않으면 그냥 낱개
+              // 루틴 여러 개로 읽힌다(#709).
+              if (routine.programName.isNotEmpty &&
+                  (index == 0 ||
+                      routines[index - 1].programName != routine.programName))
+                _ProgramHeading(name: routine.programName),
+              _RecommendedExerciseRow(
+                routine: routine,
+                sourceLabel: routineSourceLabel(routine, coach),
+              ),
               const SizedBox(height: 10),
             ],
+          ],
         ],
       ),
     );
   }
 }
 
+/// 회원이 읽을 수 있는 추천 출처 문구.
+///
+/// 내부 `source` 값을 그대로 보여 주지 않는다. 회원이 알아야 할 것은 "누가
+/// 확인했는가" 다 — 트레이너가 본 추천과 AI 가 혼자 낸 추천은 무게가 다르다.
+///
+/// 담당 트레이너가 있으면 AI 추천은 승인된 것만 내려온다(#790). 그래서 여기
+/// 도착한 AI 추천에 `트레이너 확인` 을 붙이는 것이 사실이다.
+String routineSourceLabel(CoachRoutine routine, MemberCoach? coach) {
+  if (routine.isTrainerRecommended) return '트레이너 직접 추천';
+  if (coach != null) return 'AI 추천 · ${coach.name} 확인';
+  return 'AI 자동 추천';
+}
+
 class _RecommendedExerciseRow extends ConsumerStatefulWidget {
-  const _RecommendedExerciseRow({required this.routine});
+  const _RecommendedExerciseRow({
+    required this.routine,
+    required this.sourceLabel,
+  });
+
+  /// 회원이 읽는 출처 한 줄 — `AI 추천 · 김트레이너 확인` 처럼.
+  final String sourceLabel;
 
   final CoachRoutine routine;
 
@@ -335,6 +376,19 @@ class _RecommendedExerciseRowState
                         ),
                       ),
                     ],
+                    // 누가 이 운동을 정했는지. 트레이너가 본 추천과 AI 가 혼자
+                    // 낸 추천은 회원에게 무게가 다르다(#782).
+                    const SizedBox(height: 4),
+                    Text(
+                      widget.sourceLabel,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        fontSize: 11.5,
+                        fontWeight: FontWeight.w600,
+                        color: FigmaColors.textMuted,
+                      ),
+                    ),
                   ],
                 ),
               ),

--- a/frontend/flutter/test/features/member_coach/recommended_exercise_cards_test.dart
+++ b/frontend/flutter/test/features/member_coach/recommended_exercise_cards_test.dart
@@ -15,6 +15,9 @@ import 'package:oncare/features/member_coach/presentation/widgets/coach_card.dar
 import 'package:oncare/features/member_coach/presentation/widgets/coach_chat_sheet.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 
+/// 코칭 포인트 — 운동 주간 데이터의 `aiCoachMessage` 자리에 들어가는 값.
+const String _coachingPoint = '오른쪽 어깨가 들리는 경향이 있어 어깨 안정화에 집중해요.';
+
 const MemberCoach _trainer = MemberCoach(
   trainerId: 'trainer-1',
   name: '김트레이너',
@@ -115,11 +118,11 @@ void main() {
             body: SingleChildScrollView(
               child: Column(
                 children: <Widget>[
-                  CoachCard(),
                   Padding(
                     padding: EdgeInsets.all(24),
-                    child: AiRecommendedExerciseCard(),
+                    child: AiCoachingCard(coachingPoint: _coachingPoint),
                   ),
+                  CoachCard(),
                 ],
               ),
             ),
@@ -130,7 +133,7 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  testWidgets('source에 따라 트레이너와 AI 추천 운동을 각각 표시한다', (
+  testWidgets('코칭 포인트와 추천 개인운동이 한 영역에 함께 있다 (#782)', (
     WidgetTester tester,
   ) async {
     await pumpRecommendationCards(tester, const <CoachRoutine>[
@@ -138,34 +141,115 @@ void main() {
       _aiRoutine,
     ]);
 
-    final Finder trainerCard = find.byType(CoachCard);
-    final Finder aiCard = find.byType(AiRecommendedExerciseCard);
+    final Finder coaching = find.byType(AiCoachingCard);
 
-    expect(find.text('트레이너 추천 추가 개인운동'), findsOneWidget);
-    expect(find.text('트레이너와 채팅'), findsOneWidget);
+    // 예전에는 조언(맨 위)과 추천 운동(맨 아래)이 멀리 떨어져 있었다.
+    expect(find.text('AI 코칭'), findsOneWidget);
+    expect(
+      find.descendant(of: coaching, matching: find.text('이번 코칭 포인트')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: coaching, matching: find.text(_coachingPoint)),
+      findsOneWidget,
+    );
+    // 트레이너 추천과 AI 추천이 같은 목록에 있다 — 회원에게는 한 가지 질문이다.
+    expect(
+      find.descendant(of: coaching, matching: find.text(_trainerRoutine.name)),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: coaching, matching: find.text(_aiRoutine.name)),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('추천 운동이 같은 화면에 두 번 나오지 않는다 (#782)', (
+    WidgetTester tester,
+  ) async {
+    await pumpRecommendationCards(tester, const <CoachRoutine>[
+      _trainerRoutine,
+      _aiRoutine,
+    ]);
+
+    // 예전에는 트레이너 추천이 CoachCard 에, AI 추천이 별도 카드에 있었다.
+    // 한 곳으로 모았으므로 각 운동은 화면에 한 번만 나와야 한다.
+    expect(find.text(_trainerRoutine.name), findsOneWidget);
+    expect(find.text(_aiRoutine.name), findsOneWidget);
     expect(
       find.descendant(
-        of: trainerCard,
+        of: find.byType(CoachCard),
         matching: find.text(_trainerRoutine.name),
       ),
-      findsOneWidget,
-    );
-    expect(
-      find.descendant(of: trainerCard, matching: find.text(_aiRoutine.name)),
       findsNothing,
     );
-    expect(
-      find.descendant(of: aiCard, matching: find.text(_aiRoutine.name)),
-      findsOneWidget,
+  });
+
+  testWidgets('담당 트레이너가 있으면 AI 추천에 확인한 사람을 밝힌다 (#782)', (
+    WidgetTester tester,
+  ) async {
+    await pumpRecommendationCards(tester, const <CoachRoutine>[
+      _trainerRoutine,
+      _aiRoutine,
+    ]);
+
+    // 담당 트레이너가 있으면 AI 추천은 승인된 것만 내려온다(#790).
+    expect(find.text('AI 추천 · 김트레이너 확인'), findsOneWidget);
+    expect(find.text('트레이너 직접 추천'), findsOneWidget);
+    expect(find.text('AI 자동 추천'), findsNothing);
+  });
+
+  testWidgets('담당 트레이너가 없으면 AI 자동 추천으로 표시한다 (#782)', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          memberCoachProvider.overrideWith((ref) async => null),
+          coachRoutinesProvider.overrideWith(
+            (ref) async => const <CoachRoutine>[_aiRoutine],
+          ),
+          coachUnreadProvider.overrideWith((ref) async => 0),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: AiCoachingCard(coachingPoint: _coachingPoint),
+            ),
+          ),
+        ),
+      ),
     );
-    expect(
-      find.descendant(of: aiCard, matching: find.text(_trainerRoutine.name)),
-      findsNothing,
-    );
-    expect(
-      find.text('나의 건강 기록과 트레이너 PT 피드백을 바탕으로 AI가 추천한 개인운동이에요'),
-      findsOneWidget,
-    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('AI 자동 추천'), findsOneWidget);
+    expect(find.textContaining('확인'), findsNothing);
+  });
+
+  testWidgets('추천 운동이 없으면 코칭 포인트만 보여 준다 (#782)', (
+    WidgetTester tester,
+  ) async {
+    await pumpRecommendationCards(tester, const <CoachRoutine>[]);
+
+    expect(find.text('이번 코칭 포인트'), findsOneWidget);
+    expect(find.text(_coachingPoint), findsOneWidget);
+    // 빈 추천 카드를 만들지 않는다 — AI 가 매번 운동을 지어낼 이유가 없다.
+    expect(find.text('추천 개인운동'), findsNothing);
+    expect(find.text('현재 추천할 수 있는 AI 맞춤 운동이 없어요'), findsNothing);
+  });
+
+  testWidgets('담당 트레이너 카드는 관계와 소통만 남긴다 (#782)', (
+    WidgetTester tester,
+  ) async {
+    await pumpRecommendationCards(tester, const <CoachRoutine>[
+      _trainerRoutine,
+    ]);
+
+    // 프로필 이동과 채팅은 그대로 남는다.
+    expect(find.byKey(const Key('assignedTrainerProfile')), findsOneWidget);
+    expect(find.text('트레이너와 채팅'), findsOneWidget);
+    // 추천 운동 목록은 AI 코칭으로 옮겼다.
+    expect(find.text('트레이너 추천 추가 개인운동'), findsNothing);
   });
 
   testWidgets('여러 세션짜리 프로그램은 프로그램 이름과 세션 구분을 함께 보여 준다 (#709)', (
@@ -206,7 +290,7 @@ void main() {
       ),
     ]);
 
-    final Finder trainerCard = find.byType(CoachCard);
+    final Finder trainerCard = find.byType(AiCoachingCard);
     // 프로그램 이름은 묶음마다 한 번만 — 세션마다 반복하면 목록이 이름으로 찬다.
     expect(
       find.descendant(of: trainerCard, matching: find.text('주 2회 분할')),
@@ -244,13 +328,13 @@ void main() {
       _trainerRoutine,
     ]);
 
-    final Finder trainerCard = find.byType(CoachCard);
+    final Finder coaching = find.byType(AiCoachingCard);
     expect(
-      find.descendant(of: trainerCard, matching: find.byIcon(Icons.list_alt_outlined)),
+      find.descendant(of: coaching, matching: find.byIcon(Icons.list_alt_outlined)),
       findsNothing,
     );
     expect(
-      find.descendant(of: trainerCard, matching: find.text('허리 부담 완화')),
+      find.descendant(of: coaching, matching: find.text('허리 부담 완화')),
       findsOneWidget,
     );
   });
@@ -263,7 +347,9 @@ void main() {
           memberCoachRepositoryProvider.overrideWithValue(repository),
           myTrainerProvider.overrideWith((ref) async => _assignedTrainer),
         ],
-        child: const MaterialApp(home: Scaffold(body: CoachCard())),
+        child: const MaterialApp(
+          home: Scaffold(body: AiCoachingCard(coachingPoint: _coachingPoint)),
+        ),
       ),
     );
     await tester.pumpAndSettle();
@@ -303,13 +389,6 @@ void main() {
 
     expect(find.text('트레이너 피드백: 자세가 좋았어요'), findsOneWidget);
     expect(find.byKey(const Key('routineFeedback-done')), findsOneWidget);
-  });
-
-  testWidgets('각 출처의 추천 운동이 없으면 안내 문구를 표시한다', (WidgetTester tester) async {
-    await pumpRecommendationCards(tester, const <CoachRoutine>[]);
-
-    expect(find.text('아직 트레이너가 추천한 개인운동이 없어요'), findsOneWidget);
-    expect(find.text('현재 추천할 수 있는 AI 맞춤 운동이 없어요'), findsOneWidget);
   });
 
   testWidgets('담당 트레이너 프로필은 트레이너 상세 경로로 이동한다', (WidgetTester tester) async {


### PR DESCRIPTION
Closes #782

#782 의 회원 앱 범위를 처리한다. `### 트레이너 웹` 항목은 제외했다(사유는 #782 댓글 — #780 에서 같은 파일을 재구성 중).

> **#810 을 먼저 병합해 주세요.** 출처 표기 `AI 추천 · 김트레이너 확인` 은 "담당 트레이너가 있으면 AI 추천이 승인된 것만 내려온다" 는 백엔드 계약(#790) 위에서만 사실이다. 순서가 뒤집히면 배지가 잠시 거짓말을 한다.

## Summary

`AI 맞춤 조언`(맨 위)과 `AI 맞춤 운동`(맨 아래)이 멀리 떨어져 있고 그 사이에 운동 현황·트레이너 카드가 끼어 있었다. 둘은 같은 기록에서 나온 같은 판단인데, 회원은 "왜 이 운동인지" 를 직접 이어 붙여야 했다.

## Changes

- `AI 코칭` 한 영역에 **코칭 포인트 + 추천 개인운동**을 담았다(`AiCoachingCard`).
- 화면 순서: `주간 요약 → 운동 현황 → 오늘 완료한 PT → AI 코칭 → 담당 트레이너`. PT 피드백 바로 다음에 AI 코칭을 둔다.
- 트레이너 추천과 AI 추천을 한 목록으로 합치고, 줄마다 출처를 적는다.
  - `트레이너 직접 추천` / `AI 추천 · {트레이너}님 확인` / `AI 자동 추천`
- 추천할 것이 없는 날은 빈 카드를 만들지 않고 코칭 포인트만 남긴다.
- `CoachCard` 는 관계와 소통만 담는다 — 이름·전문 분야·프로필 이동·채팅.

## Notes

- **출처를 어떻게 정하는가.** 새 API 필드를 만들지 않았다. 회원에게 도착한 AI 추천은 담당 트레이너가 있으면 이미 승인된 것이므로(#790 게이팅), `source == 'ai'` + 담당 트레이너 유무만으로 세 문구가 갈린다. 내부 `source` 값은 화면에 그대로 노출하지 않는다.
- **한 곳에만 보이게 한 이유.** 예전에는 트레이너 추천이 `CoachCard` 에, AI 추천이 별도 카드에 있어 회원이 둘의 관계와 우선순위를 다시 해석해야 했다. 같은 추천이 화면 두 곳에 나오지 않는지 테스트로 못박았다.
- **빈 상태 카드를 없앴다.** `현재 추천할 수 있는 AI 맞춤 운동이 없어요` 카드는 자리만 차지하고 아무것도 알려 주지 않았다. AI 가 매번 운동을 지어낼 이유가 없다는 것이 #782 의 판단이라 그대로 따랐다.
- **기존 테스트 두 건을 의도에 맞게 고쳤다.** 하나는 두 카드 분리(이번에 없앤 구조)를 검증하고 있었고, 하나는 빈 상태 문구를 검증하고 있었다. 프로그램 세션 묶음(#709)·수행 완료·프로필 이동·채팅 테스트는 그대로 살아 있다.
- **트레이너 없는 회원의 자동 추천 생성은 아직이다.** 화면은 `AI 자동 추천` 을 표시할 준비가 됐지만, 백엔드가 담당 트레이너 없는 회원에게 루틴을 내려주지 않는다(`TrainerRoutine.trainer_id` 가 NOT NULL). 별도로 처리한다.
- 검증: `flutter analyze` 무경고, 전체 `flutter test` 701건 통과. 배치는 실제 렌더 이미지로 확인했다.
