### PR TITLE
refactor(schedule): 일정 카드 세션 종류·소요 시간 강조 및 우측 배치

### DIFF
--- a/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
@@ -2803,18 +2803,24 @@ class _SessionCard extends ConsumerWidget {
                           // 세션 종류·소요 시간만큼 자리에서 필요하다(#898).
                           ClientGoalLabel(client: client),
                         ],
-                        Text(
-                          l.sessionTypeAndDuration(
-                            sessionTypeLabel(l, s.type),
-                            s.durationMinutes,
-                          ),
-                          style: const TextStyle(
-                            fontSize: 11.5,
-                            fontWeight: FontWeight.w500,
-                            color: AppColors.subtleForeground,
-                          ),
-                        ),
                       ],
+                    ),
+                  ),
+                  // 세션 종류·소요 시간은 **이 약속이 무엇인가**를 말한다.
+                  // 프로필 열 세 번째 줄에 가장 흐린 색으로 두었더니 회원의
+                  // 부가 정보처럼 읽혔다 — 정작 하루를 훑을 때는 "몇 분짜리 무슨
+                  // 수업인가" 로 앞뒤 일정을 가늠한다(#938). 비어 있던 오른쪽
+                  // 여백으로 옮겨 상태 칩 옆에 세운다.
+                  Flexible(
+                    child: Padding(
+                      padding: const EdgeInsets.only(right: AppSpacing.sm),
+                      child: _SessionTypeChip(
+                        label: l.sessionTypeAndDuration(
+                          sessionTypeLabel(l, s.type),
+                          s.durationMinutes,
+                        ),
+                        muted: s.isDone,
+                      ),
                     ),
                   ),
                   _StatusChip(status: s.status),
@@ -2952,6 +2958,58 @@ class _EndedBox extends StatelessWidget {
             ),
           ],
         ],
+      ),
+    );
+  }
+}
+
+/// `1:1 PT · 60분` — 이 약속이 무엇인가. (#938)
+///
+/// 상태 칩과 나란히 서지만 뜻이 갈린다. 상태는 "어떻게 됐나"(예정·완료·취소),
+/// 이쪽은 "무엇인가" 다. 그래서 색도 갈라 둔다 — 상태 칩이 색으로 결과를
+/// 말하는 동안 이쪽은 늘 같은 남색이다. 끝난 세션만 함께 흐려진다.
+///
+/// 좁아지면 **이 알약이 먼저 줄어든다.** 이름과 상태는 잘리면 안 되는 값이라,
+/// 글자를 자르는 대신 `FittedBox` 로 통째로 작게 그린다.
+class _SessionTypeChip extends StatelessWidget {
+  const _SessionTypeChip({required this.label, required this.muted});
+
+  final String label;
+
+  /// 끝난 세션인가. 상태 칩과 같은 기준으로 함께 물러난다.
+  final bool muted;
+
+  @override
+  Widget build(BuildContext context) {
+    return FittedBox(
+      fit: BoxFit.scaleDown,
+      alignment: Alignment.centerRight,
+      child: Container(
+        key: const ValueKey<String>('session-type-chip'),
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.sm,
+          vertical: 2,
+        ),
+        decoration: BoxDecoration(
+          color: muted
+              ? AppColors.inputBackground
+              : AppColors.primary.withValues(alpha: 0.10),
+          borderRadius: const BorderRadius.all(AppRadius.pill),
+          border: Border.all(
+            color: muted
+                ? AppColors.border
+                : AppColors.primary.withValues(alpha: 0.25),
+          ),
+        ),
+        child: Text(
+          label,
+          maxLines: 1,
+          style: TextStyle(
+            fontSize: 11,
+            fontWeight: FontWeight.w800,
+            color: muted ? AppColors.disabledForeground : AppColors.primary,
+          ),
+        ),
       ),
     );
   }

