### PR TITLE
style(trainer-web): 고객 상세 빠른 동작 줄의 메모 버튼 강조 색

### DIFF
--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_detail_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_detail_view.dart
@@ -352,10 +352,9 @@ class _Header extends ConsumerWidget {
             alignment: WrapAlignment.end,
             spacing: AppSpacing.sm,
             runSpacing: AppSpacing.sm,
-            // 파랑·하양이 번갈아 선다 — 메시지 · 프로그램 · 신체·목표.
-            // 같은 무게로만 서면 어느 것이 이 화면의 주된 동작인지 읽히지 않는다.
-            // 끝의 후속 관리 · 메모는 둘 다 내가 남기는 기록이라 한 쌍으로 묶어
-            // 하양을 잇는다.
+            // 파랑·하양이 번갈아 선다 — 메시지 · 프로그램 · 신체·목표 · 후속 관리 ·
+            // 메모. 같은 무게로만 서면 어느 것이 이 화면의 주된 동작인지 읽히지
+            // 않는다.
             children: <Widget>[
               // 이 회원을 보다가 바로 이어지는 두 자리. 예전에는 식단·운동을
               // 다 읽고도 메시지 탭·프로그램 탭으로 건너가 같은 사람을 목록에서
@@ -399,6 +398,7 @@ class _Header extends ConsumerWidget {
               ActionButton(
                 label: l.clientTrainerMemo,
                 icon: Icons.edit_note_outlined,
+                primary: true,
                 onPressed: () => showClientMemoDialog(
                   context,
                   clientId: client.id,

--- a/frontend/flutter_trainer/lib/shared/widgets/action_button.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/action_button.dart
@@ -7,8 +7,9 @@ import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 /// Compact page-header action. [primary] fills with the navy brand;
 /// otherwise it's an outlined, quieter sibling.
 ///
-/// One primary per header — when two actions both fill, neither reads as
-/// the main one.
+/// In a row, the two weights alternate — filled, outlined, filled. The rhythm
+/// is what makes the row readable; a run of the same weight is what flattens
+/// it, so keep filled buttons from standing next to each other.
 class ActionButton extends StatelessWidget {
   /// Creates a header action.
   const ActionButton({


### PR DESCRIPTION
Closes #879

## Summary

고객 상세 헤더의 빠른 동작 줄에서 `메모` 버튼을 `메시지` 버튼과 같은 네이비 채움으로 세운다.

## Changes

- `메모` 버튼을 `primary` 로 올려 `AppColors.primary` 채움 스타일을 쓴다. 줄이 메시지(파랑) · 프로그램(하양) · 신체·목표(파랑) · 후속 관리(하양) · 메모(파랑)로 다시 번갈아 선다.
- 색 배치를 설명하던 주석을 지금 줄의 구성에 맞춘다.
- `ActionButton` 문서 주석의 강조 규칙을 정정한다. "헤더당 primary 하나"가 아니라 파랑·하양이 번갈아 서는 배치가 이 앱의 규칙이다.

동작·라우팅·문구는 그대로다. 강조 단계만 바뀐다.

## Commits

- `style(trainer-web): 고객 상세 메모 버튼의 강조 색 통일`
- `style(trainer-web): 빠른 동작 버튼의 강조 규칙 주석 정정`

## Notes

- `flutter analyze` 두 파일 모두 통과, `test/features/clients/client_detail_states_test.dart` 통과.
- 빠른 동작 줄을 검사하는 기존 테스트는 키와 이동 경로만 보므로 영향이 없다.