### PR TITLE
fix(e2e): 상담 실 API 스위트의 낡은 응답 필드 단언과 파인더 오용 수정

### DIFF
--- a/frontend/flutter/test_e2e/consultation_member_test.dart
+++ b/frontend/flutter/test_e2e/consultation_member_test.dart
@@ -107,7 +107,9 @@ void main() {
         final Map<String, dynamic>? saved = await _waitForPending(acceptApi);
         expect(saved, isNotNull, reason: 'UI 제출이 서버에 상담을 남기지 않았습니다.');
         expect(saved!['trainer_id'], trainerId);
-        expect(saved['target_type'], 'trainer');
+        // `target_type` 은 단언하지 않는다. #727 이 헬스장 대상 갈래를 없애면서 응답
+        // 필드에서 뺐다 — 값이 `trainer` 하나뿐이라 실어 보낼 이유가 없어졌다.
+        // 대상이 트레이너라는 것은 위의 `trainer_id` 가 이미 증명한다.
         expect(saved['exercise_goal'], 'strength');
         expect(saved['health_purpose_type'], 'rehab');
         expect(saved['preferred_time_slot'], 'evening');

--- a/frontend/flutter_trainer/test_e2e/consultation_trainer_test.dart
+++ b/frontend/flutter_trainer/test_e2e/consultation_trainer_test.dart
@@ -39,8 +39,14 @@ Future<Finder> _requestCard(WidgetTester tester, String consultationId) async {
   final Finder card = find.byKey(
     ValueKey<String>('consult-request-$consultationId'),
   );
-  await pumpUntil(tester, find.byKey(const Key('consult-accept')).first,
-      step: '인박스 카드');
+  // `pumpUntil` 은 `finder.evaluate()` 로 기다린다. 여기에 `.first` 를 넘기면 대상이
+  // 아직 없을 때 빈 목록에서 `first` 를 불러 `Bad state: No element` 로 즉사한다 —
+  // 타임아웃 메시지도 못 보고 원인이 가려진다. 기다릴 때는 맨 파인더를 쓴다.
+  await pumpUntil(
+    tester,
+    find.byKey(const Key('consult-accept')),
+    step: '인박스 카드',
+  );
   if (card.evaluate().isEmpty) {
     await tester.scrollUntilVisible(card, 200, maxScrolls: 40);
   }


### PR DESCRIPTION
## Summary

* 상담 실 API E2E(`run_consultation_e2e.sh`)가 첫 단계 `member-request` 에서 떨어지고, 그 뒤 27분을 매달려 있던 문제를 고칩니다.
* 원인은 서버가 아니라 **테스트의 낡은 단언**이었습니다. #727 이 헬스장 대상 갈래를 없애면서 `ConsultationOut` 에서 `target_type` 을 뺐는데, 스위트가 그 필드를 계속 단언하고 있었습니다.
* 이어서 드러난 `trainer-accept` 의 `Bad state: No element` 도 함께 잡았습니다. `pumpUntil` 에 `.first` 파인더를 넘긴 탓이었습니다.
* 두 단계를 고치자 매달림도 사라졌습니다 — 27분은 실패 경로가 만든 부산물이었습니다.

---

## Changes

### ✨ Features

* 없음

### 🔧 Improvements

* 없음

### 🎨 UI/UX

* 없음

### 📝 Docs

* 없음

### 🐛 Fixes

* `consultation_member_test.dart`: `POST /consultations` 응답의 `target_type` 단언 제거. 대상이 트레이너라는 사실은 같은 응답의 `trainer_id` 가 이미 증명합니다.
* `consultation_trainer_test.dart`: 인박스 카드를 기다릴 때 `find.byKey(...).first` 대신 맨 파인더 사용. `.first` 는 아직 대상이 없을 때 빈 목록에서 호출돼 즉사하고, 정작 필요한 타임아웃 사유를 가립니다.

---

## Commits

1. `399ca9a3` fix(e2e): #727 이 없앤 응답 필드 단언 제거와 pumpUntil 파인더 교정

---

## Notes

* **서버는 정상입니다.** 로깅 프록시로 확인한 결과 `POST /consultations` 는 201 과 올바른 `trainer_id` 를 돌려주고 있었고, 응답에 `target_type` 이 없을 뿐이었습니다. 이슈 본문에 적힌 `422` 는 로컬 컨테이너가 #727 이전 이미지였을 때의 증상으로, `docker compose up -d --build` 후 재현되지 않습니다.
* `ConsultationCreate.target_type` 은 기본값이 있어 요청에서 생략해도 되고, `ConsultationOut` 에는 애초에 없는 필드입니다. 즉 이 PR 은 스키마를 되돌리는 게 아니라 스키마에 맞춰 테스트를 고칩니다.
* `pumpUntil` + `.first` 조합이 다른 곳에도 있는지 두 패키지의 `test_e2e` 를 전수 확인했고, 남은 곳은 없습니다.
* 이 PR 이 머지되면 [#838](https://github.com/CSE-Sudo-26/on-care/pull/838) 의 `E2E_QUARANTINE` 에서 `run_consultation_e2e.sh` 를 빼야 합니다. 두 PR 중 나중에 머지되는 쪽에서 정리하겠습니다.

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [ ] UI 확인 (해당 없음 — 테스트 코드만 변경)
* [x] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. `cd backend && docker compose up -d --build` 로 백엔드를 최신 이미지로 띄웁니다.
2. `bash tool/run_consultation_e2e.sh` 를 실행합니다.
3. `member-request` → `trainer-accept` → `member-status` → `empty-inbox` → `edge-cases` → `cleanup` 전 단계가 통과하고 마지막에 `✅ 상담 실 API E2E 전 단계 통과` 가 찍히는지 확인합니다.

* 최신 `main` 위로 리베이스한 상태에서 전 단계 통과를 확인했습니다.
* `flutter analyze test_e2e` 두 패키지 모두 `No issues found`.

---

## Related Issues

Closes #837

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인
