### PR TITLE
feat(trainer-web): 완료 세션 프로그램 전송 경로 추가

### DIFF
--- a/backend/app/api/v1/trainer.py
+++ b/backend/app/api/v1/trainer.py
@@ -49,7 +49,8 @@ from app.schemas.trainer_api import (
     RoutineFeedbackRequest,
     ProgramAssignRequest,
     RoutineOptionsOut, RoutineOptionsRequest, RoutineUpdateRequest,
-    ScheduleCompleteRequest, ScheduleCreateRequest, ScheduleProgramRegisterOut,
+    ScheduleCompleteRequest,
+    ScheduleProgramSendRequest, ScheduleCreateRequest, ScheduleProgramRegisterOut,
     ScheduleProgramRegisterRequest, ScheduleSessionOut, ScheduleUpdateRequest,
     TrainerClientOut, TrainerClientStatusOut, TrainerClientStatusUpdate,
     TrainerGymAffiliation, TrainerMe, TrainerMeUpdate,
@@ -1060,6 +1061,34 @@ def trainer_complete_session(
     """세션 완료(예정→완료). 매칭된 회원이 있으면 운동기록으로 적재."""
     try:
         out = trainer_service.complete_session(db, trainer.id, session_id, payload.note)
+    except trainer_service.ScheduleError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    if out is None:
+        raise HTTPException(status_code=404, detail="일정을 찾을 수 없습니다.")
+    return out
+
+
+@router.post(
+    "/trainer/schedule/{session_id}/program/send",
+    response_model=ScheduleSessionOut,
+)
+def trainer_send_session_program(
+    session_id: str,
+    payload: ScheduleProgramSendRequest,
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> ScheduleSessionOut:
+    """완료한 세션의 프로그램을 그 회원에게 보낸다. (#822)
+
+    수업을 마친 뒤 오늘 한 것을 회원 앱으로 넘기는 마지막 한 걸음이다. 배정
+    자체는 코칭 탭의 프로그램 배정과 같은 경로를 타므로, 회원은 출처와 무관하게
+    같은 모양의 루틴을 받는다. 같은 세션을 두 번 눌러도 배정은 한 번이다.
+    """
+    try:
+        out = trainer_service.send_session_program(
+            db, trainer.id, session_id,
+            client_request_id=payload.client_request_id,
+        )
     except trainer_service.ScheduleError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
     if out is None:

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -961,6 +961,11 @@ class TrainerSchedule(Base):
     status: Mapped[str] = mapped_column(String(10), default="예정")  # 예정|완료|공백
     note: Mapped[str] = mapped_column(Text, default="")
     program_json: Mapped[str] = mapped_column(Text, default="[]")
+    # 완료한 세션의 프로그램을 회원에게 보낸 시각. NULL 은 아직 보내지 않은
+    # 것이다 — 화면의 '전송됨' 표시와 재전송 방지가 이 값을 읽는다(#822).
+    program_sent_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     sort_order: Mapped[int] = mapped_column(Integer, default=0)
     # 트레이너의 예약 생성 시도 단위 멱등키. 다른 create operation 과는 테이블이
     # 달라 같은 문자열을 써도 충돌하지 않는다. NULL 은 구버전 요청 호환용이다.

--- a/backend/app/schemas/trainer_api.py
+++ b/backend/app/schemas/trainer_api.py
@@ -591,6 +591,19 @@ class ScheduleSessionOut(BaseModel):
     status: str          # 예정|완료|공백
     note: str
     program: list[ProgramItem]
+    #: 완료한 세션의 프로그램을 회원에게 보냈는가. 보낸 적 없는 세션과 이미
+    #: 보낸 세션은 화면에서 다른 것을 말해야 한다(#822).
+    program_sent: bool = False
+
+
+class ScheduleProgramSendRequest(BaseModel):
+    """완료한 세션의 프로그램을 회원에게 보내는 입력. (#822)
+
+    본문은 멱등키뿐이다 — 무엇을 보낼지는 세션 행이 이미 알고 있고, 클라이언트가
+    다시 실어 보내면 화면과 저장된 프로그램이 갈릴 수 있다. 재시도에 같은 키를
+    다시 보내면 배정이 두 번 만들어지지 않는다(단일·프로그램 배정과 같은 규약).
+    """
+    client_request_id: str | None = Field(default=None, max_length=48)
 
 
 class ScheduleCreateRequest(BaseModel):

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -1624,6 +1624,7 @@ def _schedule_out(s: TrainerSchedule) -> ScheduleSessionOut:
         id=s.id, date=s.date, time=s.time, client_name=s.client_name,
         type=s.type, duration_minutes=s.duration_minutes, status=s.status,
         note=s.note, program=_program_items(s.program_json),
+        program_sent=s.program_sent_at is not None,
     )
 
 
@@ -2116,6 +2117,67 @@ def _add_member_exercise_log(
     )
     db.add(row)
     return row
+
+
+def send_session_program(
+    db: Session,
+    trainer_id: str,
+    session_id: str,
+    *,
+    client_request_id: str | None = None,
+) -> ScheduleSessionOut | None:
+    """완료한 세션의 프로그램을 그 회원에게 배정한다. (#822)
+
+    수업을 마친 뒤 "오늘 이걸 했습니다" 를 회원 앱으로 넘기는 자리다. 새 배정
+    경로를 만들지 않고 [assign_program] 을 그대로 쓴다 — 회원이 받는 모양이
+    트레이너가 코칭 탭에서 보내던 것과 같아야, 회원 화면에 출처마다 다른 루틴이
+    생기지 않는다.
+
+    - 소유 슬롯 아님 → None(404).
+    - 회원이 없는 슬롯(상담·공백) → ScheduleError(400): 보낼 상대가 없다.
+    - 완료 전 → ScheduleError(400): 아직 한 것이 아니라 할 것이다.
+    - 프로그램이 비었으면 → ScheduleError(400): 빈 루틴만 간다.
+    - 이미 보냈으면 그대로 반환(멱등). 두 번 눌러도 회원 루틴이 겹치지 않는다.
+    """
+    s = _get_owned_session(db, trainer_id, session_id)
+    if s is None:
+        return None
+    if not s.member_id:
+        raise ScheduleError("회원이 연결되지 않은 일정입니다.")
+    if s.status != "완료":
+        raise ScheduleError("완료한 일정만 보낼 수 있습니다.")
+    items = _program_items(s.program_json)
+    if not items:
+        raise ScheduleError("보낼 프로그램이 없습니다.")
+    if s.program_sent_at is not None:
+        return _schedule_out(s)  # 멱등 no-op
+
+    # 일정의 프로그램 항목({name,sets,reps,weight})을 배정 계약의 운동으로 옮긴다.
+    # 세션은 하나다 — 회원 화면에 없던 세션 라벨이 생기지 않는다.
+    exercises = [
+        ProgramDraftExercise(
+            id=f"{s.id}#{index}",
+            name=item.name,
+            sets=str(item.sets) if item.sets else "",
+            reps=item.reps,
+            weight=item.weight,
+        )
+        for index, item in enumerate(items)
+    ]
+    assign_program(
+        db,
+        trainer_id,
+        s.member_id,
+        name=f"{s.date} {s.type}".strip() or s.date,
+        sessions=[ProgramDraftSession(id=s.id, name="", exercises=exercises)],
+        client_request_id=client_request_id,
+    )
+    # 배정이 커밋된 뒤에만 보낸 것으로 남긴다. 반대 순서면 배정에 실패한 세션이
+    # 화면에서 '전송됨' 이 되어 다시 보낼 수 없다.
+    s.program_sent_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(s)
+    return _schedule_out(s)
 
 
 def complete_session(

--- a/backend/migrations/versions/0041_schedule_program_sent.py
+++ b/backend/migrations/versions/0041_schedule_program_sent.py
@@ -1,0 +1,33 @@
+"""Record when a completed session's program was delivered to the member.
+
+트레이너가 수업을 마친 뒤 그날 한 프로그램을 회원에게 보내는 자리가 화면에는
+있었지만 저장할 곳이 없어 눌리지 않았다(#822). 보낸 시각을 세션 행에 남겨,
+같은 세션을 두 번 보내지 않고 화면이 '전송됨' 을 사실대로 말할 수 있게 한다.
+
+Revision ID: 0041_schedule_program_sent
+Revises: 0039_program_sessions
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0041_schedule_program_sent"
+down_revision: str | Sequence[str] | None = "0039_program_sessions"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # 기존 행은 모두 '보낸 적 없음'(NULL)이다 — 보낸 적이 있었다면 그 사실이
+    # 어딘가에 남아 있었을 텐데, 지금까지 보낼 방법 자체가 없었다.
+    op.add_column(
+        "trainer_schedule",
+        sa.Column("program_sent_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("trainer_schedule", "program_sent_at")

--- a/backend/tests/test_trainer_schedule.py
+++ b/backend/tests/test_trainer_schedule.py
@@ -754,3 +754,92 @@ def test_member_own_log_still_editable(client):
     assert put.status_code == 200, put.text
     assert put.json()["source"] == "member"
     assert client.delete(f"/v1/exercise/sessions/{sid}", headers=mh).status_code == 200
+
+
+def test_send_completed_program_assigns_routine_once(client, db_session, make_pt_session):
+    """완료한 세션의 프로그램이 회원 루틴으로 가고, 두 번 눌러도 한 번만 간다. (#822)
+
+    수업 뒤 "오늘 이걸 했습니다" 를 넘기는 자리다. 새 배정 경로가 아니라 코칭
+    탭과 같은 배정을 타므로, 회원 화면에는 출처마다 다른 루틴이 생기지 않는다.
+    """
+    token = _tok(client)
+    sid = make_pt_session(
+        token,
+        time="19:30",
+        duration_minutes=50,
+        program=[
+            {"name": "레그프레스", "sets": 3, "reps": "12회", "weight": "80kg"},
+            {"name": "코어 강화", "sets": 3, "reps": "10회", "weight": ""},
+        ],
+    )
+
+    # 시드에 이미 배정된 루틴이 있으므로 개수의 **변화**로 센다.
+    before = client.get("/v1/trainer/clients/user-jisu/routines", headers=_h(token))
+    assert before.status_code == 200
+    before_count = len(before.json())
+
+    # 완료 전에는 보낼 수 없다 — 아직 한 것이 아니라 할 것이다.
+    early = client.post(
+        f"/v1/trainer/schedule/{sid}/program/send", json={}, headers=_h(token)
+    )
+    assert early.status_code == 400
+
+    done = client.post(
+        f"/v1/trainer/schedule/{sid}/complete", json={"note": ""}, headers=_h(token)
+    )
+    assert done.status_code == 200
+    assert done.json()["program_sent"] is False
+
+    sent = client.post(
+        f"/v1/trainer/schedule/{sid}/program/send",
+        json={"client_request_id": "send-1"},
+        headers=_h(token),
+    )
+    assert sent.status_code == 200, sent.text
+    assert sent.json()["program_sent"] is True
+
+    routines = client.get(
+        "/v1/trainer/clients/user-jisu/routines", headers=_h(token)
+    ).json()
+    assert len(routines) == before_count + 1, "전송이 회원 루틴을 만들지 않았다"
+
+    # 두 번째 호출은 멱등 — 회원 루틴이 겹치지 않는다.
+    again = client.post(
+        f"/v1/trainer/schedule/{sid}/program/send",
+        json={"client_request_id": "send-1"},
+        headers=_h(token),
+    )
+    assert again.status_code == 200
+    assert again.json()["program_sent"] is True
+    after = client.get(
+        "/v1/trainer/clients/user-jisu/routines", headers=_h(token)
+    ).json()
+    assert len(after) == len(routines), "재전송이 회원 루틴을 늘렸다"
+
+    # 조회 경로도 전송 사실을 그대로 말한다.
+    listed = client.get(
+        "/v1/trainer/schedule", params={"date": _today()}, headers=_h(token)
+    ).json()
+    row = next(s for s in listed if s["id"] == sid)
+    assert row["program_sent"] is True
+
+
+def test_send_program_requires_a_linked_member_and_a_program(client, make_pt_session):
+    """보낼 상대나 보낼 내용이 없으면 400 — 빈 루틴이 회원에게 가지 않는다. (#822)"""
+    token = _tok(client)
+
+    # 프로그램이 없는 세션
+    empty = make_pt_session(token, time="20:30", duration_minutes=30, program=[])
+    client.post(
+        f"/v1/trainer/schedule/{empty}/complete", json={"note": ""}, headers=_h(token)
+    )
+    r = client.post(
+        f"/v1/trainer/schedule/{empty}/program/send", json={}, headers=_h(token)
+    )
+    assert r.status_code == 400
+
+    # 없는 일정
+    missing = client.post(
+        "/v1/trainer/schedule/no-such-session/program/send", json={}, headers=_h(token)
+    )
+    assert missing.status_code == 404

--- a/frontend/flutter_trainer/lib/core/storage/app_database.dart
+++ b/frontend/flutter_trainer/lib/core/storage/app_database.dart
@@ -138,6 +138,12 @@ class TrainerScheduleEntries extends Table {
   TextColumn get note => text().withDefault(const Constant(''))();
   TextColumn get programJson =>
       text().withDefault(const Constant('[]'))(); // [{name,sets,reps,weight}]
+
+  /// 완료한 세션의 프로그램을 회원에게 보냈는가. 데모에는 받을 회원 백엔드가
+  /// 없어 전송은 이 표시로 끝나지만, 화면이 '전송됨' 을 사실대로 말하고 같은
+  /// 세션을 두 번 보내지 않게 하려면 어딘가에 남아야 한다(#822).
+  BoolColumn get programSent =>
+      boolean().withDefault(const Constant(false))();
   IntColumn get sortOrder => integer().withDefault(const Constant(0))();
 
   @override
@@ -204,7 +210,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.executor);
 
   @override
-  int get schemaVersion => 8;
+  int get schemaVersion => 9;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -259,6 +265,15 @@ class AppDatabase extends _$AppDatabase {
         await m.createTable(clientDailyMetrics);
       } else if (from < 8) {
         await m.addColumn(clientDailyMetrics, clientDailyMetrics.exercisesJson);
+      }
+      // v9: 완료한 세션의 프로그램을 보냈는지 표시한다(#822). 기본값이 false 라
+      // 기존 행은 모두 '보낸 적 없음' 으로 읽힌다 — 지금까지 보낼 방법 자체가
+      // 없었으니 사실과 같다.
+      if (from < 9) {
+        await m.addColumn(
+          trainerScheduleEntries,
+          trainerScheduleEntries.programSent,
+        );
       }
     },
   );

--- a/frontend/flutter_trainer/lib/core/storage/app_database.g.dart
+++ b/frontend/flutter_trainer/lib/core/storage/app_database.g.dart
@@ -3402,6 +3402,21 @@ class $TrainerScheduleEntriesTable extends TrainerScheduleEntries
     requiredDuringInsert: false,
     defaultValue: const Constant('[]'),
   );
+  static const VerificationMeta _programSentMeta = const VerificationMeta(
+    'programSent',
+  );
+  @override
+  late final GeneratedColumn<bool> programSent = GeneratedColumn<bool>(
+    'program_sent',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("program_sent" IN (0, 1))',
+    ),
+    defaultValue: const Constant(false),
+  );
   static const VerificationMeta _sortOrderMeta = const VerificationMeta(
     'sortOrder',
   );
@@ -3426,6 +3441,7 @@ class $TrainerScheduleEntriesTable extends TrainerScheduleEntries
     status,
     note,
     programJson,
+    programSent,
     sortOrder,
   ];
   @override
