### PR TITLE
fix(exercise): 운동 기록 기본 조회 기준을 `오늘`로 통일

### DIFF
--- a/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
@@ -900,7 +900,12 @@ class _ActivityStatus extends StatefulWidget {
 }
 
 class _ActivityStatusState extends State<_ActivityStatus> {
-  int _period = 1; // 0 = 오늘, 1 = 이번 주, 2 = 이번 달
+  /// 0 = 오늘, 1 = 이번 주, 2 = 이번 달.
+  ///
+  /// 기본은 **오늘**이다(#863). 식단 탭이 `오늘` 로 열리는데 운동 기록만 `이번 주`
+  /// 로 열려, 같은 회원 기록 화면인데도 탭마다 첫 화면의 기준이 달랐다. 두 탭 모두
+  /// "오늘을 보고, 필요하면 주로 넓힌다" 는 같은 흐름을 따른다.
+  int _period = 0;
 
   /// 오늘 요일 인덱스(0=월 … 6=일)를 이번 주 범위로 클램프. 홈 주간추이와 같은
   /// 실제 오늘을 가리키도록 해, '오늘=일 고정' 문제를 없앤다.
@@ -1209,9 +1214,15 @@ class _DonutLegendRow extends StatelessWidget {
           ),
         ),
         const SizedBox(width: 8),
