### PR TITLE
chore(ui): 고객 앱 AI 조언 플로팅 버튼 임시 숨김

### DIFF
--- a/frontend/flutter/lib/app/router/main_shell.dart
+++ b/frontend/flutter/lib/app/router/main_shell.dart
@@ -17,6 +17,18 @@ import 'package:oncare/shared/widgets/oni_fab.dart';
 /// Persistent `Scaffold` hosting the bottom navigation bar. Icons and
 /// labels mirror the original React `BottomNav.tsx` (Home / 식단 /
 /// 운동 / My).
+/// AI 조언 플로팅 버튼을 회원 화면에 띄울지. (#862)
+///
+/// **기능을 지우지 않고 노출만 끈 상태다.** AI 조언 화면·라우트(`/ai-coach`)·
+/// 시트(`showCoachingSheet`)·배지(`coachingBadgeCountProvider`)는 모두 그대로고,
+/// 홈의 `AI 조언` 배너가 같은 시트를 여는 진입점으로 남아 있다.
+///
+/// 이 기능의 최종 위치와 역할이 정해지면 값을 `true` 로 되돌리는 것으로 복원된다.
+/// 지우지 않고 상수 하나로 둔 까닭이 그것이다 — 방향이 바뀌었을 때 다시 만드는
+/// 비용을 치르지 않기 위해서다. 설정 화면이나 feature flag 체계를 새로 들이지도
+/// 않는다: 지금 필요한 것은 "잠시 감춘다" 하나뿐이다.
+const bool kShowCoachingFab = false;
+
 class MainShell extends ConsumerStatefulWidget {
   const MainShell({required this.navigationShell, super.key});
 
@@ -104,12 +116,18 @@ class _MainShellState extends ConsumerState<MainShell>
       // showing a separate white strip above the navigation bar.
       extendBody: true,
       body: navigationShell,
-      floatingActionButton: OniFab(
-        key: const Key('coachingFab'),
-        // 배지는 시트가 실제로 보여 줄 카드 수를 따른다. 열어서 확인하면 내려간다.
-        badgeCount: ref.watch(coachingBadgeCountProvider),
-        onTap: () => showCoachingSheet(context, ref: ref),
-      ),
+      // AI 조언 진입점이 이 자리에 있을지가 아직 정해지지 않아 **노출만** 끈다
+      // (#862). 기능·라우트·provider 는 그대로라, 자리가 정해지면 이 상수를
+      // 되돌리는 것으로 복원된다 — 아래 [kShowCoachingFab] 주석 참고.
+      floatingActionButton: kShowCoachingFab
+          ? OniFab(
+              key: const Key('coachingFab'),
+              // 배지는 시트가 실제로 보여 줄 카드 수를 따른다. 열어서 확인하면
+              // 내려간다.
+              badgeCount: ref.watch(coachingBadgeCountProvider),
+              onTap: () => showCoachingSheet(context, ref: ref),
+            )
+          : null,
       bottomNavigationBar: SizedBox(
         height: barHeight + lift + effectiveBottomPadding,
         child: Center(

--- a/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
@@ -212,6 +212,8 @@ class _CoachingBanner extends StatelessWidget {
       color: Colors.transparent,
       borderRadius: BorderRadius.circular(20),
       child: InkWell(
+        // 플로팅 버튼을 감춘 동안(#862) AI 조언으로 들어가는 자리는 여기 하나다.
+        key: const ValueKey<String>('home-coaching-banner'),
         onTap: onTap,
         borderRadius: BorderRadius.circular(20),
         child: Container(

--- a/frontend/flutter/test/app/coaching_fab_hidden_test.dart
+++ b/frontend/flutter/test/app/coaching_fab_hidden_test.dart
@@ -1,0 +1,67 @@
+/// AI 조언 플로팅 버튼 임시 숨김. (#862)
+///
+/// 지우는 것이 아니라 감추는 것이라 확인할 것이 둘이다 — 화면에 없다는 것과,
+/// 되살리는 방법이 상수 하나라는 것. 기능으로 들어가는 길(홈의 AI 조언 배너)이
+/// 살아 있다는 것은 `widget_test.dart` 의 시트 테스트가 그 배너로 시트를 열어
+/// 확인한다.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:oncare/app/router/app_router.dart';
+import 'package:oncare/app/router/main_shell.dart';
+import 'package:oncare/app/router/routes.dart';
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+import 'package:oncare/shared/widgets/oni_fab.dart';
+
+const AppConfig _config = AppConfig(
+  environment: Environment.dev,
+  apiBaseUrl: 'https://dev.api.test',
+  useMockApi: true,
+);
+
+void main() {
+  Future<void> pumpShell(WidgetTester tester) async {
+    final GoRouter router = buildAppRouter(config: _config);
+    addTearDown(router.dispose);
+    router.go(AppRoutes.dashboard);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[appConfigProvider.overrideWithValue(_config)],
+        child: MaterialApp.router(
+          routerConfig: router,
+          locale: const Locale('ko'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('회원 화면에 AI 조언 플로팅 버튼이 노출되지 않는다', (tester) async {
+    await pumpShell(tester);
+
+    expect(find.byKey(const Key('coachingFab')), findsNothing);
+    expect(find.byType(OniFab), findsNothing);
+  });
+
+  testWidgets('가운데 기록 추가 버튼과 하단 네비는 그대로다', (tester) async {
+    await pumpShell(tester);
+
+    // 가운데 + 는 AI 조언이 아니라 기록 추가다 — 함께 사라지면 안 된다.
+    expect(find.byIcon(Icons.add), findsWidgets);
+    expect(find.byKey(const ValueKey<String>('nav-exercise')), findsOneWidget);
+  });
+
+  test('숨김은 상수 하나로 되돌린다', () {
+    // 값을 true 로 되돌리면 위 두 위젯 테스트가 실패하며 알려 준다 — 복원할 때
+    // 함께 손봐야 할 자리가 테스트에 적혀 있는 셈이다.
+    expect(kShowCoachingFab, isFalse);
+  });
+}

--- a/frontend/flutter/test/widget_test.dart
+++ b/frontend/flutter/test/widget_test.dart
@@ -284,7 +284,10 @@ void main() {
     addTearDown(tester.view.resetDevicePixelRatio);
 
     await pumpApp(tester, locale: const Locale('ko'));
-    await tester.tap(find.byKey(const Key('coachingFab')));
+    // 플로팅 버튼을 감춘 뒤(#862) 같은 시트를 여는 자리는 홈의 AI 조언 배너다.
+    await tester.tap(
+      find.byKey(const ValueKey<String>('home-coaching-banner')),
+    );
     await tester.pumpAndSettle();
 
     expect(
@@ -304,7 +307,10 @@ void main() {
     addTearDown(tester.view.resetPadding);
 
     await pumpApp(tester, locale: const Locale('ko'));
-    await tester.tap(find.byKey(const Key('coachingFab')));
+    // 플로팅 버튼을 감춘 뒤(#862) 같은 시트를 여는 자리는 홈의 AI 조언 배너다.
+    await tester.tap(
+      find.byKey(const ValueKey<String>('home-coaching-banner')),
+    );
     await tester.pumpAndSettle();
 
     expect(


### PR DESCRIPTION
Closes #862

## Summary

AI 조언 진입점이 지금 자리에 있을지가 아직 정해지지 않았습니다. 코드를 지우면 방향이 바뀌었을 때 다시 만드는 비용을 치르므로, **기능은 그대로 두고 노출만** 껐습니다.

## Changes

- `kShowCoachingFab` 상수 하나로 플로팅 버튼을 감춥니다. 되살릴 때는 이 값만 `true`로 되돌리면 됩니다.
- 설정 화면이나 feature flag 체계를 새로 들이지 않았습니다 — 지금 필요한 것은 "잠시 감춘다" 하나뿐입니다.
- AI 조언 화면·라우트(`/ai-coach`)·시트(`showCoachingSheet`)·배지(`coachingBadgeCountProvider`)는 전부 유지했습니다. **홈의 `AI 조언` 배너가 같은 시트를 여는 진입점으로 남아 있어** 기능이 끊기지 않습니다.
- 시트 여백 회귀 테스트(#297 계열)는 플로팅 버튼 대신 홈 배너로 시트를 엽니다 — 검증 대상은 시트의 여백이지 여는 자리가 아닙니다.

## Notes

- 하단 네비 **가운데 + 버튼은 기록 추가**로, AI 조언 버튼과 다른 위젯입니다. 레이아웃의 64px 중앙 공백도 그 버튼 기준이라 이번 변경으로 빈자리가 생기지 않습니다.
- 새 테스트가 "버튼이 없다"와 "상수가 꺼져 있다"를 함께 잠급니다. 나중에 `kShowCoachingFab`을 `true`로 되돌리면 이 테스트들이 실패하며 무엇을 함께 손봐야 하는지 알려 줍니다 — 복원 절차를 코드에 남겨 둔 셈입니다.

## Verification

- `flutter test` **731 passed**, `flutter analyze` clean.