### PR TITLE
fix(recommendation): 현재 연결된 헬스장·담당 트레이너를 추천 목록에서 제외

### DIFF
--- a/frontend/flutter/lib/features/exercise/presentation/controllers/exercise_controller.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/controllers/exercise_controller.dart
@@ -280,8 +280,62 @@ final trainerProvider = FutureProvider.family<Trainer?, String>((
   return ref.watch(gymRepositoryProvider).fetchTrainer(trainerId);
 }, name: 'trainer');
 
-final recommendedTrainersProvider = FutureProvider<List<Trainer>>((ref) {
-  return ref.watch(gymRepositoryProvider).fetchRecommendedTrainers();
+/// 이미 연결된 대상을 추천에서 빼기 위한 현재 연결 id. (#864)
+///
+/// 조회가 실패하면 `null` 을 돌려 **필터를 걸지 않는다**. 연결 정보 하나 때문에
+/// 추천 영역 전체가 실패하면, 고객은 탐색할 후보조차 못 본다 — 걸러지지 않은
+/// 목록이 아무것도 없는 화면보다 낫다.
+Future<String?> _connectedId(Future<Object?> lookup) async {
+  try {
+    final Object? connected = await lookup;
+    return switch (connected) {
+      final Gym gym => gym.id,
+      final Trainer trainer => trainer.id,
+      _ => null,
+    };
+  } on Object {
+    return null;
+  }
+}
+
+/// 추천 헬스장 — 지금 연결된 헬스장은 뺀다. (#864)
+///
+/// 추천 영역의 목적은 **새로 연결할 후보**를 보여 주는 것이다. 이미 연결된
+/// 헬스장이 거기 다시 서면 "연결이 된 것이 맞나" 를 되묻게 된다. 내 헬스장
+/// 카드에는 그대로 보이므로 정보가 사라지는 것은 아니다.
+///
+/// 이름이 아니라 **id 로 거른다.** 같은 이름의 다른 지점을 함께 지우거나,
+/// 표기가 조금 다른 같은 헬스장을 놓치지 않기 위해서다.
+///
+/// [nearbyGymsProvider] 자체는 그대로 둔다 — 상담 신청·트레이너 목록이 같은
+/// provider 를 읽고, 그 화면들에서는 연결된 헬스장도 후보로 남아야 한다.
+final recommendedGymsProvider = FutureProvider<List<Gym>>((ref) async {
+  final List<Gym> gyms = await ref.watch(nearbyGymsProvider.future);
+  // 연결 정보를 기다렸다가 거른다. 먼저 그려 두고 나중에 지우면 이미 연결된
+  // 헬스장이 한 번 깜빡이고 사라진다.
+  final String? connectedId = await _connectedId(
+    ref.watch(myGymProvider.future),
+  );
+  if (connectedId == null) return gyms;
+  return gyms.where((Gym gym) => gym.id != connectedId).toList(growable: false);
+}, name: 'recommendedGyms');
+
+/// 추천 트레이너 — 지금 담당인 트레이너는 뺀다. (#864)
+///
+/// 담당이 이미 지정돼 있는데 같은 사람이 `추천 트레이너` 에 다시 서는 것은
+/// 추천의 의미와 맞지 않는다. 같은 헬스장의 **다른** 트레이너는 그대로 후보다 —
+/// 담당이 있다고 그 헬스장 사람들을 모두 지우면 탐색이 막힌다.
+final recommendedTrainersProvider = FutureProvider<List<Trainer>>((ref) async {
+  final List<Trainer> trainers = await ref
+      .watch(gymRepositoryProvider)
+      .fetchRecommendedTrainers();
+  final String? connectedId = await _connectedId(
+    ref.watch(myTrainerProvider.future),
+  );
+  if (connectedId == null) return trainers;
+  return trainers
+      .where((Trainer trainer) => trainer.id != connectedId)
+      .toList(growable: false);
 }, name: 'recommendedTrainers');
 
 /// "트레이너 찾기" 목록이 읽는 전체 디렉터리.

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/gym_tab.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/gym_tab.dart
@@ -33,7 +33,6 @@ class GymTab extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final AppLocalizations l = AppLocalizations.of(context);
     final AsyncValue<Gym?> myGymAsync = ref.watch(myGymProvider);
-    final AsyncValue<List<Gym>> nearbyAsync = ref.watch(nearbyGymsProvider);
     // 트레이너 소속 헬스장 이름은 제휴 + 카카오를 모두 아는 목록에서 찾아야 한다.
     // 제휴 목록만 보면 카카오 헬스장 소속 트레이너의 헬스장 이름이 빈칸이 된다(#329).
     final AsyncValue<List<Gym>> knownGymsAsync = ref.watch(
@@ -109,7 +108,9 @@ class GymTab extends ConsumerWidget {
           ],
           const SizedBox(height: 28),
           _RecommendedGymSection(
-            gymsAsync: nearbyAsync,
+            // 이미 연결된 헬스장은 빠진 목록이다(#864) — 내 헬스장 카드는 위에
+            // 그대로 있으므로 정보가 사라지지 않는다.
+            gymsAsync: ref.watch(recommendedGymsProvider),
             onMore: () => context.push(AppRoutes.gyms),
             onRetry: () => ref.invalidate(nearbyGymsProvider),
           ),

--- a/frontend/flutter/test/features/exercise/gym_finder_results_test.dart
+++ b/frontend/flutter/test/features/exercise/gym_finder_results_test.dart
@@ -200,8 +200,20 @@ void main() {
         .map((Trainer t) => t.name);
     expect(missing, isEmpty, reason: '추천 사유가 없는 트레이너');
 
-    // 전원이 사유를 가지므로 추천 레일 = 전체 트레이너
-    expect(recommended.length, trainers.length);
+    // 전원이 사유를 가지므로 추천 레일 = 전체 트레이너 **에서 담당 트레이너를 뺀
+    // 만큼**이다(#864). 이미 담당인 사람이 추천에 다시 서지 않는다.
+    final Trainer? assigned = await container.read(myTrainerProvider.future);
+    final int expected = trainers
+        .where((Trainer t) => t.id != assigned?.id)
+        .length;
+    expect(recommended.length, expected);
+    if (assigned != null) {
+      expect(
+        recommended.where((Trainer t) => t.id == assigned.id),
+        isEmpty,
+        reason: '담당 트레이너가 추천에 남아 있다',
+      );
+    }
 
     final reasons = trainers.map((Trainer t) => t.reason!).toList();
     expect(reasons.toSet().length, reasons.length, reason: '추천 사유 문구 중복');

--- a/frontend/flutter/test/features/exercise/recommendation_excludes_connected_test.dart
+++ b/frontend/flutter/test/features/exercise/recommendation_excludes_connected_test.dart
@@ -1,0 +1,144 @@
+/// 이미 연결된 대상은 추천 후보에서 뺀다. (#864)
+///
+/// 추천 영역이 답하는 질문은 "새로 연결할 만한 곳이 어디인가" 다. 이미 연결된
+/// 헬스장·담당 트레이너가 거기 다시 서면 "연결이 된 것이 맞나" 를 되묻게 된다.
+/// 내 헬스장·담당 트레이너 카드에는 그대로 보이므로 정보가 사라지지는 않는다.
+library;
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/features/exercise/data/repositories/mock_gym_repository.dart';
+import 'package:oncare/features/exercise/domain/entities/gym.dart';
+import 'package:oncare/features/exercise/domain/entities/trainer.dart';
+import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
+
+/// 연결 정보 조회만 실패하는 저장소 — 추천까지 함께 무너지는지 본다.
+class _BrokenLinkGymRepository extends MockGymRepository {
+  @override
+  Future<Gym?> fetchMyGym() async => throw Exception('내 헬스장 조회 실패');
+
+  @override
+  Future<Trainer?> fetchMyTrainer() async => throw Exception('담당 조회 실패');
+}
+
+ProviderContainer _containerWith(MockGymRepository repository) {
+  final container = ProviderContainer(
+    overrides: <Override>[
+      gymRepositoryProvider.overrideWithValue(repository),
+      appConfigProvider.overrideWithValue(
+        const AppConfig(
+          environment: Environment.dev,
+          apiBaseUrl: 'http://localhost',
+          useMockApi: true,
+        ),
+      ),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  test('연결된 헬스장은 추천 목록에 없고, 나머지는 그대로다', () async {
+    final repository = MockGymRepository();
+    final container = _containerWith(repository);
+
+    final Gym? mine = await container.read(myGymProvider.future);
+    expect(mine, isNotNull, reason: '데모는 연결된 헬스장으로 시작한다');
+
+    final List<Gym> all = await container.read(nearbyGymsProvider.future);
+    final List<Gym> recommended = await container.read(
+      recommendedGymsProvider.future,
+    );
+
+    expect(recommended.where((Gym gym) => gym.id == mine!.id), isEmpty);
+    expect(recommended.length, all.length - 1);
+    // 연결되지 않은 후보는 하나도 빠지지 않는다.
+    expect(
+      recommended.map((Gym gym) => gym.id).toSet(),
+      all.map((Gym gym) => gym.id).toSet()..remove(mine!.id),
+    );
+  });
+
+  test('담당 트레이너는 추천에서 빠지고 같은 헬스장 동료는 남는다', () async {
+    final repository = MockGymRepository();
+    final container = _containerWith(repository);
+
+    final Trainer? assigned = await container.read(myTrainerProvider.future);
+    expect(assigned, isNotNull, reason: '데모는 담당 트레이너로 시작한다');
+
+    final List<Trainer> recommended = await container.read(
+      recommendedTrainersProvider.future,
+    );
+    expect(
+      recommended.where((Trainer t) => t.id == assigned!.id),
+      isEmpty,
+      reason: '담당 트레이너가 추천에 남아 있다',
+    );
+
+    // 같은 헬스장의 다른 트레이너까지 지우면 탐색이 막힌다 — 그들은 남아야 한다.
+    final List<Trainer> sameGym = await container.read(
+      gymTrainersProvider(assigned!.gymId).future,
+    );
+    final Iterable<Trainer> colleagues = sameGym.where(
+      (Trainer t) => t.id != assigned.id,
+    );
+    if (colleagues.isNotEmpty) {
+      final Set<String> recommendedIds = recommended
+          .map((Trainer t) => t.id)
+          .toSet();
+      expect(
+        colleagues.any((Trainer t) => recommendedIds.contains(t.id)),
+        isTrue,
+        reason: '같은 헬스장 동료까지 추천에서 사라졌다',
+      );
+    }
+  });
+
+  test('연결을 해제하면 그 대상이 다시 추천 후보가 된다', () async {
+    final repository = MockGymRepository();
+    final container = _containerWith(repository);
+
+    final Gym? mine = await container.read(myGymProvider.future);
+    final Trainer? assigned = await container.read(myTrainerProvider.future);
+    expect(mine, isNotNull);
+    expect(assigned, isNotNull);
+
+    await repository.disconnectMyGym();
+    container
+      ..invalidate(myGymProvider)
+      ..invalidate(myTrainerProvider)
+      ..invalidate(recommendedGymsProvider)
+      ..invalidate(recommendedTrainersProvider);
+
+    final List<Gym> gyms = await container.read(recommendedGymsProvider.future);
+    expect(
+      gyms.where((Gym gym) => gym.id == mine!.id),
+      isNotEmpty,
+      reason: '해제한 헬스장이 다시 후보가 되지 않았다',
+    );
+
+    final List<Trainer> trainers = await container.read(
+      recommendedTrainersProvider.future,
+    );
+    expect(
+      trainers.where((Trainer t) => t.id == assigned!.id),
+      isNotEmpty,
+      reason: '해제한 트레이너가 다시 후보가 되지 않았다',
+    );
+  });
+
+  test('연결 정보 조회가 실패해도 추천은 살아 있다', () async {
+    final container = _containerWith(_BrokenLinkGymRepository());
+
+    // 걸러지지 않은 목록이, 아무것도 없는 화면보다 낫다.
+    final List<Gym> gyms = await container.read(recommendedGymsProvider.future);
+    expect(gyms, isNotEmpty);
+    final List<Trainer> trainers = await container.read(
+      recommendedTrainersProvider.future,
+    );
+    expect(trainers, isNotEmpty);
+  });
+}


### PR DESCRIPTION
Closes #864

## Summary

추천 영역이 답하는 질문은 "새로 연결할 만한 곳이 어디인가"입니다. 이미 연결된 헬스장이나 담당 트레이너가 거기 다시 서면 고객은 연결이 된 것이 맞는지, 같은 곳을 또 골라야 하는지 되묻게 됩니다. 내 헬스장·담당 트레이너 카드에는 그대로 보이므로 정보가 사라지지는 않습니다.

## Changes

- `recommendedGymsProvider`를 새로 두고, `recommendedTrainersProvider`가 담당 트레이너를 거르도록 했습니다. 필터를 provider 한 곳에 두어 화면마다 같은 로직이 흩어지지 않게 했습니다.
- **id 기준 비교**입니다. 이름으로 지우면 같은 이름의 다른 지점이 함께 사라지거나, 표기가 조금 다른 같은 헬스장을 놓칩니다.
- **연결 정보를 기다렸다가 거릅니다.** 먼저 그려 두고 나중에 지우면 이미 연결된 대상이 한 번 깜빡이고 사라집니다.
- **연결 정보 조회가 실패하면 필터를 걸지 않고** 원래 목록을 보여 줍니다. 그 하나 때문에 추천 전체가 실패하면 고객은 탐색할 후보조차 못 봅니다.
- `nearbyGymsProvider` 자체는 그대로입니다 — 상담 신청·트레이너 목록이 같은 provider를 읽고, 그 화면에서는 연결된 헬스장도 후보로 남아야 합니다.
- 같은 헬스장의 **다른** 트레이너는 추천에 남습니다. 담당이 있다고 그 헬스장 사람들을 모두 지우면 탐색이 막힙니다.
- backend/API는 건드리지 않았습니다(이슈 제외 범위). 연결 해제 뒤 다시 후보가 되는 동작은 기존 invalidate 경로가 그대로 처리합니다 — 추천 provider가 내 헬스장·담당 트레이너 provider에서 파생되기 때문입니다.

## Verification

- `flutter test` **732 passed**, `flutter analyze` clean.
- 신규 4건: 연결된 헬스장 제외(나머지는 전부 유지), 담당 트레이너 제외 + 같은 헬스장 동료 유지, 해제 후 재등장, 연결 조회 실패 시 추천 생존.
- 기존 `gym_finder_results_test`의 "추천 레일 = 전체 트레이너" 단언을 새 의미(전체 − 담당)로 고쳤습니다.