### PR TITLE
test(e2e): 회원 앱 E2E 에서 렌더링 넘침을 실패로 처리

### DIFF
--- a/frontend/flutter/test_e2e/support/e2e_harness.dart
+++ b/frontend/flutter/test_e2e/support/e2e_harness.dart
@@ -460,6 +460,74 @@ void useMobileViewport(WidgetTester tester) {
   addTearDown(tester.view.reset);
 }
 
+/// 이번 테스트에서 모인 렌더링 넘침의 설명. 시나리오가 끝날 때 비워진다.
+///
+/// `FlutterErrorDetails` 를 그대로 들고 있다가 끝에서 문자열로 만들면, 그때는 위젯
+/// 트리가 이미 해체돼 위치가 `DEFUNCT` 로만 남는다. 그래서 **터진 그 순간에** 설명을
+/// 만들어 둔다.
+List<String> _renderOverflows = <String>[];
+
+/// 넘침 단언을 이번 테스트에 이미 걸어 뒀는가.
+bool _overflowTearDownRegistered = false;
+
+/// 넘침(overflow)으로 보고된 렌더링 오류인가.
+///
+/// 라이브러리 이름 대신 문구로 가른다 — 넘침은 `RenderFlex` 말고도 여러 렌더
+/// 오브젝트가 같은 문장으로 보고한다.
+bool _isRenderOverflow(FlutterErrorDetails details) =>
+    details.exceptionAsString().contains('overflowed');
+
+/// 실패 메시지에 넣을 한 건의 설명.
+///
+/// 렌더 오브젝트 덤프만으로는 **어느 화면인지** 알기 어렵다. 위젯 사슬은
+/// `informationCollector` 가 들고 있으므로 함께 붙인다.
+String _describeOverflow(FlutterErrorDetails details) {
+  const int limit = 1200;
+  final StringBuffer out = StringBuffer(details.exceptionAsString());
+  final Iterable<DiagnosticsNode>? extra = details.informationCollector?.call();
+  if (extra != null) {
+    for (final DiagnosticsNode node in extra) {
+      final String line = node.toStringDeep().trimRight();
+      if (line.isNotEmpty) out.writeln('\n$line');
+    }
+  }
+  final String text = out.toString();
+  return text.length <= limit ? text : '${text.substring(0, limit)}…(생략)';
+}
+
+/// `bootstrap()` 이 덮어쓴 오류 핸들러 위에 넘침 감시를 다시 얹는다. (#844)
+///
+/// `lib/app/bootstrap.dart` 는 `FlutterError.onError` 를 **로깅 전용**으로 바꾼다.
+/// 그래서 부팅 뒤에 나는 넘침은 테스트 실패가 아니라 로그 한 줄로 끝나고, 스위트는
+/// 초록인데 화면은 잘려 있는 상태가 된다 — #840 이 정확히 그렇게 새어 나갔다.
+///
+/// 로깅은 그대로 두고(기존 출력이 달라지지 않는다) 넘침만 따로 모아, 시나리오가
+/// 끝날 때 하나라도 있으면 실패시킨다.
+///
+/// **부팅할 때마다 다시 얹어야 한다.** 재시작 검증은 [bootSignedOut] 을 다시 부르고,
+/// 그 안의 `bootstrap()` 이 핸들러를 새 것으로 갈아 끼워 앞서 얹은 감시를 지운다.
+void _watchForOverflow() {
+  final void Function(FlutterErrorDetails)? logging = FlutterError.onError;
+  FlutterError.onError = (FlutterErrorDetails details) {
+    if (_isRenderOverflow(details)) _renderOverflows.add(_describeOverflow(details));
+    logging?.call(details);
+  };
+
+  if (_overflowTearDownRegistered) return;
+  _overflowTearDownRegistered = true;
+  addTearDown(() {
+    FlutterError.onError = logging;
+    final List<String> found = List<String>.of(_renderOverflows);
+    _renderOverflows = <String>[];
+    _overflowTearDownRegistered = false;
+    if (found.isEmpty) return;
+    fail(
+      '화면이 넘쳤습니다 — ${found.length}건. E2E 가 지나는 화면은 잘린 곳 없이 그려져야 합니다.\n\n'
+      '${found.join('\n\n──────────\n\n')}',
+    );
+  });
+}
+
 /// 로그아웃 상태에서 앱을 새로 띄운다. 재시작·재로그인 검증도 이것을 다시 부른다.
 Future<void> bootSignedOut(WidgetTester tester) async {
   useMobileViewport(tester);
@@ -471,6 +539,9 @@ Future<void> bootSignedOut(WidgetTester tester) async {
   await tester.pump();
   await const FlutterSecureStorage().deleteAll();
   await bootstrap();
+  // 감시는 `bootstrap()` **뒤에** 얹는다 — 그 안에서 핸들러가 교체되므로 앞에
+  // 얹으면 그대로 지워진다.
+  _watchForOverflow();
   await pumpUntil(tester, find.byType(SignInPage), step: '로그인 화면');
 }
 


### PR DESCRIPTION
## Summary

* 회원 앱 E2E 가 **렌더링 넘침을 실패로 본다.** 지금까지는 로그에만 남고 스위트는 초록으로 통과했습니다.
* `bootstrap()` 이 덮어쓰는 오류 핸들러 **뒤에** 감시를 다시 얹어, 넘침을 모아 두고 시나리오가 끝날 때 단언합니다.
* 로깅은 그대로 둡니다 — 기존 출력이 달라지지 않습니다.

---

## Changes

### 🐛 Fixes

`test_e2e/support/e2e_harness.dart` 의 `bootSignedOut()` 이 `bootstrap()` 직후 넘침 감시를 설치합니다.

* 넘침으로 보고된 `FlutterErrorDetails` 를 모으고, 기존 로깅 핸들러를 그대로 이어서 호출합니다.
* 시나리오가 끝날 때(`addTearDown`) 하나라도 모였으면 `fail()` 로 떨어뜨립니다. 실패 메시지에 건수와 각 건의 상세가 들어갑니다.
* 설명은 **터진 그 순간에** 문자열로 만듭니다. `FlutterErrorDetails` 를 들고 있다가 끝에서 만들면 그때는 위젯 트리가 해체돼 사슬이 `DEFUNCT` 로만 남습니다 — 실제로 그렇게 나와서 고쳤습니다.
* **부팅할 때마다 다시 얹습니다.** 재시작 검증은 `bootSignedOut()` 을 다시 부르고, 그 안의 `bootstrap()` 이 핸들러를 새 것으로 갈아 끼워 앞서 얹은 감시를 지웁니다. 한 번만 설치하면 재시작 뒤 구간이 다시 무방비가 됩니다.

---

## Notes

**왜 그냥은 안 잡혔나.** `lib/app/bootstrap.dart` 가 `FlutterError.onError` 를 로깅 전용으로 바꿉니다. 하네스는 그 `bootstrap()` 을 부르므로, 이후의 넘침은 테스트 실패가 아니라 로그 한 줄로 끝납니다. #840 이 정확히 그렇게 새어 나갔습니다.

**트레이너 앱은 이 문제가 없습니다.** `frontend/flutter_trainer/lib/app/bootstrap.dart` 는 `FlutterError.onError` 를 건드리지 않아, 넘침이 기본 핸들러로 가서 이미 실패로 보고됩니다. 그래서 이 PR 은 회원 앱만 손댑니다 — 이슈 Scope 와 같습니다.

**넘침만 좁혀 겁니다.** 실 API 를 쓰는 스위트라 네트워크 사정으로 나는 예외까지 묶으면 불안정해집니다. 판별은 라이브러리 이름이 아니라 문구(`overflowed`)로 합니다 — 넘침은 `RenderFlex` 말고도 여러 렌더 오브젝트가 같은 문장으로 보고합니다.

**화면 코드는 건드리지 않았습니다.** 현재 회원 앱의 E2E 경로에는 넘치는 곳이 없습니다(#840 이 PR #843 으로 닫혔습니다).

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] 관련 실행 가능 테스트 통과

로컬에 실 백엔드(pgvector + FastAPI, 시드 포함)를 띄우고 회원 앱 E2E 를 실제로 돌렸습니다.

**게이트가 통과를 막지 않는다**

* `chat_member_test.dart` / `member-send` 단계 → 통과

**게이트가 실제로 넘침을 잡는다** — 이게 이 PR 의 핵심 주장이라 직접 확인했습니다.

* PR #843 의 채팅 헤더 수정을 일시적으로 되돌린 뒤 같은 단계를 실행 → **실패**
* 실패 메시지: `화면이 넘쳤습니다 — 1건.` + `A RenderFlex overflowed by 59 pixels on the right.` +
  `debugCreator: Row ← Column ← Expanded ← Row ← Padding ← ColoredBox ← Container ← …` (채팅 헤더의 구조 그대로)
* 59px 은 #840 이 E2E 로그에서 보고했던 바로 그 값입니다
* 수정을 복원하니 다시 통과

`dart analyze test_e2e` → No issues found

### 확인하지 않은 것

`reservation_member_test.dart` 의 `edge-cases` 단계는 선행 단계가 쓴 상태 파일을 요구해 단독 실행이 되지 않습니다(`E2eState.require` 가 null 에서 실패). 이 PR 과 무관한 실행 순서 문제이며, 전체 순서는 `tool/run_reservation_e2e.sh` 가 담당합니다. 이 머신에 Docker Compose 가 없어 그 스크립트(정리 단계가 `docker compose exec` 를 씁니다)는 돌리지 못했고, 대신 백엔드를 직접 띄워 단계별로 확인했습니다.

---

## Related Issues

Closes #844