@@ -3511,6 +3527,15 @@ class $TrainerScheduleEntriesTable extends TrainerScheduleEntries
         ),
       );
     }
+    if (data.containsKey('program_sent')) {
+      context.handle(
+        _programSentMeta,
+        programSent.isAcceptableOrUnknown(
+          data['program_sent']!,
+          _programSentMeta,
+        ),
+      );
+    }
     if (data.containsKey('sort_order')) {
       context.handle(
         _sortOrderMeta,
@@ -3566,6 +3591,10 @@ class $TrainerScheduleEntriesTable extends TrainerScheduleEntries
         DriftSqlType.string,
         data['${effectivePrefix}program_json'],
       )!,
+      programSent: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}program_sent'],
+      )!,
       sortOrder: attachedDatabase.typeMapping.read(
         DriftSqlType.int,
         data['${effectivePrefix}sort_order'],
@@ -3599,6 +3628,11 @@ class TrainerScheduleRow extends DataClass
   final String status;
   final String note;
   final String programJson;
+
+  /// 완료한 세션의 프로그램을 회원에게 보냈는가. 데모에는 받을 회원 백엔드가
+  /// 없어 전송은 이 표시로 끝나지만, 화면이 '전송됨' 을 사실대로 말하고 같은
+  /// 세션을 두 번 보내지 않게 하려면 어딘가에 남아야 한다(#822).
+  final bool programSent;
   final int sortOrder;
   const TrainerScheduleRow({
     required this.id,
@@ -3611,6 +3645,7 @@ class TrainerScheduleRow extends DataClass
     required this.status,
     required this.note,
     required this.programJson,
+    required this.programSent,
     required this.sortOrder,
   });
   @override
@@ -3628,6 +3663,7 @@ class TrainerScheduleRow extends DataClass
     map['status'] = Variable<String>(status);
     map['note'] = Variable<String>(note);
     map['program_json'] = Variable<String>(programJson);
+    map['program_sent'] = Variable<bool>(programSent);
     map['sort_order'] = Variable<int>(sortOrder);
     return map;
   }
