### PR TITLE
feat(diet): 기간 그래프에서 아직 오지 않은 날과 기록 없는 날 구분

### DIFF
--- a/frontend/flutter/lib/features/diet/presentation/widgets/diet_period_view.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/diet_period_view.dart
@@ -497,6 +497,17 @@ class _PeriodBars extends StatelessWidget {
     return source[i];
   }
 
+  /// 아직 오지 않은 날인가. (#950)
+  ///
+  /// 기록하지 않은 것이 아니라 **기록할 수 없는** 날이다. 둘을 같은 말로 그리면
+  /// 한 달을 훑으며 "며칠을 빠뜨렸나" 를 셀 때 미래의 빈 칸까지 빠뜨린 날처럼
+  /// 읽힌다 — 달 초에는 그 수가 스무 날이 넘는다.
+  ///
+  /// 운동 쪽은 트레이너 리포트의 `BarSeriesChart` 가 `pendingFromIndex` 로 이미
+  /// 같은 구분을 한다(#754). 같은 규칙을 여기에도 둔다.
+  bool _isPending(int i) =>
+      DateUtils.dateOnly(dates[i]).isAfter(DateUtils.dateOnly(nowKst()));
+
   /// 한 막대의 툴팁 내용 — 운동 탭 `운동 현황` 툴팁과 같은 구조다.
   /// `[색 사각형] 지표  값 단위` 한 줄, 목표를 넘긴 날은 초과분을 한 줄 더.
   List<InlineSpan> _tipSpans(
@@ -513,6 +524,13 @@ class _PeriodBars extends StatelessWidget {
         style: const TextStyle(color: AppColors.mutedForeground),
       ),
     ];