--- a/frontend/flutter_trainer/test/features/schedule/session_type_chip_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/session_type_chip_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare_trainer/app/router/routes.dart';
+import 'package:oncare_trainer/design_system/tokens/colors.dart';
+
+import '../../helpers/pump_app.dart';
+
+/// 일정 카드의 `1:1 PT · 60분` 은 **이 약속이 무엇인가**를 말한다. (#938)
+///
+/// 프로필 열 세 번째 줄에 가장 흐린 색으로 두었더니 회원의 부가 정보처럼
+/// 읽혔다. 비어 있던 오른쪽 여백으로 옮겨 상태 칩 옆에 세운다.
+void main() {
+  Future<void> openSchedule(WidgetTester tester) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(1280, 1000);
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+    await pumpTrainerApp(
+      tester,
+      token: 'demo-trainer-token',
+      at: AppRoutes.schedule,
+    );
+    await tester.pumpAndSettle();
+  }
+
+  Finder chip() => find.byKey(const ValueKey<String>('session-type-chip'));
+
+  testWidgets('세션 종류·소요 시간이 카드 오른쪽 알약으로 보인다', (tester) async {
+    await openSchedule(tester);
+
+    expect(chip(), findsWidgets);
+    final Finder first = chip().first;
+    expect(
+      find.descendant(of: first, matching: find.textContaining('분')),
+      findsOneWidget,
+    );
+
+    // 이름·목표가 있는 왼쪽 열이 아니라, 그 오른쪽에 선다.
+    final Finder name = find.text('김민수').first;
+    expect(
+      tester.getRect(first).left,
+      greaterThan(tester.getRect(name).right),
+      reason: '프로필 열의 세 번째 줄로 읽히면 안 된다',
+    );
+  });
+
+  testWidgets('알약 글자는 목표 줄보다 뚜렷하다', (tester) async {
+    await openSchedule(tester);
+
+    final List<Text> labels = <Text>[
+      for (final Element e in chip().evaluate())
+        tester.widget<Text>(
+          find
+              .descendant(
+                of: find.byWidget(e.widget),
+                matching: find.byType(Text),
+              )
+              .first,
+        ),
+    ];
+    expect(labels, isNotEmpty);
+    // 목표 줄은 11.5px · w500 · subtleForeground 다. 같은 무게로 두면 옮겨도
+    // 여전히 부가 정보로 읽힌다.
+    for (final Text label in labels) {
+      expect(label.style!.fontWeight, FontWeight.w800);
+    }
+    // 끝난 세션만 상태 칩과 함께 물러나고, 나머지는 브랜드 남색이다.
+    expect(labels.map((Text t) => t.style!.color), contains(AppColors.primary));
+    for (final Text label in labels) {
+      expect(
+        label.style!.color,
+        anyOf(AppColors.primary, AppColors.disabledForeground),
+      );
+    }
+  });
+
+  testWidgets('좁아지면 알약이 먼저 줄어들고 카드는 넘치지 않는다', (tester) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(1024, 900);
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+    await pumpTrainerApp(
+      tester,
+      token: 'demo-trainer-token',
+      at: AppRoutes.schedule,
+    );
+    await tester.pumpAndSettle();
+
+    // 이름과 상태는 잘리면 안 되는 값이라, 글자를 자르는 대신 알약을 통째로
+    // 작게 그린다.
+    expect(
+      find.ancestor(of: chip().first, matching: find.byType(FittedBox)),
+      findsWidgets,
+    );
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
## Summary

*   스케줄 일정 카드의 `1:1 PT · 60분` 을 프로필 열에서 빼내어, 비어 있던 **오른쪽 여백**의 상태 칩 옆으로 옮겼다.
*   이름·목표 아래에 같은 왼쪽 정렬로 가장 흐린 색(`subtleForeground` 11.5px w500)으로 놓여 있어 회원 프로필의 세 번째 줄처럼 읽혔다. 정작 하루를 훑을 때는 "몇 분짜리 무슨 수업인가" 로 앞뒤 일정을 가늠한다.
*   남색 알약으로 그려 상태 칩과 뜻을 갈랐다 — 상태는 "어떻게 됐나", 이쪽은 "무엇인가" 다.

---

## Changes

### ✨ Features

*   해당 없음

### 🔧 Improvements

*   `_SessionTypeChip` 을 새로 두고, 프로필 열의 `Text` 를 걷어냈다. 칩에 `session-type-chip` 키를 붙여 자리를 테스트가 지목할 수 있게 했다.

### 🎨 UI/UX

*   `[아바타] 이름 / 목표 … [1:1 PT · 60분] [예정] [∨]` 배치가 되었다.
*   글자를 11.5px w500 `subtleForeground` 에서 **11px w800 `primary`** 로 올렸다. 자리를 옮기기만 하고 무게를 그대로 두면 여전히 부가 정보로 읽힌다.
*   끝난 세션(`isDone`)은 상태 칩과 **같은 기준으로** 함께 물러난다(`inputBackground` + `disabledForeground`). 완료한 수업의 종류가 예정된 수업만큼 눈에 띄면 안 된다.
*   좁아지면 이 알약이 먼저 줄어든다. 이름과 상태는 잘리면 안 되는 값이라, 글자를 자르는 대신 `FittedBox(scaleDown)` 로 통째로 작게 그린다.

### 📝 Docs

*   해당 없음

### 🐛 Fixes

*   해당 없음

---

## Commits

1. `8c9e455e` refactor(schedule): 일정 카드 세션 종류·소요 시간을 오른쪽 알약으로 이동

---

## Notes

*   공백 슬롯처럼 회원 정보가 없는 행도 같은 `Row` 를 쓰므로 배치가 그대로 유지된다 — 프로필 열에서 뺀 것은 세션 종류 줄 하나뿐이다.
*   상태 칩(`_StatusChip`)은 손대지 않았다. 색으로 결과를 말하는 규칙(#871)이 그대로 살아 있어야, 새 알약이 늘 같은 남색인 것과 대비된다.
*   테스트를 새로 더했다(`session_type_chip_test.dart`). 칩이 이름 오른쪽에 있는지, 글자 무게·색이 목표 줄보다 뚜렷한지, 폭 1024px 에서 `FittedBox` 로 줄어들며 넘치지 않는지를 잰다.

---

## Screenshots (Optional)

| Before | After |
| ------ | ----- |
| 이름 / 목표 / `1:1 PT · 60분` 세 줄이 왼쪽에 쌓임 | `1:1 PT · 60분` 이 오른쪽 남색 알약으로, 상태 칩 옆에 |

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 트레이너 앱 → 스케줄 탭을 연다. 각 일정 카드 오른쪽에 `1:1 PT · 60분` 알약이 상태 칩 왼쪽에 보이는지 확인한다.
2. 왼쪽 열에 이름·성별·나이와 목표만 남았는지 확인한다.
3. 완료한 세션의 알약이 예정 세션보다 흐린지 확인한다.
4. 창을 1024px 로 좁히고 글자 배율을 1.3 으로 올려, 카드가 넘치지 않고 알약만 작아지는지 확인한다.
5. 공백 슬롯 행의 배치가 그대로인지 확인한다.

`flutter analyze lib test` · `flutter test` (808 tests) 모두 통과.

---

## Related Issues

Closes #938

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인
