### PR TITLE
fix(trainer-web): 화면에 반영되지 않던 설정 알림 항목

### DIFF
--- a/frontend/flutter_trainer/lib/app/shell/app_sidebar.dart
+++ b/frontend/flutter_trainer/lib/app/shell/app_sidebar.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:oncare_trainer/app/router/routes.dart';
+import 'package:oncare_trainer/features/my/data/trainer_settings.dart';
 import 'package:oncare_trainer/app/shell/app_shell.dart';
 import 'package:oncare_trainer/app/shell/nav_destinations.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
@@ -61,11 +62,16 @@ class AppSidebar extends ConsumerWidget {
     final l = AppLocalizations.of(context);
     // Badges are live counters, not decoration: they're the reason a
     // trainer looks at the sidebar between tasks.
-    final unread = ref
-        .watch(unreadCountsProvider)
-        .valueOrNull
-        ?.values
-        .fold<int>(0, (sum, n) => sum + n);
+    // 알림 설정이 이 배지를 끈다 — 설정 화면이 "사이드바 뱃지로 알려드려요"
+    // 라고 적어 두고 정작 아무 데서도 읽지 않아, 꺼도 배지가 그대로였다(#817).
+    final settings = ref.watch(trainerSettingsProvider);
+    final unread = settings.newMessageAlerts
+        ? ref
+              .watch(unreadCountsProvider)
+              .valueOrNull
+              ?.values
+              .fold<int>(0, (sum, n) => sum + n)
+        : null;
     final reservations = ref.watch(todayReservationCountProvider).valueOrNull;
     final profile = ref.watch(sessionControllerProvider).profile;
     // 상담 요청 only exists against the real API — the demo has no member

--- a/frontend/flutter_trainer/lib/features/dashboard/presentation/widgets/today_timeline_card.dart
+++ b/frontend/flutter_trainer/lib/features/dashboard/presentation/widgets/today_timeline_card.dart
@@ -6,6 +6,7 @@ import 'package:oncare_trainer/app/router/routes.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
+import 'package:oncare_trainer/features/my/data/trainer_settings.dart';
 import 'package:oncare_trainer/features/schedule/data/repositories/schedule_repository.dart';
 import 'package:oncare_trainer/features/schedule/domain/entities/schedule_session.dart';
 import 'package:oncare_trainer/shared/models/trainer_client.dart';
@@ -26,6 +27,10 @@ class TodayTimelineCard extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final AppLocalizations l = AppLocalizations.of(context);
     final schedule = ref.watch(todayScheduleProvider);
+    // 설정의 '수업 시작 전 알림' 이 이 강조를 켜고 끈다. 켜져 있으면 시작이
+    // 알림 시점 안으로 들어온 세션을 눈에 띄게 그린다 — 설정 화면이 "대시보드에서
+    // 강조해요" 라고 적어 두고 실제로는 아무 일도 하지 않았다(#817).
+    final settings = ref.watch(trainerSettingsProvider);
     final clients =
         ref.watch(clientsProvider).valueOrNull ?? const <TrainerClient>[];
 
@@ -59,6 +64,9 @@ class TodayTimelineCard extends ConsumerWidget {
                     clientId: session.clientId,
                     clientName: session.clientName,
                   ),
+                  imminent:
+                      settings.sessionReminders &&
+                      startsWithin(session, settings.reminderLeadMinutes),
                   onTap: () => context.go(AppRoutes.scheduleView('day')),
                 ),
             ],
