### PR TITLE
fix(trainer-web): 로스터와 어긋나던 고객 신체·목표 기본값

### DIFF
--- a/frontend/flutter_trainer/lib/shared/services/client_repository.dart
+++ b/frontend/flutter_trainer/lib/shared/services/client_repository.dart
@@ -226,13 +226,14 @@ class DriftClientRepository implements ClientRepository {
     return MemberHealthProfile(
       memberId: clientId,
       memberName: row.name,
-      heightCm: saved.containsKey('height_cm')
-          ? (saved['height_cm'] as num?)?.toDouble()
-          : 175,
-      weightKg: saved.containsKey('weight_kg')
-          ? (saved['weight_kg'] as num?)?.toDouble()
-          : 72,
-      gender: saved['gender'] as String? ?? 'male',
+      // 키·체중은 저장된 적이 없으면 비운다. 예전에는 175/72 를 채웠는데,
+      // 트레이너가 입력한 값과 앱이 지어낸 값이 화면에서 구분되지 않았고,
+      // 그대로 저장하면 남의 신체 정보로 굳었다(#818).
+      heightCm: (saved['height_cm'] as num?)?.toDouble(),
+      weightKg: (saved['weight_kg'] as num?)?.toDouble(),
+      // 성별은 로스터가 이미 말하고 있는 값을 따른다. 고정 'male' 을 두던
+      // 시절에는 헤더가 '여성'인 회원의 대화상자가 '남성'으로 열렸다(#818).
+      gender: saved['gender'] as String? ?? _toEntity(row).rosterGender,
       conditions: saved['conditions'] as String? ?? '',
       goals: saved['goals'] as String? ?? row.goal,
       weeklyWorkoutGoal: saved.containsKey('weekly_workout_goal')

--- a/frontend/flutter_trainer/test/features/clients/client_repository_provider_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_repository_provider_test.dart
@@ -157,6 +157,35 @@ void main() {
     },
   );
 
+  test('an untouched health profile agrees with the roster identity', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    await seedIfEmpty(db);
+    final repository = DriftClientRepository(db);
+    final clients = await repository.watchClients().first;
+
+    for (final client in clients) {
+      final profile = await repository.fetchHealthProfile(client.id);
+      // 헤더가 '여성'이라고 말하는 회원의 대화상자가 '남성'으로 열리면 안 된다.
+      // 예전에는 모두에게 고정 'male' 을 돌려줬다(#818).
+      expect(profile.gender, client.rosterGender, reason: client.name);
+      // 재본 적 없는 키·체중은 지어내지 않는다 — 트레이너가 입력한 값과
+      // 구분되지 않으면 그대로 저장돼 남의 신체 정보로 굳는다.
+      expect(profile.heightCm, isNull, reason: client.name);
+      expect(profile.weightKg, isNull, reason: client.name);
+    }
+
+    // 저장한 값은 그대로 돌아온다.
+    final first = clients.first;
+    await repository.updateHealthProfile(first.id, <String, Object?>{
+      'gender': 'other',
+      'height_cm': 171.0,
+    });
+    final saved = await repository.fetchHealthProfile(first.id);
+    expect(saved.gender, 'other');
+    expect(saved.heightCm, 171.0);
+  });
+
   test('watching clientsProvider + prioritizedClientsProvider together issues '
       'exactly one GET /trainer/clients in real-API mode (review: the two '
       'providers used to each fetch independently)', () async {


### PR DESCRIPTION
## Summary

고객 상세의 `고객 신체·목표 관리` 가 모든 고객에게 같은 값(성별 `남성` · 키 175 · 체중 72)을 보여 줬다. 헤더에 `강서연 여성 · 20세` 라고 적힌 회원을 열어도 대화상자는 `남성` 으로 열려, 같은 화면 안에서 두 값이 서로 다른 말을 했다. 트레이너가 그대로 저장하면 지어낸 신체 정보가 회원 데이터로 굳는다.

## Changes

- 성별 기본값을 로스터가 이미 쓰고 있는 값(`TrainerClient.rosterGender`)으로 맞춘다. 헤더와 대화상자가 한 출처를 본다.
- 키·체중은 저장된 적이 없으면 비운다. 임의의 175/72 를 채우면 트레이너가 입력한 값과 앱이 지어낸 값이 화면에서 구분되지 않는다. 입력 검증은 빈 값을 이미 허용하므로 저장 경로는 그대로다.
- 손대지 않은 프로필이 로스터 신원과 어긋나지 않는지 전 고객에 대해 확인하는 테스트를 추가한다. 저장한 값이 그대로 돌아오는 것도 같은 테스트에서 확인한다.

## Commits

- `fix(trainer-web): 로스터와 어긋나던 고객 신체·목표 기본값`

## Notes

데모/`USE_MOCK_API=true` 경로만 해당한다 — 실 API 모드는 백엔드가 준 프로필을 그대로 쓴다.

주간 운동 목표(3회 · 150분 · 1500kcal)는 그대로 뒀다. 회원 개인의 사실이 아니라 트레이너가 조정하는 기본 목표값이라, 비워 두면 매번 입력해야 한다.

Closes #818
