### PR TITLE
feat(auth): 로그아웃 시 refresh 토큰 폐기

### DIFF
--- a/backend/API_CONTRACT.md
+++ b/backend/API_CONTRACT.md
@@ -198,6 +198,24 @@ category: medical|fitness|healthy_food|pharmacy (생략 가능)
 `auth_interceptor.dart`). 발급은 `POST /auth/login`·`POST /auth/refresh`·`POST /auth/social/{provider}`
 이고, 이후 요청은 `Authorization: Bearer <access>` 를 단다.
 
+### 세션 폐기 (#966)
+
+refresh 토큰은 **일회용**이다. `POST /auth/refresh` 는 회전할 때 쓰인 토큰을 그 자리에서
+폐기하므로, 회전 결과를 저장하지 못하면 다음 회전은 401 이다. 이미 쓴 토큰이 다시 오면
+재사용으로 보고 거부하고 `auth.refresh_reuse` 감사 로그를 남긴다.
+
+`POST /auth/logout` 은 `{refresh_token}` 을 받아 그 토큰을 폐기하고 **204** 로 답한다.
+못 알아본 토큰에도 204 다 — 클라이언트가 할 일(로컬 저장소 비우기)은 어느 쪽이든 같고,
+상태 코드로 "이 토큰은 살아 있다"를 알려 줄 이유가 없다. access 토큰은 요구하지 않는다
+(이미 만료된 상태에서도 로그아웃할 수 있어야 한다).
+
+폐기는 토큰 문자열이 아니라 `jti` 만 `revoked_refresh_tokens` 에 적는다. 만료된 항목은
+새 폐기가 생길 때마다 함께 정리되므로 별도 배치가 없다. `jti` 가 없는 예전 토큰
+(#966 이전 발급)은 폐기할 이름이 없어 회전에서 거부된다 — 한 번의 재로그인이 필요하다.
+
+발급된 access 토큰 자체는 남은 수명(기본 하루)까지 유효하다. 상태 없는 JWT 의 성질이며,
+로그아웃이 끊는 것은 **세션을 계속 되살리는 능력**이다.
+
 ### 의존성 네 갈래
 
 엔드포인트가 어떤 의존성을 쓰느냐로 동작이 갈린다 (`app/api/deps.py`).

--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -27,7 +27,7 @@ from app.services.audit import client_ip, record as audit
 from app.core.security import (
     create_access_token,
     create_refresh_token,
-    decode_refresh_token,
+    decode_refresh_claims,
     hash_password,
     verify_password,
 )
@@ -48,7 +48,7 @@ from app.schemas.user import (
     UserMe,
     UserRegister,
 )
-from app.services import reservation_service, trainer_signup_service
+from app.services import reservation_service, token_revocation, trainer_signup_service
 from app.services.health_service import DEMO_SETTINGS
 
 router = APIRouter(tags=["users"])
@@ -358,17 +358,82 @@ def login(
     response_model=Token,
     dependencies=[Depends(rate_limit("auth-refresh"))],
 )
-def refresh(payload: RefreshRequest, db: Annotated[Session, Depends(get_db)]) -> Token:
-    """refresh 토큰으로 새 access(+refresh) 토큰 발급(회전)."""
+def refresh(
+    payload: RefreshRequest,
+    request: Request,
+    db: Annotated[Session, Depends(get_db)],
+) -> Token:
+    """refresh 토큰으로 새 access(+refresh) 토큰 발급(회전).
+
+    회전에 쓰인 토큰은 **그 자리에서 폐기된다** — refresh 토큰은 일회용이다.
+    이미 쓴 토큰이 다시 오면 정상 사용자와 탈취자 둘 중 하나가 같은 토큰을 들고
+    있다는 뜻이라, 회전해 주지 않고 거부하고 감사 로그에 남긴다(#966).
+    """
     invalid = HTTPException(status_code=401, detail="유효하지 않은 refresh 토큰입니다.")
     try:
-        user_id = decode_refresh_token(payload.refresh_token)
+        claims = decode_refresh_claims(payload.refresh_token)
     except jwt.InvalidTokenError:
         raise invalid
-    user = db.scalar(select(User).where(User.id == user_id))
+    user = db.scalar(select(User).where(User.id == claims.subject))
     if user is None or not user.is_active:
+        raise invalid
+    first_use = token_revocation.revoke(
+        db, jti=claims.jti, user_id=user.id, expires_at=claims.expires_at
+    )
+    if not first_use:
+        # 로그아웃된 토큰이거나 이미 회전에 쓰인 토큰이다. 어느 쪽이든 여기서 끝난다.
+        audit(
+            db,
+            event="auth.refresh_reuse",
+            user_id=user.id,
+            ip=client_ip(request),
+            success=False,
+        )
         raise invalid
     return Token(
         access_token=create_access_token(user.id),
         refresh_token=create_refresh_token(user.id),
     )
+
+
+@router.post(
+    "/auth/logout",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(rate_limit("auth-logout"))],
+)
+def logout(
+    payload: RefreshRequest,
+    request: Request,
+    db: Annotated[Session, Depends(get_db)],
+) -> None:
+    """받은 refresh 토큰을 폐기한다 — 서버 쪽에서 세션을 끊는다.
+
+    access 토큰을 요구하지 않는다. 로그아웃은 접근 토큰이 이미 만료된 상태에서도
+    되어야 하고, 여기서 하는 일은 **제시한 토큰 하나를 죽이는 것**뿐이라 그 토큰을
+    가진 것 자체가 자격이다.
+
+    못 알아본 토큰에도 204 로 답한다. 클라이언트가 할 일(로컬 저장소 비우기)은
+    어느 쪽이든 같고, 상태 코드로 "이 토큰은 살아 있다"를 알려 줄 이유도 없다.
+    """
+    try:
+        claims = decode_refresh_claims(payload.refresh_token)
+    except jwt.InvalidTokenError:
+        audit(
+            db,
+            event="auth.logout",
+            ip=client_ip(request),
+            success=False,
+            detail="유효하지 않은 refresh 토큰",
+        )
+        return None
+    token_revocation.revoke(
+        db, jti=claims.jti, user_id=claims.subject, expires_at=claims.expires_at
+    )
+    audit(
+        db,
+        event="auth.logout",
+        user_id=claims.subject,
+        ip=client_ip(request),
+        success=True,
+    )
+    return None

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,6 +1,8 @@
 """비밀번호 해싱 + JWT 토큰."""
 from __future__ import annotations
 
