### PR TITLE
fix(trainer-web): 요일에 따라 실패하던 주간 계열 테스트 고정

### DIFF
--- a/frontend/flutter_trainer/lib/core/storage/seed_data.dart
+++ b/frontend/flutter_trainer/lib/core/storage/seed_data.dart
@@ -63,8 +63,19 @@ part 'seed_clients.dart';
 /// the spread documented in `seed_clients.dart`. Note the schedule stays
 /// at six slots on purpose: fifteen clients on the books does not mean
 /// fifteen sessions in one day.
-Future<void> seedIfEmpty(AppDatabase db, {DemoFixture? fixture}) async {
-  final now = DateTime.now();
+///
+/// [clock] is the moment this seeding is anchored to. Production leaves it
+/// out and gets the real one; tests pin it, because what lands in the week
+/// depends on the weekday — a series is placed relative to today and
+/// anything before Monday belongs to last week. Pinned dates are the only
+/// way to assert that rule in both directions instead of on whichever day
+/// the suite happens to run (#826).
+Future<void> seedIfEmpty(
+  AppDatabase db, {
+  DemoFixture? fixture,
+  DateTime? clock,
+}) async {
+  final DateTime now = clock ?? DateTime.now();
   final today = ymd(now);
   // 주간 계열을 요일 자리에 놓기 위한 오늘의 인덱스(월=0).
   final todayIndex = now.weekday - 1;

--- a/frontend/flutter_trainer/test/core/storage/seed_data_test.dart
+++ b/frontend/flutter_trainer/test/core/storage/seed_data_test.dart
@@ -209,9 +209,10 @@ void main() {
       final full = clients.firstWhere(
         (c) => sodiumWeek(c).where((v) => v > 0).length > 3,
       );
-      final twelveWeeksAgo = DateTime.now().subtract(
-        const Duration(days: 7 * 11),
-      );
+      // 시드가 고정된 날짜 기준으로 만들어졌으므로, 얼마나 거슬러 올라가는지도
+      // 그 날짜에서 센다. 실제 오늘로 재면 시드가 만들어진 주와 어긋나 CI 가
+      // 도는 날에 따라 결과가 달라진다(#826).
+      final twelveWeeksAgo = pinned.subtract(const Duration(days: 7 * 11));
       final dailyRows =
           await (db.select(db.clientDailyMetrics)
                 ..where((t) => t.clientId.equals(full.id)))

--- a/frontend/flutter_trainer/test/core/storage/seed_data_test.dart
+++ b/frontend/flutter_trainer/test/core/storage/seed_data_test.dart
@@ -116,7 +116,15 @@ void main() {
     // flattening the data back out to fifteen similar weeks fails here
     // rather than silently making half the UI unreachable.
     test('the roster covers the states the console has to render', () async {
-      await seedIfEmpty(db);
+      // 시계를 고정한다. 이 테스트가 요구하는 스펙트럼("기록이 끊긴 고객" 등)은
+      // 주가 얼마나 지났는지에 달려 있어, 실행한 날에 맡기면 주 초에는 존재할
+      // 수 없다 — 월요일이면 모두에게 하루치뿐이다(#826).
+      //
+      // 목요일에 고정한다. 계열은 월요일 이전 값을 지난주로 버리므로(#746),
+      // 네 가지 모양이 한 주 안에 모두 나타나려면 며칠이 지나 있어야 한다.
+      // 2026-08-20 은 목요일이다.
+      final pinned = DateTime(2026, 8, 20, 10);
+      await seedIfEmpty(db, clock: pinned);
       final clients = await db.select(db.trainerClients).get();
 
       List<int> sodiumWeek(TrainerClientRow c) =>
@@ -145,7 +153,7 @@ void main() {
       // 세 계열은 이번 주 월→일에 놓인다(#746). 화면이 요일 라벨과 함께
       // 그리므로 길이는 늘 7이고, 오늘 값은 오늘 요일 칸에 들어간다 — 카드의
       // 숫자와 그래프의 오늘 점이 같아야 한다.
-      final todayIndex = DateTime.now().weekday - 1;
+      final todayIndex = pinned.weekday - 1;
       for (final c in clients) {
         expect(
           <int>[

--- a/frontend/flutter_trainer/test/features/clients/client_detail_diet_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_diet_test.dart
@@ -9,6 +9,7 @@ import 'package:oncare_trainer/core/storage/app_database.dart';
 import 'package:oncare_trainer/core/storage/seed_data.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/features/clients/domain/entities/client_diet_entry.dart';
+import 'package:oncare_trainer/shared/models/trainer_client.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
 
 import '../../helpers/pump_app.dart';
@@ -91,28 +92,73 @@ void main() {
       expect(jisu.first.items, '그릭요거트, 과일');
       expect(seongho[1].items, '짜장면'); // 점심
     });
+  });
 
-    test('client rows carry this week\'s sodium history on its weekdays', () async {
-      final clients = await DriftClientRepository(db).watchClients().first;
-      // 계열은 이번 주 월→일이다(#746). 요일 라벨과 함께 그리므로 길이는 늘
-      // 7이고, 오늘 값은 마지막 칸이 아니라 오늘 요일 칸에 놓인다.
-      final todayIndex = DateTime.now().weekday - 1;
-      for (final c in clients) {
-        expect(c.sodiumWeek, hasLength(7), reason: c.name);
-        expect(c.sodiumWeek[todayIndex], c.sodiumMg, reason: c.name);
-        // 아직 오지 않은 요일은 누구에게나 0 — 기록 없음과 같은 표현이다.
-        expect(
-          c.sodiumWeek.skip(todayIndex + 1),
-          everyElement(0),
-          reason: c.name,
-        );
+  group('seeded weekly series', () {
+    // 계열은 이번 주 월→일이다(#746). 아래 두 테스트는 시드 시계를 고정한다 —
+    // 무엇이 이번 주에 남는지는 요일마다 다르므로, 실행한 날에 기대값을 맡기면
+    // 코드를 건드리지 않아도 월·화요일에 깨진다(#826).
+    Future<List<TrainerClient>> seededOn(DateTime pinned) async {
+      // 이 그룹의 `db` 와 겹쳐 열어 두면 drift 가 인스턴스 중복을 경고한다.
+      // 로스터를 읽고 나면 볼 일이 없으므로 그 자리에서 닫는다.
+      final pinnedDb = AppDatabase.forTesting(NativeDatabase.memory());
+      try {
+        await seedIfEmpty(pinnedDb, clock: pinned);
+        return await DriftClientRepository(pinnedDb).watchClients().first;
+      } finally {
+        await pinnedDb.close();
       }
-      final minsu = clients.firstWhere((c) => c.name == '김민수');
-      expect(minsu.sodiumOverDays, greaterThan(0)); // 2400/2200/2300… over
-      expect(minsu.sodiumWeekAvg, isNotNull);
+    }
 
-      final jisu = clients.firstWhere((c) => c.name == '이지수');
-      expect(jisu.sodiumOverDays, 1); // only the 2100 day is over
+    test(
+      'client rows carry this week\'s sodium history on its weekdays',
+      () async {
+        // 2026-08-19 은 수요일, 2026-08-17 은 월요일이다.
+        for (final pinned in <DateTime>[
+          DateTime(2026, 8, 19, 10),
+          DateTime(2026, 8, 17, 10),
+        ]) {
+          final clients = await seededOn(pinned);
+          final todayIndex = pinned.weekday - 1;
+          for (final c in clients) {
+            // 요일 라벨과 함께 그리므로 길이는 늘 7이고, 오늘 값은 마지막 칸이
+            // 아니라 오늘 요일 칸에 놓인다.
+            expect(c.sodiumWeek, hasLength(7), reason: '${c.name} on $pinned');
+            expect(
+              c.sodiumWeek[todayIndex],
+              c.sodiumMg,
+              reason: '${c.name} on $pinned',
+            );
+            // 아직 오지 않은 요일은 누구에게나 0 — 기록 없음과 같은 표현이다.
+            expect(
+              c.sodiumWeek.skip(todayIndex + 1),
+              everyElement(0),
+              reason: '${c.name} on $pinned',
+            );
+          }
+        }
+      },
+    );
+
+    test('a seeded day from before Monday stays in last week', () async {
+      // 이지수의 시드에서 목표를 넘는 날은 2100 하나뿐이고, 그 값은 오늘에서
+      // 이틀 앞이다. 수요일에는 이번 주에 남고 월요일에는 잘려 나간다 — 잘린
+      // 날이 집계에 남으면 지난주 기록을 이번 주로 세는 것이다.
+      final onWednesday = await seededOn(DateTime(2026, 8, 19, 10));
+      final jisuWed = onWednesday.firstWhere((c) => c.name == '이지수');
+      expect(jisuWed.sodiumWeek.first, 2100);
+      expect(jisuWed.sodiumOverDays, 1);
+
+      final onMonday = await seededOn(DateTime(2026, 8, 17, 10));
+      final jisuMon = onMonday.firstWhere((c) => c.name == '이지수');
+      expect(jisuMon.sodiumWeek.where((mg) => mg > 0), hasLength(1));
+      expect(jisuMon.sodiumOverDays, 0);
+
+      // 픽스처가 정하는 김민수는 자기 날짜대로 놓이므로, 오늘까지의 기록이
+      // 있는 한 주 평균이 잡힌다.
+      final minsu = onWednesday.firstWhere((c) => c.name == '김민수');
+      expect(minsu.sodiumOverDays, greaterThan(0));
+      expect(minsu.sodiumWeekAvg, isNotNull);
     });
   });
 

--- a/frontend/flutter_trainer/test/features/reports/reports_page_test.dart
+++ b/frontend/flutter_trainer/test/features/reports/reports_page_test.dart
@@ -471,13 +471,10 @@ void main() {
     expect(client.sugarWeek.any((v) => v != v.roundToDouble()), isTrue);
   });
 
-  testWidgets('지난 주도 그 주의 계열로 그려지고 이번 주와 섞이지 않는다 (#752)', (
-    tester,
-  ) async {
+  testWidgets('지난 주도 그 주의 계열로 그려지고 이번 주와 섞이지 않는다 (#752)', (tester) async {
     await openReports(tester);
     List<double> drawnValues() =>
         tester.widget<MetricTrendChart>(find.byType(MetricTrendChart)).values;
-
 
     final thisWeek = drawnValues();
     expect(thisWeek, hasLength(7));
@@ -522,12 +519,28 @@ void main() {
   });
 
   testWidgets('평균이 며칠을 나눈 값인지 화면에 적힌다 (#754)', (tester) async {
-    final container = await openReports(tester);
-    final client = (await container.read(clientsProvider.future)).first;
+    // 기록이 빠진 날을 시드에 기대지 않고 여기서 못 박는다. 시드의 주간 계열은
+    // 이번 주 요일 자리에 놓이므로(#746) 월요일에는 오늘 하루만 남고, 기록이
+    // 빠진 날이 아예 없어 이 테스트가 요일에 따라 깨졌다(#826).
+    const weekCompletion = <int>[80, 0, 90, 70, 0, 60, 0];
+    await openReports(
+      tester,
+      extraOverrides: <Override>[
+        clientsProvider.overrideWith(
+          (ref) => Stream<List<TrainerClient>>.value(<TrainerClient>[
+            makeClient(
+              id: 'week-client',
+              name: '주간고객',
+              weekCompletion: weekCompletion,
+            ),
+          ]),
+        ),
+      ],
+    );
 
     // 기록이 없는 날은 평균에서 빠지므로 7 이 아니다 — 그 사실이 적혀 있어야
     // 트레이너가 아래 막대를 세어 평균을 확인할 수 있다.
-    final logged = client.weekCompletion.where((v) => v > 0).length;
+    final logged = weekCompletion.where((v) => v > 0).length;
     expect(logged, lessThan(7), reason: '기록이 빠진 날이 있는 고객이어야 한다');
     // 마지막 줄에 이번 주가 앞선 세 주 옆에 놓인다. 며칠을 나눈 값인지는
     // 값이 있는 막대를 세면 나오므로 따로 적지 않는다.
@@ -543,12 +556,17 @@ void main() {
     // 며칠인지는 어제가 어느 요일이냐에 따라 달라진다 — 그 수치가 카드 제목
     // 줄에 남는다는 것이 요지다.
     expect(find.textContaining('나트륨 초과'), findsOneWidget);
+  });
 
+  testWidgets('요일 칸에 그날 한 운동 이름이 남는다 (#754)', (tester) async {
     // 요일 칸에는 운동 이름만 둔다 — 퍼센트는 바로 위 막대가 말하고,
     // 아직 오지 않은 날은 빈칸으로 둔다.
     //
     // 목록의 첫 고객은 김민수라, 그의 운동 이름은 공유 픽스처가 정한다(#757).
     // 이름을 여기 적으면 픽스처와 두 벌이 되어 한쪽만 고쳤을 때 조용히 갈린다.
+    // 시드 로스터를 그대로 쓰므로 위 테스트와 달리 고객을 바꾸지 않는다.
+    await openReports(tester);
+
     expect(find.text(_minsuExerciseThisWeek()), findsWidgets);
   });
 
@@ -556,7 +574,10 @@ void main() {
     await openReports(tester);
 
     // 예전에는 이 자리에 "API 연결 후 사용할 수 있어요" 만 있었다.
-    expect(find.text('실제 리포트 요약 API 연결 후 사용할 수 있어요. 현재 문구는 자동 생성하지 않습니다.'), findsNothing);
+    expect(
+      find.text('실제 리포트 요약 API 연결 후 사용할 수 있어요. 현재 문구는 자동 생성하지 않습니다.'),
+      findsNothing,
+    );
     // 데모에는 모델이 없어 수치에서 조립한 문장이 온다 — 그래서 'AI 생성'
     // 배지는 달리지 않는다. 트레이너가 이 문장을 어디까지 믿을지 알아야 한다.
     expect(find.text('AI 생성'), findsNothing);
@@ -590,7 +611,10 @@ void main() {
     // 회원에게 그대로 나가는 글이라, 확인하고 보내라는 신호가 그 자리에
     // 있어야 한다. 'AI' 라고 하지 않는다 — 이 초안은 수치에서 조립한
     // 템플릿이지 생성된 문장이 아니다.
-    expect(find.text('수치에서 자동으로 채운 초안이에요. 보내기 전에 확인하고 고쳐 주세요.'), findsOneWidget);
+    expect(
+      find.text('수치에서 자동으로 채운 초안이에요. 보내기 전에 확인하고 고쳐 주세요.'),
+      findsOneWidget,
+    );
   });
 
   testWidgets('가져온 요약을 초안으로 되돌린다 (#755)', (tester) async {
@@ -634,7 +658,6 @@ void main() {
       findsOneWidget,
     );
   });
-
 }
 
 /// Chat repository whose sends always fail.


### PR DESCRIPTION
## Summary

시드의 주간 계열은 오늘을 이번 주 오늘 요일 자리에 놓고, 월요일보다 앞선 값은 지난주 것이라 버린다(#746). 그래서 **이번 주에 무엇이 남는지는 요일마다 다른데**, 세 테스트가 기대값을 실행한 날에 맡기고 있었다.

코드를 아무도 건드리지 않아도 주 초에는 깨진다 — 월요일에 올라오는 모든 PR 의 CI 가 이 테스트들로 함께 막힌다. CI 는 UTC 로 돌고 개발은 KST 라, 한국 시간 월요일 이른 시각에는 아직 재현되지 않아 원인을 찾기 어려운 형태였다.

## Changes

- `seedIfEmpty` 에 `clock` 을 주입할 수 있게 한다. 프로덕션은 넘기지 않고 실제 시계를 쓴다.
- 나트륨 주간 계열 — 수요일·월요일 두 날짜에 고정해 배치 규칙을 양쪽에서 확인한다. 잘려 나간 날이 집계에 남지 않는다는 것이 요지라, 상수 하나로 두던 자리를 "수요일에는 남고 월요일에는 잘린다" 로 바꿔 규칙 자체를 적는다.
- 로스터 스펙트럼 — 목요일에 고정한다. 네 가지 기록 모양(꽉 찬 주 · 끊긴 주 · 하루만 · 없음)이 한 주 안에 모두 나타나려면 며칠이 지나 있어야 한다.
- 리포트 평균 — 기록이 빠진 날을 시드에 기대지 않고 고객을 명시해 못 박는다. 같은 테스트에 섞여 있던 픽스처 운동 이름 확인은 시드 로스터를 쓰는 별도 테스트로 나눈다.

## Verification

- 오늘(월요일) 로컬에서 전체 스위트 통과 — 659 tests, `flutter analyze` 무결.
- 고친 세 테스트는 수정 전 코드에서 월요일에 실패하는 것을 확인한 자리다.

## Commits

- `fix(trainer-web): 요일에 따라 실패하던 주간 계열 테스트 고정`

## Notes

시드 규칙 자체는 바꾸지 않았다 — 주 초에 계열이 얇은 것은 의도된 동작이고(#746), 문제는 그 사실을 기대값에 반영하지 않은 테스트였다.

`reports_page_test.dart` 는 #781 도 건드린다. 이 PR 의 변경은 한 테스트 본문과 그 아래 새 테스트 하나로 좁혀 두었다.

Closes #826
