### PR TITLE
fix(trainer-web): 고객을 열면 초기화되던 목록 정렬·필터

### DIFF
--- a/frontend/flutter_trainer/lib/app/router/routes.dart
+++ b/frontend/flutter_trainer/lib/app/router/routes.dart
@@ -98,11 +98,23 @@ class AppRoutes {
 
   /// Builds `/clients/<id>/<section>`. Ids are percent-encoded — a
   /// backend member id is not guaranteed to be URL-safe.
-  static String clientDetail(String id, {String? section}) {
+  ///
+  /// [filter] carries the roster preset (`f`) into the detail URL. Dropping
+  /// it is what made the 대시보드 '주의 고객' 카드 → 목록 → 고객 순서에서
+  /// 필터가 사라지게 했다: 상세는 별개 라우트라 쿼리를 물려주지 않으면 그
+  /// 자리에서 전체 로스터로 돌아간다(#816).
+  static String clientDetail(String id, {String? section, String? filter}) {
     final safeSection = clientSections.contains(section)
         ? section!
         : defaultClientSection;
-    return '$clients/${Uri.encodeComponent(id)}/$safeSection';
+    final path = '$clients/${Uri.encodeComponent(id)}/$safeSection';
+    // 빈 맵을 넘기면 `?` 만 붙은 주소가 나온다 — 필터가 없을 때는 쿼리 자체를
+    // 만들지 않는다.
+    if (filter == null) return path;
+    return Uri(
+      path: path,
+      queryParameters: <String, String>{'f': filter},
+    ).toString();
   }
 
   /// Builds the 고객 list filtered to a preset. Used by the dashboard

--- a/frontend/flutter_trainer/lib/features/clients/presentation/controllers/roster_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/controllers/roster_view.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// 로스터를 관리 상태로 좁히는 필터. URL 의 `f` 프리셋과는 다른 축이다 —
+/// 그쪽은 대시보드가 걸어 주는 것이고, 이쪽은 트레이너가 툴바에서 고른다.
+enum RosterManagementFilter { all, attention, active, dormant }
+
+/// 로스터 정렬 기준.
+enum RosterSort { priority, name }
+
+/// 고객 탭의 보기 설정 한 벌.
+class RosterView {
+  /// Creates a view state.
+  const RosterView({
+    this.filter = RosterManagementFilter.all,
+    this.sort = RosterSort.priority,
+  });
+
+  /// 툴바에서 고른 관리 필터.
+  final RosterManagementFilter filter;
+
+  /// 툴바에서 고른 정렬.
+  final RosterSort sort;
+
+  /// Returns a copy with the given fields replaced.
+  RosterView copyWith({RosterManagementFilter? filter, RosterSort? sort}) =>
+      RosterView(filter: filter ?? this.filter, sort: sort ?? this.sort);
+}
+
+/// 고객 탭의 정렬·관리 필터.
+///
+/// 화면이 아니라 여기에 두는 이유: `/clients` 와 `/clients/<id>/<section>` 은
+/// 서로 다른 라우트라 각각 자기 `ClientsPage` 를 만든다. 이 값을 화면의 지역
+/// 상태로 들고 있으면 목록에서 고객을 여는 순간 새 상태가 만들어져 방금 고른
+/// 정렬이 기본값으로 돌아갔다 — 주의 고객만 추려 차례로 확인하는 흐름이 첫
+/// 고객에서 끊겼다(#816).
+final rosterViewProvider = StateProvider<RosterView>(
+  (ref) => const RosterView(),
+  name: 'rosterView',
+);

--- a/frontend/flutter_trainer/lib/features/clients/presentation/pages/clients_page.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/pages/clients_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:oncare_trainer/app/router/routes.dart';
+import 'package:oncare_trainer/features/clients/presentation/controllers/roster_view.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/design_system/tokens/layout.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
@@ -46,16 +47,9 @@ class ClientsPage extends ConsumerStatefulWidget {
   ConsumerState<ClientsPage> createState() => _ClientsPageState();
 }
 
-enum _ManagementFilter { all, attention, active, dormant }
-
-enum _ClientSort { priority, name }
-
 class _ClientsPageState extends ConsumerState<ClientsPage> {
-  _ManagementFilter _managementFilter = _ManagementFilter.all;
-  _ClientSort _sort = _ClientSort.priority;
-
   void _clearFilters() {
-    setState(() => _managementFilter = _ManagementFilter.all);
+    ref.read(rosterViewProvider.notifier).state = const RosterView();
     context.go(AppRoutes.clients);
   }
 
@@ -74,6 +68,9 @@ class _ClientsPageState extends ConsumerState<ClientsPage> {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations l = AppLocalizations.of(context);
+    // 정렬·관리 필터는 이 화면이 아니라 provider 가 들고 있다 — 목록과 상세가
+    // 서로 다른 라우트라, 지역 상태로 두면 고객을 여는 순간 초기화된다(#816).
+    final view = ref.watch(rosterViewProvider);
     // Priority ordering: sodium-over clients first, then recent chat.
     final clientsAsync = ref.watch(prioritizedClientsProvider);
     final unread =
@@ -117,20 +114,20 @@ class _ClientsPageState extends ConsumerState<ClientsPage> {
         var list = applyClientFilter(all, activeFilter, unread: unread);
         list = list
             .where((client) {
-              switch (_managementFilter) {
-                case _ManagementFilter.all:
+              switch (view.filter) {
+                case RosterManagementFilter.all:
                   return true;
-                case _ManagementFilter.attention:
+                case RosterManagementFilter.attention:
                   return healthAlertsFor(client).isNotEmpty ||
                       (unread[client.id] ?? 0) > 0;
-                case _ManagementFilter.active:
+                case RosterManagementFilter.active:
                   return client.active;
-                case _ManagementFilter.dormant:
+                case RosterManagementFilter.dormant:
                   return !client.active;
               }
             })
             .toList(growable: false);
-        if (_sort == _ClientSort.name) {
+        if (view.sort == RosterSort.name) {
           list = [...list]..sort((a, b) => a.name.compareTo(b.name));
         }
         // An id that isn't on the roster (deleted client, stale link) is
@@ -164,7 +161,11 @@ class _ClientsPageState extends ConsumerState<ClientsPage> {
                 totalCount: all.length,
                 trailingPadding: wide ? AppSpacing.sm : 0,
                 onOpen: (id) => context.go(
-                  AppRoutes.clientDetail(id, section: widget.section),
+                  AppRoutes.clientDetail(
+                    id,
+                    section: widget.section,
+                    filter: widget.filter,
+                  ),
                 ),
                 onClearFilter: _clearFilters,
               );
@@ -175,7 +176,11 @@ class _ClientsPageState extends ConsumerState<ClientsPage> {
                   section: widget.section,
                   showBack: true,
                   onSectionChange: (next) => context.go(
-                    AppRoutes.clientDetail(selected, section: next),
+                    AppRoutes.clientDetail(
+                      selected,
+                      section: next,
+                      filter: widget.filter,
+                    ),
                   ),
                   onClose: () => context.go(AppRoutes.clients),
                 );
@@ -198,7 +203,11 @@ class _ClientsPageState extends ConsumerState<ClientsPage> {
                               section: widget.section,
                               showBack: false,
                               onSectionChange: (next) => context.go(
-                                AppRoutes.clientDetail(selected, section: next),
+                                AppRoutes.clientDetail(
+                                  selected,
+                                  section: next,
+                                  filter: widget.filter,
+                                ),
                               ),
                               onClose: () => context.go(AppRoutes.clients),
                             ),
@@ -211,13 +220,16 @@ class _ClientsPageState extends ConsumerState<ClientsPage> {
                 children: <Widget>[
                   if (wide || selected == null)
                     _MemberManagementToolbar(
-                      managementFilter: _managementFilter,
-                      sort: _sort,
+                      managementFilter: view.filter,
+                      sort: view.sort,
                       shownCount: list.length,
                       activeCount: all.where((client) => client.active).length,
                       onFilterChanged: (value) =>
-                          setState(() => _managementFilter = value),
-                      onSortChanged: (value) => setState(() => _sort = value),
+                          ref.read(rosterViewProvider.notifier).state = view
+                              .copyWith(filter: value),
+                      onSortChanged: (value) =>
+                          ref.read(rosterViewProvider.notifier).state = view
+                              .copyWith(sort: value),
                     ),
                   Expanded(
                     child: Padding(
@@ -261,12 +273,12 @@ class _MemberManagementToolbar extends StatelessWidget {
     required this.onSortChanged,
   });
 
-  final _ManagementFilter managementFilter;
-  final _ClientSort sort;
+  final RosterManagementFilter managementFilter;
+  final RosterSort sort;
   final int shownCount;
   final int activeCount;
-  final ValueChanged<_ManagementFilter> onFilterChanged;
-  final ValueChanged<_ClientSort> onSortChanged;
+  final ValueChanged<RosterManagementFilter> onFilterChanged;
+  final ValueChanged<RosterSort> onSortChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -283,17 +295,17 @@ class _MemberManagementToolbar extends StatelessWidget {
         runSpacing: AppSpacing.sm,
         crossAxisAlignment: WrapCrossAlignment.center,
         children: <Widget>[
-          _ToolbarMenu<_ManagementFilter>(
+          _ToolbarMenu<RosterManagementFilter>(
             value: managementFilter,
             label: _managementLabel(l, managementFilter),
-            items: _ManagementFilter.values,
+            items: RosterManagementFilter.values,
             itemLabel: (value) => _managementLabel(l, value),
             onSelected: onFilterChanged,
           ),
-          _ToolbarMenu<_ClientSort>(
+          _ToolbarMenu<RosterSort>(
             value: sort,
             label: _sortLabel(l, sort),
-            items: _ClientSort.values,
+            items: RosterSort.values,
             itemLabel: (value) => _sortLabel(l, value),
             onSelected: onSortChanged,
           ),
@@ -310,24 +322,24 @@ class _MemberManagementToolbar extends StatelessWidget {
     );
   }
 
-  String _managementLabel(AppLocalizations l, _ManagementFilter value) {
+  String _managementLabel(AppLocalizations l, RosterManagementFilter value) {
     switch (value) {
-      case _ManagementFilter.all:
+      case RosterManagementFilter.all:
         return l.filterAll;
-      case _ManagementFilter.attention:
+      case RosterManagementFilter.attention:
         return l.clientsManagementAttention;
-      case _ManagementFilter.active:
+      case RosterManagementFilter.active:
         return l.clientActive;
-      case _ManagementFilter.dormant:
+      case RosterManagementFilter.dormant:
         return l.clientDormant;
     }
   }
 
-  String _sortLabel(AppLocalizations l, _ClientSort value) {
+  String _sortLabel(AppLocalizations l, RosterSort value) {
     switch (value) {
-      case _ClientSort.priority:
+      case RosterSort.priority:
         return l.clientsSortPriority;
-      case _ClientSort.name:
+      case RosterSort.name:
         return l.clientsSortName;
     }
   }

--- a/frontend/flutter_trainer/test/features/clients/clients_split_view_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/clients_split_view_test.dart
@@ -201,6 +201,53 @@ void main() {
     expect(find.textContaining('2,400', findRichText: true), findsWidgets);
   });
 
+  testWidgets('고른 정렬은 고객을 열어도 그대로다 (#816)', (tester) async {
+    await openWide(tester);
+
+    // 툴바의 정렬 메뉴에서 이름순을 고른다.
+    await tester.tap(find.text('정렬: 관리 우선'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('정렬: 이름순').last);
+    await tester.pumpAndSettle();
+    expect(find.text('정렬: 이름순'), findsOneWidget);
+
+    // 목록에서 고객을 연다 — 여기서 새 라우트가 만들어진다.
+    await scrollToCard(tester, '김민수');
+    await tester.tap(card('김민수'));
+    await tester.pumpAndSettle();
+
+    // 예전에는 상세가 자기 `ClientsPage` 를 새로 만들면서 정렬이 '관리 우선'
+    // 로 돌아갔다.
+    expect(find.text('정렬: 이름순'), findsOneWidget);
+    expect(find.text('정렬: 관리 우선'), findsNothing);
+  });
+
+  testWidgets('대시보드에서 걸어 준 필터는 고객을 열어도 유지된다 (#816)', (tester) async {
+    tester.view.physicalSize = const Size(1440, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await pumpTrainerApp(
+      tester,
+      token: 'demo-trainer-token',
+      at: AppRoutes.clientsFiltered('attention'),
+    );
+    await tester.pumpAndSettle();
+
+    final banner = find.textContaining('주의 고객');
+    expect(banner, findsWidgets);
+
+    final first = tester.widgetList<ClientCard>(find.byType(ClientCard)).first;
+    await tester.tap(card(first.client.name));
+    await tester.pumpAndSettle();
+
+    // 상세 경로가 `f` 를 물려받아야 배너와 좁힌 목록이 남는다.
+    final router = GoRouter.of(tester.element(find.byType(ClientsPage)));
+    final location = router.routerDelegate.currentConfiguration.uri.toString();
+    expect(location, contains('f=attention'));
+    expect(banner, findsWidgets);
+  });
+
   testWidgets('the list is ordered by priority: sodium-over first', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary

고객 탭에서 고른 **정렬과 관리 필터가, 고객을 여는 순간 초기값으로 돌아갔다.** 대시보드 `주의 고객` 카드로 들어와 그 목록의 고객을 클릭하면 `주의 고객 · 8/15명` 배너와 좁힌 목록까지 함께 풀렸다.

"주의 고객만 추려서 차례로 확인" 하는 흐름이 첫 고객을 여는 순간 끊긴다.

## Cause

`/clients` 와 `/clients/<id>/<section>` 은 서로 다른 라우트라 각각 자기 `ClientsPage` 를 만든다. 정렬·관리 필터가 그 화면의 지역 상태라 새 인스턴스에서 기본값으로 시작했고, `AppRoutes.clientDetail` 은 `f` 쿼리를 상세 경로로 넘기지 않았다.

## Changes

- 정렬·관리 필터를 `rosterViewProvider` 로 옮겨 두 라우트가 한 값을 본다.
- `clientDetail` 이 `f` 를 물려준다. 필터가 없을 때는 쿼리를 만들지 않아 주소 모양은 지금과 같다(빈 맵을 넘기면 `?` 만 붙는다).
- 회귀 테스트 둘 — 정렬이 고객을 열어도 남는지, 대시보드가 걸어 준 필터가 상세 주소와 배너에 남는지. 수정 전 코드에서 둘 다 실패하는 것을 확인했다.

## Commits

- `fix(trainer-web): 고객을 열면 초기화되던 목록 정렬·필터`

## Notes

정렬은 새로고침까지 살아남지는 않는다 — 주소에 싣지 않고 provider 에만 뒀다. 이번 이슈는 "고객을 여는 순간 풀린다" 는 것이고, 정렬을 URL 에 싣는 것은 별개의 판단이라 이 PR 에서 하지 않았다. 반면 `f` 는 원래부터 주소에 있던 값이라 그대로 이어 준다.

Closes #816