+        // 범례 열은 폭이 160 으로 고정이라, 큰 글자 배율에서 라벨과 분 수가
+        // 나란히 서면 그 폭을 넘긴다(#863 이 `오늘` 을 기본으로 만들면서 드러난
+        // 자리 — 폭 320 · en · 배율 2.0 에서 28px 넘쳤다). 둘 다 줄어들 수 있게
+        // 두고 한 줄로 자른다.
         Expanded(
           child: Text(
             seg.label,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
             style: const TextStyle(
               fontSize: 13.5,
               fontWeight: FontWeight.w500,
@@ -1219,12 +1230,17 @@ class _DonutLegendRow extends StatelessWidget {
             ),
           ),
         ),
-        Text(
-          l.unitMinutesValue(seg.minutes),
-          style: const TextStyle(
-            fontSize: 14,
-            fontWeight: FontWeight.w800,
-            color: FigmaColors.ink,
+        Flexible(
+          child: Text(
+            l.unitMinutesValue(seg.minutes),
+            maxLines: 1,
+            softWrap: false,
+            overflow: TextOverflow.ellipsis,
+            style: const TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w800,
+              color: FigmaColors.ink,
+            ),
           ),
         ),
       ],

--- a/frontend/flutter/test/features/exercise/exercise_chart_animation_test.dart
+++ b/frontend/flutter/test/features/exercise/exercise_chart_animation_test.dart
@@ -121,6 +121,9 @@ void main() {
 
   testWidgets('주간 스택 막대는 바닥에서 자라 오른다', (WidgetTester tester) async {
     await pumpExercise(tester);
+    // 탭은 `오늘`(도넛)로 열린다(#863). 막대는 `이번 주` 부터다.
+    await tester.tap(find.text('이번 주'));
+    await tester.pump();
 
     const Size size = Size(600, 150);
     final CustomPainter atStart = chartPainter(tester);
@@ -145,6 +148,7 @@ void main() {
 
   testWidgets('이번 주 ↔ 이번 달 전환은 막대 애니메이션을 다시 재생한다', (WidgetTester tester) async {
     await pumpExercise(tester);
+    await tester.tap(find.text('이번 주'));
     await tester.pumpAndSettle();
 
     ChartReveal reveal() =>

--- a/frontend/flutter/test/features/exercise/exercise_default_period_test.dart
+++ b/frontend/flutter/test/features/exercise/exercise_default_period_test.dart
@@ -1,0 +1,99 @@
+/// 운동 기록 탭의 기본 조회 기준. (#863)
+///
+/// 식단 탭은 `오늘` 로 열리는데 운동 기록만 `이번 주` 로 열려, 같은 회원 기록
+/// 화면인데도 첫 화면의 기준이 탭마다 달랐다. 두 탭 모두 "오늘을 보고, 필요하면
+/// 주로 넓힌다" 는 흐름을 따른다.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/features/account/data/repositories/mock_account_repository.dart';
+import 'package:oncare/features/account/domain/entities/user_profile.dart';
+import 'package:oncare/features/account/presentation/controllers/account_controller.dart';
+import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
+import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
+import 'package:oncare/features/exercise/presentation/pages/exercise_page.dart';
+import 'package:oncare/features/member_coach/data/repositories/mock_member_coach_repository.dart';
+import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+void main() {
+  // 요일마다 세 종류가 모두 있는 주 — 도넛에 세 조각, 막대에 세 층이 쌓인다.
+  const ExerciseWeek week = ExerciseWeek(
+    sessions: <ExerciseSession>[],
+    dailyMinutes: <double>[60, 45, 70, 30, 55, 40, 65],
+    dailyCalories: <double>[300, 220, 350, 150, 270, 200, 320],
+    cardioMinutes: <double>[30, 20, 35, 15, 25, 20, 30],
+    strengthMinutes: <double>[20, 15, 25, 10, 20, 12, 25],
+    stretchingMinutes: <double>[10, 10, 10, 5, 10, 8, 10],
+    dayLabels: <String>['월', '화', '수', '목', '금', '토', '일'],
+    totalMinutes: 365,
+    totalCalories: 1810,
+    streakDays: 7,
+    aiCoachMessage: '꾸준히 운동해 보세요.',
+  );
+
+  Future<void> pumpExercise(WidgetTester tester) async {
+    await tester.binding.setSurfaceSize(const Size(800, 1800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          appConfigProvider.overrideWithValue(
+            const AppConfig(
+              environment: Environment.dev,
+              apiBaseUrl: 'https://example.test',
+              useMockApi: true,
+            ),
+          ),
+          accountRepositoryProvider.overrideWithValue(
+            MockAccountRepository(
+              profile: const UserProfile(
+                id: 'member',
+                name: '테스트',
+                email: 'member@example.com',
+              ),
+            ),
+          ),
+          exerciseWeekProvider.overrideWith((ref) async => week),
+          memberCoachRepositoryProvider.overrideWithValue(
+            MockMemberCoachRepository(),
+          ),
+        ],
+        child: const MaterialApp(
+          locale: Locale('ko'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: ExercisePage(),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+  }
+
+  testWidgets('첫 진입은 오늘 기준이다 — 오늘 도넛이 보인다', (WidgetTester tester) async {
+    await pumpExercise(tester);
+    await tester.pumpAndSettle();
+
+    // `오늘` 은 도넛, `이번 주`·`이번 달` 은 막대다. 도넛에만 있는 라벨로 가른다.
+    expect(find.text('오늘 총 운동 시간'), findsOneWidget);
+  });
+
+  testWidgets('이번 주를 고르면 기존 주간 화면이 그대로 나온다', (WidgetTester tester) async {
+    await pumpExercise(tester);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('이번 주'));
+    await tester.pumpAndSettle();
+    expect(find.text('오늘 총 운동 시간'), findsNothing);
+
+    // 오늘 ↔ 이번 주 왕복이 상태를 망가뜨리지 않는다.
+    await tester.tap(find.text('오늘'));
+    await tester.pumpAndSettle();
+    expect(find.text('오늘 총 운동 시간'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #863

## Summary

식단 탭은 `오늘`로 열리는데 운동 기록 탭만 `이번 주`로 열려, 같은 회원 기록 화면인데도 첫 진입 기준이 탭마다 달랐습니다. 두 탭 모두 "오늘을 보고, 필요하면 주로 넓힌다"는 흐름으로 맞췄습니다.

## Changes

- 운동 현황의 기본 기간을 `이번 주` → `오늘`로. 바꾼 것은 기본값 하나이고 `이번 주`·`이번 달` 조회와 주간 집계 로직은 그대로입니다. API·repository 계약도 건드리지 않았습니다.
- **덤으로 잡힌 넘침 하나**: 기본값을 옮기자 그동안 첫 화면에 그려지지 않던 오늘 도넛의 범례가 폭 320·영어·글자 배율 2.0에서 28px 넘치는 것이 드러났습니다(범례 열 폭이 160 고정인데 라벨과 분 수가 함께 커집니다). 둘 다 줄어들 수 있게 두고 한 줄로 잘랐습니다 — 넘침은 이 저장소에서 실패로 잡는 회귀입니다(#766·#849).

## Verification

- `flutter test` **732 passed**, `flutter analyze` clean.
- 신규 2건(첫 진입이 오늘, 오늘 ↔ 이번 주 왕복) + 기존 좁은 화면 넘침 게이트가 위 수정을 잠급니다.
- 그래프 애니메이션 테스트 2건은 막대를 보려고 `이번 주`를 먼저 고르도록 고쳤습니다 — 검증 대상은 막대가 자라는 모습이지 어느 기간이 기본인가가 아닙니다.

## Notes

- 탭 재진입 시 임시 UI 상태 초기화 정책은 #861(seoyeon0516)에서 다루는 범위라 손대지 않았습니다. 이 PR은 첫 진입 기본값만 바꿉니다.
- 오늘 기록이 없으면 도넛이 `0분`으로 그려지는 기존 표현을 그대로 씁니다.