### PR TITLE
fix(diet): 목표를 넘겨도 100%로 적히던 회원 앱 칼로리 달성률

### DIFF
--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -754,9 +754,14 @@ class NutritionSummary extends StatelessWidget {
   }
 }
 
+/// 목표 대비 실제 비율. **자르지 않는다** — 목표를 넘기면 1.0 을 넘는다.
+///
+/// 게이지에 넣을 때만 [_NutritionSummaryItem.gaugeValue] 로 자른다. 여기서 잘라
+/// 두면 달성률 라벨도 100% 에서 멈춰, 같은 카드의 "목표보다 N kcal 많아요" 와
+/// 어긋난다(#846).
 double _nutritionRatio(num current, num goal) {
   if (goal <= 0) return 0;
-  return (current / goal).clamp(0.0, 1.0).toDouble();
+  return current / goal;
 }
 
 class _NutritionSummaryItem {
@@ -773,7 +778,14 @@ class _NutritionSummaryItem {
   final String value;
   final String goal;
   final String unit;
+
+  /// 목표 대비 실제 비율. 초과하면 1.0 을 넘는다 — 달성률 라벨이 쓰는 값이다.
   final double ratio;
+
+  /// 게이지에 넣을 값. `CircularProgressIndicator.value` 와 막대는 1.0 을 넘으면
+  /// 눈금이 깨지므로 그릴 때만 자른다.
+  double get gaugeValue => ratio.clamp(0.0, 1.0).toDouble();
+
   final bool isOverGoal;
 }
 
@@ -933,7 +945,7 @@ class _CalorieCircularProgress extends StatelessWidget {
             dimension: 92,
             child: CircularProgressIndicator(
               key: const Key('nutrition-calorie-progress'),
-              value: calories.ratio,
+              value: calories.gaugeValue,
               strokeWidth: 9,
               strokeCap: StrokeCap.round,
               backgroundColor: FigmaColors.track,
@@ -1032,7 +1044,7 @@ class _MacroProgressItem extends StatelessWidget {
         const SizedBox(height: 7),
         _NutritionProgressBar(
           key: Key('nutrition-macro-progress-${macro.item.label}'),
-          progress: macro.item.ratio,
+          progress: macro.item.gaugeValue,
           color: macro.color,
         ),
       ],
@@ -1183,7 +1195,7 @@ class _NutritionStatusCard extends StatelessWidget {
         children: <Widget>[
           _VerticalNutritionProgressBar(
             key: Key('nutrition-status-vertical-progress-${item.label}'),
-            progress: item.ratio,
+            progress: item.gaugeValue,
             color: progressColor,
           ),
           const SizedBox(width: 10),

--- a/frontend/flutter/test/features/diet/diet_macros_display_test.dart
+++ b/frontend/flutter/test/features/diet/diet_macros_display_test.dart
@@ -477,4 +477,115 @@ void main() {
     );
     expect(barColor(l.dietSodium), FigmaColors.greenText);
   });
+
+  testWidgets('목표를 넘기면 달성률이 100% 를 넘어 적힌다 (#846)', (
+    WidgetTester tester,
+  ) async {
+    // 기본 목표는 2,000 kcal. 2,500 kcal 은 125% 다 — 여기가 100% 로 적히면
+    // 같은 카드의 "목표보다 500 kcal 많아요" 와 어긋난다.
+    const DietDay day = DietDay(
+      entries: <DietEntry>[
+        DietEntry(
+          id: 'over',
+          mealType: MealType.dinner,
+          timeLabel: '19:00',
+          foods: <FoodItem>[
+            FoodItem(name: '삼겹살 정식', calories: 2500, sodiumMg: 900, sugarG: 8),
+          ],
+          totalCalories: 2500,
+          sodiumMg: 900,
+          sugarG: 8,
+          carbsG: 120,
+          proteinG: 90,
+          fatG: 130,
+        ),
+      ],
+      totalCalories: 2500,
+      totalSodiumMg: 900,
+      totalSugarG: 8,
+      macros: DietMacros(
+        carbsPct: 35,
+        proteinPct: 25,
+        fatPct: 40,
+        carbsG: 120,
+        proteinG: 90,
+        fatG: 130,
+      ),
+      aiCoachMessage: '',
+    );
+
+    await tester.pumpWidget(
+      _app(
+        const Scaffold(
+          body: SingleChildScrollView(child: NutritionSummary(day: day)),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('125%'), findsOneWidget);
+    expect(
+      find.text('100%'),
+      findsNothing,
+      reason: '초과인데 100% 로 멈추면 안 된다',
+    );
+
+    // 링은 1.0 을 넘으면 눈금이 깨진다. 라벨과 달리 잘린 값을 받아야 한다.
+    final CircularProgressIndicator ring = tester
+        .widget<CircularProgressIndicator>(
+          find.byKey(const Key('nutrition-calorie-progress')),
+        );
+    expect(ring.value, 1.0);
+  });
+
+  testWidgets('목표 안쪽이면 달성률이 실제 비율 그대로 적힌다 (#846)', (
+    WidgetTester tester,
+  ) async {
+    const DietDay day = DietDay(
+      entries: <DietEntry>[
+        DietEntry(
+          id: 'under',
+          mealType: MealType.lunch,
+          timeLabel: '12:00',
+          foods: <FoodItem>[
+            FoodItem(name: '비빔밥', calories: 1000, sodiumMg: 800, sugarG: 6),
+          ],
+          totalCalories: 1000,
+          sodiumMg: 800,
+          sugarG: 6,
+          carbsG: 60,
+          proteinG: 30,
+          fatG: 20,
+        ),
+      ],
+      totalCalories: 1000,
+      totalSodiumMg: 800,
+      totalSugarG: 6,
+      macros: DietMacros(
+        carbsPct: 50,
+        proteinPct: 25,
+        fatPct: 25,
+        carbsG: 60,
+        proteinG: 30,
+        fatG: 20,
+      ),
+      aiCoachMessage: '',
+    );
+
+    await tester.pumpWidget(
+      _app(
+        const Scaffold(
+          body: SingleChildScrollView(child: NutritionSummary(day: day)),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('50%'), findsOneWidget);
+    final CircularProgressIndicator ring = tester
+        .widget<CircularProgressIndicator>(
+          find.byKey(const Key('nutrition-calorie-progress')),
+        );
+    expect(ring.value, 0.5);
+  });
 }


### PR DESCRIPTION
## Summary

* 회원 앱 식단 카드에서 목표를 넘겨도 `100% 달성률` 에서 멈추던 라벨을 고쳤습니다. 2,000 kcal 목표에 2,500 kcal 이면 이제 `125%` 로 적힙니다.
* 자르는 자리를 **만드는 쪽에서 그리는 쪽으로** 옮겼습니다. 게이지는 그대로 1.0 에서 자릅니다.
* 초과·미달 두 방향을 고정하는 검증을 붙였습니다. 수정을 되돌리면 빨간불이 되는 것을 확인했습니다.

---

## Changes

### 🐛 Fixes

`features/diet/presentation/pages/diet_record_page.dart`

`_nutritionRatio` 가 비율을 만들면서 이미 `clamp(0.0, 1.0)` 을 걸었고, 그 하나의 값을 링 게이지와 달성률 라벨이 함께 썼습니다.

* `_nutritionRatio` 는 실제 비율을 그대로 돌려줍니다 — 초과하면 1.0 을 넘습니다.
* 자르는 것은 `_NutritionSummaryItem.gaugeValue` 로 옮겼습니다. `CircularProgressIndicator.value` 와 세로·가로 막대는 1.0 을 넘으면 눈금이 깨지므로, **그릴 때만** 자릅니다.
* 달성률 라벨은 원본 비율을 적습니다.

게이지 세 곳(칼로리 링, 탄단지 막대, 나트륨·당류 세로 막대)은 `gaugeValue` 로 바꿨습니다. 라벨은 칼로리 링 안 하나뿐입니다.

### ✅ Tests

`test/features/diet/diet_macros_display_test.dart`

* 초과: 2,500 / 2,000 kcal → 라벨 `125%`, 링 값 `1.0`. `100%` 가 어디에도 없어야 합니다.
* 미달: 1,000 / 2,000 kcal → 라벨 `50%`, 링 값 `0.5`.

---

## Notes

**같은 카드 안에서 어긋나던 표시였습니다.** `isOverGoal` 은 초과를 정확히 알고 있어서 숫자·상태 문구·색은 이미 경고로 바뀌고 있었습니다. 링 안 숫자만 100% 에서 멈춰, 사용자가 빨간 링 안에서 `100%` 를 읽는 상태였습니다. 지표의 방향이 뒤집히는 자리라 고쳤습니다 — On-Care 는 고혈압·당뇨 위험군 특화라 과다 섭취가 가장 중요한 신호입니다.

**나머지 지표는 표시가 그대로입니다.** 나트륨·당류·탄단지도 같은 헬퍼를 쓰지만 `%` 로 적히는 곳이 없어 막대 길이만 `gaugeValue` 로 받습니다. 세로 막대 위젯은 원래도 내부에서 한 번 더 자르고 있어 동작이 바뀌지 않습니다.

**트레이너 웹에는 이미 있던 수정입니다.** #820 (PR #829) 이 `nutrition_summary_card.dart` 에서 같은 결함을 고쳤고, 그때 회원 앱을 함께 보지 않아 남았습니다.

---

## Test Plan

* [x] `flutter analyze` 무결
* [x] 회원 앱 테스트 전체 통과 (717건)
* [x] 수정을 되돌리면 새 검증이 실패하는 것 확인

Closes #846
