### PR TITLE
feat(diet): 회원 앱 식단 탭 월간 막대 수치 툴팁 및 지난 날짜 기간 토글 정리

### DIFF
--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -185,7 +185,7 @@ class _DietRecordPageState extends ConsumerState<DietRecordPage> {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations l = AppLocalizations.of(context);
-    final DietPeriodTab period = ref.watch(dietPeriodTabProvider);
+    final DietPeriodTab selectedPeriod = ref.watch(dietPeriodTabProvider);
     final DateTime today = _today;
     // Window is always centred on today (+ whole-week shifts): 3 days before,
     // today in the middle, 3 days after.
@@ -195,6 +195,14 @@ class _DietRecordPageState extends ConsumerState<DietRecordPage> {
       (int i) => center.add(Duration(days: i - 3)),
     );
     final bool atToday = _weekShift == 0 && _selected == today;
+    // 날짜를 옮기면 기간 토글이 사라진다 — 운동 탭이 오늘이 아닌 날에
+    // `운동 현황` 을 그날 기록으로 갈아 끼우는 것과 같은 규칙이다. 12일을 고른
+    // 채 `이번 달` 을 누르면 위 스트립은 하루를, 아래 그래프는 한 달을 가리켜
+    // 한 화면이 서로 다른 두 기간을 말했다. 기간 기록은 따로 뗄 예정이다.
+    //
+    // 고른 기간(`dietPeriodTabProvider`)은 **건드리지 않는다.** `오늘` 로
+    // 돌아오면 보던 기간이 그대로 살아나야 한다.
+    final DietPeriodTab period = atToday ? selectedPeriod : DietPeriodTab.day;
     final AsyncValue<DietDay> diet = atToday
         ? ref.watch(dietTodayProvider)
         : ref.watch(dietByDateProvider(_selected));
@@ -246,6 +254,7 @@ class _DietRecordPageState extends ConsumerState<DietRecordPage> {
                 // 통째로 사라지고 토글마저 없어져 되돌아갈 수도 없었다(#684 리뷰).
                 _NutritionSectionHeader(
                   period: period,
+                  showToggle: atToday,
                   onChanged: (DietPeriodTab t) =>
                       ref.read(dietPeriodTabProvider.notifier).state = t,
                 ),
@@ -381,10 +390,15 @@ class _NutritionSectionHeader extends StatelessWidget {
   const _NutritionSectionHeader({
     required this.period,
     required this.onChanged,
+    this.showToggle = true,
   });
 
   final DietPeriodTab period;
   final ValueChanged<DietPeriodTab> onChanged;
+
+  /// 기간 토글을 그릴지. 오늘이 아닌 날짜를 보고 있으면 끈다 — 제목 줄 자체는
+  /// 남아, 아래 영양 요약이 무엇에 대한 것인지는 계속 읽힌다.
+  final bool showToggle;
 
   @override
   Widget build(BuildContext context) {
@@ -427,9 +441,10 @@ class _NutritionSectionHeader extends StatelessWidget {
           ),
           // 토글은 카드 오른쪽 끝 — 운동 탭 '운동 현황' 과 같은 자리라 두 탭을
           // 오가며 같은 곳에서 기간을 바꾼다.
-          Flexible(
-            child: _PeriodToggle(active: period, onChanged: onChanged),
-          ),
+          if (showToggle)
+            Flexible(
+              child: _PeriodToggle(active: period, onChanged: onChanged),
+            ),
         ],
       ),
     );
@@ -490,6 +505,10 @@ class _DateStrip extends StatelessWidget {
                 ),
                 if (showTodayButton)
                   GestureDetector(
+                    // 기간 토글이 오늘이 아닌 날에는 사라지므로, 되돌아오는
+                    // 길은 이 버튼 하나다 — 테스트가 그 길을 지목할 수 있어야
+                    // 한다(#912).
+                    key: const ValueKey<String>('diet-today-button'),
                     onTap: onToday,
                     child: Container(
                       padding: const EdgeInsets.symmetric(

--- a/frontend/flutter/lib/features/diet/presentation/widgets/diet_period_view.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/diet_period_view.dart
@@ -401,7 +401,8 @@ class _PeriodBody extends StatelessWidget {
               // 보고 있으면) 마지막 칸까지 전부 그린다.
               todayIndex: _todayIndexIn(dates),
               replayKey: replayKey,
-              goalLabel: '${AppLocalizations.of(context).homeGoal}\n${format(goal)}',
+              goalLabel:
+                  '${AppLocalizations.of(context).homeGoal}\n${format(goal)}',
               formatTick: (double v) => format(v),
             )
           else
@@ -411,6 +412,11 @@ class _PeriodBody extends StatelessWidget {
               goal: goal,
               color: color,
               replayKey: replayKey,
+              // 막대 툴팁이 "무슨 값을 얼마나" 라고 말하려면 지표 이름·단위와
+              // 숫자 서식이 카드 머리 숫자와 같아야 한다.
+              metricLabel: metricLabel,
+              unit: unit,
+              format: format,
             ),
         ],
       ),
@@ -427,6 +433,9 @@ class _PeriodBars extends StatelessWidget {
     required this.goal,
     required this.color,
     required this.replayKey,
+    required this.metricLabel,
+    required this.unit,
+    required this.format,
   });
 
   final List<double> values;
@@ -435,8 +444,69 @@ class _PeriodBars extends StatelessWidget {
   final Color color;
   final Object replayKey;
 
+  /// 툴팁이 부를 지표 이름(칼로리·나트륨·당류)과 단위, 그리고 카드 머리 숫자와
+  /// 같은 숫자 서식.
+  final String metricLabel;
+  final String unit;
+  final String Function(num) format;
+
+  /// 한 막대의 툴팁 내용 — 운동 탭 `운동 현황` 툴팁과 같은 구조다.
+  /// `[색 사각형] 지표  값 단위` 한 줄, 목표를 넘긴 날은 초과분을 한 줄 더.
+  List<InlineSpan> _tipSpans(
+    AppLocalizations l,
+    DateFormat dayFormat,
+    int i,
+    bool hasGoal,
+  ) {
+    final double value = values[i];
+    final bool over = hasGoal && value > goal;
+    final List<InlineSpan> spans = <InlineSpan>[
+      TextSpan(
+        text: '${dayFormat.format(dates[i])}\n',
+        style: const TextStyle(color: AppColors.mutedForeground),
+      ),
+    ];
+    // 기록이 없는 날은 0 이 아니라 '기록 없음' 이다. 0 으로 적으면 굶은 날과
+    // 적지 않은 날이 같은 말이 된다.
+    if (value <= 0) {
+      spans.add(TextSpan(text: l.dietPeriodNoRecord));
+      return spans;
+    }
+    spans.add(
+      WidgetSpan(
+        alignment: PlaceholderAlignment.middle,
+        child: Container(
+          width: 9,
+          height: 9,
+          margin: const EdgeInsets.only(right: 6),
+          decoration: BoxDecoration(
+            color: over ? FigmaColors.dangerRed : color,
+            borderRadius: BorderRadius.circular(2),
+          ),
+        ),
+      ),
+    );
+    spans.add(TextSpan(text: '$metricLabel   ${format(value)} $unit'));
+    // 막대가 왜 빨간지를 색이 아니라 글로도 말한다.
+    if (over) {
+      spans.add(
+        TextSpan(
+          text: '\n${l.dietPeriodOverGoal(format(value - goal), unit)}',
+          style: const TextStyle(color: FigmaColors.dangerRed),
+        ),
+      );
+    }
+    return spans;
+  }
+
   @override
   Widget build(BuildContext context) {
+    final AppLocalizations l = AppLocalizations.of(context);
+    // `8월 12일 (화)` / `Tue, Aug 12` — 어느 막대가 며칠인지 x축 라벨만으로는
+    // 짚을 수 없다(달은 6칸에 하나만 적는다).
+    final DateFormat dayFormat = DateFormat.MMMEd(
+      Localizations.localeOf(context).toString(),
+    );
     const double chartHeight = 120;
     // 축 위쪽에 여유를 둔다. 목표를 넘은 날이 없으면 목표가 곧 최댓값이 되어
     // 목표선이 차트 맨 위(=바깥)에 놓여 잘려 보이지 않았다.
@@ -499,6 +569,41 @@ class _PeriodBars extends StatelessWidget {
                               ),
                             ),
                           ),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+              // 막대 위에 겹치는 투명한 hover 영역. 운동 탭 `운동 현황` 이
+              // 쓰는 것과 **같은 툴팁 규격**이라, 두 탭에서 같은 조작이 같은
+              // 모양으로 답한다.
+              Positioned.fill(
+                child: Row(
+                  children: <Widget>[
+                    for (int i = 0; i < values.length; i++)
+                      Expanded(
+                        child: Tooltip(
+                          key: Key('diet-period-bar-tip-$i'),
+                          richMessage: TextSpan(
+                            style: const TextStyle(
+                              fontSize: 12.5,
+                              fontWeight: FontWeight.w600,
+                              color: FigmaColors.ink,
+                              height: 1.3,
+                            ),
+                            children: _tipSpans(l, dayFormat, i, hasGoal),
+                          ),
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 10,
+                            vertical: 8,
+                          ),
+                          decoration: BoxDecoration(
+                            color: const Color(0xFFF1F3F5),
+                            borderRadius: BorderRadius.circular(10),
+                            border: Border.all(color: FigmaColors.hairline),
+                            boxShadow: kCardShadow,
+                          ),
+                          child: const SizedBox.expand(),
                         ),
                       ),
                   ],

--- a/frontend/flutter/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations.dart
@@ -662,6 +662,18 @@ abstract class AppLocalizations {
   /// **'{start} - {end}'**
   String dietPeriodRange(String start, String end);
 
+  /// No description provided for @dietPeriodNoRecord.
+  ///
+  /// In en, this message translates to:
+  /// **'No record'**
+  String get dietPeriodNoRecord;
+
+  /// No description provided for @dietPeriodOverGoal.
+  ///
+  /// In en, this message translates to:
+  /// **'{amount} {unit} over goal'**
+  String dietPeriodOverGoal(String amount, String unit);
+
   /// No description provided for @otherDateEmpty.
   ///
   /// In en, this message translates to:

--- a/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
@@ -327,6 +327,14 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get dietPeriodNoRecord => 'No record';
+
+  @override
+  String dietPeriodOverGoal(String amount, String unit) {
+    return '$amount $unit over goal';
+  }
+
+  @override
   String otherDateEmpty(Object section) {
     return 'No $section records for the selected date.';
   }

--- a/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
@@ -320,6 +320,14 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String get dietPeriodNoRecord => '기록 없음';
+
+  @override
+  String dietPeriodOverGoal(String amount, String unit) {
+    return '목표 초과 +$amount $unit';
+  }
+
+  @override
   String otherDateEmpty(Object section) {
     return '선택한 날짜에 기록된 $section이 없어요.';
   }

--- a/frontend/flutter/lib/l10n/app_en.arb
+++ b/frontend/flutter/lib/l10n/app_en.arb
@@ -184,6 +184,18 @@
       }
     }
   },
