### PR TITLE
fix(messages): 신체 부위 감지의 부분 문자열 오탐 차단

### DIFF
--- a/frontend/flutter_trainer/lib/features/messages/domain/chat_context_insight.dart
+++ b/frontend/flutter_trainer/lib/features/messages/domain/chat_context_insight.dart
@@ -20,6 +20,19 @@ class ChatContextInsight {
   final String? bodyPart;
 }
 
+/// 문장에서 신체 부위 하나를 찾는 규칙.
+///
+/// 부위를 **부분 문자열**로 찾으면 다른 낱말 안에 우연히 든 음절까지 걸린다.
+/// `목` 은 목요일·목표에, `back` 은 come back 에 들어 있다. 그래서 부위마다
+/// "어디까지가 그 낱말인가" 를 규칙으로 갖는다.
+class _BodyPartRule {
+  const _BodyPartRule(this.display, this.pattern);
+
+  /// 배너에 그대로 박히는 이름. 문장이 한국어면 한국어, 영어면 영어를 준다.
+  final String display;
+  final RegExp pattern;
+}
+
 /// Lightweight fallback used by the web demo and while the insight API is
 /// unavailable. Keeping it deterministic makes every highlighted signal
 /// traceable to the exact member message instead of presenting a black-box
@@ -31,10 +44,7 @@ class ChatContextInsightDetector {
     if (message.fromTrainer) return null;
     final text = message.body.toLowerCase();
 
-    final part = _bodyParts.entries
-        .where((entry) => text.contains(entry.key))
-        .map((entry) => entry.value)
-        .firstOrNull;
+    final part = _bodyPartIn(text);
     if (_discomfortTerms.any(text.contains)) {
       return ChatContextInsight(
         id: '${message.id}:discomfort',
@@ -56,19 +66,46 @@ class ChatContextInsightDetector {
     return null;
   }
 
-  static const Map<String, String> _bodyParts = <String, String>{
-    '무릎': '무릎',
-    '허리': '허리',
-    '발목': '발목',
-    '어깨': '어깨',
-    '손목': '손목',
-    '목': '목',
-    'knee': 'Knee',
-    'back': 'Back',
-    'ankle': 'Ankle',
-    'shoulder': 'Shoulder',
-    'wrist': 'Wrist',
-  };
+  /// 문장이 가리키는 신체 부위. 짚을 것이 없으면 null 이고, 그때 배너는
+  /// 부위 없는 문구로 뜬다.
+  static String? _bodyPartIn(String text) {
+    for (final rule in _bodyParts) {
+      if (rule.pattern.hasMatch(text)) return rule.display;
+    }
+    return null;
+  }
+
+  /// 한국어는 앞 음절이 한글이면 **다른 낱말의 꼬리**로 본다 — `발목`·`손목`·
+  /// `골목` 의 `목` 이 목으로 잡히지 않게 하는 것이 이 조건이고, 덕분에 이
+  /// 목록의 순서가 정확성을 좌우하지 않는다(예전에는 `목` 을 맨 뒤에 둔 덕에
+  /// 우연히 맞고 있었다).
+  ///
+  /// 뒤쪽은 조사가 붙어야 하므로(`목이`·`목만`) 한글을 막을 수 없다. 대신 그
+  /// 음절로 시작하는 **다른 낱말**을 명시해 배제한다.
+  static final List<_BodyPartRule> _bodyParts = <_BodyPartRule>[
+    _BodyPartRule('무릎', RegExp(r'(?<![가-힣])무릎')),
+    _BodyPartRule('허리', RegExp(r'(?<![가-힣])허리(?!띠|춤)')),
+    _BodyPartRule('발목', RegExp(r'(?<![가-힣])발목')),
+    _BodyPartRule('어깨', RegExp(r'(?<![가-힣])어깨')),
+    _BodyPartRule('손목', RegExp(r'(?<![가-힣])손목(?!시계)')),
+    // 목요일·목표·목적·목록·목소리·목도리·목걸이·목욕.
+    _BodyPartRule('목', RegExp(r'(?<![가-힣])목(?!요일|표|적|록|소리|도리|걸이|욕)')),
+    _BodyPartRule('Knee', RegExp(r'\bknees?\b')),
+    _BodyPartRule('Ankle', RegExp(r'\bankles?\b')),
+    _BodyPartRule('Shoulder', RegExp(r'\bshoulders?\b')),
+    _BodyPartRule('Wrist', RegExp(r'\bwrists?\b')),
+    _BodyPartRule('Neck', RegExp(r'\bnecks?\b')),
+    // `back` 만 단어 경계로는 못 가른다 — "i'm back", "back at the gym" 이
+    // 전부 온전한 낱말이다. 부위로 읽으려면 그 앞에 소유격·위치어가 오거나
+    // 뒤에 통증어가 붙어야 한다.
+    _BodyPartRule(
+      'Back',
+      RegExp(
+        r'\b(?:my|your|his|her|their|our|the|lower|upper|mid|middle)\s+backs?\b'
+        r'|\bbacks?\s+(?:pain|ache|aches|injury)\b',
+      ),
+    ),
+  ];
 
   static const List<String> _discomfortTerms = <String>[
     '아프',
@@ -78,6 +115,8 @@ class ChatContextInsightDetector {
     '저리',
     '쑤',
     '붓',
+    // 영어 쪽 `stiff` 와 짝이 없어 비어 있던 자리.
+    '뻐근',
     'pain',
     'hurt',
     'sore',

--- a/frontend/flutter_trainer/test/features/messages/chat_context_insight_test.dart
+++ b/frontend/flutter_trainer/test/features/messages/chat_context_insight_test.dart
@@ -40,4 +40,73 @@ void main() {
 
     expect(insight, isNull);
   });
+
+  group('body part matching stops at word boundaries', () {
+    test('a weekday is not the neck', () {
+      final insight = detector.detect(message('목요일에 무리했더니 아직 아프네요'));
+
+      expect(insight?.kind, ChatInsightKind.discomfort);
+      expect(insight?.bodyPart, isNull);
+    });
+
+    test('a goal is not the neck', () {
+      final insight = detector.detect(message('이번 주 목표를 못 했어요'));
+
+      expect(insight?.kind, ChatInsightKind.negativeFeedback);
+      expect(insight?.bodyPart, isNull);
+    });
+
+    test('a scarf is not the neck', () {
+      final insight = detector.detect(message('목도리를 두르니 좀 불편해요'));
+
+      expect(insight?.bodyPart, isNull);
+    });
+
+    test('the neck itself is still matched', () {
+      final insight = detector.detect(message('목이 뻐근해요'));
+
+      expect(insight?.kind, ChatInsightKind.discomfort);
+      expect(insight?.bodyPart, '목');
+    });
+
+    test('the neck is matched with a particle attached', () {
+      expect(detector.detect(message('목도 좀 아프네요'))?.bodyPart, '목');
+    });
+
+    test('ankle and wrist win over the neck regardless of rule order', () {
+      expect(detector.detect(message('발목이 아프네요'))?.bodyPart, '발목');
+      expect(detector.detect(message('손목이 불편해요'))?.bodyPart, '손목');
+    });
+
+    test('a wristwatch is not the wrist', () {
+      expect(detector.detect(message('손목시계가 불편해요'))?.bodyPart, isNull);
+    });
+  });
+
+  group('english body parts need real word context', () {
+    test('coming back to the gym is not the back', () {
+      final insight = detector.detect(
+        message('back at the gym today, legs are sore'),
+      );
+
+      expect(insight?.kind, ChatInsightKind.discomfort);
+      expect(insight?.bodyPart, isNull);
+    });
+
+    test('a possessive marks the back as a body part', () {
+      expect(detector.detect(message('my back is sore'))?.bodyPart, 'Back');
+    });
+
+    test('a pain word after it marks the back as a body part', () {
+      expect(
+        detector.detect(message('lower back pain since monday'))?.bodyPart,
+        'Back',
+      );
+    });
+
+    test('unambiguous parts match on their own, singular or plural', () {
+      expect(detector.detect(message('my neck hurts'))?.bodyPart, 'Neck');
+      expect(detector.detect(message('both knees are sore'))?.bodyPart, 'Knee');
+    });
+  });
 }


### PR DESCRIPTION
Closes #963

## Summary
채팅 신호 감지가 신체 부위를 **부분 문자열**로 찾다 보니 다른 낱말 안에 우연히 든 음절까지 걸렸다. `목` 은 목요일·목표·목도리에, `back` 은 "back at the gym" 에 들어 있다. 통증어가 함께 있으면 그 자리에서 엉뚱한 부위가 붙은 신호가 만들어졌고, 이 신호는 회원 메시지 아래에 근거와 함께 그려지는 데다 트레이너가 그대로 메모로 저장할 수 있다 — 틀린 부위가 고객 기록에 남는다는 뜻이다. 부위마다 "어디까지가 그 낱말인가" 를 규칙으로 갖게 한다.

## Changes
### 한국어 — 앞 음절이 한글이면 다른 낱말의 꼬리
- `(?<![가-힣])` 로 앞을 막는다. `발목`·`손목`·`골목` 의 `목` 이 목으로 잡히지 않는다.
- 덕분에 **규칙 목록의 순서가 정확성을 좌우하지 않는다.** 전에는 `목` 을 맵 맨 뒤에 둔 덕에 우연히 맞고 있었고, 순서를 건드리면 조용히 깨지는 상태였다.
- 뒤쪽은 조사가 붙어야 하므로(`목이`·`목도`) 한글을 막을 수 없다. 대신 그 음절로 시작하는 다른 낱말만 배제한다 — 요일·표·적·록·소리·도리·걸이·욕. 같은 방식으로 `허리띠`·`손목시계` 도 뺀다.

### 영어 — 단어 경계, `back` 만 예외
- `knee`·`ankle`·`shoulder`·`wrist`·`neck` 은 단어 경계로 가른다. 복수형도 받는다.
- `back` 은 경계로 안 갈라진다. "i'm back" 도 온전한 낱말이기 때문이다. 앞에 소유격·위치어(`my`·`lower` 등)가 오거나 뒤에 통증어(`pain`·`ache` 등)가 붙을 때만 부위로 읽는다.

### 통증어
- `뻐근` 을 더한다. 영어 쪽 `stiff` 와 짝이 없어 비어 있던 자리다.

## Commits
- `fix(messages): 신체 부위 감지에 낱말 경계 적용`

## Notes
- 감지 결과의 표시 이름(`무릎` / `Knee`)과 배너 문구는 건드리지 않았다. 문자열 자원은 손대지 않았으므로 트레이너 앱 arb 를 건드리는 다른 작업과 겹치지 않는다.
- 오탐 8건과 정상 감지 6건을 회귀 테스트로 고정했다 — 목요일·목표·목도리·손목시계·"back at the gym", 그리고 `발목`·`손목` 이 규칙 순서와 무관하게 `목` 보다 먼저 잡히는 것까지.
- 통증어 목록에 `아프` 만 있어 **`아파요` 가 감지되지 않는다.** 여기에 `아파` 를 그대로 넣으면 `아파트` 가 걸려 이번과 같은 종류의 오탐이 생기므로, 통증어에도 같은 경계 규칙을 씌우는 별도 작업으로 남긴다. 이번 범위 밖이다.
- 트레이너 앱 테스트 891개 전부 통과. `flutter analyze` 무경고.