+    // 아직 오지 않은 날과 지나갔는데 비운 날은 다른 말이다(#950). 하루 평균이
+    // 이미 **기록이 있는 날만으로** 나누므로, 계산은 둘을 구분하는데 화면만
+    // 구분하지 않는 셈이었다.
+    if (_isPending(i)) {
+      spans.add(TextSpan(text: l.dietPeriodNotYet));
+      return spans;
+    }
     // 기록이 없는 날은 0 이 아니라 '기록 없음' 이다. 0 으로 적으면 굶은 날과
     // 적지 않은 날이 같은 말이 된다.
     if (value <= 0) {
@@ -647,6 +665,7 @@ class _PeriodBars extends StatelessWidget {
                                 chartHeight *
                                 (values[i] / maxValue).clamp(0.0, 1.0) *
                                 chartStagger(t, i, values.length),
+                            pending: _isPending(i),
                             day: _dayAt(i),
                             // 목표를 넘긴 날은 한 색(경고)으로 칠한다. 쌓은
                             // 막대까지 빨갛게 물들이면 무엇이 얼마인지가
@@ -733,9 +752,15 @@ class _Bar extends StatelessWidget {
     required this.day,
     required this.over,
     required this.color,
+    this.pending = false,
   });
 
   final double height;
+
+  /// 아직 오지 않은 날인가. 지나간 빈 날의 그루터기보다 **더 옅게** 그린다 —
+  /// 트레이너 리포트가 `pendingFromIndex` 에 쓰는 규칙과 같다(#754, #950).
+  final bool pending;
+
   final DietPeriodDay? day;
 
   /// 목표를 넘긴 날인가. 쌓을 성분이 없을 때만 색으로 말한다.
@@ -746,6 +771,17 @@ class _Bar extends StatelessWidget {
   Widget build(BuildContext context) {
     final DietPeriodDay? d = day;
     const BorderRadius radius = BorderRadius.vertical(top: Radius.circular(3));
+    if (pending) {
+      // 아직 오지 않은 날은 **빈 트랙**이다. 지나간 빈 날과 같은 그루터기를
+      // 그리면 둘이 구분되지 않는다.
+      return Container(
+        height: 2,
+        decoration: const BoxDecoration(
+          color: FigmaColors.hairline,
+          borderRadius: radius,
+        ),
+      );
+    }
     if (d == null || !d.hasMacros) {
       return Container(
         height: height,

--- a/frontend/flutter/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations.dart
@@ -668,6 +668,12 @@ abstract class AppLocalizations {
   /// **'No record'**
   String get dietPeriodNoRecord;
 
+  /// No description provided for @dietPeriodNotYet.
+  ///
+  /// In en, this message translates to:
+  /// **'Not yet'**
+  String get dietPeriodNotYet;
+
   /// No description provided for @dietPeriodOverGoal.
   ///
   /// In en, this message translates to:

--- a/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
@@ -330,6 +330,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get dietPeriodNoRecord => 'No record';
 
   @override
+  String get dietPeriodNotYet => 'Not yet';
+
+  @override
   String dietPeriodOverGoal(String amount, String unit) {
     return '$amount $unit over goal';
   }

--- a/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
@@ -323,6 +323,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get dietPeriodNoRecord => '기록 없음';
 
   @override
+  String get dietPeriodNotYet => '아직 오지 않은 날';
+
+  @override
   String dietPeriodOverGoal(String amount, String unit) {
     return '목표 초과 +$amount $unit';
   }

--- a/frontend/flutter/lib/l10n/app_en.arb
+++ b/frontend/flutter/lib/l10n/app_en.arb
@@ -185,6 +185,7 @@
     }
   },
   "dietPeriodNoRecord": "No record",
+  "dietPeriodNotYet": "Not yet",
   "dietPeriodOverGoal": "{amount} {unit} over goal",
   "@dietPeriodOverGoal": {
     "placeholders": {

--- a/frontend/flutter/lib/l10n/app_ko.arb
+++ b/frontend/flutter/lib/l10n/app_ko.arb
@@ -119,6 +119,7 @@
   "dietPeriodEmpty": "이 기간에 기록된 식단이 없어요.",
   "dietPeriodRange": "{start} ~ {end}",
   "dietPeriodNoRecord": "기록 없음",
+  "dietPeriodNotYet": "아직 오지 않은 날",
   "dietPeriodOverGoal": "목표 초과 +{amount} {unit}",
   "otherDateEmpty": "선택한 날짜에 기록된 {section}이 없어요.",
   "dietMealBreakfast": "아침",

--- a/frontend/flutter/test/features/diet/diet_period_macro_bars_test.dart
+++ b/frontend/flutter/test/features/diet/diet_period_macro_bars_test.dart
@@ -194,6 +194,55 @@ void main() {
       expect(segments[2].height / total, closeTo(800 / 1560, 0.02));
     });
 
+    /// 막대 툴팁의 글자.
+    String tipTextAt(WidgetTester tester, int index) => tester
+        .widget<Tooltip>(find.byKey(Key('diet-period-bar-tip-$index')))
+        .richMessage!
+        .toPlainText();
+
+    testWidgets('아직 오지 않은 날과 기록 없는 날을 다르게 말한다 (#950)', (
+      WidgetTester tester,
+    ) async {
+      await openMonth(tester);
+
+      final AppLocalizations l = AppLocalizations.of(
+        tester.element(find.byType(DietRecordPage)),
+      );
+      final int today = nowKst().day;
+      final int lastDay = dietRangeDates(
+        dietRangeForTab(DietPeriodTab.month, nowKst()),
+      ).length;
+
+      // 달의 마지막 날이 아직 오지 않았다면 그 칸으로 확인한다. 오늘이 말일이면
+      // 미래 칸이 없으므로 이 단언은 건너뛴다.
+      if (lastDay > today) {
+        final String future = tipTextAt(tester, lastDay - 1);
+        expect(future, contains(l.dietPeriodNotYet));
+        // 기록할 수 없었던 날을 '기록 없음' 이라고 말하면, 한 달을 훑으며
+        // 빠뜨린 날을 셀 때 미래까지 빠뜨린 날로 세게 된다.
+        expect(future, isNot(contains(l.dietPeriodNoRecord)));
+      }
+
+      // 오늘은 지나간 날이므로 미래 문구를 쓰지 않는다.
+      expect(tipTextAt(tester, today - 1), isNot(contains(l.dietPeriodNotYet)));
+    });
+
+    testWidgets('아직 오지 않은 날의 막대는 빈 트랙이다 (#950)', (WidgetTester tester) async {
+      await openMonth(tester);
+
+      final int today = nowKst().day;
+      final int lastDay = dietRangeDates(
+        dietRangeForTab(DietPeriodTab.month, nowKst()),
+      ).length;
+      if (lastDay <= today) return; // 말일에는 미래 칸이 없다.
+
+      double heightAt(int index) =>
+          tester.getRect(find.byKey(Key('diet-period-bar-$index'))).height;
+
+      // 지나간 빈 날의 그루터기보다 더 옅고 낮다 — 둘이 눈으로 갈려야 한다.
+      expect(heightAt(lastDay - 1), lessThanOrEqualTo(2.5));
+    });
+
     testWidgets('막대가 탄단지 3색으로 쌓인다', (WidgetTester tester) async {
       await openMonth(tester);
 


### PR DESCRIPTION
## Summary

*   `이번 달` 막대에서 **아직 오지 않은 날**과 **지나갔는데 적지 않은 날**을 갈랐다. 오늘이 19일일 때 26일에 마우스를 올려도 `기록 없음` 이 떴다.
*   운동 쪽이 이미 쓰는 규칙을 그대로 가져왔다 — 트레이너 리포트의 `BarSeriesChart` 가 `pendingFromIndex` 로 아직 오지 않은 요일을 빈 트랙으로 두는 방식이다(#754).

---

## Changes

### ✨ Features

*   `_PeriodBars._isPending` — 그 칸의 날짜가 오늘(KST)보다 뒤인지 본다.
*   툴팁 문구를 가른다: 아직 오지 않은 날은 `아직 오지 않은 날`(`Not yet`), 지나간 빈 날은 지금처럼 `기록 없음`.
*   `_Bar` 에 `pending` 을 더해, 아직 오지 않은 날은 **빈 트랙**(2px 헤어라인)으로 그린다. 지나간 빈 날의 그루터기와 눈으로 갈린다.

### 🎨 UI/UX

*   한 달을 훑으며 '며칠을 빠뜨렸나' 를 셀 때 미래의 빈 칸이 빠뜨린 날로 읽히지 않는다. 달 초에는 그 수가 스무 날이 넘었다.

### 📝 Docs

*   `_isPending` 문서에 왜 둘을 갈라야 하는지와 운동 쪽 선례(#754)를 적었다.

---

## Commits

1. `19951e50` feat(diet): 기간 그래프에서 아직 오지 않은 날과 기록 없는 날 구분

---

## Notes

*   **계산은 손대지 않았습니다.** 하루 평균·기록 일수는 이미 `hasRecord` 인 날만 셉니다(`DietPeriod.avgCalories`). 계산은 처음부터 둘을 구분하고 있었고, 화면만 구분하지 않던 것입니다.
*   **`이번 주` 꺾은선은 그대로입니다.** 이미 `todayIndex` 까지만 선을 잇습니다 — 아직 오지 않은 요일의 0 이 급락으로 보이지 않게 하는 같은 취지의 장치입니다.
*   **지난 달을 보면 모든 날이 '지나간 날'** 입니다. `_isPending` 이 실제 날짜를 비교하므로, 기간이 과거면 미래 칸 자체가 없습니다.
*   테스트는 **오늘이 말일인 경우를 건너뜁니다.** 그날은 미래 칸이 존재하지 않아 단언할 대상이 없습니다 — 없는 것을 억지로 만들면 그날만 깨지는 테스트가 됩니다.
*   #954(탄단지 색상) 위에 쌓았습니다. 같은 테스트 파일을 건드려서입니다.

---

## Screenshots (Optional)

| Before | After |
| ------ | ----- |
| 8월 26일(미래) 툴팁이 `기록 없음` | `아직 오지 않은 날`, 막대도 빈 트랙 |

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 회원 앱 식단 탭 → `이번 달`. 오늘 이후 날짜의 막대가 빈 트랙인지 확인한다.
2. 그 칸에 마우스를 올려 `아직 오지 않은 날` 이 뜨는지 확인한다.
3. 지나갔는데 기록이 없는 날은 그대로 `기록 없음` 인지 확인한다.
4. 하루 평균과 `N일 기록` 이 바뀌지 않았는지 확인한다.
5. `이번 주` 꺾은선이 그대로인지 확인한다.

`flutter analyze lib test` · `flutter test` (777 tests) 통과.

---

## Related Issues

Closes #950

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인