+import uuid
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
 import jwt
@@ -23,9 +25,13 @@ def verify_password(plain: str, hashed: str) -> bool:
     return _password_hash.verify(plain, hashed)
 
 
-def _encode(subject: str, token_type: str, ttl: timedelta) -> str:
+def _encode(
+    subject: str, token_type: str, ttl: timedelta, *, jti: str | None = None
+) -> str:
     now = datetime.now(timezone.utc)
     payload = {"sub": subject, "type": token_type, "iat": now, "exp": now + ttl}
+    if jti is not None:
+        payload["jti"] = jti
     return jwt.encode(payload, settings.jwt_secret, algorithm=settings.jwt_algorithm)
 
 
@@ -34,7 +40,17 @@ def create_access_token(subject: str) -> str:
 
 
 def create_refresh_token(subject: str) -> str:
-    return _encode(subject, "refresh", timedelta(days=settings.refresh_token_expire_days))
+    """폐기 가능한 refresh 토큰을 만든다.
+
+    `jti` 는 이 토큰 한 장의 이름이다. 로그아웃과 회전이 "이 토큰은 이제 쓸 수
+    없다"고 남길 대상이 있어야 서버가 세션을 끊을 수 있다(#966).
+    """
+    return _encode(
+        subject,
+        "refresh",
+        timedelta(days=settings.refresh_token_expire_days),
+        jti=uuid.uuid4().hex,
+    )
 
 
 def decode_access_token(token: str) -> str:
@@ -48,11 +64,36 @@ def decode_access_token(token: str) -> str:
     return str(sub)
 
 
-def decode_refresh_token(token: str) -> str:
+@dataclass(frozen=True)
+class RefreshClaims:
+    """refresh 토큰에서 폐기 판단에 필요한 값만 뽑은 것."""
+
+    subject: str
+    jti: str
+    expires_at: datetime
+
+
+def decode_refresh_claims(token: str) -> RefreshClaims:
+    """refresh 토큰을 검증하고 `sub`·`jti`·`exp` 를 돌려준다.
+
+    `jti` 가 없는 토큰(#966 이전에 발급된 것)은 거부한다. 폐기 표에 적을 이름이
+    없어 **일회용으로 만들 수 없는** 토큰이라, 받아 주면 로그아웃도 재사용 탐지도
+    그 토큰만 비껴간다. 거부의 대가는 한 번의 재로그인이다.
+    """
     payload = jwt.decode(token, settings.jwt_secret, algorithms=[settings.jwt_algorithm])
     if payload.get("type") != "refresh":
         raise jwt.InvalidTokenError("refresh 토큰이 아닙니다.")
     sub = payload.get("sub")
     if sub is None:
         raise jwt.InvalidTokenError("sub 없음")
-    return str(sub)
+    jti = payload.get("jti")
+    if not jti:
+        raise jwt.InvalidTokenError("jti 없음 — 폐기할 수 없는 토큰")
+    exp = payload.get("exp")
+    if exp is None:
+        raise jwt.InvalidTokenError("exp 없음")
+    return RefreshClaims(
+        subject=str(sub),
+        jti=str(jti),
+        expires_at=datetime.fromtimestamp(float(exp), tz=timezone.utc),
+    )

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -1349,6 +1349,33 @@ class AuditLog(Base):
     )
 
 