@@ -73,11 +81,16 @@ class _Row extends StatelessWidget {
   const _Row({
     required this.session,
     required this.client,
+    required this.imminent,
     required this.onTap,
   });
 
   final ScheduleSession session;
   final TrainerClient? client;
+
+  /// 시작이 알림 시점 안으로 들어온 세션인가. (#817)
+  final bool imminent;
+
   final VoidCallback onTap;
 
   Color get _statusColor {
@@ -93,7 +106,13 @@ class _Row extends StatelessWidget {
     return InkWell(
       onTap: onTap,
       borderRadius: const BorderRadius.all(AppRadius.sm),
-      child: Padding(
+      child: Container(
+        decoration: imminent
+            ? const BoxDecoration(
+                color: AppColors.accentSurface,
+                borderRadius: BorderRadius.all(AppRadius.sm),
+              )
+            : null,
         padding: const EdgeInsets.symmetric(vertical: 7, horizontal: 2),
         child: Opacity(
           opacity: muted ? 0.55 : 1,

--- a/frontend/flutter_trainer/lib/features/schedule/domain/entities/schedule_session.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/domain/entities/schedule_session.dart
@@ -95,3 +95,27 @@ class ScheduleSession {
   /// both expose the manage/chat actions.
   bool get expandable => !isGap;
 }
+
+/// [session] 이 지금부터 [leadMinutes] 안에 시작하는가. (#817)
+///
+/// 이미 지난 시각과 완료·공백 슬롯은 대상이 아니다 — 강조는 "곧 해야 할 일"
+/// 을 가리키는 표시이고, 끝난 수업을 다시 눈에 띄게 만들 이유가 없다.
+/// `HH:mm` 이 아닌 값(빈 시간 등)은 시각을 알 수 없으므로 조용히 false 다.
+bool startsWithin(ScheduleSession session, int leadMinutes, {DateTime? now}) {
+  if (!session.isUpcoming || leadMinutes <= 0) return false;
+  final parts = session.time.split(':');
+  if (parts.length != 2) return false;
+  final hour = int.tryParse(parts[0]);
+  final minute = int.tryParse(parts[1]);
+  if (hour == null || minute == null) return false;
+  final current = now ?? DateTime.now();
+  final startsAt = DateTime(
+    current.year,
+    current.month,
+    current.day,
+    hour,
+    minute,
+  );
+  if (!startsAt.isAfter(current)) return false;
+  return startsAt.difference(current).inMinutes <= leadMinutes;
+}

--- a/frontend/flutter_trainer/test/features/my/notification_settings_effect_test.dart
+++ b/frontend/flutter_trainer/test/features/my/notification_settings_effect_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare_trainer/app/router/routes.dart';
+import 'package:oncare_trainer/features/my/data/trainer_settings.dart';
+
+import '../../helpers/pump_app.dart';
+
+/// 설정의 알림 항목이 실제로 화면을 바꾸는지. 예전에는 이 값을 설정 화면
+/// 자신 말고 아무도 읽지 않아, 꺼도 사이드바 배지가 그대로였다(#817).
+void main() {
+  testWidgets('새 메시지 알림을 끄면 사이드바 배지가 사라진다', (tester) async {
+    await withWideSurface(tester, () async {
+      final container = await pumpTrainerApp(
+        tester,
+        token: 'demo-trainer-token',
+        at: AppRoutes.dashboard,
+      );
+      await tester.pumpAndSettle();
+
+      // 시드에는 읽지 않은 대화가 있어 사이드바에 숫자 배지가 떠 있다.
+      final beforeCounts = tester
+          .widgetList<Text>(find.byType(Text))
+          .map((t) => t.data)
+          .where((d) => d != null && RegExp(r'^\d+$').hasMatch(d))
+          .toList();
+      expect(beforeCounts, isNotEmpty, reason: '읽지 않은 대화가 있으면 사이드바에 숫자가 떠야 한다');
+
+      // 설정을 끈다. 설정 화면을 거치지 않고 값만 바꿔도 같은 결과여야 한다 —
+      // 배지는 이 설정을 읽는 쪽이지, 설정 화면이 그리는 것이 아니다.
+      final controller = container.read(trainerSettingsProvider.notifier);
+      await controller.setNewMessageAlerts(false);
+      await tester.pumpAndSettle();
+
+      final afterCounts = tester
+          .widgetList<Text>(find.byType(Text))
+          .map((t) => t.data)
+          .where((d) => d != null && RegExp(r'^\d+$').hasMatch(d))
+          .toList();
+      expect(
+        afterCounts.length,
+        lessThan(beforeCounts.length),
+        reason: '알림을 껐는데 사이드바 배지가 그대로다',
+      );
+
+      // 다시 켜면 돌아온다 — 끄는 것이 데이터를 지우는 것이 아니다.
+      await controller.setNewMessageAlerts(true);
+      await tester.pumpAndSettle();
+      final restored = tester
+          .widgetList<Text>(find.byType(Text))
+          .map((t) => t.data)
+          .where((d) => d != null && RegExp(r'^\d+$').hasMatch(d))
+          .toList();
+      expect(restored.length, beforeCounts.length);
+    });
+  });
+}

--- a/frontend/flutter_trainer/test/features/schedule/session_reminder_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/session_reminder_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare_trainer/features/schedule/domain/entities/schedule_session.dart';
+import 'package:oncare_trainer/features/schedule/domain/entities/schedule_status.dart';
+
+/// 대시보드의 임박 세션 강조가 읽는 규칙. 설정의 '알림 시점' 이 실제로 무엇을
+/// 가리키는지가 여기서 정해진다(#817).
+ScheduleSession _session({
+  required String time,
+  String status = ScheduleStatus.upcoming,
+}) => ScheduleSession(
+  id: 's1',
+  date: '2026-08-17',
+  time: time,
+  clientName: '김민수',
+  type: '1:1 PT',
+  durationMinutes: 60,
+  status: status,
+  note: '',
+  program: const <ProgramItem>[],
+);
+
+void main() {
+  final now = DateTime(2026, 8, 17, 9, 40);
+
+  test('알림 시점 안에 시작하는 예정 세션은 임박이다', () {
+    expect(
+      startsWithin(_session(time: '10:00'), 30, now: now),
+      isTrue,
+      reason: '20분 뒤 시작 · 30분 전 알림',
+    );
+    expect(
+      startsWithin(_session(time: '10:00'), 10, now: now),
+      isFalse,
+      reason: '10분 전 알림이면 아직 이르다',
+    );
+  });
+
+  test('이미 시작한 세션과 끝난 수업은 강조하지 않는다', () {
+    // 강조는 "곧 해야 할 일" 을 가리킨다. 지난 시각을 다시 눈에 띄게 만들면
+    // 트레이너가 놓친 것으로 읽는다.
+    expect(startsWithin(_session(time: '09:40'), 30, now: now), isFalse);
+    expect(startsWithin(_session(time: '09:00'), 30, now: now), isFalse);
+    expect(
+      startsWithin(
+        _session(time: '10:00', status: ScheduleStatus.done),
+        30,
+        now: now,
+      ),
+      isFalse,
+    );
+  });
+
+  test('시각을 알 수 없는 슬롯은 조용히 지나간다', () {
+    // 빈 시간 행처럼 `HH:mm` 이 아닌 값이 들어와도 대시보드가 깨지지 않는다.
+    expect(startsWithin(_session(time: ''), 30, now: now), isFalse);
+    expect(startsWithin(_session(time: '빈 시간'), 30, now: now), isFalse);
+    expect(startsWithin(_session(time: '25:00'), 30, now: now), isFalse);
+  });
+
+  test('알림 시점이 0이면 아무것도 임박하지 않는다', () {
+    expect(startsWithin(_session(time: '09:41'), 0, now: now), isFalse);
+  });
+}


### PR DESCRIPTION
## Summary

내 정보 → 설정의 알림 항목 세 개가 **저장만 되고 화면 어디에도 반영되지 않았다.** 설정이 하지 않는 일을 한다고 적어 둔 상태였다.

- `새 메시지 알림` — "고객이 메시지를 보내면 사이드바 뱃지로 알려드려요" 라고 적혀 있는데, 꺼도 배지가 그대로였다
- `수업 시작 전 알림` — "예정된 세션이 다가오면 대시보드에서 강조해요" 인데, 강조하는 코드가 없었다
- `알림 시점` (10/30/60분 전) — 위 항목이 동작하지 않아 선택이 무의미했다

`trainerSettingsProvider` 를 읽는 곳이 설정 화면 자신뿐이었다.

## Changes

- 사이드바의 메시지 배지가 `새 메시지 알림` 을 따른다. 끄면 사라지고 켜면 돌아온다 — 끄는 것이 읽지 않은 대화를 지우는 것은 아니다.
- 대시보드 `오늘의 일정` 이 `수업 시작 전 알림` 이 켜져 있을 때, 시작이 `알림 시점` 안으로 들어온 **예정** 세션을 눈에 띄게 그린다. 이미 시작했거나 끝난 수업은 대상이 아니다 — 강조는 곧 해야 할 일을 가리키는 표시다.
- 임박 판정을 순수 함수(`startsWithin`)로 분리하고 시각을 주입할 수 있게 했다. 실행한 시각에 기대를 맡기면 도는 시간에 따라 깨지는 테스트가 된다(#826 과 같은 함정).

문구는 새로 만들지 않았다 — 강조는 색과 배경이 말하고, 설정 화면의 설명이 이제 사실과 맞는다. `.arb` 를 건드리지 않아 #781 과 겹치는 파일이 없다.

## Verification

- 임박 규칙 단위 테스트 — 알림 시점 안/밖, 이미 시작한 세션, 완료된 수업, `HH:mm` 이 아닌 슬롯, 알림 시점 0.
- 위젯 테스트 — 설정을 끄면 사이드바 숫자 배지가 줄고, 다시 켜면 원래대로 돌아온다. 설정 화면을 거치지 않고 값만 바꿔도 같은 결과다(배지는 이 값을 읽는 쪽이지 설정 화면이 그리는 것이 아니다).
- `flutter analyze` 무결, `668 passed`.

## Notes — 데모에서 보이는 모습

- `새 메시지 알림` 은 데모에서 항상 확인된다. 시드에 읽지 않은 대화가 있어 배지가 떠 있고, 끄면 그 자리에서 사라진다.
- `수업 시작 전 알림` 은 데모 시드의 예정 세션(15:00 · 17:00)이 고른 알림 시점 안으로 들어올 때 강조된다. 규칙대로 동작하는 것이라, 그 시간대가 아니면 강조할 대상이 없는 것이 맞다 — 데모를 위해 없는 임박 세션을 지어내지 않았다.

Closes #817
