### PR TITLE
test(trainer-web): 요일에 따라 값이 달라지던 대시보드 주의 고객 검증

### DIFF
--- a/frontend/flutter_trainer/test/features/dashboard/dashboard_page_test.dart
+++ b/frontend/flutter_trainer/test/features/dashboard/dashboard_page_test.dart
@@ -44,6 +44,41 @@ void main() {
     return GoRouter.of(ctx).routerDelegate.currentConfiguration.uri.toString();
   }
 
+  /// 주의 고객 검증이 쓰는 고정 로스터. (#907)
+  ///
+  /// 건강 신호 여덟(나트륨 5 · 당류 1 · 이행률 2)과 답장 대기 둘. 기대값을
+  /// 데이터 바로 옆에 두어, 숫자가 어디서 왔는지 읽는 사람이 세어 볼 수 있게 한다.
+  ///
+  /// 이행률 경고는 `weekCompletion` 을 직접 준다 — 시드처럼 오늘 요일에 따라
+  /// 잘리는 값을 쓰면 판정이 요일을 탄다.
+  List<Override> attentionRosterOverrides() {
+    const List<int> lowWeek = <int>[40, 40, 0, 0, 0, 0, 0];
+    final List<TrainerClient> roster = <TrainerClient>[
+      for (var i = 0; i < 5; i++)
+        makeClient(id: 'sodium-$i', name: '나트륨 고객 $i', sodiumMg: 2500),
+      makeClient(id: 'sugar-0', name: '당류 고객', sugarG: 80),
+      for (var i = 0; i < 2; i++)
+        makeClient(
+          id: 'completion-$i',
+          name: '이행률 고객 $i',
+          weekCompletion: lowWeek,
+        ),
+      makeClient(id: 'reply-0', name: '답장 고객 0'),
+      makeClient(id: 'reply-1', name: '답장 고객 1'),
+    ];
+    return <Override>[
+      clientsProvider.overrideWith(
+        (ref) => Stream<List<TrainerClient>>.value(roster),
+      ),
+      unreadCountsProvider.overrideWith(
+        (ref) => Stream<Map<String, int>>.value(const <String, int>{
+          'reply-0': 1,
+          'reply-1': 2,
+        }),
+      ),
+    ];
+  }
+
   testWidgets('is the landing page after a restored session', (tester) async {
     await openDashboard(tester);
     expect(find.text('대시보드'), findsWidgets);
@@ -107,14 +142,16 @@ void main() {
   testWidgets('주의 고객 counts health signals, not the reply backlog', (
     tester,
   ) async {
-    await openDashboard(tester);
+    // 로스터를 이 테스트가 직접 만든다(#907). 데모 시드는 주간 이행률을 **오늘
+    // 요일까지만** 채우므로(`_upToToday`), 기록이 있는 날의 평균으로 판정하는
+    // 이행률 경고가 요일마다 붙었다 떨어졌다 한다 — 시드에 기대면 이 숫자가
+    // 수요일에 하나 늘고 화요일에 하나 줄어, 어느 요일에 CI 가 도느냐로
+    // 통과·실패가 갈렸다.
+    await openDashboard(tester, extraOverrides: attentionRosterOverrides());
 
-    // 답장을 기다리는 스레드가 여섯이지만 주의는 건강 신호만 센다 — 나트륨 5 ·
+    // 답장을 기다리는 스레드가 둘이지만 주의는 건강 신호만 센다 — 나트륨 5 ·
     // 당류 1 · 이행률 2 로 여덟이다. 답장 대기는 목록에는 남되 주의가 아니다.
     // 둘이 다시 합쳐지면 이 카드가 더 큰 수를 말하며 뜻을 잃는다.
-    //
-    // 류태경(벌크업)은 칼로리가 3,120kcal 로 높지만 여기 없다 — 칼로리는 신호가
-    // 아니고, 그의 식단 수치는 목표 안이다(#767·#768).
     final attention = tester.widget<StatCard>(
       find.ancestor(of: find.text('주의 고객'), matching: find.byType(StatCard)),
     );
@@ -143,14 +180,12 @@ void main() {
 
   testWidgets('주의 고객 rows carry the reason and open the section that '
       'fixes it', (tester) async {
-    await openDashboard(tester);
+    await openDashboard(tester, extraOverrides: attentionRosterOverrides());
 
     expect(find.text('확인 필요 고객'), findsOneWidget);
-    // Ten clients carry an alert of some kind — note this list is wider
-    // than the 주의 고객 count above it, which is health signals only and
-    // reads 9. The card shows five, so the overflow link into the
-    // filtered roster is finally reachable; with the old three-client
-    // roster it could never appear.
+    // 신호를 가진 회원은 열이다 — 건강 신호 여덟에 답장 대기 둘. 위의 `주의 고객`
+    // 수(여덟)보다 이 목록이 넓은 것이 정상이다. 카드는 다섯 줄까지만 세우고
+    // 나머지는 링크로 넘긴다.
     expect(find.text('+5명'), findsOneWidget);
 
     // The badge is a client's FIRST alert, and health reasons sort ahead


### PR DESCRIPTION
Closes #907

## Summary

main이 red입니다. 대시보드 테스트 두 건이 **요일에 따라 통과·실패가 갈리는** 상태였고, 날짜가 넘어가면서 터졌습니다. 코드 변경 때문이 아닙니다 — Trainer CI가 마지막으로 돈 커밋(`1c587c12`)까지 green이었고, 그 뒤 머지된 두 건은 회원 앱 경로만 건드려 이 스위트가 아예 돌지 않았습니다.

## 원인

데모 시드가 주간 이행률을 **오늘 요일까지만** 채웁니다(`_upToToday`). `isLowCompletion`은 기록이 있는 날의 평균으로 판정하므로, 요일이 바뀌면 평균이 달라지고 이행률 경고가 붙는 회원 수가 달라집니다. 그래서 `주의 고객` 수가 화요일 8, 수요일 9로 움직였고 테스트는 8로 못 박혀 있었습니다.

두 테스트의 주석이 서로 다른 수(한쪽 "여덟", 다른 쪽 "9")를 말하고 있던 것도 같은 이유입니다.

## Changes

- 두 테스트가 시드 대신 **자기 로스터를 주입**합니다 — 나트륨 5 · 당류 1 · 이행률 2(건강 신호 8)에 답장 대기 2(총 10). 같은 파일의 다른 테스트가 이미 쓰는 방식입니다.
- 이행률 경고는 `weekCompletion`을 직접 주어 요일을 타지 않습니다.
- 기대값이 데이터 바로 옆에 있어, 8과 `+5명`이 어디서 나온 수인지 읽는 사람이 세어 볼 수 있습니다.
- 어긋나 있던 주석을 정리했습니다.

**검증 의도는 그대로입니다**: 답장 대기가 주의 수에 섞이면 여전히 실패하고, 카드가 다섯 줄까지만 세우고 나머지를 링크로 넘기는 규칙도 그대로 확인합니다.

## Verification

- `flutter test` **781 passed**, `flutter analyze` clean.
- 대시보드 스위트 50건 통과.

## Notes

- 시드의 `_upToToday`는 건드리지 않았습니다 — 데모가 "오늘까지 기록"을 보여 주는 것은 의도된 동작이고, 고칠 곳은 그 위에 기대값을 박아 둔 테스트입니다.
- 이 PR이 들어가야 #905·#906이 머지될 수 있습니다.