### PR TITLE
fix(trainer-web): 목표를 넘겨도 100%로 적히던 식단 달성률

### DIFF
--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/nutrition_summary_card.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/nutrition_summary_card.dart
@@ -52,8 +52,15 @@ class _Item {
   final num current;
   final num target;
 
+  /// 링이 그리는 비율. 한 바퀴에서 멈춘다 — 넘긴 양은 링이 아니라 옆의
+  /// 문구가 말한다.
   double get ratio =>
       target <= 0 ? 0 : (current / target).clamp(0.0, 1.0).toDouble();
+
+  /// 화면에 적는 비율. 링과 달리 자르지 않는다. 예전에는 링의 비율을 그대로
+  /// 적어, 목표를 260kcal 넘긴 날에도 '100% 달성률' 이라고 말했다 — 바로
+  /// 아래의 '목표보다 260 kcal 넘었어요' 와 정면으로 어긋났다(#820).
+  double get labelRatio => target <= 0 ? 0 : current / target;
 
   bool get isOverGoal => current > target;
 
@@ -283,7 +290,7 @@ class _CalorieRow extends StatelessWidget {
                 mainAxisSize: MainAxisSize.min,
                 children: <Widget>[
                   Text(
-                    '${(calories.ratio * 100).round()}%',
+                    '${(calories.labelRatio * 100).round()}%',
                     style: TextStyle(
                       fontSize: 18,
                       fontWeight: FontWeight.w800,

--- a/frontend/flutter_trainer/test/features/clients/client_detail_diet_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_diet_test.dart
@@ -92,28 +92,31 @@ void main() {
       expect(seongho[1].items, '짜장면'); // 점심
     });
 
-    test('client rows carry this week\'s sodium history on its weekdays', () async {
-      final clients = await DriftClientRepository(db).watchClients().first;
-      // 계열은 이번 주 월→일이다(#746). 요일 라벨과 함께 그리므로 길이는 늘
-      // 7이고, 오늘 값은 마지막 칸이 아니라 오늘 요일 칸에 놓인다.
-      final todayIndex = DateTime.now().weekday - 1;
-      for (final c in clients) {
-        expect(c.sodiumWeek, hasLength(7), reason: c.name);
-        expect(c.sodiumWeek[todayIndex], c.sodiumMg, reason: c.name);
-        // 아직 오지 않은 요일은 누구에게나 0 — 기록 없음과 같은 표현이다.
-        expect(
-          c.sodiumWeek.skip(todayIndex + 1),
-          everyElement(0),
-          reason: c.name,
-        );
-      }
-      final minsu = clients.firstWhere((c) => c.name == '김민수');
-      expect(minsu.sodiumOverDays, greaterThan(0)); // 2400/2200/2300… over
-      expect(minsu.sodiumWeekAvg, isNotNull);
+    test(
+      'client rows carry this week\'s sodium history on its weekdays',
+      () async {
+        final clients = await DriftClientRepository(db).watchClients().first;
+        // 계열은 이번 주 월→일이다(#746). 요일 라벨과 함께 그리므로 길이는 늘
+        // 7이고, 오늘 값은 마지막 칸이 아니라 오늘 요일 칸에 놓인다.
+        final todayIndex = DateTime.now().weekday - 1;
+        for (final c in clients) {
+          expect(c.sodiumWeek, hasLength(7), reason: c.name);
+          expect(c.sodiumWeek[todayIndex], c.sodiumMg, reason: c.name);
+          // 아직 오지 않은 요일은 누구에게나 0 — 기록 없음과 같은 표현이다.
+          expect(
+            c.sodiumWeek.skip(todayIndex + 1),
+            everyElement(0),
+            reason: c.name,
+          );
+        }
+        final minsu = clients.firstWhere((c) => c.name == '김민수');
+        expect(minsu.sodiumOverDays, greaterThan(0)); // 2400/2200/2300… over
+        expect(minsu.sodiumWeekAvg, isNotNull);
 
-      final jisu = clients.firstWhere((c) => c.name == '이지수');
-      expect(jisu.sodiumOverDays, 1); // only the 2100 day is over
-    });
+        final jisu = clients.firstWhere((c) => c.name == '이지수');
+        expect(jisu.sodiumOverDays, 1); // only the 2100 day is over
+      },
+    );
   });
 
   group('DietView', () {
@@ -278,6 +281,21 @@ void main() {
         scrollable: detailScrollable('seed-client-1'),
       );
       expect(find.textContaining('나트륨이 목표치를 1428mg 초과했어요'), findsOneWidget);
+    });
+
+    testWidgets('목표를 넘긴 날은 링을 채우되 100%라고 적지 않는다 (#820)', (tester) async {
+      // 강서연은 2,260 / 2,000 kcal 로 목표를 넘겼다.
+      await openDiet(tester, '강서연');
+
+      final ring = tester.widget<CircularProgressIndicator>(
+        find.byKey(const Key('client-nutrition-calorie-progress')),
+      );
+      // 링은 한 바퀴에서 멈춘다 — 넘긴 양은 링이 그릴 수 없다.
+      expect(ring.value, 1.0);
+      // 숫자는 자르지 않는다. '100%' 는 바로 아래 '목표보다 260 kcal 넘었어요'
+      // 와 정면으로 어긋난다.
+      expect(find.text('113%'), findsOneWidget);
+      expect(find.text('100%'), findsNothing);
     });
 
     testWidgets('normal sodium and sugar use the user app sugar green', (


### PR DESCRIPTION
## Summary

고객 식단 탭의 칼로리 링이 목표를 넘긴 날에도 `100% 달성률` 로 적혔다. 링은 한 바퀴에서 멈추는 것이 맞는데, 링 옆 숫자가 그 **잘린** 비율을 그대로 적은 탓이다.

강서연은 `2,260 / 2,000 kcal` 이고 바로 아래에 `목표보다 260 kcal 넘었어요` 가 함께 나온다. 색은 이미 빨강이라 경고로 읽히지만, 숫자는 "목표를 다 채웠다" 는 뜻이라 한 카드 안에서 두 표시가 반대로 말했다.

## Changes

- 링이 쓰는 비율(한 바퀴에서 멈춤)과 화면에 적는 비율(자르지 않음)을 나눈다. 링의 모양은 그대로고, 숫자만 실제 비율을 적는다 — 위 예시는 `113%` 가 된다.
- 목표를 넘긴 고객에서 링은 가득 차되 `100%` 라고 적지 않는지 확인하는 테스트를 추가한다.

## Commits

- `fix(trainer-web): 목표를 넘겨도 100%로 적히던 식단 달성률`

## Notes

색 규칙(초과 시 빨강)은 이미 맞게 동작하고 있어 건드리지 않았다. `달성률` 이라는 라벨도 그대로 뒀다 — 넘긴 상태는 숫자와 색이 이미 말한다.

Closes #820
