### PR TITLE
fix(member): 하단 네비와 트레이너 채팅 헤더 넘침 해소

### DIFF
--- a/frontend/flutter/lib/app/router/main_shell.dart
+++ b/frontend/flutter/lib/app/router/main_shell.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -93,12 +92,10 @@ class _MainShellState extends ConsumerState<MainShell>
     final double navBottomPadding = bottomInset > maxNavBottomPadding
         ? maxNavBottomPadding
         : bottomInset;
-    // Mobile safe areas already leave enough room for the destination labels.
-    // Flutter web usually reports a zero bottom inset, so the 4dp paint
-    // translation below can put the web font's descenders beyond the viewport
-    // edge. Reserve web-only paint room without changing the mobile layout.
-    const double webClipGuard = kIsWeb ? 12 : 0;
-    final double effectiveBottomPadding = navBottomPadding + webClipGuard;
+    // 예전에는 라벨을 4dp 아래로 '그려서' 미는 바람에 바닥 여백이 0 인 웹에서
+    // 글자 아래가 잘렸고, 그만큼을 웹에서만 따로 확보하고 있었다. 이제
+    // 목적지 열이 바 높이 안에서 가운데 정렬되므로 그 보정은 필요 없다(#840).
+    final double effectiveBottomPadding = navBottomPadding;
     // The larger navigation labels need a little more vertical room.
     const double barHeight = 58;
     const double lift = 24; // headroom so the + button floats above the bar
@@ -221,28 +218,32 @@ class _Destination extends StatelessWidget {
     return Expanded(
       child: InkWell(
         onTap: onTap,
-        child: Padding(
-          // Keep the original space above the icon while using less space
-          // below the label, so the whole destination sits slightly lower.
-          padding: const EdgeInsets.only(top: 8),
-          child: Transform.translate(
-            offset: const Offset(0, 4),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: <Widget>[
-                Icon(selected ? activeIcon : icon, size: 24, color: color),
-                const SizedBox(height: 4),
-                Text(
+        // 아이콘+라벨을 바 높이 안에서 가운데 정렬한다. 예전에는 위쪽 여백
+        // 8dp 로 아래로 민 뒤 `Transform.translate` 로 4dp 더 밀었는데, 앞의
+        // 여백이 열이 쓸 높이를 줄여 배율을 조금만 올려도 넘쳤고(#840), 뒤의
+        // 밀기는 그리기 단계라 라벨 아래가 잘렸다.
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Icon(selected ? activeIcon : icon, size: 24, color: color),
+            const SizedBox(height: 4),
+            // 접근성 배율에서 라벨이 커져도 열이 넘치지 않게 줄여서 그린다 —
+            // 잘라내면 '대시보드' 가 '대시…' 로 읽힌다.
+            Flexible(
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Text(
                   label,
+                  maxLines: 1,
                   style: TextStyle(
                     fontSize: 13.5,
                     color: color,
                     fontWeight: selected ? FontWeight.w600 : FontWeight.w400,
                   ),
                 ),
-              ],
+              ),
             ),
-          ),
+          ],
         ),
       ),
     );

