### PR TITLE
feat(trainer-web): 고객 상세에서 그 회원의 메시지·프로그램으로 바로 가기

### DIFF
--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_detail_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_detail_view.dart
@@ -354,7 +354,26 @@ class _Header extends ConsumerWidget {
             alignment: WrapAlignment.end,
             spacing: AppSpacing.sm,
             runSpacing: AppSpacing.sm,
+            // 파랑·하양이 번갈아 선다 — 메시지 · 프로그램 · 신체·목표 · 메모.
+            // 넷이 같은 무게로 보이면 어느 것이 이 화면의 주된 동작인지 읽히지
+            // 않는다.
             children: <Widget>[
+              // 이 회원을 보다가 바로 이어지는 두 자리. 예전에는 식단·운동을
+              // 다 읽고도 메시지 탭·프로그램 탭으로 건너가 같은 사람을 목록에서
+              // 다시 찾아야 했다(#823).
+              ActionButton(
+                key: const ValueKey<String>('client-detail-open-messages'),
+                label: l.clientQuickMessages,
+                icon: Icons.chat_bubble_outline,
+                primary: true,
+                onPressed: () => context.go(AppRoutes.messagesFor(client.id)),
+              ),
+              ActionButton(
+                key: const ValueKey<String>('client-detail-open-program'),
+                label: l.clientQuickProgram,
+                icon: Icons.auto_awesome_outlined,
+                onPressed: () => context.go(AppRoutes.coachingFor(client.id)),
+              ),
               ActionButton(
                 label: l.clientHealthGoals,
                 icon: Icons.badge_outlined,

--- a/frontend/flutter_trainer/test/features/clients/client_detail_states_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_states_test.dart
@@ -114,17 +114,21 @@ void main() {
     expect(view.resolvedSection, AppRoutes.defaultClientSection);
   });
 
-  testWidgets('quick actions keep only health goals and memo', (tester) async {
+  testWidgets('빠른 동작이 이 회원의 메시지·프로그램까지 잇는다 (#823)', (tester) async {
     await pumpTrainerApp(
       tester,
       token: 'demo-trainer-token',
       at: AppRoutes.clientDetail('seed-client-3'),
     );
 
+    // 식단·운동을 읽다가 그 자리에서 이어지는 동작들. 예전에는 이 줄이
+    // 신체·목표와 메모 둘뿐이라, 말을 걸려면 메시지 탭에서 같은 사람을 다시
+    // 찾아야 했다(#823).
+    expect(find.text('메시지'), findsOneWidget);
+    expect(find.text('프로그램'), findsOneWidget);
     expect(find.text('고객 신체·목표 관리'), findsOneWidget);
     expect(find.text('메모'), findsOneWidget);
-    expect(find.text('메시지'), findsNothing);
-    expect(find.text('프로그램'), findsNothing);
+    // 일정 등록은 스케줄 라우트에 고객을 실을 자리가 없어 아직 넣지 않는다.
     expect(find.text('일정 등록'), findsNothing);
     expect(find.text('주간 리포트'), findsNothing);
 
@@ -132,9 +136,29 @@ void main() {
       const ValueKey<String>('client-detail-quick-actions'),
     );
     expect(actions, findsOneWidget);
+    // 메모가 줄의 오른쪽 끝을 지킨다 — 새 버튼은 왼쪽에 붙어 이 정렬을 깨지
+    // 않는다(#729).
     expect(
       tester.getRect(find.widgetWithText(ActionButton, '메모')).right,
       closeTo(tester.getRect(actions).right, 0.1),
     );
+  });
+
+  testWidgets('빠른 동작이 지금 보고 있는 회원을 물고 간다 (#823)', (tester) async {
+    await pumpTrainerApp(
+      tester,
+      token: 'demo-trainer-token',
+      at: AppRoutes.clientDetail('seed-client-3'),
+    );
+    final router = GoRouter.of(tester.element(find.byType(ClientDetailView)));
+    String location() =>
+        router.routerDelegate.currentConfiguration.uri.toString();
+
+    await tester.tap(
+      find.byKey(const ValueKey<String>('client-detail-open-program')),
+    );
+    await tester.pumpAndSettle();
+    expect(location(), contains('/coaching'));
+    expect(location(), contains('client=seed-client-3'));
   });
 }


### PR DESCRIPTION
## Summary

고객 상세에서 **그 회원을 물고 다른 탭으로 넘어가는 자리가 없었다.** 식단·운동을 다 읽고 나서 말을 걸거나 프로그램을 짜려면, 메시지 탭·프로그램 탭으로 건너가 목록에서 같은 사람을 다시 찾아야 했다. 스케줄 상세에는 `채팅` 이 있고 운동 탭에는 `새 루틴` 이 있는데 정작 상세 헤더에는 없었다.

빠른 동작 줄에 `메시지` 와 `프로그램` 을 더한다.

```
[💬 메시지]  [✨ 프로그램]  [🪪 고객 신체·목표 관리]  [✎ 메모]
   파랑         하양              파랑                하양
```

## Changes

- `메시지` → `/messages?client=<id>`, `프로그램` → `/coaching?client=<id>`. 라우트와 문구(`clientQuickMessages` · `clientQuickProgram`)는 이미 있었고 쓰이지 않은 채 남아 있었다 — 새로 만든 것은 버튼뿐이라 **`.arb` 는 건드리지 않았다.**
- 색은 파랑·하양이 번갈아 서고 넷 다 아이콘을 단다. 같은 무게로 늘어놓으면 어느 것이 이 화면의 주된 동작인지 읽히지 않는다.
- 새 버튼은 **왼쪽에** 붙였다. 메모가 줄의 오른쪽 끝을 지키던 배치(#729)가 그대로 남는다.

## Notes — #729 와의 관계

이 줄을 `고객 신체·목표 관리` · `메모` 둘로 줄인 것은 #729 의 의도적인 정리였고, `quick actions keep only health goals and memo` 테스트가 "메시지·프로그램·일정 등록·주간 리포트가 없어야 한다" 를 못 박고 있었다. **그 결정을 되돌리는 변경이므로 리뷰에서 한 번 봐 주시면 좋겠다.**

그 테스트는 이제 사실과 달라져, 새 구성을 검증하는 테스트로 바꿨다 — 네 버튼이 다 있는지, `일정 등록`·`주간 리포트` 는 여전히 없는지, 메모의 오른쪽 끝이 줄 끝과 맞는지, 그리고 버튼이 **지금 보고 있는 회원의 id 를 물고 가는지**.

## Notes — 범위에서 뺀 것

`일정 등록` 은 넣지 않았다. 스케줄 라우트에 고객을 실어 새 일정 시트를 여는 자리가 없어, 버튼 하나가 아니라 라우트를 새로 만드는 일이다. 필요해지면 별도 이슈로 다루는 편이 낫다.

## Verification

- 데모에서 확인 — 박성호 상세에서 `프로그램` 을 누르면 프로그램 탭이 박성호가 선택된 채로 열린다(좌측 목록 하이라이트·고객 요약 모두 박성호).
- `flutter analyze` 무결, `675 passed`.

Closes #823