+class RevokedRefreshToken(Base):
+    """폐기된 refresh 토큰 — 로그아웃과 회전이 여기에 이름을 적는다.
+
+    JWT 는 서버가 상태를 두지 않는 대신 **한 번 발급하면 만료까지 유효**하다.
+    그래서 로그아웃이 로컬 저장소만 지우면, 그 사이 새어 나간 토큰은 남은 수명
+    (기본 30일) 동안 계속 통한다. 이 표에 적힌 `jti` 는 `/auth/refresh` 에서
+    거부되어 세션이 그 자리에서 끊긴다(#966).
+
+    담는 것은 **아직 만료되지 않은 토큰뿐**이다. `expires_at` 이 지난 항목은
+    이미 JWT 검증에서 걸리므로 폐기 여부를 물을 이유가 없고, 새 폐기가 생길 때마다
+    정리한다(`token_revocation.purge_expired`).
+    """
+
+    __tablename__ = "revoked_refresh_tokens"
+
+    #: 토큰의 `jti` 클레임. 토큰 자체가 아니라 이름만 저장한다.
+    jti: Mapped[str] = mapped_column(String(64), primary_key=True)
+    user_id: Mapped[str] = mapped_column(
+        String(64), ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
+    #: 이 토큰이 스스로 만료되는 시각. 정리 기준.
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), index=True)
+    revoked_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+
 class AiConversation(Base):
     """AI 코치(온이)와의 대화 스레드.
 

--- a/backend/app/services/token_revocation.py
+++ b/backend/app/services/token_revocation.py
@@ -1,0 +1,70 @@
+"""refresh 토큰 폐기 — 로그아웃과 회전이 세션을 실제로 끊는 자리.
+
+JWT 는 서명만 맞으면 만료까지 유효하다. 서버가 "이 토큰은 끝났다"고 말할 곳이
+없으면 로그아웃은 **그 기기의 저장소를 지우는 일**에 그치고, 이미 빠져나간
+토큰에는 아무 영향도 없다. 여기서 폐기된 `jti` 를 들고, `/auth/refresh` 가
+그것을 확인한다(#966).
+
+토큰 문자열이 아니라 `jti` 만 담는다 — 표가 새어도 그것으로 인증할 수는 없다.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import delete, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.models.models import RevokedRefreshToken
+
+
+def is_revoked(db: Session, jti: str) -> bool:
+    return (
+        db.scalar(
+            select(RevokedRefreshToken.jti).where(RevokedRefreshToken.jti == jti)
+        )
+        is not None
+    )
+
+
+def revoke(db: Session, *, jti: str, user_id: str, expires_at: datetime) -> bool:
+    """`jti` 를 폐기한다. 처음 폐기하면 True, 이미 폐기돼 있었으면 False.
+
+    두 번째 폐기가 실패가 아니라 **False** 인 것은 호출부의 판단이 갈리기 때문이다.
+    로그아웃은 이미 끊긴 세션을 다시 끊는 것이라 그냥 성공이지만, 회전에서는 같은
+    사건이 **이미 쓴 refresh 토큰이 다시 왔다**는 뜻이라 거부해야 한다.
+
+    같은 토큰으로 동시에 두 요청이 들어오면 둘 다 빈 표를 보고 넣으려 할 수 있다.
+    이때 지는 쪽을 유일 키(PK)가 잡아 주므로, 조회 결과가 아니라 **삽입 성공 여부**로
+    판정한다.
+    """
+    if is_revoked(db, jti):
+        return False
+    db.add(
+        RevokedRefreshToken(jti=jti, user_id=user_id, expires_at=expires_at)
+    )
+    try:
+        db.flush()
+    except IntegrityError:
+        db.rollback()
+        return False
+    purge_expired(db)
+    db.commit()
+    return True
+
+
+def purge_expired(db: Session, *, now: datetime | None = None) -> int:
+    """만료된 폐기 기록을 지우고 지운 수를 돌려준다.
+
+    만료된 토큰은 JWT 검증에서 이미 거부되므로 폐기 여부를 물을 이유가 없다.
+    남겨 두면 표가 발급량만큼 무한히 자란다. 폐기가 생길 때마다 함께 도는 정리라
+    별도 배치나 스케줄러가 필요 없다.
+
+    커밋하지 않는다 — 폐기와 같은 트랜잭션에서 끝나야 정리만 남고 폐기가 사라지는
+    조합이 생기지 않는다.
+    """
+    cutoff = now or datetime.now(timezone.utc)
+    result = db.execute(
+        delete(RevokedRefreshToken).where(RevokedRefreshToken.expires_at < cutoff)
+    )
+    return int(result.rowcount or 0)

--- a/backend/migrations/versions/0052_refresh_token_revocation.py
+++ b/backend/migrations/versions/0052_refresh_token_revocation.py
@@ -1,0 +1,63 @@
+"""Give logout something to revoke.
+
+로그아웃이 두 앱 모두에서 **로컬 저장소를 지우는 것**뿐이었다. JWT 는 발급 뒤
+만료까지 유효하므로, 공용 PC 에서 브라우저 저장소가 복사되거나 토큰이 새면
+사용자가 로그아웃을 눌러도 그 refresh 토큰으로 최대 30일 동안 세션을 계속
+되살릴 수 있었다. 트레이너 계정은 담당 회원의 식단·운동·건강 정보를 전부 읽는
+계정이라 영향 범위가 좁지 않다(#966).
+
+토큰 전체가 아니라 `jti`(토큰 한 장의 이름)만 담는다 — 표가 새어도 그것으로
+인증할 수는 없다. 만료된 항목은 JWT 검증에서 이미 걸리므로 남겨 둘 이유가 없어
+새 폐기가 생길 때마다 지운다.
+
+Revision ID: 0052_refresh_token_revocation
+Revises: 0051_trainer_program_template
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0052_refresh_token_revocation"
+down_revision: str | Sequence[str] | None = "0051_trainer_program_template"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "revoked_refresh_tokens",
+        sa.Column("jti", sa.String(64), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.String(64),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "revoked_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "ix_revoked_refresh_tokens_user_id", "revoked_refresh_tokens", ["user_id"]
+    )
+    # 정리(purge)는 만료 시각으로 훑는다.
+    op.create_index(
+        "ix_revoked_refresh_tokens_expires_at", "revoked_refresh_tokens", ["expires_at"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_revoked_refresh_tokens_expires_at", table_name="revoked_refresh_tokens"
+    )
+    op.drop_index(
+        "ix_revoked_refresh_tokens_user_id", table_name="revoked_refresh_tokens"
+    )
+    op.drop_table("revoked_refresh_tokens")

--- a/backend/tests/test_auth_logout.py
+++ b/backend/tests/test_auth_logout.py
@@ -1,0 +1,167 @@
+"""로그아웃 · refresh 토큰 폐기 — DB 필요(로컬 skip, CI 실행).
+
+로그아웃이 로컬 저장소만 지우던 때에는, 새어 나간 refresh 토큰이 남은 수명
+(기본 30일) 동안 계속 세션을 되살릴 수 있었다. 여기서 확인하는 것은 **서버가
+그 토큰을 실제로 끊는가**다(#966).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+from app.core.security import decode_refresh_claims
+from app.models.models import RevokedRefreshToken
+from app.services import token_revocation
+
+
+def _sign_up(client) -> tuple[str, str]:
+    """새 계정을 만들고 (user_id, refresh_token) 을 돌려준다."""
+    email = f"logout-{uuid4().hex[:8]}@oncare.com"
+    password = "pw-12345!"
+    created = client.post(
+        "/v1/auth/register",
+        json={"email": email, "password": password, "name": "로그아웃"},
+    )
+    assert created.status_code == 201, created.text
+    login = client.post(
+        "/v1/auth/login", data={"username": email, "password": password}
+    )
+    assert login.status_code == 200, login.text
+    return created.json()["id"], login.json()["refresh_token"]
+
+
+def test_logout_revokes_refresh_token(client):
+    """로그아웃한 토큰으로는 더 이상 회전할 수 없다."""
+    _, refresh_token = _sign_up(client)
+
+    out = client.post("/v1/auth/logout", json={"refresh_token": refresh_token})
+    assert out.status_code == 204, out.text
+
+    denied = client.post("/v1/auth/refresh", json={"refresh_token": refresh_token})
+    assert denied.status_code == 401
+
+
+def test_logout_is_idempotent_and_tolerates_garbage(client):
+    """두 번 눌러도, 못 알아볼 토큰이어도 204 — 클라이언트가 할 일은 같다."""
+    _, refresh_token = _sign_up(client)
+
+    assert (
+        client.post("/v1/auth/logout", json={"refresh_token": refresh_token})
+    ).status_code == 204
+    assert (
+        client.post("/v1/auth/logout", json={"refresh_token": refresh_token})
+    ).status_code == 204
+    assert (
+        client.post("/v1/auth/logout", json={"refresh_token": "not-a-token"})
+    ).status_code == 204
+
+
+def test_refresh_token_is_single_use(client):
+    """회전에 쓴 토큰은 두 번 쓰이지 않는다 — 두 번째는 재사용으로 거부된다."""
+    _, refresh_token = _sign_up(client)
+
+    rotated = client.post("/v1/auth/refresh", json={"refresh_token": refresh_token})
+    assert rotated.status_code == 200, rotated.text
+    next_refresh = rotated.json()["refresh_token"]
+    assert next_refresh and next_refresh != refresh_token
+
+    replayed = client.post("/v1/auth/refresh", json={"refresh_token": refresh_token})
+    assert replayed.status_code == 401
+
+    # 회전으로 받은 새 토큰은 멀쩡하다 — 재사용 거부가 정상 세션까지 끊으면 안 된다.
+    again = client.post("/v1/auth/refresh", json={"refresh_token": next_refresh})
+    assert again.status_code == 200, again.text
+
+
+def test_refresh_reuse_is_audited(client, db_session):
+    """재사용 탐지는 감사 로그에 남는다 — 토큰이 샌 정황을 나중에 볼 수 있어야 한다."""
+    from app.models.models import AuditLog
+
+    user_id, refresh_token = _sign_up(client)
+    client.post("/v1/auth/refresh", json={"refresh_token": refresh_token})
+    client.post("/v1/auth/refresh", json={"refresh_token": refresh_token})
+
+    logged = (
+        db_session.query(AuditLog)
+        .filter(AuditLog.event == "auth.refresh_reuse", AuditLog.user_id == user_id)
+        .all()
+    )
+    assert len(logged) == 1
+    assert logged[0].success is False
+
+
+def test_logout_after_account_deletion_does_not_fail(client):
+    """탈퇴한 계정의 토큰으로 로그아웃해도 204 — 폐기 표는 users 를 참조한다."""
+    email = f"gone-{uuid4().hex[:8]}@oncare.com"
+    password = "pw-12345!"
+    assert (
+        client.post(
+            "/v1/auth/register",
+            json={"email": email, "password": password, "name": "탈퇴"},
+        )
+    ).status_code == 201
+    login = client.post(
+        "/v1/auth/login", data={"username": email, "password": password}
+    )
+    tokens = login.json()
+    deleted = client.delete(
+        "/v1/users/me",
+        headers={"Authorization": f"Bearer {tokens['access_token']}"},
+    )
+    assert deleted.status_code == 200, deleted.text
+
+    out = client.post(
+        "/v1/auth/logout", json={"refresh_token": tokens["refresh_token"]}
+    )
+    assert out.status_code == 204, out.text
+    # 계정이 없으니 회전도 막힌다.
+    assert (
+        client.post(
+            "/v1/auth/refresh", json={"refresh_token": tokens["refresh_token"]}
+        )
+    ).status_code == 401
+
+
+def test_expired_revocations_are_purged(client, db_session):
+    """폐기 표는 무한히 자라지 않는다 — 만료된 항목은 다음 폐기 때 정리된다."""
+    user_id, refresh_token = _sign_up(client)
+    stale_jti = f"stale-{uuid4().hex[:8]}"
+    db_session.add(
+        RevokedRefreshToken(
+            jti=stale_jti,
+            user_id=user_id,
+            expires_at=datetime.now(timezone.utc) - timedelta(days=1),
+        )
+    )
+    db_session.commit()
+
+    out = client.post("/v1/auth/logout", json={"refresh_token": refresh_token})
+    assert out.status_code == 204
+
+    db_session.expire_all()
+    assert db_session.get(RevokedRefreshToken, stale_jti) is None
+    # 방금 폐기한 토큰은 아직 만료 전이라 남아 있어야 한다.
+    live_jti = decode_refresh_claims(refresh_token).jti
+    assert db_session.get(RevokedRefreshToken, live_jti) is not None
+
+
+def test_purge_expired_keeps_live_entries(client, db_session):
+    """정리는 만료된 것만 지운다."""
+    user_id, refresh_token = _sign_up(client)
+    live_jti = f"live-{uuid4().hex[:8]}"
+    db_session.add(
+        RevokedRefreshToken(
+            jti=live_jti,
+            user_id=user_id,
+            expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+        )
+    )
+    db_session.commit()
+
+    removed = token_revocation.purge_expired(db_session)
+    db_session.commit()
+
+    assert removed == 0
+    assert db_session.get(RevokedRefreshToken, live_jti) is not None
+    assert token_revocation.is_revoked(db_session, live_jti) is True
+    assert token_revocation.is_revoked(db_session, decode_refresh_claims(refresh_token).jti) is False

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -1,14 +1,17 @@
 """보안 유틸(비밀번호 해싱 · JWT) 검증 — DB 불필요."""
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+
 import jwt
 import pytest
 
 from app.core.security import (
+    _encode,
     create_access_token,
     create_refresh_token,
     decode_access_token,
-    decode_refresh_token,
+    decode_refresh_claims,
     hash_password,
     verify_password,
 )
@@ -37,16 +40,33 @@ def test_jwt_invalid_token_raises():
 
 def test_refresh_token_roundtrip():
     token = create_refresh_token("user-9")
-    assert decode_refresh_token(token) == "user-9"
+    assert decode_refresh_claims(token).subject == "user-9"
 
 
 def test_access_token_rejected_as_refresh():
     """액세스 토큰을 refresh 로 쓰면 거부."""
     with pytest.raises(jwt.InvalidTokenError):
-        decode_refresh_token(create_access_token("user-9"))
+        decode_refresh_claims(create_access_token("user-9"))
 
 
 def test_refresh_token_rejected_as_access():
     """refresh 토큰을 액세스로 쓰면 거부(토큰 혼용 방지)."""
     with pytest.raises(jwt.InvalidTokenError):
         decode_access_token(create_refresh_token("user-9"))
+
+
+def test_refresh_token_carries_unique_jti():
+    """폐기하려면 토큰마다 이름이 달라야 한다 — 두 장이 같은 jti 면 한쪽을 끊을 때
+    다른 쪽까지 끊긴다(#966)."""
+    first = decode_refresh_claims(create_refresh_token("user-9"))
+    second = decode_refresh_claims(create_refresh_token("user-9"))
+    assert first.jti and second.jti
+    assert first.jti != second.jti
+    assert first.expires_at > datetime.now(timezone.utc)
+
+
+def test_refresh_token_without_jti_rejected():
+    """#966 이전에 발급된 토큰 — 폐기할 이름이 없어 일회용으로 만들 수 없다."""
+    legacy = _encode("user-9", "refresh", timedelta(days=1))
+    with pytest.raises(jwt.InvalidTokenError):
+        decode_refresh_claims(legacy)

--- a/frontend/flutter/docs/API_CATALOG.md
+++ b/frontend/flutter/docs/API_CATALOG.md
@@ -23,7 +23,7 @@
 | --- | --- | --- | --- | --- |
 | POST | `/auth/social` | `{provider, id_token, nonce?}` | `{access_token, refresh_token, user: UserProfile}` | `MockAuthRepository.signIn` |
 | POST | `/auth/refresh` | `{refresh_token}` | `{access_token, refresh_token}` | dio interceptor (Stage 4 후속) |
-| POST | `/auth/logout` | — | `204` | `signOut` |
+| POST | `/auth/logout` | `{refresh_token}` | `204` | `SessionController.signOut` |
 
 `provider` enum: `apple | google | kakao | naver` (소문자, `AuthProvider.name`).
 

--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -57,6 +57,7 @@ class LocalApiInterceptor extends Interceptor {
     'POST /ai-coach/chat': _aiCoachChat,
     'POST /auth/login': _authLogin,
     'POST /auth/register': _authRegister,
+    'POST /auth/logout': _authLogout,
     'POST /auth/social/kakao': _authSocial,
     'POST /auth/social/google': _authSocial,
     'GET /users/me': _usersMe,
@@ -1381,6 +1382,12 @@ class LocalApiInterceptor extends Interceptor {
         'email': email,
       },
     );
+  }
+
+  /// POST /auth/logout — 데모에는 폐기할 서버 세션이 없다. 여기서 받아 주지 않으면
+  /// 목업 모드의 로그아웃이 실 네트워크로 새어 나가 타임아웃까지 멎는다(#966).
+  Future<Response<Object?>> _authLogout(RequestOptions options) async {
+    return Response<Object?>(requestOptions: options, statusCode: 204);
   }
 
   /// POST /auth/social/{provider} — the demo exchanges any non-empty

--- a/frontend/flutter/lib/features/auth/presentation/controllers/session_controller.dart
+++ b/frontend/flutter/lib/features/auth/presentation/controllers/session_controller.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -278,12 +280,45 @@ class SessionController extends StateNotifier<SessionState> {
 
   Future<void> signOut() async {
     _userActionStarted = true;
+    // 저장소를 지우기 **전에** 서버에 알린다 — 지운 뒤에는 폐기할 토큰이 없다.
+    await _revokeSession();
     try {
       await _ref.read(secureTokenStoreProvider).clear();
     } catch (_) {}
     _setToken(null);
     _resetFeatureState();
     state = const SessionState(status: SessionStatus.signedOut);
+  }
+
+  /// 저장된 갱신 토큰을 서버에서 폐기한다(`POST /auth/logout`).
+  ///
+  /// 지금까지 로그아웃은 이 기기의 저장소를 비우는 일이었다. 토큰 자체는 만료까지
+  /// 살아 있어서, 어딘가로 새어 나갔다면 로그아웃을 눌러도 그 세션은 그대로였다(#966).
+  ///
+  /// **어떤 실패도 로그아웃을 막지 않는다.** 사용자가 이미 결정한 일이고, 네트워크가
+  /// 끊겼다고 로그인 화면으로 못 나가는 쪽이 더 나쁘다. 기본 타임아웃(연결 10초)을
+  /// 그대로 기다리면 나가는 데 그만큼 걸리므로 짧게 끊는다 — 서버가 못 받은 폐기는
+  /// 그 토큰의 만료까지 남지만, 이 기기에서는 어차피 지워진다.
+  Future<void> _revokeSession() async {
+    String? refresh;
+    try {
+      refresh = await _ref.read(secureTokenStoreProvider).readRefreshToken();
+    } catch (_) {
+      return;
+    }
+    // 데모 세션에는 토큰이 없다 — 부를 것도 없다.
+    if (refresh == null || refresh.isEmpty) return;
+    try {
+      await _ref
+          .read(dioProvider)
+          .post<void>(
+            '/auth/logout',
+            data: <String, Object?>{'refresh_token': refresh},
+          )
+          .timeout(const Duration(seconds: 3));
+    } catch (_) {
+      // 무시한다 — 위 주석 참고.
+    }
   }
 }
 

--- a/frontend/flutter/test/features/auth/session_logout_test.dart
+++ b/frontend/flutter/test/features/auth/session_logout_test.dart
@@ -1,0 +1,154 @@
+/// 로그아웃이 서버 쪽 세션까지 끊는가 — #966.
+///
+/// 예전에는 로그아웃이 이 기기의 저장소를 비우는 일이었다. 갱신 토큰은 만료
+/// (기본 30일)까지 살아 있어서, 어딘가로 새어 나갔다면 로그아웃을 눌러도 그
+/// 세션은 그대로였다. 이제 지우기 전에 `POST /auth/logout` 으로 그 토큰을
+/// 폐기한다 — 다만 **그 호출이 실패해도 로그아웃은 끝까지 간다.**
+library;
+
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/app/session_feature_reset.dart';
+import 'package:oncare/core/network/dio_client.dart';
+import 'package:oncare/core/storage/secure_token_store.dart';
+import 'package:oncare/features/auth/presentation/controllers/session_controller.dart';
+
+/// 나간 요청을 기록하는 Dio. `failLogout` 이면 로그아웃 호출만 연결 실패로 답한다.
+class _RecordingDio {
+  _RecordingDio({this.failLogout = false});
+
+  final bool failLogout;
+  final List<RequestOptions> requests = <RequestOptions>[];
+
+  Dio build() {
+    final Dio dio = Dio(BaseOptions(baseUrl: 'https://example.test'));
+    dio.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (RequestOptions options, RequestInterceptorHandler handler) {
+          requests.add(options);
+          if (failLogout && options.path == '/auth/logout') {
+            handler.reject(
+              DioException.connectionError(
+                requestOptions: options,
+                reason: '연결 실패',
+              ),
+            );
+            return;
+          }
+          handler.resolve(
+            Response<Map<String, Object?>>(
+              requestOptions: options,
+              statusCode: 200,
+              data: <String, Object?>{'id': 'u1'},
+            ),
+          );
+        },
+      ),
+    );
+    return dio;
+  }
+
+  List<RequestOptions> get logoutCalls =>
+      requests.where((r) => r.path == '/auth/logout').toList();
+}
+
+ProviderContainer _container(Dio dio) {
+  final ProviderContainer container = ProviderContainer(
+    overrides: <Override>[
+      dioProvider.overrideWithValue(dio),
+      sessionFeatureResetOverride(),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+/// 세션 상태가 정해질 때까지(그리고 뒤따르는 저장소 작업까지) 기다린다.
+Future<void> _settle(ProviderContainer container) async {
+  for (var attempt = 0; attempt < 40; attempt++) {
+    if (container.read(sessionControllerProvider).status !=
+        SessionStatus.unknown) {
+      for (var tick = 0; tick < 5; tick++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      return;
+    }
+    await Future<void>.delayed(Duration.zero);
+  }
+  fail('세션 상태가 정해지지 않았다');
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    FlutterSecureStorage.setMockInitialValues(<String, String>{
+      'access_token': 'stored-access',
+      'refresh_token': 'stored-refresh',
+    });
+  });
+
+  test('로그아웃은 저장된 갱신 토큰을 서버에서 폐기한다', () async {
+    final recorder = _RecordingDio();
+    final container = _container(recorder.build());
+    container.read(sessionControllerProvider.notifier);
+    await _settle(container);
+
+    await container.read(sessionControllerProvider.notifier).signOut();
+
+    expect(recorder.logoutCalls, hasLength(1));
+    expect(
+      (recorder.logoutCalls.single.data as Map<String, Object?>)['refresh_token'],
+      'stored-refresh',
+    );
+    // 폐기는 지우기 전에 나가야 한다 — 지운 뒤에는 보낼 토큰이 없다.
+    expect(
+      await container.read(secureTokenStoreProvider).readRefreshToken(),
+      isNull,
+    );
+  });
+
+  test('폐기 호출이 실패해도 로그아웃 상태가 된다', () async {
+    final recorder = _RecordingDio(failLogout: true);
+    final container = _container(recorder.build());
+    container.read(sessionControllerProvider.notifier);
+    await _settle(container);
+
+    await container.read(sessionControllerProvider.notifier).signOut();
+
+    expect(recorder.logoutCalls, hasLength(1));
+    expect(
+      container.read(sessionControllerProvider).status,
+      SessionStatus.signedOut,
+    );
+    expect(
+      await container.read(secureTokenStoreProvider).readAccessToken(),
+      isNull,
+    );
+    expect(
+      await container.read(secureTokenStoreProvider).readRefreshToken(),
+      isNull,
+    );
+  });
+
+  test('저장된 갱신 토큰이 없으면 부르지 않는다', () async {
+    // 데모 세션에는 토큰이 없다 — 끊을 서버 세션도 없다.
+    FlutterSecureStorage.setMockInitialValues(<String, String>{});
+    final recorder = _RecordingDio();
+    final container = _container(recorder.build());
+    final controller = container.read(sessionControllerProvider.notifier);
+    await _settle(container);
+    controller.enterDemo();
+
+    await controller.signOut();
+
+    expect(recorder.logoutCalls, isEmpty);
+    expect(
+      container.read(sessionControllerProvider).status,
+      SessionStatus.signedOut,
+    );
+  });
+}

--- a/frontend/flutter_trainer/lib/features/auth/data/repositories/dio_trainer_auth_repository.dart
+++ b/frontend/flutter_trainer/lib/features/auth/data/repositories/dio_trainer_auth_repository.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -89,6 +91,19 @@ class DioTrainerAuthRepository implements TrainerAuthRepository {
       ),
       on401: AuthFailure.sessionExpired,
     );
+  }
+
+  @override
+  Future<void> logout(String refreshToken) async {
+    if (refreshToken.isEmpty) return;
+    await _dio
+        .post<void>(
+          '/auth/logout',
+          data: <String, Object?>{'refresh_token': refreshToken},
+        )
+        // 기본 타임아웃(연결 10초)을 그대로 기다리면 로그아웃 버튼이 그만큼 멎는다.
+        // 폐기는 성사되면 좋은 일이지 사용자를 붙잡을 일이 아니다.
+        .timeout(const Duration(seconds: 3));
   }
 
   @override