@@ -3646,6 +3682,7 @@ class TrainerScheduleRow extends DataClass
       status: Value(status),
       note: Value(note),
       programJson: Value(programJson),
+      programSent: Value(programSent),
       sortOrder: Value(sortOrder),
     );
   }
@@ -3666,6 +3703,7 @@ class TrainerScheduleRow extends DataClass
       status: serializer.fromJson<String>(json['status']),
       note: serializer.fromJson<String>(json['note']),
       programJson: serializer.fromJson<String>(json['programJson']),
+      programSent: serializer.fromJson<bool>(json['programSent']),
       sortOrder: serializer.fromJson<int>(json['sortOrder']),
     );
   }
@@ -3683,6 +3721,7 @@ class TrainerScheduleRow extends DataClass
       'status': serializer.toJson<String>(status),
       'note': serializer.toJson<String>(note),
       'programJson': serializer.toJson<String>(programJson),
+      'programSent': serializer.toJson<bool>(programSent),
       'sortOrder': serializer.toJson<int>(sortOrder),
     };
   }
@@ -3698,6 +3737,7 @@ class TrainerScheduleRow extends DataClass
     String? status,
     String? note,
     String? programJson,
+    bool? programSent,
     int? sortOrder,
   }) => TrainerScheduleRow(
     id: id ?? this.id,
@@ -3710,6 +3750,7 @@ class TrainerScheduleRow extends DataClass
     status: status ?? this.status,
     note: note ?? this.note,
     programJson: programJson ?? this.programJson,
+    programSent: programSent ?? this.programSent,
     sortOrder: sortOrder ?? this.sortOrder,
   );
   TrainerScheduleRow copyWithCompanion(TrainerScheduleEntriesCompanion data) {
@@ -3730,6 +3771,9 @@ class TrainerScheduleRow extends DataClass
       programJson: data.programJson.present
           ? data.programJson.value
           : this.programJson,
+      programSent: data.programSent.present
+          ? data.programSent.value
+          : this.programSent,
       sortOrder: data.sortOrder.present ? data.sortOrder.value : this.sortOrder,
     );
   }
