### PR TITLE
fix(diet): 이번 달 칼로리 탄단지 누적 막대가 그려지지 않는 문제

### DIFF
--- a/frontend/flutter/lib/features/diet/presentation/widgets/diet_period_view.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/diet_period_view.dart
@@ -772,6 +772,12 @@ class _Bar extends StatelessWidget {
         // 위에서부터 지방·단백질·탄수화물 — 아래가 탄수화물이라 눈이 바닥부터
         // 읽는 순서가 라벨 순서(탄·단·지)와 같아진다.
         child: Column(
+          // **stretch 여야 한다.** 기본값(center)이면 자식이 가로로 느슨하게
+          // 제약되는데, 자식 없는 `ColoredBox` 의 고유 너비는 0 이라 세 구간이
+          // 통째로 사라진다(#947). 한 색 막대가 멀쩡했던 이유는 그쪽이
+          // `Container` 라서다 — 자식도 크기도 없는 Container 는 들어온 제약만큼
+          // 커지려고 하므로 폭을 다 채운다.
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: <Widget>[
             Expanded(
               flex: (d.fatKcal / total * 1000).round(),

--- a/frontend/flutter/test/features/diet/diet_period_macro_bars_test.dart
+++ b/frontend/flutter/test/features/diet/diet_period_macro_bars_test.dart
@@ -137,6 +137,63 @@ void main() {
         .map((ColoredBox b) => b.color)
         .toList();
 
+    /// 구간의 **그려진 사각형**. 색만 확인하면 폭 0 을 그대로 통과시킨다 —
+    /// 실제로 #947 이 그렇게 새어 나갔다.
+    List<Rect> segmentRectsOf(WidgetTester tester, int index) => <Rect>[
+      // `find.byWidget` 은 쓸 수 없다 — 세 구간이 const 라 서른한 칸의 같은
+      // 색 구간이 전부 같은 위젯으로 잡힌다. Element 의 RenderBox 에서 직접
+      // 잰다.
+      for (final Element e
+          in find
+              .descendant(
+                of: find.byKey(Key('diet-period-bar-$index')),
+                matching: find.byType(ColoredBox),
+              )
+              .evaluate())
+        (e.renderObject! as RenderBox).localToGlobal(Offset.zero) &
+            (e.renderObject! as RenderBox).size,
+    ];
+
+    testWidgets('쌓은 구간이 막대 폭을 채운다 (#947)', (WidgetTester tester) async {
+      await openMonth(tester);
+
+      final Rect bar = tester.getRect(
+        find.byKey(const Key('diet-period-bar-0')),
+      );
+      final List<Rect> segments = segmentRectsOf(tester, 0);
+      expect(segments, hasLength(3));
+
+      for (final Rect seg in segments) {
+        // Column 의 기본 정렬(center)이면 자식 없는 ColoredBox 가 폭 0 으로
+        // 그려져 막대가 통째로 사라진다.
+        expect(seg.width, greaterThan(0));
+        expect(seg.width, closeTo(bar.width, 0.5));
+      }
+
+      // 세 구간을 합치면 막대 높이가 된다 — 한 조각이 빠지면 여기서 드러난다.
+      final double stacked = segments.fold<double>(
+        0,
+        (double a, Rect r) => a + r.height,
+      );
+      expect(stacked, closeTo(bar.height, 0.5));
+      expect(bar.height, greaterThan(0));
+    });
+
+    testWidgets('구간 높이가 칼로리 기여분을 따른다 (#947)', (WidgetTester tester) async {
+      await openMonth(tester);
+
+      // 탄 200g(800kcal) · 단 100g(400kcal) · 지 40g(360kcal) = 1,560kcal.
+      // 위에서부터 지방 · 단백질 · 탄수화물 순으로 쌓인다.
+      final List<Rect> segments = segmentRectsOf(tester, 0);
+      final double total = segments.fold<double>(
+        0,
+        (double a, Rect r) => a + r.height,
+      );
+      expect(segments[0].height / total, closeTo(360 / 1560, 0.02));
+      expect(segments[1].height / total, closeTo(400 / 1560, 0.02));
+      expect(segments[2].height / total, closeTo(800 / 1560, 0.02));
+    });
+
     testWidgets('막대가 탄단지 3색으로 쌓인다', (WidgetTester tester) async {
       await openMonth(tester);
 


### PR DESCRIPTION
## Summary

*   회원 앱 식단 탭 `이번 달` + `칼로리` 에서 **막대가 하나도 그려지지 않던** 문제를 고쳤다.
*   원인은 `Column` 의 기본 `crossAxisAlignment`(`center`)다. 자식이 없는 `ColoredBox` 의 고유 너비는 0 이라, 세 구간이 폭 0 으로 그려져 화면에서 사라졌다.
*   테스트를 **그려진 사각형**으로 재도록 고쳤다. 색만 확인하던 기존 테스트는 폭 0 을 그대로 통과시켰다.

#931 에서 들어온 회귀다.

---

## Changes

### ✨ Features

*   해당 없음

### 🔧 Improvements

*   `_Bar` 누적 경로의 `Column` 에 `crossAxisAlignment: CrossAxisAlignment.stretch` 를 줬다. 왜 stretch 여야 하는지, 한 색 막대가 왜 멀쩡했는지를 주석으로 남겼다.
*   회귀 테스트 두 개를 더했다.
    *   `쌓은 구간이 막대 폭을 채운다` — 구간 폭 > 0 이고 막대 폭과 같은지, 세 구간 높이의 합이 막대 높이와 같은지.
    *   `구간 높이가 칼로리 기여분을 따른다` — 탄 800 · 단 400 · 지 360kcal 비율대로 쌓이는지.

### 🎨 UI/UX

*   `이번 달` + `칼로리` 에서 탄단지 3색 막대가 다시 보인다.

### 📝 Docs

*   해당 없음

### 🐛 Fixes

*   탄단지 누적 막대가 폭 0 으로 사라지던 문제.

---

## Commits

1. `58e795b3` fix(diet): 이번 달 칼로리 탄단지 막대가 폭 0 으로 사라지던 문제

---

## Notes

*   **한 색 막대(나트륨·당류)는 왜 멀쩡했나.** 그쪽은 `Container(height:, decoration:)` 인데, 자식도 크기도 없는 `Container` 는 들어온 제약만큼 **커지려고** 한다. 두 경로가 다른 위젯을 쓰고 있어 차이가 눈에 띄지 않았다.
*   **기존 테스트가 왜 못 잡았나.** `ColoredBox` 의 **색**만 확인했는데, 색은 폭이 0 이어도 그대로 있다. 그림을 그리는 코드는 색·개수가 아니라 **그려진 크기**로 재야 한다는 것이 이번 교훈이다.
*   **수정을 되돌리면 새 테스트가 실패하는 것을 확인했다.** 회귀 테스트가 실제로 이 버그를 잡는지 검증한 결과다.
*   테스트에서 `find.byWidget` 은 쓸 수 없었다 — 세 구간이 `const` 라 서른한 칸의 같은 색 구간이 전부 같은 위젯으로 잡힌다. `Element` 의 `RenderBox` 에서 직접 잰다.

---

## Screenshots (Optional)

| Before | After |
| ------ | ----- |
| `이번 달` + `칼로리` 에서 막대 자리가 비어 있음 | 탄단지 3색 막대가 보임 |

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 회원 앱 식단 탭 → `이번 달` → `칼로리`. 탄단지 3색 막대가 보이는지 확인한다.
2. 막대에 마우스를 올려 날짜·칼로리·탄단지 수치가 뜨는지 확인한다.
3. `나트륨`·`당류` 로 바꿔 한 색 막대가 그대로인지 확인한다.
4. `이번 주` 꺾은선이 영향을 받지 않았는지 확인한다.

`flutter analyze lib test` · `flutter test` (775 tests) 모두 통과.

---

## Related Issues

Closes #947

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인
