### PR TITLE
fix(trainer-web): 메모 없는 고객의 메모함 불러오기 실패

### DIFF
--- a/frontend/flutter_trainer/lib/shared/services/trainer_memo_repository.dart
+++ b/frontend/flutter_trainer/lib/shared/services/trainer_memo_repository.dart
@@ -56,9 +56,15 @@ class LocalTrainerMemoRepository implements TrainerMemoRepository {
 
   static String _key(String clientId) => 'trainer_memos:$clientId';
 
+  /// This client's stored memos.
+  ///
+  /// Always a **fresh growable list**: every caller below sorts, edits or
+  /// removes in place. Returning `const []` for the empty cases made the
+  /// first read of a client with no memos throw on `..sort()`, so the memo
+  /// dialog showed a load failure instead of its empty state (#814).
   List<TrainerMemo> _read(String clientId) {
     final raw = _prefs.getString(_key(clientId));
-    if (raw == null) return const <TrainerMemo>[];
+    if (raw == null) return <TrainerMemo>[];
     try {
       return (jsonDecode(raw) as List<Object?>)
           .map(
@@ -70,7 +76,7 @@ class LocalTrainerMemoRepository implements TrainerMemoRepository {
     } on Object {
       // A payload written by an older build is not worth crashing the
       // screen over — the demo starts from an empty list instead.
-      return const <TrainerMemo>[];
+      return <TrainerMemo>[];
     }
   }
 

--- a/frontend/flutter_trainer/test/features/clients/local_trainer_memo_repository_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/local_trainer_memo_repository_test.dart
@@ -1,0 +1,132 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:oncare_trainer/features/clients/domain/entities/trainer_memo.dart';
+import 'package:oncare_trainer/shared/services/trainer_memo_repository.dart';
+
+/// The demo build's memo store. Its reads used to hand back a `const` list,
+/// which every mutating caller then tried to sort or edit in place — so a
+/// client with no memos yet failed to load instead of showing an empty
+/// list (#814).
+Future<LocalTrainerMemoRepository> _repoWith(
+  Map<String, Object> initialValues,
+) async {
+  SharedPreferences.setMockInitialValues(initialValues);
+  return LocalTrainerMemoRepository(await SharedPreferences.getInstance());
+}
+
+Map<String, Object?> _memoJson({
+  required String id,
+  required String body,
+  required String createdAt,
+}) => <String, Object?>{
+  'id': id,
+  'body': body,
+  'source': 'trainer',
+  'insight_id': null,
+  'insight_kind': '',
+  'created_at': createdAt,
+  'updated_at': createdAt,
+};
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test(
+    'a client with no memos reads as an empty list, not a failure',
+    () async {
+      final repo = await _repoWith(<String, Object>{});
+
+      await expectLater(repo.fetch('m1'), completion(isEmpty));
+    },
+  );
+
+  test('a payload from an older build reads as an empty list', () async {
+    final repo = await _repoWith(<String, Object>{
+      'trainer_memos:m1': '{"not":"a list"}',
+    });
+
+    await expectLater(repo.fetch('m1'), completion(isEmpty));
+  });
+
+  test('deleting against a client with no memos does not throw', () async {
+    final repo = await _repoWith(<String, Object>{});
+
+    await expectLater(repo.delete('m1', 'memo-1'), completes);
+  });
+
+  test('fetch returns the stored memos newest first', () async {
+    final repo = await _repoWith(<String, Object>{
+      'trainer_memos:m1': jsonEncode(<Map<String, Object?>>[
+        _memoJson(
+          id: 'memo-old',
+          body: '지난주 무릎 통증',
+          createdAt: '2026-08-10T09:00:00.000Z',
+        ),
+        _memoJson(
+          id: 'memo-new',
+          body: '오늘 나트륨 초과',
+          createdAt: '2026-08-16T09:00:00.000Z',
+        ),
+      ]),
+    });
+
+    final memos = await repo.fetch('m1');
+
+    expect(memos.map((memo) => memo.id), <String>['memo-new', 'memo-old']);
+  });
+
+  test('a memo written to an empty store is read back', () async {
+    final repo = await _repoWith(<String, Object>{});
+
+    await repo.create('m1', body: '무릎 상태 확인');
+    final memos = await repo.fetch('m1');
+
+    expect(memos.single.body, '무릎 상태 확인');
+    expect(memos.single.source, TrainerMemoSource.trainer);
+  });
+
+  test('saving the same chat insight twice keeps one memo', () async {
+    final repo = await _repoWith(<String, Object>{});
+
+    final first = await repo.create(
+      'm1',
+      body: '무릎이 아파요',
+      source: TrainerMemoSource.chatInsight,
+      insightId: 'msg-3:discomfort',
+      insightKind: 'discomfort',
+    );
+    final second = await repo.create(
+      'm1',
+      body: '무릎이 아파요',
+      source: TrainerMemoSource.chatInsight,
+      insightId: 'msg-3:discomfort',
+      insightKind: 'discomfort',
+    );
+
+    expect(second.id, first.id);
+    await expectLater(repo.fetch('m1'), completion(hasLength(1)));
+  });
+
+  test('a memo can be edited and removed', () async {
+    final repo = await _repoWith(<String, Object>{});
+    final memo = await repo.create('m1', body: '초안');
+
+    final updated = await repo.update('m1', memo.id, '수정한 메모');
+    expect(updated.body, '수정한 메모');
+    await expectLater(repo.fetch('m1'), completion(hasLength(1)));
+
+    await repo.delete('m1', memo.id);
+    await expectLater(repo.fetch('m1'), completion(isEmpty));
+  });
+
+  test('memos are kept per client', () async {
+    final repo = await _repoWith(<String, Object>{});
+
+    await repo.create('m1', body: 'm1 메모');
+
+    await expectLater(repo.fetch('m2'), completion(isEmpty));
+  });
+}


### PR DESCRIPTION
## Summary

데모 빌드에서 아직 메모를 남기지 않은 고객의 메모함을 열면, 빈 상태 대신 "메모를 불러오지 못했어요. 잠시 후 다시 시도해 주세요." 가 떴다. 메모를 하나 저장하면 그때부터 정상이라, 모든 고객이 **처음 열 때** 이 상태였다.

읽기가 저장된 값이 없을 때 `const` 리스트를 돌려주는데 `fetch` 가 그 결과에 정렬을 걸어, 수정 불가 리스트에서 예외가 났다. 같은 이유로 빈 상태에서의 삭제도 실패했다.

## Changes

- 로컬 메모 저장소의 읽기가 늘 새 growable 리스트를 돌려주게 해, 정렬·수정·삭제가 제자리에서 동작하도록 한다. 이유는 주석으로 남겨 다음 사람이 `const` 로 되돌리지 않게 한다.
- 로컬 저장소 동작 테스트를 새로 추가한다 — 빈 상태 읽기·과거 페이로드·빈 상태 삭제·정렬 순서·인사이트 중복 저장·수정/삭제·고객별 분리.

수정 전 코드에서 새 테스트 3건이 `Unsupported operation: Cannot modify an unmodifiable list` 로 실패하는 것을 확인했다.

## Commits

- `fix(trainer-web): 메모 없는 고객의 메모함 불러오기 실패`

## Notes

실 API 빌드는 `DioTrainerMemoRepository` 를 쓰므로 영향이 없다. 데모/`USE_MOCK_API=true` 경로만 해당한다. 빈 상태 문구(`clientTrainerMemoEmpty`)는 이 수정으로 처음 화면에 나온다.

`client_detail_diet_test.dart` 의 `client rows carry this week's sodium history on its weekdays` 는 이 브랜치와 무관하게 **main 에서도 실패**한다(월요일에만 재현). 별도로 다룬다.

Closes #814