@@ -3747,6 +3791,7 @@ class TrainerScheduleRow extends DataClass
           ..write('status: $status, ')
           ..write('note: $note, ')
           ..write('programJson: $programJson, ')
+          ..write('programSent: $programSent, ')
           ..write('sortOrder: $sortOrder')
           ..write(')'))
         .toString();
@@ -3764,6 +3809,7 @@ class TrainerScheduleRow extends DataClass
     status,
     note,
     programJson,
+    programSent,
     sortOrder,
   );
   @override
@@ -3780,6 +3826,7 @@ class TrainerScheduleRow extends DataClass
           other.status == this.status &&
           other.note == this.note &&
           other.programJson == this.programJson &&
+          other.programSent == this.programSent &&
           other.sortOrder == this.sortOrder);
 }
 
@@ -3795,6 +3842,7 @@ class TrainerScheduleEntriesCompanion
   final Value<String> status;
   final Value<String> note;
   final Value<String> programJson;
+  final Value<bool> programSent;
   final Value<int> sortOrder;
   final Value<int> rowid;
   const TrainerScheduleEntriesCompanion({
@@ -3808,6 +3856,7 @@ class TrainerScheduleEntriesCompanion
     this.status = const Value.absent(),
     this.note = const Value.absent(),
     this.programJson = const Value.absent(),
+    this.programSent = const Value.absent(),
     this.sortOrder = const Value.absent(),
     this.rowid = const Value.absent(),
   });
@@ -3822,6 +3871,7 @@ class TrainerScheduleEntriesCompanion
     required String status,
     this.note = const Value.absent(),
     this.programJson = const Value.absent(),
+    this.programSent = const Value.absent(),
     this.sortOrder = const Value.absent(),
     this.rowid = const Value.absent(),
   }) : id = Value(id),
@@ -3839,6 +3889,7 @@ class TrainerScheduleEntriesCompanion
     Expression<String>? status,
     Expression<String>? note,
     Expression<String>? programJson,
+    Expression<bool>? programSent,
     Expression<int>? sortOrder,
     Expression<int>? rowid,
   }) {
@@ -3853,6 +3904,7 @@ class TrainerScheduleEntriesCompanion
       if (status != null) 'status': status,
       if (note != null) 'note': note,
       if (programJson != null) 'program_json': programJson,
+      if (programSent != null) 'program_sent': programSent,
       if (sortOrder != null) 'sort_order': sortOrder,
       if (rowid != null) 'rowid': rowid,
     });
@@ -3869,6 +3921,7 @@ class TrainerScheduleEntriesCompanion
     Value<String>? status,
     Value<String>? note,
     Value<String>? programJson,
+    Value<bool>? programSent,
     Value<int>? sortOrder,
     Value<int>? rowid,
   }) {
@@ -3883,6 +3936,7 @@ class TrainerScheduleEntriesCompanion
       status: status ?? this.status,
       note: note ?? this.note,
       programJson: programJson ?? this.programJson,
+      programSent: programSent ?? this.programSent,
       sortOrder: sortOrder ?? this.sortOrder,
       rowid: rowid ?? this.rowid,
     );
@@ -3921,6 +3975,9 @@ class TrainerScheduleEntriesCompanion
     if (programJson.present) {
       map['program_json'] = Variable<String>(programJson.value);
     }
+    if (programSent.present) {
+      map['program_sent'] = Variable<bool>(programSent.value);
+    }
     if (sortOrder.present) {
       map['sort_order'] = Variable<int>(sortOrder.value);
     }
@@ -3943,6 +4000,7 @@ class TrainerScheduleEntriesCompanion
           ..write('status: $status, ')
           ..write('note: $note, ')
           ..write('programJson: $programJson, ')
+          ..write('programSent: $programSent, ')
           ..write('sortOrder: $sortOrder, ')
           ..write('rowid: $rowid')
           ..write(')'))
@@ -6177,6 +6235,7 @@ typedef $$TrainerScheduleEntriesTableCreateCompanionBuilder =
       required String status,
       Value<String> note,
       Value<String> programJson,
+      Value<bool> programSent,
       Value<int> sortOrder,
       Value<int> rowid,
     });
@@ -6192,6 +6251,7 @@ typedef $$TrainerScheduleEntriesTableUpdateCompanionBuilder =
       Value<String> status,
       Value<String> note,
       Value<String> programJson,
+      Value<bool> programSent,
       Value<int> sortOrder,
       Value<int> rowid,
     });
