### PR TITLE
fix(coaching): 프로그램 탭 운동 이행률 막대 남색 고정

### DIFF
--- a/frontend/flutter_trainer/lib/features/coaching/presentation/pages/coaching_page.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/pages/coaching_page.dart
@@ -1055,6 +1055,15 @@ class _MemberProgramListState extends State<_MemberProgramList> {
                                 // 글로 두었을 때 영어의 `Workout completion
                                 // 72%` 가 배율 1.3 에서 접혀 고정 행 높이를
                                 // 넘긴 적이 있다(#849).
+                                //
+                                // 이행률이 낮아도 **빨강으로 칠하지 않는다**
+                                // (#913). 이 앱에서 빨강은 `목표 초과` 다 —
+                                // 나트륨·당류가 기준을 넘었다는 뜻으로 회원
+                                // 앱과 색을 맞춰 둔 상태다(#690). 이행률이
+                                // 낮은 것은 초과가 아니라 아직 덜 한 것이고,
+                                // 그 사실은 막대 길이와 값이 이미 말한다.
+                                // 같은 카드의 `요일별 운동 이행률` 도 남색
+                                // 계열로만 그린다.
                                 () {
                                   final mean = recordedCompletionMean(client);
                                   return InlineBarValue(
@@ -1066,8 +1075,6 @@ class _MemberProgramListState extends State<_MemberProgramList> {
                                     text: mean == null
                                         ? l.reportsDataInsufficient
                                         : '${mean.round()}%',
-                                    // 주의 배지와 같은 기준.
-                                    warn: mean != null && mean < 70,
                                     // `데이터 부족` 이 들어갈 폭.
                                     valueWidth: mean == null ? 60 : 40,
                                   );

--- a/frontend/flutter_trainer/lib/shared/widgets/mini_charts.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/mini_charts.dart
@@ -145,6 +145,10 @@ class BarSeriesChart extends StatelessWidget {
 ///
 /// 값이 없으면([fraction] 이 null) 막대를 그리지 않는다 — 빈 트랙에 0 을
 /// 채우면 `기록 없음` 이 `0% 수행` 으로 읽힌다.
+///
+/// 값이 있는 줄은 **언제나 남색**이다(#913). 기준 미달을 빨강으로 칠하던
+/// 분기가 있었는데, 이 앱에서 빨강은 `목표 초과` 라는 다른 뜻으로 이미
+/// 쓰이고 있었다(#690). 낮다는 사실은 막대 길이와 값이 말한다.
 class InlineBarValue extends StatelessWidget {
   /// Creates an inline bar with [text] to its right.
   const InlineBarValue({
@@ -153,7 +157,6 @@ class InlineBarValue extends StatelessWidget {
     required this.text,
     this.label,
     this.labelWidth = 56,
-    this.warn = false,
     this.valueWidth = 40,
   });
 
@@ -170,9 +173,6 @@ class InlineBarValue extends StatelessWidget {
   /// 막대 오른쪽에 찍을 값. 값이 없으면 부르는 쪽이 안내 문구를 준다.
   final String text;
 
-  /// 기준을 벗어난 값. 색으로 드러낸다.
-  final bool warn;
-
   /// 값 칸 너비. 단위가 붙으면 넓혀 준다.
   final double valueWidth;
 
@@ -182,11 +182,7 @@ class InlineBarValue extends StatelessWidget {
     // 채로 남아, 잴 값이 있는데 못 읽은 것처럼 보인다. 흐린 줄은 누를 것도
     // 읽을 것도 없다는 뜻이다.
     final bool empty = fraction == null;
-    final Color tone = empty
-        ? AppColors.borderStrong
-        : warn
-        ? AppColors.overTarget
-        : AppColors.primary;
+    final Color tone = empty ? AppColors.borderStrong : AppColors.primary;
     return Row(
       children: <Widget>[
         if (label != null) ...<Widget>[

--- a/frontend/flutter_trainer/test/features/coaching/program_completion_bars_test.dart
+++ b/frontend/flutter_trainer/test/features/coaching/program_completion_bars_test.dart
@@ -44,6 +44,21 @@ void main() {
     matching: find.byType(InlineBarValue),
   );
 
+  /// 이행률 막대가 실제로 칠해진 색. 채워진 쪽(`FractionallySizedBox` 안의
+  /// `Container`)만 본다 — 트랙은 늘 회색이다.
+  Color barFill(WidgetTester tester, String id) => (tester
+              .widget<Container>(
+                find.descendant(
+                  of: find.descendant(
+                    of: rowBar(id),
+                    matching: find.byType(FractionallySizedBox),
+                  ),
+                  matching: find.byType(Container),
+                ),
+              )
+              .color) ??
+      const Color(0x00000000);
+
   testWidgets('회원 목록 행의 이행률이 막대와 값으로 함께 보인다', (tester) async {
     await openCoaching(tester, <TrainerClient>[
       makeClient(
@@ -56,11 +71,10 @@ void main() {
     final bar = tester.widget<InlineBarValue>(rowBar('steady'));
     expect(bar.fraction, closeTo(0.9, 0.001));
     expect(bar.text, '90%');
-    // 이행률이 기준 위면 주의 색을 쓰지 않는다.
-    expect(bar.warn, isFalse);
+    expect(barFill(tester, 'steady'), AppColors.primary);
   });
 
-  testWidgets('이행률이 낮은 회원은 막대가 주의 색을 쓴다', (tester) async {
+  testWidgets('이행률이 낮아도 막대는 남색이다 (#913)', (tester) async {
     await openCoaching(tester, <TrainerClient>[
       makeClient(
         id: 'slipping',
@@ -69,7 +83,18 @@ void main() {
       ),
     ]);
 
-    expect(tester.widget<InlineBarValue>(rowBar('slipping')).warn, isTrue);
+    // 빨강은 이 앱에서 `목표 초과` 다(#690). 이행률이 낮은 것은 초과가
+    // 아니라 아직 덜 한 것이고, 그 사실은 길이와 값이 이미 말한다.
+    expect(barFill(tester, 'slipping'), AppColors.primary);
+    expect(barFill(tester, 'slipping'), isNot(AppColors.overTarget));
+
+    final Color valueColor = tester
+        .widget<Text>(
+          find.descendant(of: rowBar('slipping'), matching: find.text('40%')),
+        )
+        .style!
+        .color!;
+    expect(valueColor, AppColors.primary);
   });
 
   testWidgets('기록이 없는 회원은 막대를 그리지 않는다', (tester) async {


### PR DESCRIPTION
## Summary

*   트레이너 앱 프로그램 탭 회원 목록의 `운동 이행률` 막대가 이행률 70% 미만일 때 빨강으로 바뀌던 분기를 걷어내고, **언제나 남색**(`AppColors.primary`)으로 그린다.
*   이 앱에서 빨강은 `목표 초과` 다 — 나트륨·당류가 기준을 넘었다는 뜻으로 회원 앱과 색을 맞춰 둔 상태다(#690). 이행률이 낮은 것은 초과가 아니라 아직 덜 한 것이다.
*   같은 `회원 요약` 카드의 `요일별 운동 이행률` 막대그래프는 이미 남색 계열로만 그리고 있었다. 한 카드가 같은 지표를 두 색 규칙으로 말하던 것을 하나로 맞췄다.
*   쓰는 곳이 한 군데뿐이던 `InlineBarValue.warn` 인자를 함께 제거했다.

---

## Changes

### ✨ Features

*   해당 없음

### 🔧 Improvements

*   `InlineBarValue` 의 `warn` 필드와 색 분기를 제거하고, 채워진 막대 색을 `empty ? borderStrong : primary` 로 단순화했다.
*   제거 이유를 클래스 문서에 남겨, 나중에 다시 빨강을 넣으려는 사람이 배경을 읽을 수 있게 했다.

### 🎨 UI/UX

*   프로그램 탭 회원 목록에서 이행률이 낮은 회원과 높은 회원의 색이 같아졌다. 처지는 회원은 **막대 길이와 숫자**로 드러난다.
*   목록에 빨간 줄이 늘어서 색이 값보다 먼저 읽히던 상황이 사라졌다.

### 📝 Docs

*   해당 없음

### 🐛 Fixes

*   프로그램 탭 이행률 막대가 `목표 초과` 와 같은 빨강을 쓰던 문제를 고쳤다.

---

## Commits

1. `b964247b` fix(coaching): 프로그램 탭 운동 이행률 막대 남색 고정

---

## Notes

*   **범위**: 프로그램 탭만 손댔다. 리포트 탭 주간 추이(`_WeekTrendBar`)와 고객 카드의 나트륨 지표(`_Metric`)는 각자 다른 위젯이고, 그쪽의 `warn` 은 실제로 '초과' 를 말하고 있어 그대로 뒀다.
*   이슈 본문에서는 `고객 관리` 탭 카드가 같은 `InlineBarValue` 를 쓴다고 적었는데, 실제로는 이 위젯을 쓰는 곳이 프로그램 탭 한 곳뿐이었다. 그래서 인자를 남겨 두는 대신 아예 제거했다 — 남겨 두면 아무도 부르지 않는 죽은 갈래가 된다.
*   테스트 `이행률이 낮은 회원은 막대가 주의 색을 쓴다` 는 새 규칙과 정면으로 어긋나 `이행률이 낮아도 막대는 남색이다 (#913)` 로 다시 썼다. `warn` 플래그를 보던 단언 대신, 실제로 칠해진 `Container` 색을 확인한다.

---

## Screenshots (Optional)

| Before | After |
| ------ | ----- |
| 이행률 40% 회원의 막대·값·라벨이 빨강 | 이행률과 무관하게 남색, 길이와 숫자로만 구분 |

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 트레이너 앱 → 프로그램 탭을 연다.
2. 이행률이 70% 미만인 회원 행의 막대와 값이 남색인지 확인한다.
3. 이행률이 높은 회원과 색이 같고, 막대 길이·숫자로만 구분되는지 확인한다.
4. 기록이 없는 회원 행이 여전히 막대 없이 흐린 `데이터 부족` 인지 확인한다.
5. 고객 관리 탭 카드의 나트륨 초과 표시가 그대로 빨강인지 확인한다.

`flutter analyze lib test` · `flutter test` (798 tests) 모두 통과.

---

## Related Issues

Closes #913

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인
