### PR TITLE
feat(exercise): 담당 트레이너 없는 회원의 안전 범위 AI 자동 추천

### DIFF
--- a/backend/app/api/v1/member_coach.py
+++ b/backend/app/api/v1/member_coach.py
@@ -98,7 +98,9 @@ def complete_my_routine(
     """나에게 배정된 루틴을 회원 운동 기록으로 한 번만 완료한다."""
     if payload.intensity not in {"light", "moderate", "high"}:
         raise HTTPException(status_code=400, detail="허용되지 않는 운동 강도입니다.")
-    trainer_id = _my_trainer_or_404(db, member.id)
+    # 담당 트레이너가 없는 회원도 AI 자동 추천을 수행한다(#782). 예전에는 여기서
+    # 404 로 끊겨, 화면에 보이는 운동을 완료할 수 없었다.
+    trainer_id = trainer_service.get_member_trainer_id(db, member.id)
     try:
         return trainer_service.complete_assigned_routine(
             db,

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -785,8 +785,10 @@ class TrainerRoutine(Base):
     __tablename__ = "trainer_routines"
 
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
-    trainer_id: Mapped[str] = mapped_column(
-        ForeignKey("users.id", ondelete="CASCADE"), index=True
+    #: 배정한 트레이너. 담당 트레이너가 없는 회원에게 AI 가 안전 범위에서 직접
+    #: 추천한 개인운동은 이 값이 비어 있다(#782) — 승인할 사람이 없기 때문이다.
+    trainer_id: Mapped[str | None] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True, nullable=True
     )
     member_id: Mapped[str] = mapped_column(
         ForeignKey("users.id", ondelete="CASCADE"), index=True

--- a/backend/app/services/auto_routine_service.py
+++ b/backend/app/services/auto_routine_service.py
@@ -1,0 +1,107 @@
+"""담당 트레이너가 없는 회원에게 주는 안전 범위 개인운동. (#782)
+
+담당 트레이너가 있으면 AI 후보는 트레이너 검토를 거쳐 회원에게 간다(#790).
+승인할 사람이 없는 회원에게는 그 단계가 없으므로, **추천 자체를 보수적으로**
+가져간다.
+
+무엇을 추천하지 않는가가 이 모듈의 핵심이다.
+
+- 고강도·고위험 운동을 회원 기록만으로 새로 처방하지 않는다.
+- 질환을 근거로 치료 목적 운동을 처방하지 않는다.
+- 건강 정보를 읽어 강도를 올리지 않는다 — 읽더라도 내리는 쪽으로만 쓴다.
+
+남는 것은 걷기·스트레칭 같은 회복 범위다. 트레이너가 붙는 순간 이 경로는 멈추고
+검토 흐름으로 넘어간다.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import date
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core import clock
+from app.models.models import TrainerRoutine
+
+#: 검토 상태 상수는 [app.services.trainer_service] 가 갖고 있지만, 그 모듈이 이
+#: 모듈을 import 하므로 값을 여기서 다시 적는다(순환 import 회피). 문자열 하나라
+#: 어긋날 여지가 작고, 어긋나면 회원 조회에서 곧바로 빈 목록으로 드러난다.
+ROUTINE_APPROVED = "approved"
+
+#: 하루에 준비하는 추천. 개수를 묶어 두는 이유는 "할 일 목록" 이 되지 않게
+#: 하려는 것이다 — PT 사이를 메우는 운동이지 프로그램이 아니다.
+SAFE_ROUTINES: tuple[tuple[str, int, str, str], ...] = (
+    (
+        "저강도 걷기",
+        20,
+        "유산소",
+        "회복 목적의 가벼운 유산소예요. 대화할 수 있는 속도로 걸어 보세요.",
+    ),
+    (
+        "전신 스트레칭",
+        10,
+        "스트레칭",
+        "굳은 근육을 풀어 다음 운동을 준비해요. 통증이 있으면 멈추세요.",
+    ),
+)
+
+
+def _key_for(day: date) -> str:
+    """그날의 추천 묶음을 가리키는 키. 같은 날 여러 번 불려도 한 번만 만든다."""
+    return f"auto-{day.isoformat()}"
+
+
+def _existing_for(
+    db: Session, member_id: str, key: str
+) -> list[TrainerRoutine]:
+    """그날 이미 만들어 둔 자동 추천.
+
+    유니크 제약(`trainer_id`, `member_id`, `client_request_id`)에 기대지 않는다 —
+    `trainer_id` 가 NULL 이면 Postgres 는 그 행들을 서로 다른 것으로 보아 제약이
+    걸리지 않는다. 그래서 여기서 직접 확인한다.
+    """
+    return list(
+        db.scalars(
+            select(TrainerRoutine).where(
+                TrainerRoutine.member_id == member_id,
+                TrainerRoutine.trainer_id.is_(None),
+                TrainerRoutine.client_request_id == key,
+            )
+        ).all()
+    )
+
+
+def ensure_auto_routines(db: Session, member_id: str) -> None:
+    """담당 트레이너가 없는 회원의 오늘 추천을 준비한다. 이미 있으면 아무것도 안 한다.
+
+    부르는 쪽은 회원의 루틴 조회다. 스케줄러 없이 "회원이 볼 때 준비돼 있다" 를
+    만족시키는 가장 단순한 방법이고, 같은 날 여러 번 열어도 목록이 늘지 않는다.
+
+    알림을 보내지 않는다 — 회원이 직접 열어 본 화면에서 이미 보고 있다.
+    """
+    key = _key_for(clock.now().date())
+    if _existing_for(db, member_id, key):
+        return
+
+    now = clock.now()
+    for order, (name, minutes, type_, reason) in enumerate(SAFE_ROUTINES):
+        db.add(
+            TrainerRoutine(
+                id=f"auto-{uuid.uuid4().hex[:12]}",
+                trainer_id=None,
+                member_id=member_id,
+                name=name,
+                minutes=minutes,
+                type=type_,
+                reason=reason,
+                source="ai",
+                # 승인할 사람이 없으므로 바로 보이는 상태로 만든다. 보수적인
+                # 범위로 좁힌 것이 여기서의 안전장치다.
+                status=ROUTINE_APPROVED,
+                sort_order=order,
+                client_request_id=key,
+                created_at=now,
+            )
+        )
+    db.commit()

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -34,7 +34,12 @@ from app.schemas.trainer_api import (
     TrainerProgramDraftOut, TrainerProgramDraftSummary, WeeklyReportDayOut,
     WeeklyReportOut,
 )
-from app.services import diet_photo_service, exercise_service, notification_service
+from app.services import (
+    auto_routine_service,
+    diet_photo_service,
+    exercise_service,
+    notification_service,
+)
 from app.services.coach import personal_ingest
 
 # 일일 나트륨 목표(mg). 프론트 `sodiumTargetMg` 와 같은 값 — 리포트의
@@ -793,8 +798,13 @@ ROUTINE_DISMISSED = "dismissed"
 ROUTINE_STATUSES = frozenset({ROUTINE_APPROVED, ROUTINE_PENDING, ROUTINE_DISMISSED})
 
 
-def build_routines(db: Session, member_id: str, trainer_id: str) -> list[RoutineOut]:
+def build_routines(
+    db: Session, member_id: str, trainer_id: str | None
+) -> list[RoutineOut]:
     """이 트레이너가 회원에게 배정한 루틴(정렬순).
+
+    [trainer_id] 가 None 이면 트레이너 없이 만들어진 자동 추천을 읽는다 —
+    SQLAlchemy 가 `== None` 을 `IS NULL` 로 옮기므로 조건은 그대로 쓴다.
 
     한 프로그램의 세션들은 `sort_order` 를 연속으로 받으므로 이 정렬만으로
     세션 순서가 지켜진다 — 별도 그룹핑 없이 배열 순서가 곧 프로그램 순서다.
@@ -830,7 +840,7 @@ class RoutineNotFound(Exception):
 
 
 def _owned_routine(
-    db: Session, trainer_id: str, member_id: str, routine_id: str
+    db: Session, trainer_id: str | None, member_id: str, routine_id: str
 ) -> TrainerRoutine:
     """이 트레이너가 이 회원에게 배정한 루틴. 아니면 [RoutineNotFound]. (#504)
 
@@ -1087,7 +1097,7 @@ def dismiss_routine_suggestion(
 
 def complete_assigned_routine(
     db: Session,
-    trainer_id: str,
+    trainer_id: str | None,
     member_id: str,
     routine_id: str,
     *,
@@ -2499,10 +2509,16 @@ def build_member_coach(db: Session, member_id: str) -> MemberCoachOut | None:
 
 
 def build_member_routines(db: Session, member_id: str) -> list[RoutineOut]:
-    """회원이 받은 루틴(담당 트레이너 배정). 담당 없으면 빈 목록."""
+    """회원이 받은 개인운동.
+
+    담당 트레이너가 있으면 그 트레이너가 배정한 것(승인된 것만, #790).
+    담당이 없으면 AI 가 안전 범위에서 직접 준비한 것(#782) — 예전에는 이 경우
+    늘 빈 목록이라, 트레이너 없는 회원은 운동 탭에서 받을 것이 아무것도 없었다.
+    """
     trainer_id = get_member_trainer_id(db, member_id)
     if trainer_id is None:
-        return []
+        auto_routine_service.ensure_auto_routines(db, member_id)
+        return build_routines(db, member_id, None)
     return build_routines(db, member_id, trainer_id)
 
 

--- a/backend/migrations/versions/0041_routine_without_trainer.py
+++ b/backend/migrations/versions/0041_routine_without_trainer.py
@@ -1,0 +1,43 @@
+"""Let an assigned routine exist without a trainer, for members who have none.
+
+담당 트레이너가 없는 회원에게도 안전 범위의 개인운동을 내려주려면 배정 행이
+트레이너 없이 설 수 있어야 한다(#782). 지금까지는 `trainer_id` 가 NOT NULL 이라
+그런 회원에게는 루틴을 만들 수 없었고, 회원 조회는 늘 빈 목록이었다.
+
+기존 행은 그대로다 — 값이 있던 행이 NULL 이 되지 않는다.
+
+Revision ID: 0041_routine_without_trainer
+Revises: 0040_routine_review_status
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0041_routine_without_trainer"
+down_revision: str | Sequence[str] | None = "0040_routine_review_status"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "trainer_routines",
+        "trainer_id",
+        existing_type=sa.String(length=64),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    # 트레이너 없이 만들어진 행은 되돌릴 자리가 없다. NOT NULL 로 되돌리기 전에
+    # 지운다 — 남겨 두면 alter 자체가 실패한다.
+    op.execute("DELETE FROM trainer_routines WHERE trainer_id IS NULL")
+    op.alter_column(
+        "trainer_routines",
+        "trainer_id",
+        existing_type=sa.String(length=64),
+        nullable=False,
+    )

--- a/backend/migrations/versions/0043_routine_without_trainer.py
+++ b/backend/migrations/versions/0043_routine_without_trainer.py
@@ -6,8 +6,8 @@
 
 기존 행은 그대로다 — 값이 있던 행이 NULL 이 되지 않는다.
 
-Revision ID: 0041_routine_without_trainer
-Revises: 0040_routine_review_status
+Revision ID: 0043_routine_without_trainer
+Revises: 0042_routine_review_status
 """
 from __future__ import annotations
 
@@ -16,8 +16,8 @@ from collections.abc import Sequence
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "0041_routine_without_trainer"
-down_revision: str | Sequence[str] | None = "0040_routine_review_status"
+revision: str = "0043_routine_without_trainer"
+down_revision: str | Sequence[str] | None = "0042_routine_review_status"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/tests/test_auto_routine_without_trainer.py
+++ b/backend/tests/test_auto_routine_without_trainer.py
@@ -1,0 +1,128 @@
+"""담당 트레이너가 없는 회원의 AI 자동 추천. (#782) DB 필요.
+
+예전에는 담당이 없으면 `/me/coach/routines` 가 늘 빈 목록이라, 그 회원은 운동
+탭에서 받을 것이 아무것도 없었다. 승인할 사람이 없으므로 추천 범위 자체를
+보수적으로 좁혀 내려준다.
+"""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+
+from app.db.session import SessionLocal
+from app.models.models import TrainerClient, TrainerRoutine
+from app.services import auto_routine_service
+
+
+def _token(client, email: str) -> str:
+    return client.post(
+        "/v1/auth/login",
+        data={"username": email, "password": "oncare123"},
+    ).json()["access_token"]
+
+
+def _h(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture()
+def lone_member(client):
+    """담당 트레이너 링크를 잠시 끊어 '담당 없는 회원' 을 만든다.
+
+    시드 회원을 쓰되 끝나면 되돌린다 — 다른 테스트가 같은 회원의 담당 관계를
+    전제하므로 여기서 영구히 끊으면 안 된다.
+    """
+    member_id = "user-jisu"
+    db = SessionLocal()
+    links = list(
+        db.scalars(
+            select(TrainerClient).where(TrainerClient.member_id == member_id)
+        ).all()
+    )
+    saved = [(link.trainer_id, link.active) for link in links]
+    for link in links:
+        link.active = False
+    db.commit()
+    db.close()
+
+    yield member_id
+
+    db = SessionLocal()
+    for (trainer_id, active), link in zip(
+        saved,
+        db.scalars(
+            select(TrainerClient).where(TrainerClient.member_id == member_id)
+        ).all(),
+        strict=False,
+    ):
+        link.active = active
+    # 이 테스트가 만든 자동 추천은 남기지 않는다.
+    for row in db.scalars(
+        select(TrainerRoutine).where(
+            TrainerRoutine.member_id == member_id,
+            TrainerRoutine.trainer_id.is_(None),
+        )
+    ).all():
+        db.delete(row)
+    db.commit()
+    db.close()
+
+
+def test_member_without_a_trainer_now_gets_routines(client, lone_member):
+    mine = client.get(
+        "/v1/me/coach/routines", headers=_h(_token(client, "jisu@oncare.com"))
+    )
+
+    assert mine.status_code == 200, mine.text
+    body = mine.json()
+    assert body, "담당이 없어도 받을 것이 있어야 한다"
+    assert {r["name"] for r in body} == {
+        name for name, _, _, _ in auto_routine_service.SAFE_ROUTINES
+    }
+
+
+def test_auto_recommendations_stay_in_a_safe_range(client, lone_member):
+    mine = client.get(
+        "/v1/me/coach/routines", headers=_h(_token(client, "jisu@oncare.com"))
+    )
+
+    # 승인할 사람이 없으므로 범위 자체가 안전장치다. 고강도·고위험 운동을
+    # 회원 기록만으로 새로 처방하지 않는다.
+    assert {r["type"] for r in mine.json()} <= {"유산소", "스트레칭"}
+    assert all(r["minutes"] <= 30 for r in mine.json())
+    assert all(r["reason"] for r in mine.json()), "왜 하는지 없이 주지 않는다"
+
+
+def test_opening_twice_does_not_pile_up_recommendations(client, lone_member):
+    token = _token(client, "jisu@oncare.com")
+
+    first = client.get("/v1/me/coach/routines", headers=_h(token)).json()
+    second = client.get("/v1/me/coach/routines", headers=_h(token)).json()
+
+    # 화면을 열 때마다 만들면 목록이 하루 만에 길어진다.
+    assert [r["id"] for r in first] == [r["id"] for r in second]
+
+
+def test_auto_recommendation_can_be_completed(client, lone_member):
+    token = _token(client, "jisu@oncare.com")
+    routine = client.get("/v1/me/coach/routines", headers=_h(token)).json()[0]
+
+    done = client.post(
+        f"/v1/me/coach/routines/{routine['id']}/complete",
+        headers=_h(token),
+        json={"minutes": 15, "intensity": "light", "member_note": ""},
+    )
+
+    # 담당이 없다고 완료가 막히면, 화면에 보이는 운동을 수행할 수 없다.
+    assert done.status_code == 200, done.text
+    assert done.json()["completed"] is True
+
+
+def test_a_member_with_a_trainer_gets_no_auto_recommendation(client):
+    """담당이 있으면 이 경로는 아예 돌지 않는다 — 검토 흐름이 대신한다(#790)."""
+    mine = client.get(
+        "/v1/me/coach/routines", headers=_h(_token(client, "jisu@oncare.com"))
+    ).json()
+
+    safe_names = {name for name, _, _, _ in auto_routine_service.SAFE_ROUTINES}
+    assert not (safe_names & {r["name"] for r in mine})

--- a/backend/tests/test_member_coach.py
+++ b/backend/tests/test_member_coach.py
@@ -124,8 +124,11 @@ def test_member_without_coach_404(client):
     assert client.post(
         "/v1/me/coach/chat", json={"text": "hi"}, headers=_h(tok)
     ).status_code == 404
-    # 받은 루틴은 빈 목록(에러 아님)
-    assert client.get("/v1/me/coach/routines", headers=_h(tok)).json() == []
+    # 루틴은 에러가 아니다. 예전에는 빈 목록이었지만, 지금은 담당이 없는 회원에게
+    # AI 가 안전 범위에서 직접 준비해 준다(#782) — 트레이너가 배정한 것은 없다.
+    routines = client.get("/v1/me/coach/routines", headers=_h(tok))
+    assert routines.status_code == 200
+    assert all(r["source"] == "ai" for r in routines.json())
 
 
 def test_trainer_token_rejected_on_member_coach(client):
@@ -145,7 +148,11 @@ def test_inactive_link_member_has_no_current_coach(client):
         "/v1/auth/login", data={"username": "sungho@oncare.com", "password": "oncare123"}
     ).json()["access_token"]
     assert client.get("/v1/me/coach", headers=_h(tok)).status_code == 404
-    assert client.get("/v1/me/coach/routines", headers=_h(tok)).json() == []
+    # 휴면 링크만 있는 회원도 '담당 없음'이라, 트레이너 배정 대신 AI 자동 추천을
+    # 받는다(#782). 배정된 것이 새어 나오지 않는지가 이 줄의 관심사다.
+    routines = client.get("/v1/me/coach/routines", headers=_h(tok))
+    assert routines.status_code == 200
+    assert all(r["source"] == "ai" for r in routines.json())
     assert client.post(
         "/v1/me/coach/chat", json={"text": "안녕하세요"}, headers=_h(tok)
     ).status_code == 404


### PR DESCRIPTION
#782 의 `### 트레이너가 없는 회원` 항목을 처리한다.

> **스택 PR** — base 가 `feat/routine-suggestion-review-backend`(#810)다. `status` 칼럼 위에 서 있다. #810 을 먼저 병합하고, 그다음 이 PR 의 base 를 `main` 으로 옮겨 병합한다.

## Summary

담당 트레이너가 없으면 `GET /me/coach/routines` 가 늘 빈 목록이었다. 그 회원은 운동 탭에서 받을 것이 아무것도 없었고, #812 가 준비한 `AI 자동 추천` 표기도 쓰일 자리가 없었다.

`trainer_routines.trainer_id` 를 nullable 로 바꿔 트레이너 없이도 개인운동 행이 설 수 있게 한다.

## Changes

- 마이그레이션 `0041_routine_without_trainer` — `trainer_id` NOT NULL 해제.
- `auto_routine_service` — 담당이 없는 회원에게 안전 범위 개인운동을 하루 한 번 준비.
- 회원 루틴 조회가 담당 유무에 따라 갈린다: 있으면 그 트레이너의 승인된 배정, 없으면 자동 추천.
- 완료 경로(`POST /me/coach/routines/{id}/complete`)의 담당 트레이너 404 를 푼다.

## Notes

- **안전은 범위로 지킨다.** 승인할 사람이 없으므로 추천 자체를 보수적으로 좁혔다 — 걷기·스트레칭 같은 회복 범위만 준다. 회원 기록만으로 고강도·고위험 운동을 새로 처방하지 않고, 질환을 근거로 치료 목적 운동을 만들지 않는다. 무엇을 추천하지 않는가를 모듈 상단에 적어 뒀다.
- **생성 시점은 회원이 목록을 열 때다.** 스케줄러 없이 "열면 준비돼 있다" 를 만족시키는 가장 단순한 방법이다. 같은 날 여러 번 열어도 목록이 늘지 않는 것을 테스트로 못박았다.
- **유니크 제약에 기대지 않는다.** 중복 방지 제약은 `(trainer_id, member_id, client_request_id)` 인데 `trainer_id` 가 NULL 이면 Postgres 는 그 행들을 서로 다른 것으로 보아 제약이 걸리지 않는다. 그래서 삽입 전에 직접 확인한다.
- **알림을 보내지 않는다.** 회원이 직접 열어 본 화면에서 이미 보고 있다. 트레이너 승인(#810)은 회원이 모르는 변화라 알림이 나가지만, 이 경로는 다르다.
- **기존 테스트 두 건을 계약 변경에 맞춰 고쳤다.** `담당 없으면 루틴은 빈 목록` 을 검증하던 부분인데, 그것이 이번에 바꾸는 지점이다. 담당 코치 조회·채팅이 여전히 404 인 것과, 트레이너가 배정한 것이 새어 나오지 않는 것은 그대로 검증한다.
- **`trainer_id` 가 nullable 이 되면서 테이블 의미가 넓어졌다.** "트레이너가 배정한 루틴" → "회원에게 배정된 개인운동". 별도 경로로 서빙하는 대안도 있었지만, 완료 기록이 이미 `assigned_routine_id` 로 묶여 있어 그 연결을 통째로 다시 만들어야 했다. 설계 의도와 다르면 알려주세요.
- 검증: 백엔드 전체 `pytest` 873건 통과(신규 5건 포함).