--- a/frontend/flutter_trainer/lib/features/auth/data/repositories/mock_trainer_auth_repository.dart
+++ b/frontend/flutter_trainer/lib/features/auth/data/repositories/mock_trainer_auth_repository.dart
@@ -69,6 +69,11 @@ class MockTrainerAuthRepository implements TrainerAuthRepository {
   }
 
   @override
+  Future<void> logout(String refreshToken) async {
+    // 데모에는 폐기할 서버가 없다. 로그아웃은 로컬 자격을 지우는 것으로 끝난다.
+  }
+
+  @override
   Future<TrainerProfile> fetchProfile(String accessToken) async {
     if (accessToken.isEmpty) {
       throw const AuthException(AuthFailure.sessionExpired);

--- a/frontend/flutter_trainer/lib/features/auth/domain/repositories/trainer_auth_repository.dart
+++ b/frontend/flutter_trainer/lib/features/auth/domain/repositories/trainer_auth_repository.dart
@@ -83,7 +83,24 @@ abstract class TrainerAuthRepository {
 
   /// Rotates an expired session (POST /v1/auth/refresh). Throws
   /// [AuthException] when the refresh token is invalid/expired.
+  ///
+  /// 회전에 쓴 토큰은 서버에서 **그 자리에 폐기된다** — 한 번 쓴 갱신 토큰으로
+  /// 다시 회전하면 재사용으로 보고 거부된다(#966). 회전 결과는 반드시 저장해야
+  /// 하고, 같은 토큰으로 두 번 부르면 안 된다.
   Future<TrainerAuthTokens> refresh(String refreshToken);
+
+  /// 서버 쪽 세션을 끊는다 (POST /v1/auth/logout) — [refreshToken] 을 폐기해
+  /// 더 이상 회전에 쓰이지 못하게 한다.
+  ///
+  /// 공용 PC 에서 브라우저 저장소가 복사되거나 토큰이 새면, 로컬 저장소를 지우는
+  /// 것만으로는 그 세션이 끊기지 않는다 — 갱신 토큰은 만료(기본 30일)까지
+  /// 살아 있다(#966).
+  ///
+  /// 다른 메서드처럼 실패하면 던진다. 다만 **로그아웃은 그 실패로 멈추지 않는다** —
+  /// 사용자가 이미 결정한 일이라, 네트워크가 끊겼다고 로그인 화면으로 못 나가면 안 된다.
+  /// 그 판단은 호출부(`SessionController.signOut`)가 한곳에서 한다. 서버가 못 받은
+  /// 폐기는 그 토큰의 만료까지 남지만, 이 기기의 자격은 어차피 지워진다.
+  Future<void> logout(String refreshToken);
 
   /// Reads the signed-in trainer's profile (GET /v1/trainer/me) using
   /// [accessToken].

--- a/frontend/flutter_trainer/lib/features/auth/presentation/controllers/session_controller.dart
+++ b/frontend/flutter_trainer/lib/features/auth/presentation/controllers/session_controller.dart
@@ -276,11 +276,43 @@ class SessionController extends StateNotifier<SessionState> {
     state = SessionState(status: status, profile: profile);
   }
 
-  /// Signs out — clears persisted tokens and returns to the login screen.
+  /// Signs out — revokes the session server-side, clears persisted tokens,
+  /// and returns to the login screen.
   Future<void> signOut() async {
     _userActionStarted = true;
+    // 지우기 **전에** 서버에 알린다 — 지운 뒤에는 폐기할 토큰이 없다.
+    await _revokeSession();
     // 사용자가 직접 요청한 만료다 — 자기 자신의 가드에 막히면 안 된다.
     await _expire(userInitiated: true);
+  }
+
+  /// 저장된 갱신 토큰을 서버에서 폐기한다(`POST /auth/logout`).
+  ///
+  /// 여기까지 로그아웃은 이 브라우저의 저장소를 비우는 일이었다. 갱신 토큰은 만료
+  /// (기본 30일)까지 살아 있어서, 공용 PC 에서 저장소가 복사되거나 토큰이 새면
+  /// 로그아웃을 눌러도 그 세션은 그대로였다 — 트레이너 계정은 담당 회원의 식단·운동·
+  /// 건강 정보를 전부 읽는 계정이라 영향 범위가 좁지 않다(#966).
+  ///
+  /// **어떤 실패도 로그아웃을 막지 않는다.** 폐기는 성사되면 좋은 일이고, 실패했다고
+  /// 사용자를 로그인된 화면에 붙잡아 두는 쪽이 훨씬 나쁘다.
+  Future<void> _revokeSession() async {
+    String? refresh;
+    try {
+      // 읽기도 저장 큐를 탄다 — 회전이 방금 저장한 토큰이 있다면 그것을 끊어야 한다.
+      await _serializeTokenStorage(() async {
+        refresh = await _tokens.readRefreshToken();
+      });
+    } catch (_) {
+      return; // secure storage 를 못 읽으면 끊을 대상도 모른다.
+    }
+    final token = refresh;
+    // 데모 세션에는 저장된 토큰이 없다 — 부를 것도 없다.
+    if (token == null || token.isEmpty) return;
+    try {
+      await _repo.logout(token);
+    } catch (_) {
+      // 위 주석 참고 — 삼킨다.
+    }
   }
 
   // --- helpers ------------------------------------------------------------

--- a/frontend/flutter_trainer/test/features/auth/session_controller_test.dart
+++ b/frontend/flutter_trainer/test/features/auth/session_controller_test.dart
@@ -388,6 +388,69 @@ void main() {
       },
     );
 
+    test('signOut revokes the stored refresh token server-side', () async {
+      // 로컬 저장소만 지우면 그 갱신 토큰은 만료까지 살아 있다 — 새어 나갔다면
+      // 로그아웃을 눌러도 세션이 그대로다(#966).
+      final repo = _FakeAuthRepository();
+      final container = _makeContainer(
+        tokens: <String, String>{
+          'access_token': 'stored-access',
+          'refresh_token': 'stored-refresh',
+        },
+        repoOverride: trainerAuthRepositoryProvider.overrideWithValue(repo),
+      );
+      container.read(sessionControllerProvider.notifier);
+      await _settle();
+
+      await container.read(sessionControllerProvider.notifier).signOut();
+
+      expect(repo.logoutTokens, <String>['stored-refresh']);
+    });
+
+    test('signOut completes even when the revoke call fails', () async {
+      final repo = _FakeAuthRepository()..logoutThrows = true;
+      final container = _makeContainer(
+        tokens: <String, String>{
+          'access_token': 'stored-access',
+          'refresh_token': 'stored-refresh',
+        },
+        repoOverride: trainerAuthRepositoryProvider.overrideWithValue(repo),
+      );
+      container.read(sessionControllerProvider.notifier);
+      await _settle();
+
+      await container.read(sessionControllerProvider.notifier).signOut();
+
+      expect(repo.logoutTokens, <String>['stored-refresh']);
+      expect(
+        container.read(sessionControllerProvider).status,
+        SessionStatus.signedOut,
+      );
+      expect(
+        await container.read(secureTokenStoreProvider).readRefreshToken(),
+        isNull,
+      );
+    });
+
+    test('signOut without a stored refresh token skips the revoke', () async {
+      // 데모 세션에는 저장된 토큰이 없다 — 끊을 서버 세션도 없다.
+      final repo = _FakeAuthRepository();
+      final container = _makeContainer(
+        repoOverride: trainerAuthRepositoryProvider.overrideWithValue(repo),
+      );
+      final controller = container.read(sessionControllerProvider.notifier);
+      await _settle();
+      controller.enterDemo();
+
+      await controller.signOut();
+
+      expect(repo.logoutTokens, isEmpty);
+      expect(
+        container.read(sessionControllerProvider).status,
+        SessionStatus.signedOut,
+      );
+    });
+
     test('signOut clears tokens and returns to signed out', () async {
       final container = _makeContainer();
       final controller = container.read(sessionControllerProvider.notifier);
@@ -431,6 +494,10 @@ class _FakeAuthRepository implements TrainerAuthRepository {
   int refreshCalls = 0;
   int _profileCalls = 0;
 
+  /// `logout()` 이 받은 갱신 토큰들. 로그아웃이 서버 폐기를 부르는지 본다(#966).
+  final List<String> logoutTokens = <String>[];
+  bool logoutThrows = false;
+
   TrainerAuthTokens _tokens(String tag) =>
       TrainerAuthTokens(access: '$tag-access', refresh: '$tag-refresh');
 
@@ -453,6 +520,12 @@ class _FakeAuthRepository implements TrainerAuthRepository {
     required String provider,
     required String token,
   }) async => _tokens('social');
+
+  @override
+  Future<void> logout(String refreshToken) async {
+    logoutTokens.add(refreshToken);
+    if (logoutThrows) throw const AuthException(AuthFailure.network);
+  }
 
   @override
   Future<TrainerAuthTokens> refresh(String refreshToken) async {

--- a/frontend/flutter_trainer/test/features/auth/trainer_sign_up_page_test.dart
+++ b/frontend/flutter_trainer/test/features/auth/trainer_sign_up_page_test.dart
@@ -53,6 +53,9 @@ class _RecordingAuthRepository implements TrainerAuthRepository {
   Future<TrainerAuthTokens> refresh(String refreshToken) async => _tokens;
 
   @override
+  Future<void> logout(String refreshToken) async {}
+
+  @override
   Future<TrainerProfile> fetchProfile(String accessToken) async =>
       const TrainerProfile(
         name: '신규 트레이너',

--- a/frontend/flutter_trainer/test/features/coaching/coaching_page_test.dart
+++ b/frontend/flutter_trainer/test/features/coaching/coaching_page_test.dart
@@ -326,6 +326,9 @@ class _FakeTrainerAuthRepository implements TrainerAuthRepository {
   Future<TrainerAuthTokens> refresh(String refreshToken) async => _tokens;
 
   @override
+  Future<void> logout(String refreshToken) async {}
+
+  @override
   Future<TrainerProfile> fetchProfile(String accessToken) async =>
       seedTrainerProfile;
 }


### PR DESCRIPTION
## Summary

로그아웃이 **서버 쪽 세션을 실제로 끊게** 한다. 지금까지 두 앱의 로그아웃은 로컬 저장소를 지우는 것뿐이라, 공용 PC 에서 브라우저 저장소가 복사되거나 토큰이 새면 사용자가 로그아웃을 눌러도 그 refresh 토큰으로 최대 30일 동안 세션을 계속 되살릴 수 있었다. 트레이너 계정은 담당 회원의 식단·운동·건강 정보를 전부 읽는 계정이라 영향 범위가 좁지 않다.

Closes #966

## Changes

- **토큰**: refresh 토큰에 `jti` 를 넣는다. 폐기하려면 토큰 한 장을 가리킬 이름이 있어야 한다. 폐기 표에는 토큰 문자열이 아니라 이 이름만 적는다 — 표가 새어도 그것으로 인증할 수는 없다.
- **`POST /auth/logout`** (신설): 받은 refresh 토큰을 폐기하고 **204**. access 토큰을 요구하지 않는다 — 접근 토큰이 이미 만료된 상태에서도 로그아웃할 수 있어야 하고, 여기서 하는 일은 제시한 토큰 하나를 죽이는 것뿐이라 그 토큰을 가진 것 자체가 자격이다. 못 알아본 토큰에도 204 다: 클라이언트가 할 일은 어느 쪽이든 같고, 상태 코드로 "이 토큰은 살아 있다"를 알려 줄 이유가 없다.
- **`/auth/refresh` 는 일회용**: 회전에 쓰인 토큰을 그 자리에서 폐기한다. 이미 쓴 토큰이 다시 오면 정상 사용자와 탈취자 중 하나가 같은 토큰을 들고 있다는 뜻이라 거부하고 `auth.refresh_reuse` 감사 로그를 남긴다. 폐기 판정은 조회가 아니라 **삽입 성공 여부**로 한다 — 같은 토큰으로 동시에 두 요청이 오면 유일 키가 한쪽을 잡아 준다.
- **정리**: 만료된 폐기 기록은 새 폐기가 생길 때마다 함께 지운다. 만료된 토큰은 JWT 검증에서 이미 거부되므로 폐기 여부를 물을 이유가 없고, 남겨 두면 표가 발급량만큼 자란다. 별도 배치·스케줄러가 없다.
- **두 앱**: 로그아웃이 저장소를 지우기 **전에** `/auth/logout` 을 부른다. **어떤 실패도 로그아웃을 막지 않는다** — 폐기는 성사되면 좋은 일이고, 네트워크가 끊겼다고 사용자를 로그인된 화면에 붙잡아 두는 쪽이 훨씬 나쁘다. 기본 타임아웃(연결 10초)을 그대로 기다리면 나가는 데 그만큼 걸려 3초로 끊는다. 저장된 토큰이 없는 데모 세션에서는 부르지 않는다.
- 마이그레이션 1건(`revoked_refresh_tokens`). 사용자 삭제에 CASCADE 로 따라간다.

## Tests

- 백엔드: 로그아웃 뒤 회전이 401 인지, 두 번 눌러도·못 알아볼 토큰에도 204 인지, 회전에 쓴 토큰이 두 번 쓰이지 않는지(그리고 **회전으로 받은 새 토큰은 멀쩡한지**), 재사용이 감사 로그에 남는지, 탈퇴한 계정의 토큰으로 로그아웃해도 실패하지 않는지, 만료된 폐기 기록이 정리되고 **살아 있는 것은 남는지**. 토큰 단위로는 `jti` 가 매번 달라지는지, `jti` 없는 예전 토큰이 거부되는지.
- 두 앱: 로그아웃이 저장된 갱신 토큰으로 폐기를 부르는지, **폐기가 실패해도 로그아웃 상태가 되고 저장소가 비는지**, 저장된 토큰이 없으면 부르지 않는지.
- `flutter analyze` 무경고(두 앱), `flutter test` 회원 앱·트레이너 앱 전건 통과, 백엔드 `pytest` 전건 통과. 빈 DB 에 `alembic upgrade head` → `downgrade` → `upgrade` 확인, head 1개.

## Notes

- **`jti` 가 없는 예전 refresh 토큰(이 PR 이전 발급)은 회전에서 거부된다.** 폐기할 이름이 없어 일회용으로 만들 수 없는 토큰이라, 받아 주면 로그아웃도 재사용 탐지도 그 토큰만 비껴간다. 대가는 이미 로그인해 둔 사용자의 **한 번의 재로그인**이다.
- 발급된 access 토큰 자체는 남은 수명(기본 하루)까지 유효하다. 상태 없는 JWT 의 성질이며, 로그아웃이 끊는 것은 세션을 계속 되살리는 능력이다. access 까지 즉시 끊으려면 요청마다 폐기 조회가 붙는다 — 이 규모에서 그 비용을 치를 이유는 아직 없다.
- 일회용 회전의 알려진 대가: 트레이너 웹을 **탭 두 개**로 열어 둔 채 access 토큰이 만료된 순간 둘이 동시에 회전하면, 진 쪽이 401 로 로그인 화면에 간다. 재사용 탐지의 정의상 피할 수 없는 쪽이라 그대로 두었다(회전 유예 창을 두려면 교체 토큰까지 표에 들고 있어야 한다).
