### PR TITLE
fix(backend): 주 초에 실패하던 로스터 상태 테스트

### DIFF
--- a/backend/tests/test_roster_states.py
+++ b/backend/tests/test_roster_states.py
@@ -57,9 +57,15 @@ def test_every_alert_state_is_reachable_through_the_api(client):
     """화면 상태를 그릴 수 있는 고객이 상태별로 최소 1명씩 있다."""
     rows = _roster(client)
 
+    # 계열은 이번 주 월→일이라(#746) 주 초에는 지난 날이 얼마 없다. '3일 초과'
+    # 같은 상수를 기대하면 코드를 아무도 건드리지 않아도 월·화요일에 깨진다 —
+    # 지난 날 수 안에서 셀 수 있는 만큼으로 본다(#833).
+    elapsed = clock.today().weekday() + 1
+    over_days_needed = min(3, elapsed)
     sodium_over = [
         r for r in rows
-        if sum(1 for v in r.get("sodium_week") or [] if v > _SODIUM_OVER) >= 3
+        if sum(1 for v in r.get("sodium_week") or [] if v > _SODIUM_OVER)
+        >= over_days_needed
     ]
     assert sodium_over, "나트륨 초과 경고를 그릴 고객이 없다"
 
@@ -92,8 +98,14 @@ def test_sparklines_cover_empty_short_and_full_weeks(client):
         len([v for v in (r.get("sodium_week") or []) if v > 0]) for r in _roster(client)
     }
     assert 0 in lengths, "기록이 전혀 없는 고객이 없다"
-    assert any(0 < n < elapsed for n in lengths), "기록이 일부만 있는 고객이 없다"
     assert elapsed in lengths, "이번 주를 하루도 빠짐없이 기록한 고객이 없다"
+    # '일부만' 은 0 과 '꽉 찬 주' 사이가 존재해야 성립한다. 월요일에는 지난
+    # 날이 하루뿐이라 그 사이가 없다 — 시드가 잘못된 것이 아니라 아직 주가
+    # 시작되지 않은 것이다(#833).
+    if elapsed >= 3:
+        assert any(
+            0 < n < elapsed for n in lengths
+        ), "기록이 일부만 있는 고객이 없다"
 
 
 def test_detailed_records_stay_with_the_original_three(client):


### PR DESCRIPTION
## Summary

`tests/test_roster_states.py` 의 두 테스트가 월·화요일에 실패해, 주 초에 올라오는 모든 백엔드 PR 의 CI 를 함께 막았다. 프론트엔드에서 같은 성격의 문제를 다룬 #826 의 백엔드 짝이다.

## Cause

주간 계열은 이번 주 월→일이다(#746). 아직 오지 않은 요일은 0 이라, 주 초에는 지난 날 자체가 얼마 없다.

- `나트륨 초과 ≥ 3일` — 월요일에는 지난 날이 하루뿐이라 성립할 수 없다.
- `0 < 기록일 수 < 지난 날 수` — 월요일에는 0 과 1 사이가 없어 존재할 수 없다.

시드가 잘못된 것이 아니라 기대값이 지난 날 수를 보지 않았다.

## Changes

- 나트륨 초과 판정을 `min(3, 지난 날 수)` 로 본다. 주 중반부터는 지금과 같고, 주 초에는 셀 수 있는 만큼만 요구한다.
- '기록이 일부만 있는 고객' 은 0 과 꽉 찬 주 사이가 존재해야 성립하므로 사흘이 지난 뒤에만 확인한다. 나머지 단언(전혀 없음·꽉 찬 주)은 요일과 무관하게 늘 성립하므로 그대로 둔다.

## Verification

오늘(월요일) 로컬에서 `tests/test_roster_states.py` 8건 통과. 이 브랜치 없이는 같은 환경에서 2건이 실패한다.

Closes #833