@@ -6252,6 +6312,11 @@ class $$TrainerScheduleEntriesTableFilterComposer
 
   ColumnFilters<String> get programJson => $composableBuilder(
     column: $table.programJson,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get programSent => $composableBuilder(
+    column: $table.programSent,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -6320,6 +6385,11 @@ class $$TrainerScheduleEntriesTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<bool> get programSent => $composableBuilder(
+    column: $table.programSent,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<int> get sortOrder => $composableBuilder(
     column: $table.sortOrder,
     builder: (column) => ColumnOrderings(column),
@@ -6368,6 +6438,11 @@ class $$TrainerScheduleEntriesTableAnnotationComposer
 
   GeneratedColumn<String> get programJson => $composableBuilder(
     column: $table.programJson,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<bool> get programSent => $composableBuilder(
+    column: $table.programSent,
     builder: (column) => column,
   );
 
@@ -6431,6 +6506,7 @@ class $$TrainerScheduleEntriesTableTableManager
                 Value<String> status = const Value.absent(),
                 Value<String> note = const Value.absent(),
                 Value<String> programJson = const Value.absent(),
+                Value<bool> programSent = const Value.absent(),
                 Value<int> sortOrder = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => TrainerScheduleEntriesCompanion(
@@ -6444,6 +6520,7 @@ class $$TrainerScheduleEntriesTableTableManager
                 status: status,
                 note: note,
                 programJson: programJson,
+                programSent: programSent,
                 sortOrder: sortOrder,
                 rowid: rowid,
               ),
@@ -6459,6 +6536,7 @@ class $$TrainerScheduleEntriesTableTableManager
                 required String status,
                 Value<String> note = const Value.absent(),
                 Value<String> programJson = const Value.absent(),
+                Value<bool> programSent = const Value.absent(),
                 Value<int> sortOrder = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => TrainerScheduleEntriesCompanion.insert(
@@ -6472,6 +6550,7 @@ class $$TrainerScheduleEntriesTableTableManager
                 status: status,
                 note: note,
                 programJson: programJson,
+                programSent: programSent,
                 sortOrder: sortOrder,
                 rowid: rowid,
               ),

--- a/frontend/flutter_trainer/lib/features/schedule/data/dtos/schedule_dtos.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/data/dtos/schedule_dtos.dart
@@ -18,6 +18,7 @@ ScheduleSession scheduleSessionFromJson(Map<String, dynamic> json) {
     status: _str(json['status']),
     note: _str(json['note']),
     program: _programFromJson(json['program']),
+    programSent: json['program_sent'] == true,
   );
 }
 

--- a/frontend/flutter_trainer/lib/features/schedule/data/repositories/dio_schedule_repository.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/data/repositories/dio_schedule_repository.dart
@@ -244,6 +244,16 @@ class DioScheduleRepository implements ScheduleRepository {
     );
   }
 
+  @override
+  Future<void> sendProgram(String id, {String? clientRequestId}) async {
+    await _mutate(
+      () => _dio.post<Map<String, dynamic>>(
+        '/trainer/schedule/${Uri.encodeComponent(id)}/program/send',
+        data: <String, Object?>{'client_request_id': ?clientRequestId},
+      ),
+    );
+  }
+
   Future<List<ScheduleSession>> _fetch(Map<String, String> query) async {
     try {
       final res = await _dio.get<List<dynamic>>(

--- a/frontend/flutter_trainer/lib/features/schedule/data/repositories/schedule_repository.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/data/repositories/schedule_repository.dart
@@ -93,6 +93,13 @@ abstract interface class ScheduleRepository {
 
   /// Marks an 예정 session 완료 with the trainer's [note].
   Future<void> completeSession(String id, {String note});
+
+  /// 완료한 세션의 프로그램을 그 회원에게 보낸다. (#822)
+  ///
+  /// [clientRequestId] 는 전송 시도의 멱등키다 — 실패해서 다시 눌러도 회원의
+  /// 루틴이 두 벌 생기지 않는다. 보낼 상대(회원)나 보낼 내용(프로그램)이 없거나
+  /// 아직 완료 전이면 예외다. 이미 보낸 세션에 다시 부르면 조용히 성공한다.
+  Future<void> sendProgram(String id, {String? clientRequestId});
 }
 
 /// Reads the trainer's daily timeline from the local drift DB.
@@ -349,6 +356,28 @@ class DriftScheduleRepository implements ScheduleRepository {
 
   /// Removes a session from the timeline.
   @override
+  /// 데모에는 받을 회원 백엔드가 없다. 전송은 이 표시로 끝나지만, 화면이
+  /// '전송됨' 을 사실대로 말하고 같은 세션을 두 번 보내지 않으려면 남아야 한다.
+  @override
+  Future<void> sendProgram(String id, {String? clientRequestId}) async {
+    final table = _db.trainerScheduleEntries;
+    final session = await (_db.select(
+      table,
+    )..where((t) => t.id.equals(id))).getSingleOrNull();
+    if (session == null) throw StateError('session not found: $id');
+    if (session.programSent) return; // 이미 보냈다 — 멱등.
+    if (session.status != ScheduleStatus.done) {
+      throw StateError('session not completed: $id');
+    }
+    if ((jsonDecode(session.programJson) as List<Object?>).isEmpty) {
+      throw StateError('session has no program: $id');
+    }
+    await (_db.update(table)..where((t) => t.id.equals(id))).write(
+      const TrainerScheduleEntriesCompanion(programSent: Value(true)),
+    );
+  }
+
+  @override
   Future<void> deleteSession(String id) async {
     await (_db.delete(
       _db.trainerScheduleEntries,
@@ -473,6 +502,7 @@ class DriftScheduleRepository implements ScheduleRepository {
       status: row.status,
       note: row.note,
       program: program,
+      programSent: row.programSent,
     );
   }
 }

--- a/frontend/flutter_trainer/lib/features/schedule/domain/entities/schedule_session.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/domain/entities/schedule_session.dart
@@ -45,10 +45,15 @@ class ScheduleSession {
     required this.status,
     required this.note,
     required this.program,
+    this.programSent = false,
   });
 
   /// Row id.
   final String id;
+
+  /// 완료한 세션의 프로그램을 회원에게 보냈는가. 보낸 적 없는 세션과 이미 보낸
+  /// 세션은 화면에서 다른 것을 말해야 한다(#822).
+  final bool programSent;
 
   /// Calendar day (`YYYY-MM-DD`). Carried on the entity because the week
   /// calendar and the client's 루틴 tab both render sessions from more

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import 'package:oncare_trainer/app/router/routes.dart';
 import 'package:oncare_trainer/core/utils/date_format.dart';
+import 'package:oncare_trainer/core/utils/request_id.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/design_system/tokens/elevation.dart';
 import 'package:oncare_trainer/design_system/tokens/layout.dart';
@@ -64,6 +65,13 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
 
   /// Session shown in the week view's detail panel.
   String? _selectedSessionId;
+
+  /// 프로그램 전송이 진행 중인 세션. 두 번 눌러 두 번 보내지 않는다.
+  String? _sendingProgramId;
+
+  /// 세션별 전송 멱등키. 실패한 시도의 키를 그대로 다시 써야 재시도가 중복
+  /// 배정을 만들지 않는다(#581 과 같은 규약).
+  final Map<String, String> _sendRequestIds = <String, String>{};
 
   static DateTime _dateOnly(DateTime d) => DateTime(d.year, d.month, d.day);
 
@@ -240,6 +248,35 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
       // the session stays 예정 and the trainer is told (review PR 237).
       if (!mounted) return;
       messenger.showSnackBar(SnackBar(content: Text(l.schedCompleteFailed)));
+    }
+  }
+
+  /// 완료한 세션의 프로그램을 그 회원에게 보낸다. (#822)
+  ///
+  /// 멱등키를 실어 보내므로 실패 후 다시 눌러도 회원의 루틴이 두 벌 생기지
+  /// 않는다. 성공하면 세션 행에 남아, 화면이 '전송됨' 을 사실대로 말한다.
+  Future<void> _sendProgram(ScheduleSession s) async {
+    if (_sendingProgramId != null) return;
+    final messenger = ScaffoldMessenger.of(context);
+    final AppLocalizations l = AppLocalizations.of(context);
+    setState(() => _sendingProgramId = s.id);
+    try {
+      await ref
+          .read(scheduleRepositoryProvider)
+          .sendProgram(
+            s.id,
+            clientRequestId: _sendRequestIds[s.id] ??= newClientRequestId(),
+          );
+      if (!mounted) return;
+      _sendRequestIds.remove(s.id); // 다음 전송은 새 시도다.
+      messenger.showSnackBar(
+        SnackBar(content: Text(l.schedSentTo(s.clientName))),
+      );
+    } catch (_) {
+      if (!mounted) return;
+      messenger.showSnackBar(SnackBar(content: Text(l.coachSendFailed)));
+    } finally {
+      if (mounted) setState(() => _sendingProgramId = null);
     }
   }
 
@@ -481,6 +518,8 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
               ? () => _confirmComplete(session)
               : null,
           programDateLabel: dateText,
+          sendingProgram: _sendingProgramId == session.id,
+          onSendProgram: () => _sendProgram(session),
           inlineEditor: _editingScheduleId == session.id
               ? _SessionSheet(
                   key: ValueKey<String>('week-session-editor-${session.id}'),
@@ -623,6 +662,8 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
               ? () => _confirmComplete(s)
               : null,
           programDateLabel: dateLabel,
+          sendingProgram: _sendingProgramId == s.id,
+          onSendProgram: () => _sendProgram(s),
           inlineEditor: _editingScheduleId == s.id
               ? _SessionSheet(
                   key: ValueKey<String>('inline-session-editor-${s.id}'),
@@ -1828,6 +1869,8 @@ class _TimelineRow extends StatelessWidget {
     required this.onChat,
     required this.onComplete,
     required this.programDateLabel,
+    required this.sendingProgram,
+    required this.onSendProgram,
     required this.inlineEditor,
   });
 
@@ -1839,6 +1882,12 @@ class _TimelineRow extends StatelessWidget {
   final VoidCallback onDelete;
   final VoidCallback onChat;
   final String programDateLabel;
+
+  /// 이 세션의 프로그램 전송이 진행 중인가. (#822)
+  final bool sendingProgram;
+
+  /// 완료한 세션의 프로그램을 회원에게 보낸다.
+  final VoidCallback onSendProgram;
   final Widget? inlineEditor;
 
   /// 예정 sessions only — flips to 완료 and logs the 운동기록.
@@ -1880,6 +1929,8 @@ class _TimelineRow extends StatelessWidget {
                   onChat: onChat,
                   onComplete: onComplete,
                   programDateLabel: programDateLabel,
+                  sendingProgram: sendingProgram,
+                  onSendProgram: onSendProgram,
                   inlineEditor: inlineEditor,
                 ),
         ),
@@ -1925,6 +1976,8 @@ class _SessionCard extends ConsumerWidget {
     required this.onChat,
     required this.onComplete,
     required this.programDateLabel,
+    required this.sendingProgram,
+    required this.onSendProgram,
     required this.inlineEditor,
   });
 
@@ -1937,6 +1990,12 @@ class _SessionCard extends ConsumerWidget {
   final VoidCallback onChat;
   final String programDateLabel;
   final Widget? inlineEditor;
+
+  /// 이 세션의 프로그램 전송이 진행 중인가. (#822)
+  final bool sendingProgram;
+
+  /// 완료한 세션의 프로그램을 회원에게 보낸다.
+  final VoidCallback onSendProgram;
 
   /// 예정 sessions only — flips to 완료 and logs the 운동기록.
   final VoidCallback? onComplete;
@@ -2076,6 +2135,11 @@ class _SessionCard extends ConsumerWidget {
                       _SendButton(
                         clientName: s.clientName,
                         dateLabel: programDateLabel,
+                        sent: s.programSent,
+                        sending: sendingProgram,
+                        onSend: (s.programSent || sendingProgram)
+                            ? null
+                            : onSendProgram,
                       ),
                     ],
                   ],
@@ -2398,44 +2462,74 @@ class _NoteBox extends StatelessWidget {
 }
 
 class _SendButton extends StatelessWidget {
-  const _SendButton({required this.clientName, required this.dateLabel});
+  const _SendButton({
+    required this.clientName,
+    required this.dateLabel,
+    required this.sent,
+    required this.sending,
+    required this.onSend,
+  });
 
   final String clientName;
   final String dateLabel;
 
+  /// 이미 보낸 세션인가. 보낸 뒤에는 같은 자리에서 그 사실을 말한다 — 다시
+  /// 누를 수 있게 두면 트레이너가 두 번 보냈는지 알 수 없다.
+  final bool sent;
+
+  /// 전송이 진행 중인가.
+  final bool sending;
+
+  /// 보내기. 이미 보냈거나 진행 중이면 null 이다.
+  final VoidCallback? onSend;
+
   @override
   Widget build(BuildContext context) {
     final AppLocalizations l = AppLocalizations.of(context);
-    return Tooltip(
-      message: l.schedSendUnsupported,
-      child: Container(
-        height: 42,
-        alignment: Alignment.center,
-        decoration: const BoxDecoration(
-          color: AppColors.inputBackground,
-          borderRadius: BorderRadius.all(AppRadius.lg),
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
-            const Icon(
-              Icons.send_outlined,
-              size: 15,
-              color: AppColors.disabledForeground,
-            ),
-            const SizedBox(width: AppSpacing.xs),
-            Flexible(
-              child: Text(
-                l.schedSentProgramTo(clientName, dateLabel),
-                overflow: TextOverflow.ellipsis,
-                style: const TextStyle(
-                  fontSize: 13,
-                  fontWeight: FontWeight.w700,
-                  color: AppColors.disabledForeground,
+    final Color foreground = sent
+        ? AppColors.success
+        : (sending ? AppColors.disabledForeground : AppColors.primary);
+    return Material(
+      color: AppColors.inputBackground,
+      borderRadius: const BorderRadius.all(AppRadius.lg),
+      child: InkWell(
+        key: const ValueKey<String>('schedule-send-program'),
+        onTap: onSend,
+        borderRadius: const BorderRadius.all(AppRadius.lg),
+        child: Container(
+          height: 42,
+          alignment: Alignment.center,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              if (sending)
+                const SizedBox(
+                  width: 14,
+                  height: 14,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              else
+                Icon(
+                  sent ? Icons.check_circle_outline : Icons.send_outlined,
+                  size: 15,
+                  color: foreground,
+                ),
+              const SizedBox(width: AppSpacing.xs),
+              Flexible(
+                child: Text(
+                  sent
+                      ? l.schedSentTo(clientName)
+                      : l.schedSentProgramTo(clientName, dateLabel),
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    color: foreground,
+                  ),
                 ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/frontend/flutter_trainer/test/core/storage/app_database_migration_test.dart
+++ b/frontend/flutter_trainer/test/core/storage/app_database_migration_test.dart
@@ -5,7 +5,7 @@ import 'package:oncare_trainer/core/storage/app_database.dart';
 
 void main() {
   test(
-    'v3 to v8 adds macro·주간 계열 columns and preserves existing rows',
+    'v3 to v9 adds macro·주간 계열 columns and preserves existing rows',
     () async {
       final executor = NativeDatabase.memory(
         setup: (database) {
@@ -55,6 +55,23 @@ void main() {
             'existing-meal', 'existing-client', '아침', '기존 식단', 500, 700, 0
           )
         ''');
+          // 이 테이블은 v1 부터 있었다. 스냅샷이 빼먹으면 그 위에서 도는
+          // 마이그레이션이 실제 DB 와 다른 것을 보게 된다(#822).
+          database.execute('''
+          CREATE TABLE trainer_schedule_entries (
+            id TEXT NOT NULL PRIMARY KEY,
+            date TEXT NOT NULL,
+            time TEXT NOT NULL,
+            client_id TEXT,
+            client_name TEXT NOT NULL DEFAULT '',
+            type TEXT NOT NULL DEFAULT '',
+            duration_minutes INTEGER NOT NULL DEFAULT 0,
+            status TEXT NOT NULL,
+            note TEXT NOT NULL DEFAULT '',
+            program_json TEXT NOT NULL DEFAULT '[]',
+            sort_order INTEGER NOT NULL DEFAULT 0
+          )
+        ''');
           database.execute('PRAGMA user_version = 3');
         },
       );
@@ -65,7 +82,7 @@ void main() {
       final meal = await db.select(db.clientDietEntries).getSingle();
       final version = await db.customSelect('PRAGMA user_version').getSingle();
 
-      expect(version.read<int>('user_version'), 8);
+      expect(version.read<int>('user_version'), 9);
       expect(client.id, 'existing-client');
       expect(client.caloriesToday, 500);
       expect(client.sugarG, 12.0);
@@ -83,7 +100,7 @@ void main() {
     },
   );
 
-  test('v4 to v8 preserves integer sugar and all client rows', () async {
+  test('v4 to v9 preserves integer sugar and all client rows', () async {
     final executor = NativeDatabase.memory(
       setup: (database) {
         database.execute('''
@@ -118,6 +135,23 @@ void main() {
             ('client-b', '기존 회원 B', 'B', '체중 감량', '다른 메시지', '1시간 전', 0,
              900, 1200, 61, 80, 35.5, 22, '3일 전', '[50]', '[1200]', 2)
         ''');
+        // 이 테이블은 v1 부터 있었다. 스냅샷이 빼먹으면 그 위에서 도는
+        // 마이그레이션이 실제 DB 와 다른 것을 보게 된다(#822).
+        database.execute('''
+          CREATE TABLE trainer_schedule_entries (
+            id TEXT NOT NULL PRIMARY KEY,
+            date TEXT NOT NULL,
+            time TEXT NOT NULL,
+            client_id TEXT,
+            client_name TEXT NOT NULL DEFAULT '',
+            type TEXT NOT NULL DEFAULT '',
+            duration_minutes INTEGER NOT NULL DEFAULT 0,
+            status TEXT NOT NULL,
+            note TEXT NOT NULL DEFAULT '',
+            program_json TEXT NOT NULL DEFAULT '[]',
+            sort_order INTEGER NOT NULL DEFAULT 0
+          )
+        ''');
         database.execute('PRAGMA user_version = 4');
       },
     );
@@ -128,7 +162,7 @@ void main() {
       ..sort((a, b) => a.sortOrder.compareTo(b.sortOrder));
     final version = await db.customSelect('PRAGMA user_version').getSingle();
 
-    expect(version.read<int>('user_version'), 8);
+    expect(version.read<int>('user_version'), 9);
     expect(clients, hasLength(2));
     expect(clients[0].name, '기존 회원 A');
     expect(clients[0].sugarG, 12.0);
@@ -142,7 +176,7 @@ void main() {
   });
 
   test(
-    'v5 to v8 adds the weekly calorie·sugar series to existing rows',
+    'v5 to v9 adds the weekly calorie·sugar series to existing rows',
     () async {
       final executor = NativeDatabase.memory(
         setup: (database) {
@@ -177,6 +211,23 @@ void main() {
             500, 700, 17.8, 40.5, 20, 10, '어제', '[100]', '[700,800]', 1
           )
         ''');
+          // 이 테이블은 v1 부터 있었다. 스냅샷이 빼먹으면 그 위에서 도는
+          // 마이그레이션이 실제 DB 와 다른 것을 보게 된다(#822).
+          database.execute('''
+          CREATE TABLE trainer_schedule_entries (
+            id TEXT NOT NULL PRIMARY KEY,
+            date TEXT NOT NULL,
+            time TEXT NOT NULL,
+            client_id TEXT,
+            client_name TEXT NOT NULL DEFAULT '',
+            type TEXT NOT NULL DEFAULT '',
+            duration_minutes INTEGER NOT NULL DEFAULT 0,
+            status TEXT NOT NULL,
+            note TEXT NOT NULL DEFAULT '',
+            program_json TEXT NOT NULL DEFAULT '[]',
+            sort_order INTEGER NOT NULL DEFAULT 0
+          )
+        ''');
           database.execute('PRAGMA user_version = 5');
         },
       );
@@ -186,7 +237,7 @@ void main() {
       final client = await db.select(db.trainerClients).getSingle();
       final version = await db.customSelect('PRAGMA user_version').getSingle();
 
-      expect(version.read<int>('user_version'), 8);
+      expect(version.read<int>('user_version'), 9);
       // 기존 값은 그대로 두고, 새 계열만 기본값으로 붙는다.
       expect(client.sugarG, 17.8);
       expect(client.sodiumWeekJson, '[700,800]');

--- a/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
@@ -566,32 +566,42 @@ void main() {
       expect(find.text('열기'), findsOneWidget);
     });
 
-    testWidgets(
-      'completed session shows program and disables unsupported send',
-      (tester) async {
+    testWidgets('완료 세션의 프로그램을 회원에게 보내고 그 사실이 남는다 (#822)', (tester) async {
+      // 펼친 완료 카드와 그 아래 전송 버튼이 한 화면에 들어와야 탭이 닿는다.
+      await withWideSurface(tester, () async {
         await openSchedule(tester);
 
         // Expand 김민수 (완료).
         await tester.tap(find.text('김민수'));
         await tester.pump();
-        await tester.scrollUntilVisible(
-          find.textContaining('오늘 PT 프로그램 전송'),
-          150,
-        );
         expect(find.text('레그프레스'), findsOneWidget);
         expect(find.text('카프레이즈'), findsOneWidget);
         expect(find.text('트레이너 메모'), findsOneWidget);
         expect(find.text('무릎 컨디션 양호. 레그프레스 중량 소폭 증가 가능.'), findsOneWidget);
 
-        final sendLabel = find.textContaining('오늘 PT 프로그램 전송');
-        final tooltip = tester.widget<Tooltip>(
-          find.ancestor(of: sendLabel, matching: find.byType(Tooltip)),
-        );
-        expect(tooltip.message, '완료 프로그램 전송 API가 아직 없어 전송할 수 없어요.');
-        expect(find.text('고객 앱으로 전송 완료!'), findsNothing);
+        // 예전에는 이 자리가 눌리지 않는 안내였다("전송 API가 아직 없어…").
         expect(find.text('김민수님에게 전송됨'), findsNothing);
-      },
-    );
+        final send = find.byKey(
+          const ValueKey<String>('schedule-send-program'),
+        );
+        await tester.ensureVisible(send);
+        await tester.pumpAndSettle();
+        await tester.tap(send);
+        await tester.pumpAndSettle();
+
+        // 보낸 뒤에는 같은 자리가 그 사실을 말하고, 다시 누를 수 없다.
+        expect(find.text('김민수님에게 전송됨'), findsWidgets);
+        final button = tester.widget<InkWell>(
+          find
+              .ancestor(
+                of: find.text('김민수님에게 전송됨').first,
+                matching: find.byType(InkWell),
+              )
+              .first,
+        );
+        expect(button.onTap, isNull);
+      }, size: const Size(1100, 2000));
+    });
 
     testWidgets('예정 session expands to the plan preview with manage '
         'actions', (tester) async {


### PR DESCRIPTION
## Summary

스케줄에서 완료된 세션을 펼치면 맨 아래에 `○○님에게 오늘 PT 프로그램 전송` 이라는 막대가 있었지만 **누를 수 없었다.** 툴팁은 "완료 프로그램 전송 API가 아직 없어 전송할 수 없어요." 였다. 수업을 마친 뒤 오늘 한 것을 회원에게 넘기는 마지막 한 걸음이 그 자리에서 끊겨 있었다.

## Changes — backend

- `POST /trainer/schedule/{session_id}/program/send` 추가. **새 배정 개념을 만들지 않고** 프로그램 배정(`assign_program`)을 그대로 탄다 — 회원은 출처와 무관하게 같은 모양의 루틴을 받아야, 화면에 출처마다 다른 루틴이 생기지 않는다.
- 세션 행에 `program_sent_at` 을 남긴다(마이그레이션 `0041`). 같은 세션을 두 번 보내지 않고, 조회 응답(`ScheduleSessionOut.program_sent`)이 그 사실을 함께 싣는다.
- 거절 조건: 남의 일정 404, 회원이 없는 슬롯(상담·공백) 400, 완료 전 400, 프로그램이 빈 세션 400 — 빈 루틴이 회원에게 가지 않는다.
- 배정이 커밋된 뒤에만 '보냄' 으로 남긴다. 반대 순서면 배정에 실패한 세션이 화면에서 전송됨이 되어 다시 보낼 수 없다.

## Changes — trainer web

- 막대를 실제 버튼으로 바꾼다. 전송 중에는 진행 표시, 보낸 뒤에는 같은 자리가 `○○님에게 전송됨` 으로 남고 다시 눌리지 않는다.
- 재시도는 같은 멱등키를 다시 보낸다(#581 과 같은 규약) — 실패 후 다시 눌러도 회원 루틴이 두 벌 생기지 않는다.
- 데모에는 받을 회원 백엔드가 없어 전송이 로컬 표시로 끝난다. 그래도 화면이 사실대로 말해야 하므로 드리프트 스키마에도 같은 표시를 둔다(v9, 기본값 false).

## Verification

- 백엔드: 전송이 회원 루틴을 만들고 재호출이 늘리지 않는지, 완료 전·회원 없음·프로그램 없음·없는 일정이 각각 막히는지 확인하는 테스트 추가. `851 passed`.
- 트레이너 웹: 완료 카드에서 눌러 보내고 그 자리가 `전송됨` 으로 바뀌며 다시 눌리지 않는지 확인하는 테스트로 기존 "눌리지 않음" 테스트를 대체. `663 passed`, `flutter analyze` 무결.
- 마이그레이션 테스트 스냅샷이 `trainer_schedule_entries` 를 빼먹고 있어 함께 채웠다 — v1 부터 있던 테이블이라, 없으면 그 위에서 도는 마이그레이션이 실제 DB 와 다른 것을 보게 된다.

## Notes

**마이그레이션 번호.** #781 도 `0040` 을 쓴다. 충돌을 피하려고 이 PR 은 `0041`(`down_revision = 0039`)로 두었다. 두 PR 이 모두 병합되면 head 가 둘이 되므로, **나중에 병합되는 쪽이 `down_revision` 을 앞선 것으로 바꿔야 한다.** 이 PR 이 먼저 들어가면 #781 이 `0041` 뒤로, 반대면 이 PR 을 `0040` 뒤로 옮긴다.

기존 문구(`schedSentTo` 등)가 이미 두 로케일에 있어 **`.arb` 는 건드리지 않았다** — #781 과 겹치는 파일이 없다.

`tests/test_roster_states.py` 2건은 이 브랜치와 무관하게 main 에서도 실패한다(요일 의존, #826 과 같은 계열). 별도로 다룬다.

Closes #822