+  "dietPeriodNoRecord": "No record",
+  "dietPeriodOverGoal": "{amount} {unit} over goal",
+  "@dietPeriodOverGoal": {
+    "placeholders": {
+      "amount": {
+        "type": "String"
+      },
+      "unit": {
+        "type": "String"
+      }
+    }
+  },
   "otherDateEmpty": "No {section} records for the selected date.",
   "dietMealBreakfast": "Breakfast",
   "dietMealLunch": "Lunch",

--- a/frontend/flutter/lib/l10n/app_ko.arb
+++ b/frontend/flutter/lib/l10n/app_ko.arb
@@ -118,6 +118,8 @@
   "dietPeriodLoggedDays": "{days}일 기록",
   "dietPeriodEmpty": "이 기간에 기록된 식단이 없어요.",
   "dietPeriodRange": "{start} ~ {end}",
+  "dietPeriodNoRecord": "기록 없음",
+  "dietPeriodOverGoal": "목표 초과 +{amount} {unit}",
   "otherDateEmpty": "선택한 날짜에 기록된 {section}이 없어요.",
   "dietMealBreakfast": "아침",
   "dietMealLunch": "점심",

--- a/frontend/flutter/test/features/diet/diet_period_test.dart
+++ b/frontend/flutter/test/features/diet/diet_period_test.dart
@@ -178,11 +178,7 @@ void main() {
         ),
         matching: range,
       );