--- a/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_chat_sheet.dart
+++ b/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_chat_sheet.dart
@@ -174,6 +174,8 @@ class _TrainerChatPageState extends ConsumerState<TrainerChatPage> {
                       children: <Widget>[
                         Text(
                           widget.trainerName,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
                           style: const TextStyle(
                             fontSize: 16,
                             fontWeight: FontWeight.w800,
@@ -191,12 +193,18 @@ class _TrainerChatPageState extends ConsumerState<TrainerChatPage> {
                               child: SizedBox(width: 7, height: 7),
                             ),
                             const SizedBox(width: 5),
-                            Text(
-                              l.coachChatSubtitle,
-                              style: const TextStyle(
-                                fontSize: 12,
-                                fontWeight: FontWeight.w600,
-                                color: AppColors.mutedForeground,
+                            // 부제는 로케일마다 길이가 다르다 — 영어가 한국어보다
+                            // 훨씬 길어 고정 폭으로 두면 그대로 넘친다(#840).
+                            Flexible(
+                              child: Text(
+                                l.coachChatSubtitle,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: const TextStyle(
+                                  fontSize: 12,
+                                  fontWeight: FontWeight.w600,
+                                  color: AppColors.mutedForeground,
+                                ),
                               ),
                             ),
                           ],

--- a/frontend/flutter/test/app/main_shell_overflow_test.dart
+++ b/frontend/flutter/test/app/main_shell_overflow_test.dart
@@ -1,0 +1,88 @@
+/// 하단 네비게이션이 넘치지 않는지 (#840).
+///
+/// 430px 는 iPhone 15 Pro Max 의 논리 폭이라 특별히 좁은 조건이 아닌데도
+/// `_Destination` 의 아이콘+라벨 열이 배정된 높이를 넘겨 세로로 잘렸다. E2E
+/// 로그에만 `RenderFlex overflowed by 19 pixels on the bottom` 으로 남아 있어
+/// 아무도 보지 못했다 — 앱의 전역 오류 핸들러가 예외를 받아 로깅만 하기 때문이다.
+///
+/// 한국어와 영어를 모두 돈다. 영어 라벨이 더 길어 같은 자리가 다시 샐 수 있다
+/// (#743 과 같은 계열).
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:oncare/app/router/app_router.dart';
+import 'package:oncare/app/router/routes.dart';
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+const AppConfig _config = AppConfig(
+  environment: Environment.dev,
+  apiBaseUrl: 'https://dev.api.test',
+  useMockApi: true,
+);
+
+void main() {
+  Future<void> pumpShell(
+    WidgetTester tester, {
+    required String lang,
+    required Size size,
+  }) async {
+    await tester.binding.setSurfaceSize(size);
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final GoRouter router = buildAppRouter(config: _config);
+    addTearDown(router.dispose);
+    router.go(AppRoutes.dashboard);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[appConfigProvider.overrideWithValue(_config)],
+        child: MaterialApp.router(
+          routerConfig: router,
+          locale: Locale(lang),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  group('하단 네비게이션 레이아웃 (#840)', () {
+    for (final String lang in <String>['ko', 'en']) {
+      for (final double scale in <double>[1.0, 1.3]) {
+        testWidgets('폭 430 · $lang · 글자 배율 $scale 에서 넘치지 않는다', (
+          WidgetTester tester,
+        ) async {
+          tester.platformDispatcher.textScaleFactorTestValue = scale;
+          addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
+
+          await pumpShell(tester, lang: lang, size: const Size(430, 932));
+
+          // overflow 는 렌더링 예외로 보고된다. 예외가 없으면 넘친 곳이 없다.
+          expect(tester.takeException(), isNull);
+        });
+      }
+    }
+
+    testWidgets('네 개의 목적지 라벨이 모두 보인다', (WidgetTester tester) async {
+      await pumpShell(tester, lang: 'ko', size: const Size(430, 932));
+
+      final AppLocalizations l = AppLocalizations.of(
+        tester.element(find.byType(Scaffold).first),
+      );
+      for (final String label in <String>[
+        l.navDashboard,
+        l.navDiet,
+        l.navExercise,
+        l.navMyHealth,
+      ]) {
+        expect(find.text(label), findsOneWidget);
+      }
+    });
+  });
+}

--- a/frontend/flutter/test/features/member_coach/coach_chat_header_overflow_test.dart
+++ b/frontend/flutter/test/features/member_coach/coach_chat_header_overflow_test.dart
@@ -1,0 +1,89 @@
+/// 트레이너 채팅 헤더가 넘치지 않는지 (#840).
+///
+/// 헤더의 상태 점 + 부제가 든 `Row` 가 고정 폭이라, 부제가 길어지면 그대로
+/// 넘쳤다. 영어 부제(`Personal trainer · Available`)가 한국어(`담당 트레이너 ·
+/// 상담 가능`)보다 길어 같은 자리에서 먼저 샌다 — #743 과 같은 계열이다.
+///
+/// 430px 는 iPhone 15 Pro Max 의 논리 폭이다. E2E 로그에는
+/// `RenderFlex overflowed by 59 pixels on the right` 로 남아 있었다.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/features/member_coach/data/repositories/mock_member_coach_repository.dart';
+import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
+import 'package:oncare/features/member_coach/presentation/widgets/coach_chat_sheet.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+const AppConfig _config = AppConfig(
+  environment: Environment.dev,
+  apiBaseUrl: 'https://dev.api.test',
+  useMockApi: true,
+);
+
+void main() {
+  Future<void> pumpChat(
+    WidgetTester tester, {
+    required String lang,
+    required Size size,
+    String trainerName = '김트레이너',
+  }) async {
+    await tester.binding.setSurfaceSize(size);
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          appConfigProvider.overrideWithValue(_config),
+          memberCoachRepositoryProvider.overrideWithValue(
+            MockMemberCoachRepository(),
+          ),
+        ],
+        child: MaterialApp(
+          locale: Locale(lang),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: TrainerChatPage(trainerName: trainerName),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  group('트레이너 채팅 헤더 레이아웃 (#840)', () {
+    for (final String lang in <String>['ko', 'en']) {
+      for (final double scale in <double>[1.0, 1.3]) {
+        testWidgets('폭 430 · $lang · 글자 배율 $scale 에서 넘치지 않는다', (
+          WidgetTester tester,
+        ) async {
+          tester.platformDispatcher.textScaleFactorTestValue = scale;
+          addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
+
+          await pumpChat(tester, lang: lang, size: const Size(430, 932));
+
+          expect(tester.takeException(), isNull);
+        });
+      }
+    }
+
+    testWidgets('아주 긴 트레이너 이름에도 헤더가 넘치지 않는다', (WidgetTester tester) async {
+      await pumpChat(
+        tester,
+        lang: 'ko',
+        size: const Size(430, 932),
+        trainerName: '아주아주긴이름을가진트레이너선생님입니다정말로깁니다',
+      );
+
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('부제는 잘려도 트레이너 이름은 그대로 보인다', (WidgetTester tester) async {
+      await pumpChat(tester, lang: 'en', size: const Size(430, 932));
+
+      expect(find.text('김트레이너'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

* 회원 앱의 `RenderFlex overflow` 두 건을 없앴습니다. 하단 네비게이션(세로)과 트레이너 채팅 헤더(가로)입니다.
* 두 곳 모두 넘침을 실패로 보는 위젯 검증을 붙였습니다. 수정을 되돌리면 빨간불이 되는 것을 확인했습니다.
* 430px(iPhone 15 Pro Max 논리 폭)에서 한·영, 글자 배율 1.0·1.3 을 함께 돕니다.

---

## Changes

### 🐛 Fixes

**하단 네비게이션** (`main_shell.dart`)

`_Destination` 의 아이콘+라벨 열이 바 높이를 넘겼습니다. 위쪽 여백 8dp 가 열이 쓸 높이를 미리 깎아 두고, 그 위에 `Transform.translate` 로 4dp 를 더 밀던 구조였습니다.

* 여백과 `Transform.translate` 를 걷어내고 열을 바 높이 안에서 가운데 정렬합니다.
* 라벨은 `Flexible` + `FittedBox(scaleDown)` 으로 배율이 올라가도 줄여서 그립니다. 잘라내지 않는 이유는 `대시보드` 가 `대시…` 로 읽히면 안 되기 때문입니다.

**트레이너 채팅 헤더** (`coach_chat_sheet.dart`)

상태 점 + 부제가 든 `Row` 가 고정 폭이라 부제가 길어지면 그대로 넘쳤습니다.

* 부제를 `Flexible` + 말줄임으로 접히게 했습니다.
* 트레이너 이름에도 `maxLines: 1` + 말줄임을 넣었습니다. 이름이 길면 같은 자리가 다시 샙니다.

### 🔧 Improvements

* 웹 전용 보정 `webClipGuard`(12dp)를 걷어냈습니다. 이 값은 "라벨을 4dp 아래로 **그려서** 미는 바람에 바닥 여백이 0 인 웹에서 글자 아래가 잘린다" 는 이유로 있던 것인데, 그 밀기가 사라져 근거가 함께 사라졌습니다. 웹에서 하단 바가 12dp 만큼 덜 차지합니다.

---

## Notes

**`Transform.translate` 는 넘침의 직접 원인이 아니었습니다.** 그리기 단계라 레이아웃 크기를 바꾸지 않습니다. 실제로 열을 좁힌 것은 위쪽 여백 8dp 이고, 밀기는 그 위에서 라벨 아래를 화면 밖으로 내보내 **잘림**을 만들었습니다. 이슈 본문은 둘을 한 원인으로 적었는데, 고치면서 확인한 결과는 이렇습니다. 결과적으로 둘 다 걷어내는 것이 맞았습니다.

**이슈에 적힌 19px 과 4px 의 차이.** 이슈는 E2E(웹)에서 19px 을 봤고, 위젯 테스트에서는 기본 배율에서 통과하고 배율 1.3 에서 4px 이 났습니다. 폰트 메트릭이 달라 넘치는 양이 다를 뿐, 여유가 없는 구조라는 원인은 같습니다. 그래서 검증을 배율 1.0 하나로 두지 않고 1.3 까지 돕니다.

**E2E 가 overflow 를 잡게 하는 건 이 PR 범위 밖입니다.** 이슈의 "함께 볼 것" 대로, 그 하네스는 이 두 건이 닫힌 뒤에 넣는 것이 순서상 맞습니다. 이 PR 이 머지되면 막는 요인이 사라집니다.

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 빌드 성공
* [x] 관련 실행 가능 테스트 통과

* 신규 검증 11건 — 폭 430 · {ko, en} × 배율 {1.0, 1.3} 에서 넘침 없음, 목적지 라벨 4개 노출, 아주 긴 트레이너 이름, 부제가 잘려도 이름은 유지
* **수정을 되돌리면 실패하는 것을 확인했습니다** — 네비 3건, 헤더 3건이 빨간불이 됩니다
* `flutter test` → **715 passed**
* `dart analyze lib test` → No issues found
* `flutter build web --release --base-href "/frontend/"` → 성공

### Manual Test Steps

1. 회원 앱을 폭 430 근처에서 열어 하단 네비의 아이콘·라벨이 잘리지 않는지 봅니다.
2. 기기 글자 크기를 키운 뒤 같은 화면을 다시 봅니다.
3. 트레이너 채팅을 열어 헤더의 이름·상태 부제가 넘치지 않는지 확인합니다.
4. 로케일을 영어로 바꿔 1~3 을 반복합니다.

---

## Related Issues

Closes #840