-      expect(
-        rangeInRow,
-        findsWidgets,
-        reason: '날짜 범위가 지표 버튼과 다른 줄에 있습니다.',
-      );
+      expect(rangeInRow, findsWidgets, reason: '날짜 범위가 지표 버튼과 다른 줄에 있습니다.');
     });
   });
 
@@ -233,7 +229,9 @@ void main() {
       final DateTime other = today.subtract(const Duration(days: 2));
       await tester.tap(
         find.byKey(
-          ValueKey<String>('diet-day-${other.year}-${other.month}-${other.day}'),
+          ValueKey<String>(
+            'diet-day-${other.year}-${other.month}-${other.day}',
+          ),
         ),
       );
       await tester.pumpAndSettle();
@@ -306,7 +304,10 @@ void main() {
         expect(addRect.right, lessThanOrEqualTo(headerRect.right + 0.5));
 
         // 날짜와 추가 버튼이 겹치지 않는다. 겹치면 화면상 글자가 버튼을 파고든다.
-        expect(tester.getRect(date).right, lessThanOrEqualTo(addRect.left + 0.5));
+        expect(
+          tester.getRect(date).right,
+          lessThanOrEqualTo(addRect.left + 0.5),
+        );
 
         // 화면 어디에서도 넘치지 않는다. 화면 전체가 좁은 폭을 견디게 된 뒤로
         // (#739) 이 단언을 이 자리에서 그대로 쓸 수 있다.
@@ -435,8 +436,10 @@ void main() {
     expect(period.avgSugarG, closeTo(9, 0.001));
   });
 
-  group('기간 뷰는 선택한 날짜 요청에 좌우되지 않는다 (#684 리뷰)', () {
-    testWidgets('기록이 빈 날을 골라도 그래프와 토글이 남는다', (WidgetTester tester) async {
+  group('지난 날짜에서는 기간 토글이 사라진다 (#912)', () {
+    testWidgets('지난 날짜를 고르면 토글이 사라지고, 오늘로 돌아오면 고르던 기간이 살아난다', (
+      WidgetTester tester,
+    ) async {
       tester.view.physicalSize = const Size(500, 1600);
       tester.view.devicePixelRatio = 1;
       addTearDown(tester.view.reset);
@@ -460,25 +463,38 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.byKey(const Key('diet-period-card')), findsOneWidget);
 
-      final DateTime yesterday = nowKst().subtract(
-        const Duration(days: 1),
-      );
+      final DateTime yesterday = nowKst().subtract(const Duration(days: 1));
       await tester.tap(find.text('${yesterday.day}').first);
       await tester.pumpAndSettle();
 
+      // 운동 탭과 같은 규칙 — 오늘이 아닌 날은 그날 하루만 말한다.
+      expect(
+        find.byKey(const ValueKey<String>('diet-period-toggle')),
+        findsNothing,
+        reason: '스트립은 하루를, 그래프는 한 주를 가리키는 화면이 되면 안 된다',
+      );
+      expect(find.byKey(const Key('diet-period-card')), findsNothing);
+      // 되돌아오는 길은 스트립의 `오늘` 버튼이다.
+      expect(
+        find.byKey(const ValueKey<String>('diet-today-button')),
+        findsOneWidget,
+      );
+
+      await tester.tap(find.byKey(const ValueKey<String>('diet-today-button')));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const ValueKey<String>('diet-period-toggle')),
+        findsOneWidget,
+      );
       expect(
         find.byKey(const Key('diet-period-card')),
         findsOneWidget,
-        reason: '하루 기록이 비었다고 기간 그래프가 사라지면 안 된다',
-      );
-      expect(
-        find.byKey(const Key('diet-period-tab-day')),
-        findsOneWidget,
-        reason: '토글이 사라지면 오늘로 돌아갈 방법이 없다',
+        reason: '고르던 기간(이번 주)은 상태에 남아 있어야 한다',
       );
     });
 
-    testWidgets('하루 조회가 실패해도 토글이 남는다', (WidgetTester tester) async {
+    testWidgets('하루 조회가 실패해도 오늘로 돌아올 길이 남는다', (WidgetTester tester) async {
       tester.view.physicalSize = const Size(500, 1600);
       tester.view.devicePixelRatio = 1;
       addTearDown(tester.view.reset);
@@ -498,13 +514,96 @@ void main() {
       await tester.tap(find.byKey(const Key('diet-period-tab-week')));
       await tester.pumpAndSettle();
 
-      final DateTime yesterday = nowKst().subtract(
-        const Duration(days: 1),
-      );
+      final DateTime yesterday = nowKst().subtract(const Duration(days: 1));
       await tester.tap(find.text('${yesterday.day}').first);
       await tester.pumpAndSettle();
 
-      expect(find.byKey(const Key('diet-period-tab-day')), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey<String>('diet-today-button')),
+        findsOneWidget,
+      );
+    });
+  });
+
+  group('이번 달 막대는 정확한 수치를 툴팁으로 말한다 (#912)', () {
+    testWidgets('막대마다 날짜·지표·값을 담은 툴팁이 붙는다', (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(500, 1600);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        _app(
+          overrides: <Override>[
+            dietRepositoryProvider.overrideWithValue(FakeDietRepository()),
+            accountRepositoryProvider.overrideWithValue(
+              MockAccountRepository(),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('diet-period-tab-month')));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('diet-period-bar-0')), findsOneWidget);
+
+      // 막대 하나마다 hover 영역이 하나. 개수가 어긋나면 칸과 툴팁이 밀린다.
+      final int tipCount = tester
+          .widgetList<Tooltip>(
+            find.byWidgetPredicate(
+              (Widget w) =>
+                  w is Tooltip && '${w.key}'.contains('diet-period-bar-tip-'),
+            ),
+          )
+          .length;
+      expect(
+        tipCount,
+        dietRangeDates(dietRangeForTab(DietPeriodTab.month, nowKst())).length,
+      );
+
+      final AppLocalizations l = AppLocalizations.of(
+        tester.element(find.byType(DietRecordPage)),
+      );
+      // 대역은 오늘·어제·그저께에만 기록을 둔다.
+      final Tooltip todayTip = tester.widget<Tooltip>(
+        find.byKey(Key('diet-period-bar-tip-${nowKst().day - 1}')),
+      );
+      final String text = todayTip.richMessage!.toPlainText();
+      // 지표 이름과 단위가 카드 머리 숫자와 같은 말로 적혀야 한다.
+      expect(text, contains(l.dietCalories));
+      expect(text, contains(l.unitKcal));
+      expect(text, isNot(contains(l.dietPeriodNoRecord)));
+    });
+
+    testWidgets('기록이 없는 날의 툴팁은 기록 없음이다', (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(500, 1600);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        _app(
+          overrides: <Override>[
+            // 홀수 날에는 기록이 없다 — 어느 달이든 1일은 늘 비어 있다.
+            dietRepositoryProvider.overrideWithValue(_SparseDietRepository()),
+            accountRepositoryProvider.overrideWithValue(
+              MockAccountRepository(),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('diet-period-tab-month')));
+      await tester.pumpAndSettle();
+
+      final AppLocalizations l = AppLocalizations.of(
+        tester.element(find.byType(DietRecordPage)),
+      );
+      final Tooltip first = tester.widget<Tooltip>(
+        find.byKey(const Key('diet-period-bar-tip-0')),
+      );
+      expect(first.richMessage!.toPlainText(), contains(l.dietPeriodNoRecord));
     });
   });
 }


### PR DESCRIPTION
## Summary

*   회원 앱 식단 탭 `이번 달` 일별 막대에 마우스를 올리면 **날짜·지표·값**이 툴팁으로 보이도록 했다. 운동 탭 `운동 현황` 이 쓰는 것과 같은 툴팁 규격이라 두 탭이 같은 조작에 같은 모양으로 답한다.
*   목표를 넘긴 날은 툴팁에 초과분을 한 줄 더 적어, 막대가 왜 빨간지를 색이 아니라 글로도 말한다. 기록이 없는 날은 `0` 이 아니라 `기록 없음` 이다.
*   주간 스트립에서 오늘이 아닌 날짜를 고르면 `오늘 / 이번 주 / 이번 달` 토글을 그리지 않는다 — 운동 탭이 오늘이 아닌 날에 `운동 현황` 을 그날 기록으로 갈아 끼우는 것과 같은 규칙이다.
*   고른 기간 상태는 건드리지 않아, 스트립의 `오늘` 버튼으로 돌아오면 보던 기간이 그대로 살아난다.

---

## Changes

### ✨ Features

*   `_PeriodBars` 막대마다 투명한 hover 영역(`Tooltip`)을 겹쳐 `M월 D일 (요일)` + `[색] 지표  값 단위` 를 보여 준다.
*   목표 초과일에 `목표 초과 +N 단위` 줄을 더한다. 기록이 없는 날은 `기록 없음`.
*   l10n 키 `dietPeriodNoRecord`, `dietPeriodOverGoal` 을 ko·en 모두에 추가했다.

### 🔧 Improvements

*   `_NutritionSectionHeader` 에 `showToggle` 을 두어, 선택 날짜가 오늘이 아니면 기간 토글을 그리지 않는다. 그릴 기간은 `오늘` 로 고정해 읽되 Riverpod 상태는 유지한다.
*   스트립의 `오늘` 버튼에 `diet-today-button` 키를 붙여, 되돌아오는 길을 테스트가 지목할 수 있게 했다.

### 🎨 UI/UX

*   툴팁 배경(`#F1F3F5`)·헤어라인 테두리·카드 그림자·글자 규격을 운동 탭 툴팁과 동일하게 맞췄다.
*   지난 날짜를 볼 때 제목 줄(`영양 요약`)은 남기고 토글만 사라지므로, 아래 요약이 무엇에 대한 것인지는 계속 읽힌다.

### 📝 Docs

*   해당 없음

### 🐛 Fixes

*   지난 날짜를 고른 상태에서 `이번 주`·`이번 달` 을 눌러 스트립과 그래프가 서로 다른 기간을 가리키던 문제를 없앴다.

---

## Commits

1. `1a9d075c` feat(diet): 식단 탭 이번 달 막대 수치 툴팁 추가
2. `edea6225` fix(diet): 지난 날짜를 볼 때 기간 토글 숨김

---

## Notes

*   기존 테스트 `기록이 빈 날을 골라도 그래프와 토글이 남는다` / `하루 조회가 실패해도 토글이 남는다` (#684 리뷰)는 새 규칙과 정면으로 어긋나 다시 썼다. 그 테스트가 지키려던 것은 **"오늘로 돌아갈 길이 있어야 한다"** 였고, 그 길은 이제 스트립의 `오늘` 버튼이다 — 새 테스트가 그 길을 확인한다.
*   기간 기록을 별도 기록 아이콘으로 빼는 작업은 이 PR 범위 밖이다. 토글을 감추는 규칙만 먼저 맞췄다.
*   `Tooltip` 은 데스크톱·웹에서 hover, 모바일에서 길게 누르기로 뜬다. 운동 탭과 같은 동작이다.

---

## Screenshots (Optional)

| Before | After |
| ------ | ----- |
| 이번 달 막대에 값 표시가 없고, 지난 날짜에서도 기간 토글이 보임 | 막대 hover 시 날짜·수치 툴팁, 지난 날짜에서는 토글 없음 |

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 회원 앱 식단 탭 → `이번 달` 을 고르고 일별 막대에 마우스를 올린다. 날짜와 지표 값이 툴팁으로 보이는지 확인한다.
2. 지표를 `나트륨`·`당류` 로 바꾸며 툴팁 단위가 함께 바뀌는지, 목표를 넘긴 날에 초과분 줄이 붙는지 확인한다.
3. 주간 스트립에서 어제를 고른다. `오늘/이번 주/이번 달` 토글이 사라지고 그날 하루 기록만 보이는지 확인한다.
4. 스트립의 `오늘` 을 눌러 토글이 돌아오고, 3번 이전에 고르던 기간이 그대로인지 확인한다.

`flutter analyze lib` · `flutter test` (764 tests) 모두 통과.

---

## Related Issues

Closes #912

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인
