### PR TITLE
feat(a11y): 차트와 커스텀 탭 영역의 시맨틱 레이블 보강

### DIFF
--- a/frontend/flutter/lib/app/router/main_shell.dart
+++ b/frontend/flutter/lib/app/router/main_shell.dart
@@ -311,18 +311,24 @@ class _NavAddButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      key: const Key('recordAddButton'),
-      onTap: onTap,
-      behavior: HitTestBehavior.opaque,
-      child: Container(
-        width: 56,
-        height: 56,
-        decoration: const BoxDecoration(
-          color: FigmaColors.primary,
-          shape: BoxShape.circle,
+    // `GestureDetector` 는 버튼으로 인식되지 않고, 안에 있는 것은 `+` 아이콘
+    // 하나뿐이라 무엇을 여는 자리인지 말할 데가 없다(#972).
+    return Semantics(
+      button: true,
+      label: AppLocalizations.of(context).navAddRecordTitle,
+      child: GestureDetector(
+        key: const Key('recordAddButton'),
+        onTap: onTap,
+        behavior: HitTestBehavior.opaque,
+        child: Container(
+          width: 56,
+          height: 56,
+          decoration: const BoxDecoration(
+            color: FigmaColors.primary,
+            shape: BoxShape.circle,
+          ),
+          child: const Icon(Icons.add, color: Colors.white, size: 28),
         ),
-        child: const Icon(Icons.add, color: Colors.white, size: 28),
       ),
     );
   }
@@ -543,10 +549,15 @@ class _SheetCloseButton extends StatelessWidget {
       clipBehavior: Clip.antiAlias,
       child: InkWell(
         onTap: onTap,
-        child: const SizedBox(
-          width: 32,
-          height: 32,
-          child: Icon(Icons.close, size: 16, color: FigmaColors.textSub),
+        // 아이콘만 있는 버튼이라 무엇을 닫는지 말할 데가 없다(#972). 닫기는
+        // 플랫폼이 이미 제 언어로 부르는 이름이 있다.
+        child: Tooltip(
+          message: MaterialLocalizations.of(context).closeButtonTooltip,
+          child: const SizedBox(
+            width: 32,
+            height: 32,
+            child: Icon(Icons.close, size: 16, color: FigmaColors.textSub),
+          ),
         ),
       ),
     );

--- a/frontend/flutter/lib/design_system/figma/figma_kit.dart
+++ b/frontend/flutter/lib/design_system/figma/figma_kit.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:oncare/design_system/tokens/colors.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
 
 /// Exact colour tokens lifted from the On-Care Figma (TypeScript) source so the
 /// Flutter screens reproduce the redesign 1:1.
@@ -235,6 +236,7 @@ class FigmaCircleButton extends StatelessWidget {
     this.size = 36,
     this.iconSize = 18,
     this.enabled = true,
+    this.tooltip,
   });
 
   final IconData icon;
@@ -243,6 +245,10 @@ class FigmaCircleButton extends StatelessWidget {
   final Color dotColor;
   final double size;
   final double iconSize;
+
+  /// 아이콘 하나뿐인 버튼이 무엇을 하는지. 부르는 쪽이 바깥에서 `Semantics`
+  /// 로 이름을 붙였으면 비워 둔다 — 같은 말을 두 번 읽게 된다(#972).
+  final String? tooltip;
 
   /// 지금 쓸 수 있는 버튼인지. false 면 흐리게 그린다.
   ///
@@ -268,13 +274,20 @@ class FigmaCircleButton extends StatelessWidget {
               clipBehavior: Clip.antiAlias,
               child: InkWell(
                 onTap: onTap,
-                child: Center(
-                  child: Icon(
-                    icon,
-                    size: iconSize,
-                    color: usable
-                        ? FigmaColors.primary
-                        : FigmaColors.textFaint,
+                // 아이콘 하나뿐인 버튼이라 무엇을 하는지 말할 데가 툴팁뿐이다.
+                // 부르는 쪽이 밖에서 `Semantics` 로 이름을 붙였으면 여기서는
+                // 아무 말도 하지 않는다 — 같은 말을 두 번 읽게 된다(#972).
+                child: Tooltip(
+                  message: tooltip ?? '',
+                  excludeFromSemantics: tooltip == null,
+                  child: Center(
+                    child: Icon(
+                      icon,
+                      size: iconSize,
+                      color: usable
+                          ? FigmaColors.primary
+                          : FigmaColors.textFaint,
+                    ),
                   ),
                 ),
               ),
@@ -325,6 +338,7 @@ class FigmaTabHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final AppLocalizations l = AppLocalizations.of(context);
     return Padding(
       padding: const EdgeInsets.fromLTRB(24, 12, 24, 12),
       child: Row(
@@ -345,12 +359,14 @@ class FigmaTabHeader extends StatelessWidget {
           ),
           FigmaCircleButton(
             icon: Icons.notifications_none_rounded,
+            tooltip: l.pageNotificationTitle,
             showDot: bellHasUnread,
             onTap: onBell,
           ),
           const SizedBox(width: 10),
           FigmaCircleButton(
             icon: Icons.calendar_today_outlined,
+            tooltip: l.a11yOpenCalendar,
             iconSize: 16,
             onTap: onCalendar,
           ),

--- a/frontend/flutter/lib/features/ai_coach/presentation/pages/ai_coach_page.dart
+++ b/frontend/flutter/lib/features/ai_coach/presentation/pages/ai_coach_page.dart
@@ -148,6 +148,7 @@ class _AICoachPageState extends ConsumerState<AICoachPage> {
         children: <Widget>[
           _circle(
             Icons.chevron_left,
+            MaterialLocalizations.of(context).backButtonTooltip,
             () => context.canPop()
                 ? context.pop()
                 : context.go(AppRoutes.dashboard),
@@ -212,17 +213,21 @@ class _AICoachPageState extends ConsumerState<AICoachPage> {
     );
   }
 
-  Widget _circle(IconData icon, VoidCallback onTap) {
+  Widget _circle(IconData icon, String tooltip, VoidCallback onTap) {
     return Material(
       color: FigmaColors.softBlue,
       shape: const CircleBorder(),
       clipBehavior: Clip.antiAlias,
       child: InkWell(
         onTap: onTap,
-        child: SizedBox(
-          width: 36,
-          height: 36,
-          child: Icon(icon, size: 20, color: FigmaColors.primary),
+        // 아이콘만 있는 버튼이라 무엇을 하는지 말할 데가 툴팁뿐이다(#972).
+        child: Tooltip(
+          message: tooltip,
+          child: SizedBox(
+            width: 36,
+            height: 36,
+            child: Icon(icon, size: 20, color: FigmaColors.primary),
+          ),
         ),
       ),
     );
@@ -449,35 +454,39 @@ class _AICoachPageState extends ConsumerState<AICoachPage> {
               ),
             ),
             const SizedBox(width: 8),
-            GestureDetector(
-              onTap: sending ? null : () => _send(),
-              child: Container(
-                width: 32,
-                height: 32,
-                decoration: const BoxDecoration(
-                  color: FigmaColors.primary,
-                  shape: BoxShape.circle,
-                  boxShadow: kCardShadow,
-                ),
-                child: sending
-                    ? const Padding(
-                        padding: EdgeInsets.all(8),
-                        child: SizedBox(
-                          width: 16,
-                          height: 16,
-                          child: CircularProgressIndicator(
-                            strokeWidth: 2,
-                            valueColor: AlwaysStoppedAnimation<Color>(
-                              Colors.white,
+            Semantics(
+              button: true,
+              label: AppLocalizations.of(context).a11ySendMessage,
+              child: GestureDetector(
+                onTap: sending ? null : () => _send(),
+                child: Container(
+                  width: 32,
+                  height: 32,
+                  decoration: const BoxDecoration(
+                    color: FigmaColors.primary,
+                    shape: BoxShape.circle,
+                    boxShadow: kCardShadow,
+                  ),
+                  child: sending
+                      ? const Padding(
+                          padding: EdgeInsets.all(8),
+                          child: SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              valueColor: AlwaysStoppedAnimation<Color>(
+                                Colors.white,
+                              ),
                             ),
                           ),
+                        )
+                      : const Icon(
+                          Icons.arrow_upward,
+                          size: 16,
+                          color: Colors.white,
                         ),
-                      )
-                    : const Icon(
-                        Icons.arrow_upward,
-                        size: 16,
-                        color: Colors.white,
-                      ),
+                ),
               ),
             ),
           ],

--- a/frontend/flutter/lib/features/auth/presentation/pages/sign_in_page.dart
+++ b/frontend/flutter/lib/features/auth/presentation/pages/sign_in_page.dart
@@ -144,6 +144,11 @@ class _SignInPageState extends ConsumerState<SignInPage> {
                         obscure: _obscure,
                         onSubmitted: (_) => _login(),
                         trailing: IconButton(
+                          // 아이콘만 있는 버튼이라 무엇을 켜고 끄는지 말할
+                          // 데가 툴팁뿐이다(#972).
+                          tooltip: _obscure
+                              ? l.a11yShowPassword
+                              : l.a11yHidePassword,
                           icon: Icon(
                             _obscure ? Icons.visibility_off : Icons.visibility,
                             size: 20,

--- a/frontend/flutter/lib/features/auth/presentation/pages/sign_up_page.dart
+++ b/frontend/flutter/lib/features/auth/presentation/pages/sign_up_page.dart
@@ -107,6 +107,8 @@ class _SignUpPageState extends ConsumerState<SignUpPage> {
               child: Padding(
                 padding: const EdgeInsets.all(AppSpacing.xs),
                 child: IconButton(
+                  // 뒤로 가기는 플랫폼이 이미 제 언어로 부르는 이름이 있다.
+                  tooltip: MaterialLocalizations.of(context).backButtonTooltip,
                   onPressed: _backToSignIn,
                   icon: const Icon(Icons.arrow_back),
                   color: AppColors.mutedForeground,
@@ -158,6 +160,11 @@ class _SignUpPageState extends ConsumerState<SignUpPage> {
                         icon: Icons.lock_outline,
                         obscure: _obscure,
                         trailing: IconButton(
+                          // 아이콘만 있는 버튼이라 무엇을 켜고 끄는지 말할
+                          // 데가 툴팁뿐이다(#972).
+                          tooltip: _obscure
+                              ? l.a11yShowPassword
+                              : l.a11yHidePassword,
                           icon: Icon(
                             _obscure ? Icons.visibility_off : Icons.visibility,
                             size: 20,

--- a/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
@@ -24,6 +24,7 @@ import 'package:oncare/features/member_coach/presentation/widgets/trainer_chat_h
 import 'package:oncare/features/notification/presentation/controllers/notification_controller.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 import 'package:oncare/shared/services/exercise_burn_goal_provider.dart';
+import 'package:oncare/shared/widgets/chart_semantics.dart';
 import 'package:oncare/shared/widgets/coaching_sheet.dart';
 import 'package:oncare/shared/widgets/metric_trend_chart.dart';
 import 'package:oncare/shared/widgets/modals/schedule_calendar_sheet.dart';
@@ -434,6 +435,7 @@ class _DietNutritionCard extends ConsumerWidget {
     final List<String> days = weekDayLabels(l);
     final int todayIdx = _todayIndex();
     final NumberFormat nf = NumberFormat('#,###');
+    final String chartTitle = l.homeWeeklyMetricTrend(_nutLabel(l, tab));
 
     return _HomeCard(
       child: Column(
@@ -509,9 +511,7 @@ class _DietNutritionCard extends ConsumerWidget {
                     children: <Widget>[
                       // 목표는 그래프의 목표선 라벨이 말한다 — 카드 위에 또
                       // 적으면 한 화면에서 같은 말이 두 번 나온다(#756).
-                      _ChartLegend(
-                        title: l.homeWeeklyMetricTrend(_nutLabel(l, tab)),
-                      ),
+                      _ChartLegend(title: chartTitle),
                       const SizedBox(height: 6),
                       MetricTrendChart(
                         values: cfg.cur,
@@ -522,6 +522,21 @@ class _DietNutritionCard extends ConsumerWidget {
                         // 지표를 바꾸면 선을 처음부터 다시 그려 값이 바뀐 것을
                         // 눈으로 따라가게 한다.
                         replayKey: tab,
+                        // 화면 위 제목과 같은 문구로 시작한다 — 음성 안내에서도
+                        // 이 그래프가 어느 지표의 것인지가 먼저 들린다.
+                        semanticsLabel: chartSemanticsLabel(
+                          l,
+                          title: chartTitle,
+                          points: chartSeriesPoints(
+                            l,
+                            values: cfg.cur,
+                            dayLabels: days,
+                            format: (double v) => '${nf.format(v)}${cfg.unit}',
+                            // 선은 오늘까지만 잇는다. 아직 오지 않은 요일을
+                            // 읽으면 화면에 없는 값을 말하게 된다.
+                            upTo: todayIdx,
+                          ),
+                        ),
                         goalLabel: '${l.homeGoal}\n${nf.format(cfg.goal)}',
                         formatTick: nf.format,
                       ),
@@ -721,22 +736,31 @@ class _DetailLink extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations l = AppLocalizations.of(context);
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
-      onTap: onTap,
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          Text(
-            l.homeDetails,
-            style: const TextStyle(
-              fontSize: 14.5,
-              fontWeight: FontWeight.w600,
+    // `GestureDetector` 는 눌러도 버튼으로 인식되지 않는다 — 문구는 읽히지만
+    // 누를 수 있는 자리라는 사실이 빠진다(#972).
+    return Semantics(
+      button: true,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Text(
+              l.homeDetails,
+              style: const TextStyle(
+                fontSize: 14.5,
+                fontWeight: FontWeight.w600,
+                color: FigmaColors.primary,
+              ),
+            ),
+            const Icon(
+              Icons.chevron_right,
+              size: 14,
               color: FigmaColors.primary,
             ),
-          ),
-          const Icon(Icons.chevron_right, size: 14, color: FigmaColors.primary),
-        ],
+          ],
+        ),
       ),
     );
   }
@@ -921,69 +945,89 @@ class _ExerciseTrend extends StatelessWidget {
     final List<double> week = series(wk.dailyCalories, todayIndex);
     final (double lo, double hi) = _barScale(week);
     final List<String> days = weekDayLabels(l);
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        SizedBox(
-          key: const ValueKey<String>('dashboard-exercise-chart'),
-          height: _chartHeight,
-          child: ChartReveal(
-            duration: AppMotion.chartGrow,
-            // 막대마다 시작 시점을 어긋나게 하므로(chartStagger)
-            // 마스터 진행도는 선형으로 받는다.
-            curve: Curves.linear,
-            builder: (BuildContext context, double t) => CustomPaint(
-              size: Size.infinite,
-              painter: _ExerciseBarPainter(
-                data: week,
-                lo: lo,
-                hi: hi,
-                todayIndex: todayIndex,
-                color: FigmaColors.primary,
-                progress: t,
-              ),
-            ),
-          ),
+    // 막대와 요일 라벨은 한 덩어리로 읽는다 — 낱개로는 `월` `화` 뿐이라
+    // 얼마나 태웠는지가 음성 안내에서 사라진다(#972).
+    return Semantics(
+      container: true,
+      label: chartSemanticsLabel(
+        l,
+        title: '${l.homeWeeklyExerciseTrend} (${l.unitKcal})',
+        points: chartSeriesPoints(
+          l,
+          values: week,
+          dayLabels: days,
+          format: (double v) => '${v.round()}${l.unitKcal}',
+          // 아직 오지 않은 요일은 0 으로 채워져 있다. 그 자리를 읽으면
+          // 그리지도 않은 막대를 말하게 된다.
+          upTo: todayIndex,
         ),
-        const SizedBox(height: 6),
-        Row(
+      ),
+      child: ExcludeSemantics(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            for (int i = 0; i < days.length; i++)
-              Expanded(
-                child: Center(
-                  // 식단 영양 카드와 동일하게, 오늘은 #3EAFDF
-                  // 원형 안에 흰색 요일 글씨로 표기한다.
-                  child: i == todayIndex
-                      ? Container(
-                          width: 18,
-                          height: 18,
-                          alignment: Alignment.center,
-                          decoration: const BoxDecoration(
-                            color: FigmaColors.primary,
-                            shape: BoxShape.circle,
-                          ),
-                          child: Text(
-                            days[i],
-                            style: const TextStyle(
-                              fontSize: 11.5,
-                              fontWeight: FontWeight.w700,
-                              color: Colors.white,
-                            ),
-                          ),
-                        )
-                      : Text(
-                          days[i],
-                          style: const TextStyle(
-                            fontSize: 11.5,
-                            fontWeight: FontWeight.w600,
-                            color: AppColors.mutedForeground,
-                          ),
-                        ),
+            SizedBox(
+              key: const ValueKey<String>('dashboard-exercise-chart'),
+              height: _chartHeight,
+              child: ChartReveal(
+                duration: AppMotion.chartGrow,
+                // 막대마다 시작 시점을 어긋나게 하므로(chartStagger)
+                // 마스터 진행도는 선형으로 받는다.
+                curve: Curves.linear,
+                builder: (BuildContext context, double t) => CustomPaint(
+                  size: Size.infinite,
+                  painter: _ExerciseBarPainter(
+                    data: week,
+                    lo: lo,
+                    hi: hi,
+                    todayIndex: todayIndex,
+                    color: FigmaColors.primary,
+                    progress: t,
+                  ),
                 ),
               ),
+            ),
+            const SizedBox(height: 6),
+            Row(
+              children: <Widget>[
+                for (int i = 0; i < days.length; i++)
+                  Expanded(
+                    child: Center(
+                      // 식단 영양 카드와 동일하게, 오늘은 #3EAFDF
+                      // 원형 안에 흰색 요일 글씨로 표기한다.
+                      child: i == todayIndex
+                          ? Container(
+                              width: 18,
+                              height: 18,
+                              alignment: Alignment.center,
+                              decoration: const BoxDecoration(
+                                color: FigmaColors.primary,
+                                shape: BoxShape.circle,
+                              ),
+                              child: Text(
+                                days[i],
+                                style: const TextStyle(
+                                  fontSize: 11.5,
+                                  fontWeight: FontWeight.w700,
+                                  color: Colors.white,
+                                ),
+                              ),
+                            )
+                          : Text(
+                              days[i],
+                              style: const TextStyle(
+                                fontSize: 11.5,
+                                fontWeight: FontWeight.w600,
+                                color: AppColors.mutedForeground,
+                              ),
+                            ),
+                    ),
+                  ),
+              ],
+            ),
           ],
         ),
-      ],
+      ),
     );
   }
 
@@ -1774,15 +1818,18 @@ class _ScheduleCard extends ConsumerWidget {
                 ],
               ),
             ),
-            GestureDetector(
-              behavior: HitTestBehavior.opaque,
-              onTap: () => showScheduleCalendarSheet(context),
-              child: Text(
-                l.homeViewAll,
-                style: const TextStyle(
-                  fontSize: 14.5,
-                  fontWeight: FontWeight.w600,
-                  color: FigmaColors.primary,
+            Semantics(
+              button: true,
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () => showScheduleCalendarSheet(context),
+                child: Text(
+                  l.homeViewAll,
+                  style: const TextStyle(
+                    fontSize: 14.5,
+                    fontWeight: FontWeight.w600,
+                    color: FigmaColors.primary,
+                  ),
                 ),
               ),
             ),
@@ -1822,55 +1869,62 @@ class _ScheduleItemCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
-      onTap: () => showScheduleCalendarSheet(context),
-      child: Container(
-        padding: const EdgeInsets.all(16),
-        decoration: BoxDecoration(
-          color: FigmaColors.softBlue,
-          borderRadius: BorderRadius.circular(16),
-        ),
-        child: Row(
-          children: <Widget>[
-            Text(
-              item.time,
-              style: const TextStyle(
-                fontSize: 17,
-                fontWeight: FontWeight.w800,
-                color: FigmaColors.primary,
-                letterSpacing: -0.3,
+    return Semantics(
+      button: true,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () => showScheduleCalendarSheet(context),
+        child: Container(
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: FigmaColors.softBlue,
+            borderRadius: BorderRadius.circular(16),
+          ),
+          child: Row(
+            children: <Widget>[
+              Text(
+                item.time,
+                style: const TextStyle(
+                  fontSize: 17,
+                  fontWeight: FontWeight.w800,
+                  color: FigmaColors.primary,
+                  letterSpacing: -0.3,
+                ),
               ),
-            ),
-            const SizedBox(width: 16),
-            Container(width: 1, height: 34, color: FigmaColors.primaryA(0.35)),
-            const SizedBox(width: 16),
-            Expanded(
-              child: Row(
-                children: <Widget>[
-                  if (item.emoji.isNotEmpty) ...<Widget>[
-                    Text(item.emoji),
-                    const SizedBox(width: 8),
-                  ],
-                  Expanded(
-                    child: Text(
-                      item.title,
-                      style: const TextStyle(
-                        fontSize: 16,
-                        fontWeight: FontWeight.w700,
-                        color: FigmaColors.ink,
+              const SizedBox(width: 16),
+              Container(
+                width: 1,
+                height: 34,
+                color: FigmaColors.primaryA(0.35),
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Row(
+                  children: <Widget>[
+                    if (item.emoji.isNotEmpty) ...<Widget>[
+                      Text(item.emoji),
+                      const SizedBox(width: 8),
+                    ],
+                    Expanded(
+                      child: Text(
+                        item.title,
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w700,
+                          color: FigmaColors.ink,
+                        ),
                       ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
-            ),
-            const Icon(
-              Icons.chevron_right,
-              size: 18,
-              color: FigmaColors.primary,
-            ),
-          ],
+              const Icon(
+                Icons.chevron_right,
+                size: 18,
+                color: FigmaColors.primary,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -345,32 +345,38 @@ class _PeriodToggle extends StatelessWidget {
         children: <Widget>[
           for (final DietPeriodTab tab in DietPeriodTab.values)
             Flexible(
-              child: GestureDetector(
-                key: Key('diet-period-tab-${tab.name}'),
-                onTap: () => onChanged(tab),
-                behavior: HitTestBehavior.opaque,
-                child: AnimatedContainer(
-                  duration: const Duration(milliseconds: 160),
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 12,
-                    vertical: 5,
-                  ),
-                  decoration: BoxDecoration(
-                    color: active == tab
-                        ? FigmaColors.primary
-                        : Colors.transparent,
-                    borderRadius: BorderRadius.circular(999),
-                  ),
-                  child: Text(
-                    labels[tab]!,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      fontSize: 12.5,
-                      fontWeight: FontWeight.w700,
+              // 켜진 탭을 파란 알약으로만 알리면 어느 기간을 보고 있는지도,
+              // 이게 누를 수 있는 자리인지도 음성 안내에 나오지 않는다(#972).
+              child: Semantics(
+                button: true,
+                selected: active == tab,
+                child: GestureDetector(
+                  key: Key('diet-period-tab-${tab.name}'),
+                  onTap: () => onChanged(tab),
+                  behavior: HitTestBehavior.opaque,
+                  child: AnimatedContainer(
+                    duration: const Duration(milliseconds: 160),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 5,
+                    ),
+                    decoration: BoxDecoration(
                       color: active == tab
-                          ? Colors.white
-                          : AppColors.mutedForeground,
+                          ? FigmaColors.primary
+                          : Colors.transparent,
+                      borderRadius: BorderRadius.circular(999),
+                    ),
+                    child: Text(
+                      labels[tab]!,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontSize: 12.5,
+                        fontWeight: FontWeight.w700,
+                        color: active == tab
+                            ? Colors.white
+                            : AppColors.mutedForeground,
+                      ),
                     ),
                   ),
                 ),
@@ -504,28 +510,31 @@ class _DateStrip extends StatelessWidget {
                   ),
                 ),
                 if (showTodayButton)
-                  GestureDetector(
-                    // 기간 토글이 오늘이 아닌 날에는 사라지므로, 되돌아오는
-                    // 길은 이 버튼 하나다 — 테스트가 그 길을 지목할 수 있어야
-                    // 한다(#912).
-                    key: const ValueKey<String>('diet-today-button'),
-                    onTap: onToday,
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 8,
-                        vertical: 3,
-                      ),
-                      decoration: BoxDecoration(
-                        color: FigmaColors.primaryA(0.10),
-                        borderRadius: BorderRadius.circular(999),
-                        border: Border.all(color: FigmaColors.primaryA(0.25)),
-                      ),
-                      child: Text(
-                        l.dietToday,
-                        style: const TextStyle(
-                          fontSize: 12,
-                          fontWeight: FontWeight.w700,
-                          color: FigmaColors.primary,
+                  Semantics(
+                    button: true,
+                    child: GestureDetector(
+                      // 기간 토글이 오늘이 아닌 날에는 사라지므로, 되돌아오는
+                      // 길은 이 버튼 하나다 — 테스트가 그 길을 지목할 수 있어야
+                      // 한다(#912).
+                      key: const ValueKey<String>('diet-today-button'),
+                      onTap: onToday,
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 8,
+                          vertical: 3,
+                        ),
+                        decoration: BoxDecoration(
+                          color: FigmaColors.primaryA(0.10),
+                          borderRadius: BorderRadius.circular(999),
+                          border: Border.all(color: FigmaColors.primaryA(0.25)),
+                        ),
+                        child: Text(
+                          l.dietToday,
+                          style: const TextStyle(
+                            fontSize: 12,
+                            fontWeight: FontWeight.w700,
+                            color: FigmaColors.primary,
+                          ),
                         ),
                       ),
                     ),
@@ -536,7 +545,11 @@ class _DateStrip extends StatelessWidget {
           const SizedBox(height: 12),
           Row(
             children: <Widget>[
-              _Arrow(icon: Icons.chevron_left, onTap: onPrev),
+              _Arrow(
+                icon: Icons.chevron_left,
+                tooltip: l.a11yPrevWeek,
+                onTap: onPrev,
+              ),
               Expanded(
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -560,7 +573,11 @@ class _DateStrip extends StatelessWidget {
                   ],
                 ),
               ),
-              _Arrow(icon: Icons.chevron_right, onTap: onNext),
+              _Arrow(
+                icon: Icons.chevron_right,
+                tooltip: l.a11yNextWeek,
+                onTap: onNext,
+              ),
             ],
           ),
         ],
@@ -570,8 +587,15 @@ class _DateStrip extends StatelessWidget {
 }
 
 class _Arrow extends StatelessWidget {
-  const _Arrow({required this.icon, required this.onTap});
+  const _Arrow({
+    required this.icon,
+    required this.tooltip,
+    required this.onTap,
+  });
   final IconData icon;
+
+  /// 화살표 하나뿐이라 어느 쪽으로 가는지 말할 데가 툴팁뿐이다(#972).
+  final String tooltip;
   final VoidCallback? onTap;
 
   @override
@@ -584,10 +608,13 @@ class _Arrow extends StatelessWidget {
         clipBehavior: Clip.antiAlias,
         child: InkWell(
           onTap: onTap,
-          child: SizedBox(
-            width: 28,
-            height: 28,
-            child: Icon(icon, size: 16, color: FigmaColors.primary),
+          child: Tooltip(
+            message: tooltip,
+            child: SizedBox(
+              width: 28,
+              height: 28,
+              child: Icon(icon, size: 16, color: FigmaColors.primary),
+            ),
           ),
         ),
       ),
@@ -615,51 +642,55 @@ class _DayCell extends StatelessWidget {
     final Color labelColor = isSelected || isToday
         ? FigmaColors.primary
         : AppColors.mutedForeground;
-    return GestureDetector(
-      onTap: onTap,
-      behavior: HitTestBehavior.opaque,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          // 말줄임이 아니라 축소다. 'Mon' 이 'M…' 이 되면 무슨 요일인지가
-          // 사라진다 — 좁아도 읽을 수 있어야 한다(#743).
-          FittedBox(
-            fit: BoxFit.scaleDown,
-            child: Text(
-              _weekdayLabel(l, day.weekday),
-              maxLines: 1,
-              style: TextStyle(
-                fontSize: 12,
-                fontWeight: FontWeight.w600,
-                color: labelColor,
+    return Semantics(
+      button: true,
+      selected: isSelected,
+      child: GestureDetector(
+        onTap: onTap,
+        behavior: HitTestBehavior.opaque,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            // 말줄임이 아니라 축소다. 'Mon' 이 'M…' 이 되면 무슨 요일인지가
+            // 사라진다 — 좁아도 읽을 수 있어야 한다(#743).
+            FittedBox(
+              fit: BoxFit.scaleDown,
+              child: Text(
+                _weekdayLabel(l, day.weekday),
+                maxLines: 1,
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  color: labelColor,
+                ),
               ),
             ),
-          ),
-          const SizedBox(height: 3),
-          Container(
-            width: 30,
-            height: 30,
-            alignment: Alignment.center,
-            decoration: BoxDecoration(
-              color: isSelected ? FigmaColors.primary : Colors.transparent,
-              borderRadius: BorderRadius.circular(12),
-              // 선택된 날짜 칩도 카드와 같은 회색 그림자를 쓴다(예전 파란 글로우).
-              boxShadow: isSelected ? kCardShadow : null,
-            ),
-            child: Text(
-              '${day.day}',
-              style: TextStyle(
-                fontSize: 13.5,
-                fontWeight: FontWeight.w700,
-                color: isSelected
-                    ? Colors.white
-                    : isToday
-                    ? FigmaColors.primary
-                    : AppColors.mutedForeground,
+            const SizedBox(height: 3),
+            Container(
+              width: 30,
+              height: 30,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: isSelected ? FigmaColors.primary : Colors.transparent,
+                borderRadius: BorderRadius.circular(12),
+                // 선택된 날짜 칩도 카드와 같은 회색 그림자를 쓴다(예전 파란 글로우).
+                boxShadow: isSelected ? kCardShadow : null,
+              ),
+              child: Text(
+                '${day.day}',
+                style: TextStyle(
+                  fontSize: 13.5,
+                  fontWeight: FontWeight.w700,
+                  color: isSelected
+                      ? Colors.white
+                      : isToday
+                      ? FigmaColors.primary
+                      : AppColors.mutedForeground,
+                ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/frontend/flutter/lib/features/diet/presentation/widgets/diet_flows.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/diet_flows.dart
@@ -383,18 +383,21 @@ class _PhotoFailureNoticeState extends State<_PhotoFailureNotice> {
                   ),
                 ),
                 if (_canOpenAppSettings)
-                  GestureDetector(
-                    onTap: _openSettings,
-                    child: Padding(
-                      padding: const EdgeInsets.only(top: 6),
-                      child: Text(
-                        l.dietOpenSettings,
-                        key: const Key('dietOpenSettingsLink'),
-                        style: const TextStyle(
-                          fontSize: 13.5,
-                          fontWeight: FontWeight.w800,
-                          color: FigmaColors.primary,
-                          decoration: TextDecoration.underline,
+                  Semantics(
+                    button: true,
+                    child: GestureDetector(
+                      onTap: _openSettings,
+                      child: Padding(
+                        padding: const EdgeInsets.only(top: 6),
+                        child: Text(
+                          l.dietOpenSettings,
+                          key: const Key('dietOpenSettingsLink'),
+                          style: const TextStyle(
+                            fontSize: 13.5,
+                            fontWeight: FontWeight.w800,
+                            color: FigmaColors.primary,
+                            decoration: TextDecoration.underline,
+                          ),
                         ),
                       ),
                     ),
@@ -1182,30 +1185,36 @@ class _MealEditSheetState extends ConsumerState<_MealEditSheet> {
                     children: <Widget>[
                       for (final MealType t in _types) ...<Widget>[
                         Expanded(
-                          child: GestureDetector(
-                            onTap: () => setState(() => _type = t),
-                            child: Container(
-                              alignment: Alignment.center,
-                              padding: const EdgeInsets.symmetric(vertical: 10),
-                              decoration: BoxDecoration(
-                                color: _type == t
-                                    ? FigmaColors.primaryA(0.10)
-                                    : Colors.white,
-                                borderRadius: BorderRadius.circular(12),
-                                border: Border.all(
-                                  color: _type == t
-                                      ? FigmaColors.primary
-                                      : FigmaColors.hairline,
+                          child: Semantics(
+                            button: true,
+                            selected: _type == t,
+                            child: GestureDetector(
+                              onTap: () => setState(() => _type = t),
+                              child: Container(
+                                alignment: Alignment.center,
+                                padding: const EdgeInsets.symmetric(
+                                  vertical: 10,
                                 ),
-                              ),
-                              child: Text(
-                                mealBadge(l, t),
-                                style: TextStyle(
-                                  fontSize: 13.5,
-                                  fontWeight: FontWeight.w700,
+                                decoration: BoxDecoration(
                                   color: _type == t
-                                      ? FigmaColors.primary
-                                      : AppColors.mutedForeground,
+                                      ? FigmaColors.primaryA(0.10)
+                                      : Colors.white,
+                                  borderRadius: BorderRadius.circular(12),
+                                  border: Border.all(
+                                    color: _type == t
+                                        ? FigmaColors.primary
+                                        : FigmaColors.hairline,
+                                  ),
+                                ),
+                                child: Text(
+                                  mealBadge(l, t),
+                                  style: TextStyle(
+                                    fontSize: 13.5,
+                                    fontWeight: FontWeight.w700,
+                                    color: _type == t
+                                        ? FigmaColors.primary
+                                        : AppColors.mutedForeground,
+                                  ),
                                 ),
                               ),
                             ),
@@ -1257,21 +1266,24 @@ class _MealEditSheetState extends ConsumerState<_MealEditSheet> {
                   Row(
                     children: <Widget>[
                       Expanded(child: _FieldLabel(l.dietEatenFood)),
-                      GestureDetector(
-                        onTap: () => setState(
-                          () => _foods = <DietFood>[
-                            ..._foods,
-                            // Empty draft name; the localized label is shown
-                            // only as a placeholder and is validated out on save.
-                            const DietFood('', 0),
-                          ],
-                        ),
-                        child: Text(
-                          l.dietAddFood,
-                          style: const TextStyle(
-                            fontSize: 13.5,
-                            fontWeight: FontWeight.w700,
-                            color: FigmaColors.primary,
+                      Semantics(
+                        button: true,
+                        child: GestureDetector(
+                          onTap: () => setState(
+                            () => _foods = <DietFood>[
+                              ..._foods,
+                              // Empty draft name; the localized label is shown
+                              // only as a placeholder and is validated out on save.
+                              const DietFood('', 0),
+                            ],
+                          ),
+                          child: Text(
+                            l.dietAddFood,
+                            style: const TextStyle(
+                              fontSize: 13.5,
+                              fontWeight: FontWeight.w700,
+                              color: FigmaColors.primary,
+                            ),
                           ),
                         ),
                       ),
@@ -1473,9 +1485,17 @@ class _FoodRow extends StatelessWidget {
             ),
           ),
           const SizedBox(width: 8),
-          GestureDetector(
-            onTap: onDelete,
-            child: const Icon(Icons.cancel, size: 18, color: Color(0xFFFFB4A8)),
+          Semantics(
+            button: true,
+            label: l.a11yRemoveFood,
+            child: GestureDetector(
+              onTap: onDelete,
+              child: const Icon(
+                Icons.cancel,
+                size: 18,
+                color: Color(0xFFFFB4A8),
+              ),
+            ),
           ),
         ],
       ),
@@ -1565,10 +1585,14 @@ class _CircleClose extends StatelessWidget {
       clipBehavior: Clip.antiAlias,
       child: InkWell(
         onTap: onTap,
-        child: SizedBox(
-          width: 32,
-          height: 32,
-          child: Icon(icon, size: 16, color: FigmaColors.textSub),
+        // 아이콘만 있는 버튼이라 무엇을 닫는지 말할 데가 없다(#972).
+        child: Tooltip(
+          message: MaterialLocalizations.of(context).closeButtonTooltip,
+          child: SizedBox(
+            width: 32,
+            height: 32,
+            child: Icon(icon, size: 16, color: FigmaColors.textSub),
+          ),
         ),
       ),
     );

--- a/frontend/flutter/lib/features/diet/presentation/widgets/diet_period_view.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/diet_period_view.dart
@@ -11,6 +11,7 @@ import 'package:oncare/features/account/domain/entities/user_profile.dart';
 import 'package:oncare/features/diet/domain/entities/diet_period.dart';
 import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
+import 'package:oncare/shared/widgets/chart_semantics.dart';
 import 'package:oncare/shared/widgets/metric_trend_chart.dart';
 
 /// 식단 탭의 기간 뷰(이번 주 / 이번 달).
@@ -404,20 +405,38 @@ class _PeriodBody extends StatelessWidget {
           const Divider(height: 1, thickness: 1, color: FigmaColors.hairline),
           const SizedBox(height: 14),
           if (weekly)
-            MetricTrendChart(
-              values: values,
-              dayLabels: <String>[
-                for (final DateTime d in dates) labels[d.weekday - 1],
-              ],
-              goal: goal,
-              ticks: ticks,
-              // 이번 주는 오늘까지만 잇는다. 오늘이 이 범위 밖이면(지난 주를
-              // 보고 있으면) 마지막 칸까지 전부 그린다.
-              todayIndex: _todayIndexIn(dates),
-              replayKey: replayKey,
-              goalLabel:
-                  '${AppLocalizations.of(context).homeGoal}\n${format(goal)}',
-              formatTick: (double v) => format(v),
+            Builder(
+              builder: (BuildContext context) {
+                final AppLocalizations l = AppLocalizations.of(context);
+                final List<String> days = <String>[
+                  for (final DateTime d in dates) labels[d.weekday - 1],
+                ];
+                final int today = _todayIndexIn(dates);
+                return MetricTrendChart(
+                  values: values,
+                  dayLabels: days,
+                  goal: goal,
+                  ticks: ticks,
+                  // 이번 주는 오늘까지만 잇는다. 오늘이 이 범위 밖이면(지난 주를
+                  // 보고 있으면) 마지막 칸까지 전부 그린다.
+                  todayIndex: today,
+                  replayKey: replayKey,
+                  // 카드 머리의 `평균 · 칼로리` 와 같은 지표 이름으로 시작한다.
+                  semanticsLabel: chartSemanticsLabel(
+                    l,
+                    title: metricLabel,
+                    points: chartSeriesPoints(
+                      l,
+                      values: values,
+                      dayLabels: days,
+                      format: (double v) => '${format(v)} $unit',
+                      upTo: today,
+                    ),
+                  ),
+                  goalLabel: '${l.homeGoal}\n${format(goal)}',
+                  formatTick: (double v) => format(v),
+                );
+              },
             )
           else
             _PeriodBars(
@@ -513,6 +532,20 @@ class _PeriodBars extends StatelessWidget {
   /// 같은 구분을 한다(#754). 같은 규칙을 여기에도 둔다.
   bool _isPending(int i) =>
       DateUtils.dateOnly(dates[i]).isAfter(DateUtils.dateOnly(nowKst()));
+
+  /// 툴팁과 **같은 내용**을 한 줄짜리 시맨틱 라벨로. 색 사각형(`WidgetSpan`)은
+  /// 빼고 줄바꿈은 쉼표로 바꾼다 — 음성 안내는 줄을 나누어 읽지 않는다.
+  String _tipText(
+    AppLocalizations l,
+    DateFormat dayFormat,
+    int i,
+    bool hasGoal,
+  ) => TextSpan(children: _tipSpans(l, dayFormat, i, hasGoal))
+      .toPlainText(includePlaceholders: false)
+      .split('\n')
+      .map((String line) => line.trim())
+      .where((String line) => line.isNotEmpty)
+      .join(', ');
 
   /// 한 막대의 툴팁 내용 — 운동 탭 `운동 현황` 툴팁과 같은 구조다.
   /// `[색 사각형] 지표  값 단위` 한 줄, 목표를 넘긴 날은 초과분을 한 줄 더.
@@ -633,115 +666,137 @@ class _PeriodBars extends StatelessWidget {
     final bool hasGoal = goal > 0;
     // 달(30칸)에서도 라벨이 겹치지 않도록 몇 칸에 하나만 적는다.
     final int labelStep = values.length > 10 ? (values.length / 6).ceil() : 1;
+    // 기록이 하나도 없는 달은 막대마다 `기록 없음` 을 서른 번 읽히는 대신
+    // 비어 있다고 한 번만 말한다(#972).
+    final bool empty = values.every((double v) => v <= 0);
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        SizedBox(
-          height: chartHeight,
-          child: Stack(
-            children: <Widget>[
-              if (hasGoal)
-                Positioned(
-                  left: 0,
-                  right: 0,
-                  bottom: chartHeight * (goal / maxValue).clamp(0.0, 1.0),
-                  child: const Divider(
-                    height: 1,
-                    thickness: 1,
-                    color: FigmaColors.hairline,
-                  ),
-                ),
-              // 막대 전체를 하나의 ChartReveal 로 감싸고 순서만 어긋내
-              // (chartStagger) 준다. 막대마다 애니메이션을 두면 한 달치에
-              // 티커가 31개 생긴다.
-              ChartReveal(
-                curve: Curves.linear,
-                replayKey: replayKey,
-                builder: (BuildContext context, double t) => Row(
-                  crossAxisAlignment: CrossAxisAlignment.end,
-                  children: <Widget>[
-                    for (int i = 0; i < values.length; i++)
-                      Expanded(
-                        child: Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 1.5),
-                          child: _Bar(
-                            key: Key('diet-period-bar-$i'),
-                            height:
-                                chartHeight *
-                                (values[i] / maxValue).clamp(0.0, 1.0) *
-                                chartStagger(t, i, values.length),
-                            pending: _isPending(i),
-                            day: _dayAt(i),
-                            // 목표를 넘긴 날은 한 색(경고)으로 칠한다. 쌓은
-                            // 막대까지 빨갛게 물들이면 무엇이 얼마인지가
-                            // 사라지므로, 탄단지가 있는 날은 쌓은 색을 지키고
-                            // 초과는 목표선과 툴팁이 말한다.
-                            over: hasGoal && values[i] > goal,
-                            color: color,
-                          ),
-                        ),
-                      ),
-                  ],
-                ),
-              ),
-              // 막대 위에 겹치는 투명한 hover 영역. 운동 탭 `운동 현황` 이
-              // 쓰는 것과 **같은 툴팁 규격**이라, 두 탭에서 같은 조작이 같은
-              // 모양으로 답한다.
-              Positioned.fill(
-                child: Row(
-                  children: <Widget>[
-                    for (int i = 0; i < values.length; i++)
-                      Expanded(
-                        child: Tooltip(
-                          key: Key('diet-period-bar-tip-$i'),
-                          richMessage: TextSpan(
-                            style: const TextStyle(
-                              fontSize: 12.5,
-                              fontWeight: FontWeight.w600,
-                              color: FigmaColors.ink,
-                              height: 1.3,
-                            ),
-                            children: _tipSpans(l, dayFormat, i, hasGoal),
-                          ),
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 10,
-                            vertical: 8,
-                          ),
-                          decoration: BoxDecoration(
-                            color: const Color(0xFFF1F3F5),
-                            borderRadius: BorderRadius.circular(10),
-                            border: Border.all(color: FigmaColors.hairline),
-                            boxShadow: kCardShadow,
-                          ),
-                          child: const SizedBox.expand(),
-                        ),
-                      ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-        ),
-        const SizedBox(height: 6),
-        Row(
+    return Semantics(
+      container: true,
+      label: empty
+          ? chartSemanticsLabel(l, title: metricLabel, points: const <String>[])
+          : null,
+      child: ExcludeSemantics(
+        excluding: empty,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            for (int i = 0; i < dates.length; i++)
-              Expanded(
-                child: Text(
-                  i % labelStep == 0 ? '${dates[i].day}' : '',
-                  textAlign: TextAlign.center,
-                  maxLines: 1,
-                  style: const TextStyle(
-                    fontSize: 10,
-                    fontWeight: FontWeight.w600,
-                    color: AppColors.mutedForeground,
+            SizedBox(
+              height: chartHeight,
+              child: Stack(
+                children: <Widget>[
+                  if (hasGoal)
+                    Positioned(
+                      left: 0,
+                      right: 0,
+                      bottom: chartHeight * (goal / maxValue).clamp(0.0, 1.0),
+                      child: const Divider(
+                        height: 1,
+                        thickness: 1,
+                        color: FigmaColors.hairline,
+                      ),
+                    ),
+                  // 막대 전체를 하나의 ChartReveal 로 감싸고 순서만 어긋내
+                  // (chartStagger) 준다. 막대마다 애니메이션을 두면 한 달치에
+                  // 티커가 31개 생긴다.
+                  ChartReveal(
+                    curve: Curves.linear,
+                    replayKey: replayKey,
+                    builder: (BuildContext context, double t) => Row(
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      children: <Widget>[
+                        for (int i = 0; i < values.length; i++)
+                          Expanded(
+                            child: Padding(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 1.5,
+                              ),
+                              child: _Bar(
+                                key: Key('diet-period-bar-$i'),
+                                height:
+                                    chartHeight *
+                                    (values[i] / maxValue).clamp(0.0, 1.0) *
+                                    chartStagger(t, i, values.length),
+                                pending: _isPending(i),
+                                day: _dayAt(i),
+                                // 목표를 넘긴 날은 한 색(경고)으로 칠한다. 쌓은
+                                // 막대까지 빨갛게 물들이면 무엇이 얼마인지가
+                                // 사라지므로, 탄단지가 있는 날은 쌓은 색을 지키고
+                                // 초과는 목표선과 툴팁이 말한다.
+                                over: hasGoal && values[i] > goal,
+                                color: color,
+                              ),
+                            ),
+                          ),
+                      ],
+                    ),
                   ),
-                ),
+                  // 막대 위에 겹치는 투명한 hover 영역. 운동 탭 `운동 현황` 이
+                  // 쓰는 것과 **같은 툴팁 규격**이라, 두 탭에서 같은 조작이 같은
+                  // 모양으로 답한다.
+                  Positioned.fill(
+                    child: Row(
+                      children: <Widget>[
+                        for (int i = 0; i < values.length; i++)
+                          Expanded(
+                            // 툴팁은 올려야 보인다. 같은 내용을 시맨틱 라벨로도
+                            // 준다 — 막대 하나가 며칠 얼마인지는 이 노드 말고는
+                            // 음성 안내에 나올 데가 없다(#972).
+                            child: Semantics(
+                              label: _tipText(l, dayFormat, i, hasGoal),
+                              child: Tooltip(
+                                key: Key('diet-period-bar-tip-$i'),
+                                richMessage: TextSpan(
+                                  style: const TextStyle(
+                                    fontSize: 12.5,
+                                    fontWeight: FontWeight.w600,
+                                    color: FigmaColors.ink,
+                                    height: 1.3,
+                                  ),
+                                  children: _tipSpans(l, dayFormat, i, hasGoal),
+                                ),
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 10,
+                                  vertical: 8,
+                                ),
+                                decoration: BoxDecoration(
+                                  color: const Color(0xFFF1F3F5),
+                                  borderRadius: BorderRadius.circular(10),
+                                  border: Border.all(
+                                    color: FigmaColors.hairline,
+                                  ),
+                                  boxShadow: kCardShadow,
+                                ),
+                                child: const SizedBox.expand(),
+                              ),
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                ],
               ),
+            ),
+            const SizedBox(height: 6),
+            Row(
+              children: <Widget>[
+                for (int i = 0; i < dates.length; i++)
+                  Expanded(
+                    child: Text(
+                      i % labelStep == 0 ? '${dates[i].day}' : '',
+                      textAlign: TextAlign.center,
+                      maxLines: 1,
+                      style: const TextStyle(
+                        fontSize: 10,
+                        fontWeight: FontWeight.w600,
+                        color: AppColors.mutedForeground,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
           ],
         ),
-      ],
+      ),
     );
   }
 }
@@ -906,24 +961,30 @@ class _MetricPill extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      behavior: HitTestBehavior.opaque,
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-        decoration: BoxDecoration(
-          color: active ? color.withValues(alpha: 0.12) : FigmaColors.statBg,
-          borderRadius: BorderRadius.circular(999),
-          border: Border.all(
-            color: active ? color.withValues(alpha: 0.35) : Colors.transparent,
+    return Semantics(
+      button: true,
+      selected: active,
+      child: GestureDetector(
+        onTap: onTap,
+        behavior: HitTestBehavior.opaque,
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          decoration: BoxDecoration(
+            color: active ? color.withValues(alpha: 0.12) : FigmaColors.statBg,
+            borderRadius: BorderRadius.circular(999),
+            border: Border.all(
+              color: active
+                  ? color.withValues(alpha: 0.35)
+                  : Colors.transparent,
+            ),
           ),
-        ),
-        child: Text(
-          label,
-          style: TextStyle(
-            fontSize: 12.5,
-            fontWeight: FontWeight.w700,
-            color: active ? color : AppColors.mutedForeground,
+          child: Text(
+            label,
+            style: TextStyle(
+              fontSize: 12.5,
+              fontWeight: FontWeight.w700,
+              color: active ? color : AppColors.mutedForeground,
+            ),
           ),
         ),
       ),

--- a/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
@@ -24,6 +24,7 @@ import 'package:oncare/features/member_coach/presentation/widgets/trainer_chat_h
 import 'package:oncare/features/notification/presentation/controllers/notification_controller.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 import 'package:oncare/shared/services/exercise_burn_goal_provider.dart';
+import 'package:oncare/shared/widgets/chart_semantics.dart';
 import 'package:oncare/shared/widgets/modals/schedule_calendar_sheet.dart';
 
 /// 헬스장 서브탭에서 고른 예약 카드 — 탭을 벗어났다가 운동 탭에 다시 들어오면
@@ -154,45 +155,49 @@ class _SubTabs extends StatelessWidget {
   Widget _tab(int i, IconData icon, String label) {
     final bool on = active == i;
     return Expanded(
-      child: GestureDetector(
-        key: ValueKey<String>('exercise-subtab-$i'),
-        onTap: () => onChanged(i),
-        behavior: HitTestBehavior.opaque,
-        child: Container(
-          padding: const EdgeInsets.only(bottom: 10),
-          decoration: BoxDecoration(
-            border: Border(
-              bottom: BorderSide(
-                color: on ? FigmaColors.primary : Colors.transparent,
-                width: 2,
-              ),
-            ),
-          ),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: <Widget>[
-              Icon(
-                icon,
-                size: 14,
-                color: on ? FigmaColors.primary : FigmaColors.textMuted,
-              ),
-              const SizedBox(width: 6),
-              // 라벨은 남는 폭 안에서 접힌다. 아이콘·라벨 둘 다 고정 폭이면
-              // 320px 에서 탭 두 개가 화면을 넘겼다 — 영어(`Exercise log`)는
-              // 기본 배율에서도 넘친다(#766). 아이콘은 접지 않는다.
-              Flexible(
-                child: Text(
-                  label,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: TextStyle(
-                    fontSize: 15,
-                    fontWeight: FontWeight.w700,
-                    color: on ? FigmaColors.ink : AppColors.mutedForeground,
-                  ),
+      child: Semantics(
+        button: true,
+        selected: on,
+        child: GestureDetector(
+          key: ValueKey<String>('exercise-subtab-$i'),
+          onTap: () => onChanged(i),
+          behavior: HitTestBehavior.opaque,
+          child: Container(
+            padding: const EdgeInsets.only(bottom: 10),
+            decoration: BoxDecoration(
+              border: Border(
+                bottom: BorderSide(
+                  color: on ? FigmaColors.primary : Colors.transparent,
+                  width: 2,
                 ),
               ),
-            ],
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                Icon(
+                  icon,
+                  size: 14,
+                  color: on ? FigmaColors.primary : FigmaColors.textMuted,
+                ),
+                const SizedBox(width: 6),
+                // 라벨은 남는 폭 안에서 접힌다. 아이콘·라벨 둘 다 고정 폭이면
+                // 320px 에서 탭 두 개가 화면을 넘겼다 — 영어(`Exercise log`)는
+                // 기본 배율에서도 넘친다(#766). 아이콘은 접지 않는다.
+                Flexible(
+                  child: Text(
+                    label,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w700,
+                      color: on ? FigmaColors.ink : AppColors.mutedForeground,
+                    ),
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
       ),
@@ -442,25 +447,28 @@ class _ExerciseWeekStrip extends StatelessWidget {
                   ),
                 ),
                 if (showTodayButton)
-                  GestureDetector(
-                    onTap: onToday,
-                    behavior: HitTestBehavior.opaque,
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 8,
-                        vertical: 3,
-                      ),
-                      decoration: BoxDecoration(
-                        color: FigmaColors.primaryA(0.10),
-                        borderRadius: BorderRadius.circular(999),
-                        border: Border.all(color: FigmaColors.primaryA(0.25)),
-                      ),
-                      child: Text(
-                        l.dietToday,
-                        style: const TextStyle(
-                          fontSize: 12,
-                          fontWeight: FontWeight.w700,
-                          color: FigmaColors.primary,
+                  Semantics(
+                    button: true,
+                    child: GestureDetector(
+                      onTap: onToday,
+                      behavior: HitTestBehavior.opaque,
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 8,
+                          vertical: 3,
+                        ),
+                        decoration: BoxDecoration(
+                          color: FigmaColors.primaryA(0.10),
+                          borderRadius: BorderRadius.circular(999),
+                          border: Border.all(color: FigmaColors.primaryA(0.25)),
+                        ),
+                        child: Text(
+                          l.dietToday,
+                          style: const TextStyle(
+                            fontSize: 12,
+                            fontWeight: FontWeight.w700,
+                            color: FigmaColors.primary,
+                          ),
                         ),
                       ),
                     ),
@@ -471,7 +479,11 @@ class _ExerciseWeekStrip extends StatelessWidget {
           const SizedBox(height: 12),
           Row(
             children: <Widget>[
-              _Arrow(icon: Icons.chevron_left, onTap: onPrev),
+              _Arrow(
+                icon: Icons.chevron_left,
+                tooltip: l.a11yPrevWeek,
+                onTap: onPrev,
+              ),
               Expanded(
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -491,7 +503,11 @@ class _ExerciseWeekStrip extends StatelessWidget {
                   ],
                 ),
               ),
-              _Arrow(icon: Icons.chevron_right, onTap: onNext),
+              _Arrow(
+                icon: Icons.chevron_right,
+                tooltip: l.a11yNextWeek,
+                onTap: onNext,
+              ),
             ],
           ),
         ],
@@ -502,8 +518,15 @@ class _ExerciseWeekStrip extends StatelessWidget {
 
 /// Circular week-navigation arrow, dimmed when disabled (onTap == null).
 class _Arrow extends StatelessWidget {
-  const _Arrow({required this.icon, required this.onTap});
+  const _Arrow({
+    required this.icon,
+    required this.tooltip,
+    required this.onTap,
+  });
   final IconData icon;
+
+  /// 화살표 하나뿐이라 어느 쪽으로 가는지 말할 데가 툴팁뿐이다(#972).
+  final String tooltip;
   final VoidCallback? onTap;
 
   @override
@@ -516,10 +539,13 @@ class _Arrow extends StatelessWidget {
         clipBehavior: Clip.antiAlias,
         child: InkWell(
           onTap: onTap,
-          child: SizedBox(
-            width: 28,
-            height: 28,
-            child: Icon(icon, size: 16, color: FigmaColors.primary),
+          child: Tooltip(
+            message: tooltip,
+            child: SizedBox(
+              width: 28,
+              height: 28,
+              child: Icon(icon, size: 16, color: FigmaColors.primary),
+            ),
           ),
         ),
       ),
@@ -745,50 +771,54 @@ class _WeekDay extends StatelessWidget {
     final Color labelColor = isSelected || isToday
         ? FigmaColors.primary
         : AppColors.mutedForeground;
-    return GestureDetector(
-      onTap: onTap,
-      behavior: HitTestBehavior.opaque,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          // 말줄임이 아니라 축소다. 'Mon' 이 'M…' 이 되면 무슨 요일인지가
-          // 사라진다 — 좁아도 읽을 수 있어야 한다(#766).
-          FittedBox(
-            fit: BoxFit.scaleDown,
-            child: Text(
-              label,
-              maxLines: 1,
-              style: TextStyle(
-                fontSize: 12,
-                fontWeight: FontWeight.w600,
-                color: labelColor,
+    return Semantics(
+      button: true,
+      selected: isSelected,
+      child: GestureDetector(
+        onTap: onTap,
+        behavior: HitTestBehavior.opaque,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            // 말줄임이 아니라 축소다. 'Mon' 이 'M…' 이 되면 무슨 요일인지가
+            // 사라진다 — 좁아도 읽을 수 있어야 한다(#766).
+            FittedBox(
+              fit: BoxFit.scaleDown,
+              child: Text(
+                label,
+                maxLines: 1,
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  color: labelColor,
+                ),
               ),
             ),
-          ),
-          const SizedBox(height: 3),
-          Container(
-            width: 30,
-            height: 30,
-            alignment: Alignment.center,
-            decoration: BoxDecoration(
-              color: isSelected ? FigmaColors.primary : Colors.transparent,
-              borderRadius: BorderRadius.circular(12),
-              boxShadow: isSelected ? kCardShadow : null,
-            ),
-            child: Text(
-              '${day.day}',
-              style: TextStyle(
-                fontSize: 13.5,
-                fontWeight: FontWeight.w700,
-                color: isSelected
-                    ? Colors.white
-                    : isToday
-                    ? FigmaColors.primary
-                    : AppColors.mutedForeground,
+            const SizedBox(height: 3),
+            Container(
+              width: 30,
+              height: 30,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: isSelected ? FigmaColors.primary : Colors.transparent,
+                borderRadius: BorderRadius.circular(12),
+                boxShadow: isSelected ? kCardShadow : null,
+              ),
+              child: Text(
+                '${day.day}',
+                style: TextStyle(
+                  fontSize: 13.5,
+                  fontWeight: FontWeight.w700,
+                  color: isSelected
+                      ? Colors.white
+                      : isToday
+                      ? FigmaColors.primary
+                      : AppColors.mutedForeground,
+                ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }
@@ -1159,39 +1189,56 @@ class _TodayDonut extends StatelessWidget {
               SizedBox(
                 width: 116,
                 height: 116,
-                child: Stack(
-                  alignment: Alignment.center,
-                  children: <Widget>[
-                    ChartReveal(
-                      builder: (BuildContext context, double t) => CustomPaint(
-                        size: const Size.square(116),
-                        painter: _DonutPainter(segs, progress: t),
-                      ),
-                    ),
-                    Column(
-                      mainAxisSize: MainAxisSize.min,
+                // 도넛은 `CustomPaint` 라 시맨틱 트리에 아무 노드도 남기지
+                // 않고, 가운데 숫자는 `45` 와 `분` 두 조각으로 흩어져 읽힌다.
+                // 한 덩어리로 묶어 무엇의 몇 분인지 한 문장으로 말한다(#972).
+                // 유형별 내역은 오른쪽 범례가 이어서 읽어 준다.
+                child: Semantics(
+                  container: true,
+                  label: chartSemanticsLabel(
+                    l,
+                    title: l.exActivityTitle,
+                    points: total == 0
+                        ? const <String>[]
+                        : <String>[l.unitMinutesValue(total)],
+                  ),
+                  child: ExcludeSemantics(
+                    child: Stack(
+                      alignment: Alignment.center,
                       children: <Widget>[
-                        Text(
-                          '$total',
-                          style: const TextStyle(
-                            fontSize: 24,
-                            fontWeight: FontWeight.w800,
-                            color: FigmaColors.ink,
-                            height: 1,
-                            letterSpacing: -0.5,
-                          ),
+                        ChartReveal(
+                          builder: (BuildContext context, double t) =>
+                              CustomPaint(
+                                size: const Size.square(116),
+                                painter: _DonutPainter(segs, progress: t),
+                              ),
                         ),
-                        Text(
-                          l.unitMinutes,
-                          style: const TextStyle(
-                            fontSize: 12.5,
-                            fontWeight: FontWeight.w600,
-                            color: AppColors.mutedForeground,
-                          ),
+                        Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: <Widget>[
+                            Text(
+                              '$total',
+                              style: const TextStyle(
+                                fontSize: 24,
+                                fontWeight: FontWeight.w800,
+                                color: FigmaColors.ink,
+                                height: 1,
+                                letterSpacing: -0.5,
+                              ),
+                            ),
+                            Text(
+                              l.unitMinutes,
+                              style: const TextStyle(
+                                fontSize: 12.5,
+                                fontWeight: FontWeight.w600,
+                                color: AppColors.mutedForeground,
+                              ),
+                            ),
+                          ],
                         ),
                       ],
                     ),
-                  ],
+                  ),
                 ),
               ),
               const SizedBox(width: 48),
@@ -1370,31 +1417,35 @@ class _PeriodToggle extends StatelessWidget {
           // 같은 처리다(#739, #766). 보통 폭에서는 최소 폭 그대로라 모양이 같다.
           for (int i = 0; i < labels.length; i++)
             Flexible(
-              child: GestureDetector(
-                onTap: () => onChanged(i),
-                behavior: HitTestBehavior.opaque,
-                child: AnimatedContainer(
-                  duration: const Duration(milliseconds: 160),
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 12,
-                    vertical: 5,
-                  ),
-                  decoration: BoxDecoration(
-                    color: active == i
-                        ? FigmaColors.primary
-                        : Colors.transparent,
-                    borderRadius: BorderRadius.circular(999),
-                  ),
-                  child: Text(
-                    labels[i],
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      fontSize: 12.5,
-                      fontWeight: FontWeight.w700,
+              child: Semantics(
+                button: true,
+                selected: active == i,
+                child: GestureDetector(
+                  onTap: () => onChanged(i),
+                  behavior: HitTestBehavior.opaque,
+                  child: AnimatedContainer(
+                    duration: const Duration(milliseconds: 160),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 5,
+                    ),
+                    decoration: BoxDecoration(
                       color: active == i
-                          ? Colors.white
-                          : AppColors.mutedForeground,
+                          ? FigmaColors.primary
+                          : Colors.transparent,
+                      borderRadius: BorderRadius.circular(999),
+                    ),
+                    child: Text(
+                      labels[i],
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontSize: 12.5,
+                        fontWeight: FontWeight.w700,
+                        color: active == i
+                            ? Colors.white
+                            : AppColors.mutedForeground,
+                      ),
                     ),
                   ),
                 ),
@@ -1420,6 +1471,20 @@ class _ActivityChart extends StatelessWidget {
 
   /// 값이 바뀌면 막대 성장 애니메이션을 처음부터 다시 재생하기 위한 키.
   final Object? replayKey;
+
+  /// 툴팁과 **같은 내용**을 시맨틱 라벨로. 색 사각형(`WidgetSpan`)은 빼고
+  /// 줄바꿈은 쉼표로 바꾼다 — 음성 안내는 줄을 나누어 읽지 않는다. 어느 날의
+  /// 막대인지 먼저 말해야 하므로 요일을 앞에 붙인다(#972).
+  String _barSemantics(AppLocalizations l, int i) => chartPointLabel(
+    l,
+    dayLabels[i],
+    TextSpan(children: _tipSpans(l, i))
+        .toPlainText(includePlaceholders: false)
+        .split('\n')
+        .map((String line) => line.trim())
+        .where((String line) => line.isNotEmpty)
+        .join(', '),
+  );
 
   /// Hover tooltip content for a bar — one line per activity type as
   /// [color square] 종류   N분 (see the legend).
@@ -1473,94 +1538,119 @@ class _ActivityChart extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations l = AppLocalizations.of(context);
-    return Container(
-      key: bars.length > 10 ? const Key('exerciseMonthlyDailyChart') : null,
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(20),
-        boxShadow: kCardShadow,
-      ),
-      child: Column(
-        children: <Widget>[
-          SizedBox(
-            height: 150,
-            width: double.infinity,
-            child: Stack(
-              children: <Widget>[
-                Positioned.fill(
-                  child: ChartReveal(
-                    replayKey: replayKey,
-                    duration: AppMotion.chartGrow,
-                    // 막대별 stagger 는 painter 안에서 곡선을 적용한다.
-                    curve: Curves.linear,
-                    builder: (BuildContext context, double t) => CustomPaint(
-                      painter: _StackedBarPainter(
-                        bars: bars,
-                        dayLabels: dayLabels,
-                        todayIndex: todayIndex,
-                        todayLabel: l.exToday,
-                        progress: t,
+    // 한 칸도 기록이 없는 기간은 막대마다 `휴식` 을 서른 번 읽히는 대신 비어
+    // 있다고 한 번만 말한다(#972).
+    final bool empty = bars.every((_Bar b) => b.total <= 0);
+    return Semantics(
+      container: true,
+      label: empty
+          ? chartSemanticsLabel(
+              l,
+              title: l.exActivityTitle,
+              points: const <String>[],
+            )
+          : null,
+      child: ExcludeSemantics(
+        excluding: empty,
+        child: Container(
+          key: bars.length > 10 ? const Key('exerciseMonthlyDailyChart') : null,
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(20),
+            boxShadow: kCardShadow,
+          ),
+          child: Column(
+            children: <Widget>[
+              SizedBox(
+                height: 150,
+                width: double.infinity,
+                child: Stack(
+                  children: <Widget>[
+                    Positioned.fill(
+                      child: ChartReveal(
+                        replayKey: replayKey,
+                        duration: AppMotion.chartGrow,
+                        // 막대별 stagger 는 painter 안에서 곡선을 적용한다.
+                        curve: Curves.linear,
+                        builder: (BuildContext context, double t) =>
+                            CustomPaint(
+                              painter: _StackedBarPainter(
+                                bars: bars,
+                                dayLabels: dayLabels,
+                                todayIndex: todayIndex,
+                                todayLabel: l.exToday,
+                                progress: t,
+                              ),
+                            ),
                       ),
                     ),
-                  ),
-                ),
-                // Transparent per-bar hover regions aligned to the painter's
-                // slots (left axis pad = 24, label strip = bottom 24).
-                Positioned.fill(
-                  child: Padding(
-                    padding: const EdgeInsets.only(left: 24, bottom: 24),
-                    child: Row(
-                      children: <Widget>[
-                        for (int i = 0; i < bars.length; i++)
-                          Expanded(
-                            child: Tooltip(
-                              richMessage: TextSpan(
-                                style: const TextStyle(
-                                  fontSize: 12.5,
-                                  fontWeight: FontWeight.w600,
-                                  color: FigmaColors.ink,
-                                  height: 1.15,
+                    // Transparent per-bar hover regions aligned to the painter's
+                    // slots (left axis pad = 24, label strip = bottom 24).
+                    Positioned.fill(
+                      child: Padding(
+                        padding: const EdgeInsets.only(left: 24, bottom: 24),
+                        child: Row(
+                          children: <Widget>[
+                            for (int i = 0; i < bars.length; i++)
+                              Expanded(
+                                child: Semantics(
+                                  label: _barSemantics(l, i),
+                                  child: Tooltip(
+                                    richMessage: TextSpan(
+                                      style: const TextStyle(
+                                        fontSize: 12.5,
+                                        fontWeight: FontWeight.w600,
+                                        color: FigmaColors.ink,
+                                        height: 1.15,
+                                      ),
+                                      children: _tipSpans(l, i),
+                                    ),
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 10,
+                                      vertical: 8,
+                                    ),
+                                    decoration: BoxDecoration(
+                                      color: const Color(0xFFF1F3F5),
+                                      borderRadius: BorderRadius.circular(10),
+                                      border: Border.all(
+                                        color: FigmaColors.hairline,
+                                      ),
+                                      boxShadow: kCardShadow,
+                                    ),
+                                    child: const SizedBox.expand(),
+                                  ),
                                 ),
-                                children: _tipSpans(l, i),
                               ),
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 10,
-                                vertical: 8,
-                              ),
-                              decoration: BoxDecoration(
-                                color: const Color(0xFFF1F3F5),
-                                borderRadius: BorderRadius.circular(10),
-                                border: Border.all(color: FigmaColors.hairline),
-                                boxShadow: kCardShadow,
-                              ),
-                              child: const SizedBox.expand(),
-                            ),
-                          ),
-                      ],
+                          ],
+                        ),
+                      ),
                     ),
-                  ),
+                  ],
                 ),
-              ],
-            ),
-          ),
-          const SizedBox(height: 6),
-          // 범례 셋은 좁아지면 다음 줄로 넘긴다. 한 줄에 붙여 두면 320px 에서
-          // 넘쳤고, 라벨을 줄이면 무슨 색이 무엇인지가 사라진다(#766).
-          Wrap(
-            alignment: WrapAlignment.center,
-            spacing: 16,
-            runSpacing: 6,
-            children: <Widget>[
-              _Legend(color: FigmaColors.primary, label: l.exTypeCardio),
-              _Legend(color: const Color(0xFF1B6FA8), label: l.exTypeStrength),
-              _Legend(
-                color: const Color(0xFFD4EEF8),
-                label: l.exTypeStretching,
+              ),
+              const SizedBox(height: 6),
+              // 범례 셋은 좁아지면 다음 줄로 넘긴다. 한 줄에 붙여 두면 320px 에서
+              // 넘쳤고, 라벨을 줄이면 무슨 색이 무엇인지가 사라진다(#766).
+              Wrap(
+                alignment: WrapAlignment.center,
+                spacing: 16,
+                runSpacing: 6,
+                children: <Widget>[
+                  _Legend(color: FigmaColors.primary, label: l.exTypeCardio),
+                  _Legend(
+                    color: const Color(0xFF1B6FA8),
+                    label: l.exTypeStrength,
+                  ),
+                  _Legend(
+                    color: const Color(0xFFD4EEF8),
+                    label: l.exTypeStretching,
+                  ),
+                ],
               ),
             ],
           ),
-        ],
+        ),
       ),
     );
   }
@@ -1608,6 +1698,8 @@ class _Bar {
   final double cardio;
   final double strength;
   final double stretch;
+
+  double get total => cardio + strength + stretch;
 }
 
 class _StackedBarPainter extends CustomPainter {

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/exercise_flows.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/exercise_flows.dart
@@ -361,24 +361,28 @@ class _ExerciseAddSheetState extends ConsumerState<_ExerciseAddSheet> {
     VoidCallback onTap, {
     bool center = false,
   }) {
-    return GestureDetector(
-      onTap: onTap,
-      child: Container(
-        alignment: center ? Alignment.center : null,
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-        decoration: BoxDecoration(
-          color: on ? FigmaColors.primaryA(0.10) : Colors.white,
-          borderRadius: BorderRadius.circular(12),
-          border: Border.all(
-            color: on ? FigmaColors.primary : FigmaColors.hairline,
+    return Semantics(
+      button: true,
+      selected: on,
+      child: GestureDetector(
+        onTap: onTap,
+        child: Container(
+          alignment: center ? Alignment.center : null,
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+          decoration: BoxDecoration(
+            color: on ? FigmaColors.primaryA(0.10) : Colors.white,
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(
+              color: on ? FigmaColors.primary : FigmaColors.hairline,
+            ),
           ),
-        ),
-        child: Text(
-          label,
-          style: TextStyle(
-            fontSize: 14,
-            fontWeight: FontWeight.w700,
-            color: on ? FigmaColors.primary : AppColors.mutedForeground,
+          child: Text(
+            label,
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w700,
+              color: on ? FigmaColors.primary : AppColors.mutedForeground,
+            ),
           ),
         ),
       ),
@@ -471,13 +475,18 @@ class _GymLocatorSheetState extends ConsumerState<_GymLocatorSheet> {
                   clipBehavior: Clip.antiAlias,
                   child: InkWell(
                     onTap: () => Navigator.of(context).pop(),
-                    child: const SizedBox(
-                      width: 32,
-                      height: 32,
-                      child: Icon(
-                        Icons.close,
-                        size: 16,
-                        color: FigmaColors.primary,
+                    child: Tooltip(
+                      message: MaterialLocalizations.of(
+                        context,
+                      ).closeButtonTooltip,
+                      child: const SizedBox(
+                        width: 32,
+                        height: 32,
+                        child: Icon(
+                          Icons.close,
+                          size: 16,
+                          color: FigmaColors.primary,
+                        ),
                       ),
                     ),
                   ),
@@ -537,18 +546,22 @@ class _GymLocatorSheetState extends ConsumerState<_GymLocatorSheet> {
                         ),
                       ),
                       if (_query.isNotEmpty)
-                        GestureDetector(
-                          behavior: HitTestBehavior.opaque,
-                          onTap: () {
-                            _search.clear();
-                            setState(() => _query = '');
-                          },
-                          child: const Padding(
-                            padding: EdgeInsets.only(left: 6),
-                            child: Icon(
-                              Icons.close,
-                              size: 15,
-                              color: FigmaColors.textMuted,
+                        Semantics(
+                          button: true,
+                          label: l.a11yClearSearch,
+                          child: GestureDetector(
+                            behavior: HitTestBehavior.opaque,
+                            onTap: () {
+                              _search.clear();
+                              setState(() => _query = '');
+                            },
+                            child: const Padding(
+                              padding: EdgeInsets.only(left: 6),
+                              child: Icon(
+                                Icons.close,
+                                size: 15,
+                                color: FigmaColors.textMuted,
+                              ),
                             ),
                           ),
                         ),

--- a/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_chat_sheet.dart
+++ b/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_chat_sheet.dart
@@ -626,9 +626,12 @@ class _InputBar extends StatelessWidget {
               key: const ValueKey<String>('member-chat-send'),
               customBorder: const CircleBorder(),
               onTap: sending ? null : onSend,
-              child: const Padding(
-                padding: EdgeInsets.all(10),
-                child: Icon(Icons.send, size: 18, color: Colors.white),
+              child: Tooltip(
+                message: AppLocalizations.of(context).a11ySendMessage,
+                child: const Padding(
+                  padding: EdgeInsets.all(10),
+                  child: Icon(Icons.send, size: 18, color: Colors.white),
+                ),
               ),
             ),
           ),

--- a/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
@@ -211,52 +211,55 @@ class _PointsBanner extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      key: const Key('pointsBanner'),
-      behavior: HitTestBehavior.opaque,
-      onTap: () => _openPointsBenefitsPage(context, points),
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
-        decoration: BoxDecoration(
-          color: FigmaColors.primary,
-          borderRadius: BorderRadius.circular(20),
-          boxShadow: kCardShadow,
-        ),
-        child: Row(
-          children: <Widget>[
-            const Icon(
-              Icons.star_border_rounded,
-              color: Colors.white,
-              size: 24,
-            ),
-            const SizedBox(width: 12),
-            Text(
-              points != null ? '${points}P' : '—P',
-              style: const TextStyle(
-                fontSize: 18,
-                fontWeight: FontWeight.w800,
+    return Semantics(
+      button: true,
+      child: GestureDetector(
+        key: const Key('pointsBanner'),
+        behavior: HitTestBehavior.opaque,
+        onTap: () => _openPointsBenefitsPage(context, points),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+          decoration: BoxDecoration(
+            color: FigmaColors.primary,
+            borderRadius: BorderRadius.circular(20),
+            boxShadow: kCardShadow,
+          ),
+          child: Row(
+            children: <Widget>[
+              const Icon(
+                Icons.star_border_rounded,
                 color: Colors.white,
-                letterSpacing: -0.5,
+                size: 24,
               ),
-            ),
-            const SizedBox(width: 8),
-            const _PointsInfoButton(),
-            const Spacer(),
-            Container(
-              width: 26,
-              height: 26,
-              alignment: Alignment.center,
-              decoration: BoxDecoration(
-                color: Colors.white.withValues(alpha: 0.18),
-                shape: BoxShape.circle,
+              const SizedBox(width: 12),
+              Text(
+                points != null ? '${points}P' : '—P',
+                style: const TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.w800,
+                  color: Colors.white,
+                  letterSpacing: -0.5,
+                ),
               ),
-              child: const Icon(
-                Icons.chevron_right_rounded,
-                color: Colors.white,
-                size: 20,
+              const SizedBox(width: 8),
+              const _PointsInfoButton(),
+              const Spacer(),
+              Container(
+                width: 26,
+                height: 26,
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  color: Colors.white.withValues(alpha: 0.18),
+                  shape: BoxShape.circle,
+                ),
+                child: const Icon(
+                  Icons.chevron_right_rounded,
+                  color: Colors.white,
+                  size: 20,
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );
@@ -523,18 +526,22 @@ class _PointsInfoButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
-      onTap: () => _show(context),
-      child: Container(
-        width: 24,
-        height: 24,
-        alignment: Alignment.center,
-        decoration: BoxDecoration(
-          color: Colors.white.withValues(alpha: 0.22),
-          shape: BoxShape.circle,
+    return Semantics(
+      button: true,
+      label: AppLocalizations.of(context).myPointsGuideTitle,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () => _show(context),
+        child: Container(
+          width: 24,
+          height: 24,
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: Colors.white.withValues(alpha: 0.22),
+            shape: BoxShape.circle,
+          ),
+          child: const Icon(Icons.info_outline, size: 15, color: Colors.white),
         ),
-        child: const Icon(Icons.info_outline, size: 15, color: Colors.white),
       ),
     );
   }

--- a/frontend/flutter/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations.dart
@@ -3577,6 +3577,78 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{title} · {month}/{day}'**
   String exDatedTitle(int month, int day, String title);
+
+  /// No description provided for @a11yChartSummary.
+  ///
+  /// In en, this message translates to:
+  /// **'{title}. {detail}'**
+  String a11yChartSummary(String title, String detail);
+
+  /// No description provided for @a11yChartEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'{title}. No records yet'**
+  String a11yChartEmpty(String title);
+
+  /// No description provided for @a11yChartPoint.
+  ///
+  /// In en, this message translates to:
+  /// **'{day} {value}'**
+  String a11yChartPoint(String day, String value);
+
+  /// No description provided for @a11yShowPassword.
+  ///
+  /// In en, this message translates to:
+  /// **'Show password'**
+  String get a11yShowPassword;
+
+  /// No description provided for @a11yHidePassword.
+  ///
+  /// In en, this message translates to:
+  /// **'Hide password'**
+  String get a11yHidePassword;
+
+  /// No description provided for @a11yOpenCoaching.
+  ///
+  /// In en, this message translates to:
+  /// **'Open coaching tips'**
+  String get a11yOpenCoaching;
+
+  /// No description provided for @a11ySendMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'Send message'**
+  String get a11ySendMessage;
+
+  /// No description provided for @a11yClearSearch.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear search'**
+  String get a11yClearSearch;
+
+  /// No description provided for @a11yRemoveFood.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove food'**
+  String get a11yRemoveFood;
+
+  /// No description provided for @a11yOpenCalendar.
+  ///
+  /// In en, this message translates to:
+  /// **'Open schedule calendar'**
+  String get a11yOpenCalendar;
+
+  /// No description provided for @a11yPrevWeek.
+  ///
+  /// In en, this message translates to:
+  /// **'Previous week'**
+  String get a11yPrevWeek;
+
+  /// No description provided for @a11yNextWeek.
+  ///
+  /// In en, this message translates to:
+  /// **'Next week'**
+  String get a11yNextWeek;
 }
 
 class _AppLocalizationsDelegate

--- a/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
@@ -1934,4 +1934,46 @@ class AppLocalizationsEn extends AppLocalizations {
   String exDatedTitle(int month, int day, String title) {
     return '$title · $month/$day';
   }
+
+  @override
+  String a11yChartSummary(String title, String detail) {
+    return '$title. $detail';
+  }
+
+  @override
+  String a11yChartEmpty(String title) {
+    return '$title. No records yet';
+  }
+
+  @override
+  String a11yChartPoint(String day, String value) {
+    return '$day $value';
+  }
+
+  @override
+  String get a11yShowPassword => 'Show password';
+
+  @override
+  String get a11yHidePassword => 'Hide password';
+
+  @override
+  String get a11yOpenCoaching => 'Open coaching tips';
+
+  @override
+  String get a11ySendMessage => 'Send message';
+
+  @override
+  String get a11yClearSearch => 'Clear search';
+
+  @override
+  String get a11yRemoveFood => 'Remove food';
+
+  @override
+  String get a11yOpenCalendar => 'Open schedule calendar';
+
+  @override
+  String get a11yPrevWeek => 'Previous week';
+
+  @override
+  String get a11yNextWeek => 'Next week';
 }

--- a/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
@@ -1871,4 +1871,46 @@ class AppLocalizationsKo extends AppLocalizations {
   String exDatedTitle(int month, int day, String title) {
     return '$month월 $day일 $title';
   }
+
+  @override
+  String a11yChartSummary(String title, String detail) {
+    return '$title. $detail';
+  }
+
+  @override
+  String a11yChartEmpty(String title) {
+    return '$title. 기록이 없어요';
+  }
+
+  @override
+  String a11yChartPoint(String day, String value) {
+    return '$day $value';
+  }
+
+  @override
+  String get a11yShowPassword => '비밀번호 표시';
+
+  @override
+  String get a11yHidePassword => '비밀번호 숨기기';
+
+  @override
+  String get a11yOpenCoaching => '코칭 조언 열기';
+
+  @override
+  String get a11ySendMessage => '메시지 보내기';
+
+  @override
+  String get a11yClearSearch => '검색어 지우기';
+
+  @override
+  String get a11yRemoveFood => '음식 지우기';
+
+  @override
+  String get a11yOpenCalendar => '일정 달력 열기';
+
+  @override
+  String get a11yPrevWeek => '지난 주';
+
+  @override
+  String get a11yNextWeek => '다음 주';
 }

--- a/frontend/flutter/lib/l10n/app_en.arb
+++ b/frontend/flutter/lib/l10n/app_en.arb
@@ -1227,5 +1227,20 @@
         "type": "String"
       }
     }
-  }
+  },
+  "a11yChartSummary": "{title}. {detail}",
+  "@a11yChartSummary": {"placeholders": {"title": {"type": "String"}, "detail": {"type": "String"}}},
+  "a11yChartEmpty": "{title}. No records yet",
+  "@a11yChartEmpty": {"placeholders": {"title": {"type": "String"}}},
+  "a11yChartPoint": "{day} {value}",
+  "@a11yChartPoint": {"placeholders": {"day": {"type": "String"}, "value": {"type": "String"}}},
+  "a11yShowPassword": "Show password",
+  "a11yHidePassword": "Hide password",
+  "a11yOpenCoaching": "Open coaching tips",
+  "a11ySendMessage": "Send message",
+  "a11yClearSearch": "Clear search",
+  "a11yRemoveFood": "Remove food",
+  "a11yOpenCalendar": "Open schedule calendar",
+  "a11yPrevWeek": "Previous week",
+  "a11yNextWeek": "Next week"
 }

--- a/frontend/flutter/lib/l10n/app_ko.arb
+++ b/frontend/flutter/lib/l10n/app_ko.arb
@@ -665,5 +665,20 @@
   "alertJustNow": "방금",
   "exPtLogTitle": "오늘 완료한 PT",
   "exPtFeedbackTitle": "오늘의 피드백",
-  "exDatedTitle": "{month}월 {day}일 {title}"
+  "exDatedTitle": "{month}월 {day}일 {title}",
+  "a11yChartSummary": "{title}. {detail}",
+  "@a11yChartSummary": {"placeholders": {"title": {"type": "String"}, "detail": {"type": "String"}}},
+  "a11yChartEmpty": "{title}. 기록이 없어요",
+  "@a11yChartEmpty": {"placeholders": {"title": {"type": "String"}}},
+  "a11yChartPoint": "{day} {value}",
+  "@a11yChartPoint": {"placeholders": {"day": {"type": "String"}, "value": {"type": "String"}}},
+  "a11yShowPassword": "비밀번호 표시",
+  "a11yHidePassword": "비밀번호 숨기기",
+  "a11yOpenCoaching": "코칭 조언 열기",
+  "a11ySendMessage": "메시지 보내기",
+  "a11yClearSearch": "검색어 지우기",
+  "a11yRemoveFood": "음식 지우기",
+  "a11yOpenCalendar": "일정 달력 열기",
+  "a11yPrevWeek": "지난 주",
+  "a11yNextWeek": "다음 주"
 }

--- a/frontend/flutter/lib/shared/widgets/chart_semantics.dart
+++ b/frontend/flutter/lib/shared/widgets/chart_semantics.dart
@@ -1,0 +1,48 @@
+/// `CustomPaint` 로 그린 그래프를 스크린리더에 읽히게 하는 라벨 조립기. (#972)
+///
+/// `CustomPaint` 는 픽셀만 그리고 시맨틱 트리에는 아무 노드도 남기지 않는다.
+/// 감싸는 위젯이 라벨을 주지 않으면 그 그래프는 음성 안내에서 **통째로 존재하지
+/// 않는 영역**이 된다. 이 앱이 다루는 것이 혈압·혈당 위험군의 건강 지표라,
+/// 숫자를 눈으로만 읽을 수 있게 두면 안 된다.
+///
+/// 두 앱은 패키지가 갈라져 있어 코드를 공유할 수 없다 — `metric_trend_chart`
+/// 와 같은 방식으로 규칙을 양쪽에 같은 모양으로 둔다.
+library;
+
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+/// 요일(또는 날짜) 한 칸을 `월 300kcal` 처럼 읽는 한 조각으로.
+String chartPointLabel(AppLocalizations l, String day, String value) =>
+    l.a11yChartPoint(day, value);
+
+/// 그래프 하나를 한 문장으로. [points] 가 비면 비어 있다고 말한다 — 빈 그래프를
+/// 말없이 두면 "값이 0" 인지 "아직 기록이 없는지"를 구분할 수 없다.
+String chartSemanticsLabel(
+  AppLocalizations l, {
+  required String title,
+  required List<String> points,
+}) => points.isEmpty
+    ? l.a11yChartEmpty(title)
+    : l.a11yChartSummary(title, points.join(', '));
+
+/// 값이 있는 날만 골라 [chartPointLabel] 조각으로 만든다.
+///
+/// 0 은 건너뛴다. 이 앱의 그래프에서 0 은 "그날 0 만큼 했다"가 아니라 **기록이
+/// 없다**는 뜻이라(빈 트랙·회색 그루터기로 그린다), 0 을 읽어 주면 측정된 값처럼
+/// 들린다. 하루도 남지 않으면 빈 목록이 되어 위 함수가 비어 있다고 말한다.
+///
+/// [upTo] 는 그래프가 실제로 그리는 마지막 칸이다. 이번 주 꺾은선은 오늘까지만
+/// 잇는데, 아직 오지 않은 요일까지 읽으면 화면에 없는 값을 말하게 된다.
+List<String> chartSeriesPoints(
+  AppLocalizations l, {
+  required List<double> values,
+  required List<String> dayLabels,
+  required String Function(double) format,
+  int? upTo,
+}) {
+  final int last = upTo ?? values.length - 1;
+  return <String>[
+    for (int i = 0; i <= last && i < values.length && i < dayLabels.length; i++)
+      if (values[i] != 0) chartPointLabel(l, dayLabels[i], format(values[i])),
+  ];
+}

--- a/frontend/flutter/lib/shared/widgets/coaching_sheet.dart
+++ b/frontend/flutter/lib/shared/widgets/coaching_sheet.dart
@@ -342,10 +342,15 @@ class _CloseButton extends StatelessWidget {
       clipBehavior: Clip.antiAlias,
       child: InkWell(
         onTap: onTap,
-        child: const SizedBox(
-          width: 32,
-          height: 32,
-          child: Icon(Icons.close, size: 16, color: FigmaColors.textSub),
+        // 아이콘만 있는 버튼이라 무엇을 닫는지 말할 데가 없다(#972). 닫기는
+        // 플랫폼이 이미 제 언어로 부르는 이름이 있다.
+        child: Tooltip(
+          message: MaterialLocalizations.of(context).closeButtonTooltip,
+          child: const SizedBox(
+            width: 32,
+            height: 32,
+            child: Icon(Icons.close, size: 16, color: FigmaColors.textSub),
+          ),
         ),
       ),
     );

--- a/frontend/flutter/lib/shared/widgets/metric_trend_chart.dart
+++ b/frontend/flutter/lib/shared/widgets/metric_trend_chart.dart
@@ -80,6 +80,7 @@ class MetricTrendChart extends StatelessWidget {
     required this.ticks,
     required this.todayIndex,
     required this.replayKey,
+    required this.semanticsLabel,
     this.goalLabel,
     required this.formatTick,
     this.height = 68,
@@ -101,6 +102,11 @@ class MetricTrendChart extends StatelessWidget {
   /// 바뀌면 진입 애니메이션을 처음부터 다시 그린다.
   final Object replayKey;
 
+  /// 그래프가 말하는 내용 한 문장. `CustomPaint` 는 시맨틱 트리에 아무 노드도
+  /// 남기지 않아, 이게 없으면 그래프가 음성 안내에서 통째로 사라진다(#972).
+  /// [chartSemanticsLabel] 로 만든다 — 지표 이름과 단위는 부르는 쪽만 안다.
+  final String semanticsLabel;
+
   /// 목표선에 붙는 문구(예: `목표 2,000`). null 이면 선만 그린다. 문구를 밖에서
   /// 받는 것은 두 앱의 로케일 자원이 갈라져 있어서다.
   final String? goalLabel;
@@ -115,96 +121,102 @@ class MetricTrendChart extends StatelessWidget {
       ticks: ticks,
       goal: goal,
     );
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        // 목표선의 실제 높이에 맞춰 라벨 하나. 칸은 목표가 없어도 자리를
-        // 지킨다 — 지표를 바꿀 때 그래프 폭이 흔들리지 않는다.
-        //
-        // 폭은 눈금 라벨이 쓰던 38 그대로다. `목표 2,000` 을 한 줄로 두면 이
-        // 칸이 넓어져야 하는데, 그러면 360px 영어 로케일에서 요일 라벨 줄이
-        // 넘친다. 두 줄로 접어 폭을 지킨다.
-        SizedBox(
-          width: 38,
-          height: height,
-          child: Stack(
-            children: <Widget>[
-              if (goalLabel != null && goal > 0 && goal >= lo && goal <= hi)
-                Positioned(
-                  right: 0,
-                  top: (height - ((goal - lo) / (hi - lo)) * height - 13).clamp(
-                    0.0,
-                    height - 26,
-                  ),
-                  child: SizedBox(
-                    height: 26,
-                    child: Center(child: _AxisLabel(goalLabel!)),
-                  ),
-                ),
-            ],
-          ),
-        ),
-        const SizedBox(width: 6),
-        Expanded(
-          child: Column(
-            children: <Widget>[
-              SizedBox(
-                height: height,
-                child: ChartReveal(
-                  replayKey: replayKey,
-                  builder: (BuildContext context, double t) => CustomPaint(
-                    size: Size.infinite,
-                    painter: MetricTrendPainter(
-                      cur: values,
-                      goal: goal,
-                      ticks: ticks,
-                      lo: lo,
-                      hi: hi,
-                      todayIndex: todayIndex,
-                      progress: t,
-                    ),
-                  ),
-                ),
-              ),
-              const SizedBox(height: 6),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+    // 눈금·요일 라벨은 낱개로 읽어 봐야 `월` `화` 뿐이라 그래프가 무슨 값을
+    // 말하는지 알 수 없다. 한 덩어리로 묶고 요약 한 문장만 읽힌다.
+    return Semantics(
+      container: true,
+      label: semanticsLabel,
+      child: ExcludeSemantics(
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            // 목표선의 실제 높이에 맞춰 라벨 하나. 칸은 목표가 없어도 자리를
+            // 지킨다 — 지표를 바꿀 때 그래프 폭이 흔들리지 않는다.
+            //
+            // 폭은 눈금 라벨이 쓰던 38 그대로다. `목표 2,000` 을 한 줄로 두면 이
+            // 칸이 넓어져야 하는데, 그러면 360px 영어 로케일에서 요일 라벨 줄이
+            // 넘친다. 두 줄로 접어 폭을 지킨다.
+            SizedBox(
+              width: 38,
+              height: height,
+              child: Stack(
                 children: <Widget>[
-                  for (int i = 0; i < dayLabels.length; i++)
-                    if (i == todayIndex)
-                      // 오늘: 브랜드색 원 안에 흰 글씨.
-                      Container(
-                        width: 18,
-                        height: 18,
-                        alignment: Alignment.center,
-                        decoration: const BoxDecoration(
-                          color: FigmaColors.primary,
-                          shape: BoxShape.circle,
-                        ),
-                        child: Text(
-                          dayLabels[i],
-                          style: const TextStyle(
-                            fontSize: 11.5,
-                            fontWeight: FontWeight.w700,
-                            color: Colors.white,
-                          ),
-                        ),
-                      )
-                    else
-                      Text(
-                        dayLabels[i],
-                        style: const TextStyle(
-                          fontSize: 11.5,
-                          fontWeight: FontWeight.w600,
-                          color: AppColors.mutedForeground,
-                        ),
+                  if (goalLabel != null && goal > 0 && goal >= lo && goal <= hi)
+                    Positioned(
+                      right: 0,
+                      top: (height - ((goal - lo) / (hi - lo)) * height - 13)
+                          .clamp(0.0, height - 26),
+                      child: SizedBox(
+                        height: 26,
+                        child: Center(child: _AxisLabel(goalLabel!)),
                       ),
+                    ),
                 ],
               ),
-            ],
-          ),
+            ),
+            const SizedBox(width: 6),
+            Expanded(
+              child: Column(
+                children: <Widget>[
+                  SizedBox(
+                    height: height,
+                    child: ChartReveal(
+                      replayKey: replayKey,
+                      builder: (BuildContext context, double t) => CustomPaint(
+                        size: Size.infinite,
+                        painter: MetricTrendPainter(
+                          cur: values,
+                          goal: goal,
+                          ticks: ticks,
+                          lo: lo,
+                          hi: hi,
+                          todayIndex: todayIndex,
+                          progress: t,
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: <Widget>[
+                      for (int i = 0; i < dayLabels.length; i++)
+                        if (i == todayIndex)
+                          // 오늘: 브랜드색 원 안에 흰 글씨.
+                          Container(
+                            width: 18,
+                            height: 18,
+                            alignment: Alignment.center,
+                            decoration: const BoxDecoration(
+                              color: FigmaColors.primary,
+                              shape: BoxShape.circle,
+                            ),
+                            child: Text(
+                              dayLabels[i],
+                              style: const TextStyle(
+                                fontSize: 11.5,
+                                fontWeight: FontWeight.w700,
+                                color: Colors.white,
+                              ),
+                            ),
+                          )
+                        else
+                          Text(
+                            dayLabels[i],
+                            style: const TextStyle(
+                              fontSize: 11.5,
+                              fontWeight: FontWeight.w600,
+                              color: AppColors.mutedForeground,
+                            ),
+                          ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
         ),
-      ],
+      ),
     );
   }
 }

--- a/frontend/flutter/lib/shared/widgets/modals/add_event_dialog.dart
+++ b/frontend/flutter/lib/shared/widgets/modals/add_event_dialog.dart
@@ -227,10 +227,15 @@ class _EventDialogState extends ConsumerState<_EventDialog> {
                     child: InkWell(
                       customBorder: const CircleBorder(),
                       onTap: () => Navigator.of(context).pop(),
-                      child: const SizedBox(
-                        width: 32,
-                        height: 32,
-                        child: Icon(Icons.close, size: 18),
+                      child: Tooltip(
+                        message: MaterialLocalizations.of(
+                          context,
+                        ).closeButtonTooltip,
+                        child: const SizedBox(
+                          width: 32,
+                          height: 32,
+                          child: Icon(Icons.close, size: 18),
+                        ),
                       ),
                     ),
                   ),

--- a/frontend/flutter/lib/shared/widgets/modals/day_events_sheet.dart
+++ b/frontend/flutter/lib/shared/widgets/modals/day_events_sheet.dart
@@ -178,10 +178,15 @@ class _DayEventsBodyState extends ConsumerState<_DayEventsBody> {
                   clipBehavior: Clip.antiAlias,
                   child: InkWell(
                     onTap: () => Navigator.of(context).pop(_changed),
-                    child: const SizedBox(
-                      width: 32,
-                      height: 32,
-                      child: Icon(Icons.close, size: 18),
+                    child: Tooltip(
+                      message: MaterialLocalizations.of(
+                        context,
+                      ).closeButtonTooltip,
+                      child: const SizedBox(
+                        width: 32,
+                        height: 32,
+                        child: Icon(Icons.close, size: 18),
+                      ),
                     ),
                   ),
                 ),

--- a/frontend/flutter/lib/shared/widgets/modals/schedule_calendar_sheet.dart
+++ b/frontend/flutter/lib/shared/widgets/modals/schedule_calendar_sheet.dart
@@ -134,6 +134,10 @@ class _CalendarBodyState extends ConsumerState<_CalendarBody> {
             Row(
               children: <Widget>[
                 IconButton(
+                  // 달 이동은 플랫폼이 이미 제 언어로 부르는 이름이 있다.
+                  tooltip: MaterialLocalizations.of(
+                    context,
+                  ).previousMonthTooltip,
                   icon: const Icon(Icons.chevron_left),
                   onPressed: () => setState(
                     () => _month = DateTime(_month.year, _month.month - 1),
@@ -146,6 +150,7 @@ class _CalendarBodyState extends ConsumerState<_CalendarBody> {
                   style: theme.textTheme.titleMedium,
                 ),
                 IconButton(
+                  tooltip: MaterialLocalizations.of(context).nextMonthTooltip,
                   icon: const Icon(Icons.chevron_right),
                   onPressed: () => setState(
                     () => _month = DateTime(_month.year, _month.month + 1),
@@ -411,10 +416,13 @@ class _CircleClose extends StatelessWidget {
       child: InkWell(
         customBorder: const CircleBorder(),
         onTap: onTap,
-        child: const SizedBox(
-          width: 32,
-          height: 32,
-          child: Icon(Icons.close, size: 18),
+        child: Tooltip(
+          message: MaterialLocalizations.of(context).closeButtonTooltip,
+          child: const SizedBox(
+            width: 32,
+            height: 32,
+            child: Icon(Icons.close, size: 18),
+          ),
         ),
       ),
     );

--- a/frontend/flutter/lib/shared/widgets/oni_fab.dart
+++ b/frontend/flutter/lib/shared/widgets/oni_fab.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:oncare/design_system/figma/figma_kit.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
 
 /// The floating "Oni" assistant button shown on every main tab. Taps open the
 /// coaching sheet. A red badge shows the number of pending suggestions.
@@ -17,55 +18,61 @@ class OniFab extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      child: SizedBox(
-        width: 56,
-        height: 56,
-        child: Stack(
-          alignment: Alignment.center,
-          clipBehavior: Clip.none,
-          children: <Widget>[
-            Container(
-              width: 52,
-              height: 52,
-              decoration: BoxDecoration(
-                shape: BoxShape.circle,
-                boxShadow: <BoxShadow>[
-                  BoxShadow(
-                    color: FigmaColors.primary.withValues(alpha: 0.55),
-                    blurRadius: 22,
-                    offset: const Offset(0, 6),
-                  ),
-                ],
+    // 온이 얼굴은 `CustomPaint` 라 안에 읽을 글자가 없다 — 무엇을 여는
+    // 버튼인지 라벨로 말한다(#972).
+    return Semantics(
+      button: true,
+      label: AppLocalizations.of(context).a11yOpenCoaching,
+      child: GestureDetector(
+        onTap: onTap,
+        child: SizedBox(
+          width: 56,
+          height: 56,
+          child: Stack(
+            alignment: Alignment.center,
+            clipBehavior: Clip.none,
+            children: <Widget>[
+              Container(
+                width: 52,
+                height: 52,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  boxShadow: <BoxShadow>[
+                    BoxShadow(
+                      color: FigmaColors.primary.withValues(alpha: 0.55),
+                      blurRadius: 22,
+                      offset: const Offset(0, 6),
+                    ),
+                  ],
+                ),
+                child: const OniAvatar(size: 52, shadow: false),
               ),
-              child: const OniAvatar(size: 52, shadow: false),
-            ),
-            if (badgeCount > 0)
-              Positioned(
-                top: -2,
-                right: -2,
-                child: Container(
-                  width: 20,
-                  height: 20,
-                  alignment: Alignment.center,
-                  decoration: BoxDecoration(
-                    color: FigmaColors.redDot,
-                    shape: BoxShape.circle,
-                    border: Border.all(color: Colors.white, width: 2),
-                  ),
-                  child: Text(
-                    badgeCount > 9 ? '9+' : '$badgeCount',
-                    style: const TextStyle(
-                      fontSize: 12,
-                      fontWeight: FontWeight.w800,
-                      color: Colors.white,
-                      height: 1,
+              if (badgeCount > 0)
+                Positioned(
+                  top: -2,
+                  right: -2,
+                  child: Container(
+                    width: 20,
+                    height: 20,
+                    alignment: Alignment.center,
+                    decoration: BoxDecoration(
+                      color: FigmaColors.redDot,
+                      shape: BoxShape.circle,
+                      border: Border.all(color: Colors.white, width: 2),
+                    ),
+                    child: Text(
+                      badgeCount > 9 ? '9+' : '$badgeCount',
+                      style: const TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w800,
+                        color: Colors.white,
+                        height: 1,
+                      ),
                     ),
                   ),
                 ),
-              ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/frontend/flutter/test/features/dashboard/home_chart_semantics_test.dart
+++ b/frontend/flutter/test/features/dashboard/home_chart_semantics_test.dart
@@ -1,0 +1,146 @@
+/// 홈 탭의 그래프가 스크린리더에 무엇을 말하는지. (#972)
+///
+/// 두 그래프 모두 `CustomPaint` 라, 감싸는 위젯이 라벨을 주지 않으면 음성
+/// 안내에서는 통째로 존재하지 않는 영역이 된다. 이 앱이 다루는 것이 혈압·혈당
+/// 위험군의 건강 지표라, 숫자를 눈으로만 읽을 수 있게 두면 안 된다.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/features/account/data/repositories/mock_account_repository.dart';
+import 'package:oncare/features/account/presentation/controllers/account_controller.dart';
+import 'package:oncare/features/dashboard/domain/entities/dashboard_summary.dart';
+import 'package:oncare/features/dashboard/presentation/controllers/dashboard_controller.dart';
+import 'package:oncare/features/dashboard/presentation/widgets/dashboard_content.dart';
+import 'package:oncare/features/diet/domain/entities/diet_day.dart';
+import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
+import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
+import 'package:oncare/features/member_coach/data/repositories/mock_member_coach_repository.dart';
+import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+void main() {
+  const DashboardSummary summary = DashboardSummary(
+    indicators: <HealthIndicator>[
+      HealthIndicator(label: '칼로리', current: 1860, max: 2000, unit: 'kcal'),
+      HealthIndicator(label: '나트륨', current: 2329, max: 2000, unit: 'mg'),
+      HealthIndicator(label: '당류', current: 43, max: 50, unit: 'g'),
+    ],
+    macros: DietMacros.zero(),
+    dietEntries: 4,
+    exerciseMinutes: 45,
+    exerciseCalories: 520,
+    exerciseCount: 4,
+    todaySchedule: <ScheduleItem>[],
+    weekScore: 85,
+    weekScoreDelta: 12,
+    sodiumWarning: null,
+  );
+
+  ExerciseWeek weekWith(List<double> daily) => ExerciseWeek(
+    sessions: const <ExerciseSession>[],
+    dailyMinutes: const <double>[0, 0, 0, 0, 0, 0, 0],
+    dayLabels: const <String>['월', '화', '수', '목', '금', '토', '일'],
+    totalMinutes: 45,
+    totalCalories: 520,
+    streakDays: 2,
+    aiCoachMessage: '',
+    dailyCalories: daily,
+  );
+
+  Future<void> pumpHome(
+    WidgetTester tester,
+    AsyncValue<ExerciseWeek> week, {
+    Locale locale = const Locale('ko'),
+  }) async {
+    await tester.binding.setSurfaceSize(const Size(800, 1600));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          accountRepositoryProvider.overrideWithValue(MockAccountRepository()),
+          dashboardSummaryProvider.overrideWith((_) async => summary),
+          memberCoachRepositoryProvider.overrideWithValue(
+            MockMemberCoachRepository(),
+          ),
+          exerciseWeekViewProvider.overrideWithValue(week),
+        ],
+        child: MaterialApp(
+          locale: locale,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const Scaffold(body: DashboardContent()),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+  }
+
+  /// [needle] 을 담은 시맨틱 노드. 그래프가 카드 안 어디에 놓이든 잡힌다.
+  Finder labelled(String needle) =>
+      find.bySemanticsLabel(RegExp(RegExp.escape(needle)));
+
+  testWidgets('주간 소모 칼로리 그래프가 요일별 값을 말한다', (WidgetTester tester) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
+    await pumpHome(
+      tester,
+      AsyncValue<ExerciseWeek>.data(
+        weekWith(const <double>[300, 0, 0, 0, 0, 0, 0]),
+      ),
+    );
+
+    expect(
+      labelled('300kcal'),
+      findsWidgets,
+      reason: '막대 그래프가 시맨틱 트리에 아무것도 남기지 않았습니다.',
+    );
+    expect(labelled('월 300kcal'), findsWidgets);
+    handle.dispose();
+  });
+
+  testWidgets('기록이 없는 주는 비어 있다고 말한다', (WidgetTester tester) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
+    await pumpHome(
+      tester,
+      AsyncValue<ExerciseWeek>.data(
+        weekWith(const <double>[0, 0, 0, 0, 0, 0, 0]),
+      ),
+    );
+
+    // 값 없이 조용한 그래프는 "0kcal 태웠다" 와 구분되지 않는다.
+    expect(labelled('기록이 없어요'), findsWidgets);
+    handle.dispose();
+  });
+
+  testWidgets('영어 로케일에서는 비어 있다는 말도 영어다', (WidgetTester tester) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
+    await pumpHome(
+      tester,
+      AsyncValue<ExerciseWeek>.data(
+        weekWith(const <double>[0, 0, 0, 0, 0, 0, 0]),
+      ),
+      locale: const Locale('en'),
+    );
+
+    expect(labelled('No records yet'), findsWidgets);
+    expect(labelled('기록이 없어요'), findsNothing);
+    handle.dispose();
+  });
+
+  testWidgets('영양 추이 꺾은선도 요일별 값을 말한다', (WidgetTester tester) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
+    await pumpHome(
+      tester,
+      AsyncValue<ExerciseWeek>.data(
+        weekWith(const <double>[300, 0, 0, 0, 0, 0, 0]),
+      ),
+    );
+
+    // 홈의 영양 카드는 칼로리 지표로 열린다.
+    expect(labelled('kcal'), findsWidgets);
+    handle.dispose();
+  });
+}

--- a/frontend/flutter/test/shared/widgets/chart_semantics_test.dart
+++ b/frontend/flutter/test/shared/widgets/chart_semantics_test.dart
@@ -1,0 +1,138 @@
+/// `CustomPaint` 로 그린 그래프가 스크린리더에 무엇을 말하는지. (#972)
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/gen/l10n/app_localizations.dart';
+import 'package:oncare/shared/widgets/chart_semantics.dart';
+import 'package:oncare/shared/widgets/metric_trend_chart.dart';
+
+/// [body] 를 두 로케일로 각각 그려 보고, 그 안에서 만든 라벨을 돌려준다.
+Future<Map<String, String>> _perLocale(
+  WidgetTester tester,
+  String Function(AppLocalizations l) body,
+) async {
+  final Map<String, String> out = <String, String>{};
+  for (final String code in <String>['ko', 'en']) {
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: Locale(code),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (BuildContext context) {
+            out[code] = body(AppLocalizations.of(context));
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+  return out;
+}
+
+void main() {
+  testWidgets('요일별 값을 한 문장으로 모은다', (WidgetTester tester) async {
+    final Map<String, String> labels = await _perLocale(
+      tester,
+      (AppLocalizations l) => chartSemanticsLabel(
+        l,
+        title: '주간 소모 칼로리',
+        points: chartSeriesPoints(
+          l,
+          values: const <double>[300, 0, 520],
+          dayLabels: const <String>['월', '화', '수'],
+          format: (double v) => '${v.round()}kcal',
+        ),
+      ),
+    );
+
+    for (final String label in labels.values) {
+      expect(label, contains('주간 소모 칼로리'));
+      expect(label, contains('월 300kcal'));
+      expect(label, contains('수 520kcal'));
+      // 0 은 이 앱에서 `기록 없음` 이다. 측정된 0 처럼 읽히면 안 된다.
+      expect(label, isNot(contains('화')));
+    }
+  });
+
+  testWidgets('아직 오지 않은 요일은 읽지 않는다', (WidgetTester tester) async {
+    // 선은 오늘까지만 그린다 — 그 뒤 칸을 읽으면 화면에 없는 값을 말한다.
+    final Map<String, String> labels = await _perLocale(
+      tester,
+      (AppLocalizations l) => chartSemanticsLabel(
+        l,
+        title: '나트륨',
+        points: chartSeriesPoints(
+          l,
+          values: const <double>[1800, 1900, 2100],
+          dayLabels: const <String>['월', '화', '수'],
+          format: (double v) => '${v.round()}mg',
+          upTo: 1,
+        ),
+      ),
+    );
+
+    for (final String label in labels.values) {
+      expect(label, contains('월 1800mg'));
+      expect(label, contains('화 1900mg'));
+      expect(label, isNot(contains('2100mg')));
+    }
+  });
+
+  testWidgets('기록이 하나도 없으면 비어 있다고 말한다', (WidgetTester tester) async {
+    final Map<String, String> labels = await _perLocale(
+      tester,
+      (AppLocalizations l) => chartSemanticsLabel(
+        l,
+        title: '당류',
+        points: chartSeriesPoints(
+          l,
+          values: const <double>[0, 0, 0],
+          dayLabels: const <String>['월', '화', '수'],
+          format: (double v) => '${v.round()}g',
+        ),
+      ),
+    );
+
+    expect(labels['ko'], '당류. 기록이 없어요');
+    expect(labels['en'], '당류. No records yet');
+  });
+
+  testWidgets('꺾은선 그래프는 요약 한 문장만 시맨틱 트리에 남긴다', (WidgetTester tester) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
+    await tester.pumpWidget(
+      const MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: SizedBox(
+            width: 320,
+            child: MetricTrendChart(
+              values: <double>[1800, 1900, 2100, 0, 0, 0, 0],
+              dayLabels: <String>['월', '화', '수', '목', '금', '토', '일'],
+              goal: 2000,
+              ticks: <double>[0, 1750, 3500],
+              todayIndex: 2,
+              replayKey: 'sodium',
+              semanticsLabel: '나트륨 주간 추이. 월 1800mg, 화 1900mg, 수 2100mg',
+              formatTick: metricTrendNumber,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(
+      find.bySemanticsLabel('나트륨 주간 추이. 월 1800mg, 화 1900mg, 수 2100mg'),
+      findsOneWidget,
+    );
+    // 요일 낱글자는 시맨틱 트리에 남지 않는다 — `월` `화` 만 읽어서는 그래프가
+    // 무슨 값을 말하는지 알 수 없다.
+    expect(find.bySemanticsLabel('월'), findsNothing);
+    handle.dispose();
+  });
+}

--- a/frontend/flutter/test/shared/widgets/metric_trend_chart_test.dart
+++ b/frontend/flutter/test/shared/widgets/metric_trend_chart_test.dart
@@ -92,6 +92,7 @@ void main() {
               ticks: const <double>[0, 5, 10],
               todayIndex: 2,
               replayKey: 'k',
+              semanticsLabel: '나트륨 주간 추이',
               formatTick: (double v) => v.toStringAsFixed(0),
             ),
           ),

--- a/frontend/flutter_trainer/lib/features/auth/presentation/pages/trainer_sign_in_page.dart
+++ b/frontend/flutter_trainer/lib/features/auth/presentation/pages/trainer_sign_in_page.dart
@@ -177,6 +177,11 @@ class _TrainerSignInPageState extends ConsumerState<TrainerSignInPage> {
                     obscure: _obscure,
                     onSubmitted: (_) => _login(),
                     trailing: IconButton(
+                      // 아이콘만 있는 버튼이라 무엇을 켜고 끄는지 말할 데가
+                      // 툴팁뿐이다(#972).
+                      tooltip: _obscure
+                          ? l.a11yShowPassword
+                          : l.a11yHidePassword,
                       icon: Icon(
                         _obscure ? Icons.visibility_off : Icons.visibility,
                         size: 20,

--- a/frontend/flutter_trainer/lib/features/auth/presentation/pages/trainer_sign_up_page.dart
+++ b/frontend/flutter_trainer/lib/features/auth/presentation/pages/trainer_sign_up_page.dart
@@ -143,6 +143,8 @@ class _TrainerSignUpPageState extends ConsumerState<TrainerSignUpPage> {
               child: Padding(
                 padding: const EdgeInsets.all(AppSpacing.xs),
                 child: IconButton(
+                  // 뒤로 가기는 플랫폼이 이미 제 언어로 부르는 이름이 있다.
+                  tooltip: MaterialLocalizations.of(context).backButtonTooltip,
                   onPressed: _backToSignIn,
                   icon: const Icon(Icons.arrow_back),
                   color: const Color(0xFF64748B),
@@ -195,6 +197,11 @@ class _TrainerSignUpPageState extends ConsumerState<TrainerSignUpPage> {
                         icon: Icons.lock_outline,
                         obscure: _obscure,
                         trailing: IconButton(
+                          // 아이콘만 있는 버튼이라 무엇을 켜고 끄는지 말할
+                          // 데가 툴팁뿐이다(#972).
+                          tooltip: _obscure
+                              ? l.a11yShowPassword
+                              : l.a11yHidePassword,
                           icon: Icon(
                             _obscure ? Icons.visibility_off : Icons.visibility,
                             size: 20,

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
@@ -827,12 +827,15 @@ class _InputBar extends StatelessWidget {
               key: const ValueKey<String>('client-chat-send'),
               customBorder: const CircleBorder(),
               onTap: sending ? null : onSend,
-              child: const Padding(
-                padding: EdgeInsets.all(AppSpacing.sm),
-                child: Icon(
-                  Icons.send,
-                  size: 18,
-                  color: AppColors.accentForeground,
+              child: Tooltip(
+                message: AppLocalizations.of(context).a11ySendMessage,
+                child: const Padding(
+                  padding: EdgeInsets.all(AppSpacing.sm),
+                  child: Icon(
+                    Icons.send,
+                    size: 18,
+                    color: AppColors.accentForeground,
+                  ),
                 ),
               ),
             ),

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_diet_period_card.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_diet_period_card.dart
@@ -15,6 +15,7 @@ import 'package:oncare_trainer/shared/models/trainer_client.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
 import 'package:oncare_trainer/shared/widgets/action_button.dart';
 import 'package:oncare_trainer/shared/widgets/activity_charts.dart';
+import 'package:oncare_trainer/shared/widgets/chart_semantics.dart';
 import 'package:oncare_trainer/shared/widgets/metric_trend_chart.dart';
 import 'package:oncare_trainer/shared/widgets/section_card.dart';
 
@@ -299,19 +300,38 @@ class _Body extends StatelessWidget {
         ),
         const SizedBox(height: AppSpacing.md),
         if (weekly)
-          MetricTrendChart(
-            values: values,
-            dayLabels: <String>[
-              for (final DateTime d in dates) _weekdayLabel(l, d),
-            ],
-            goal: goal,
-            ticks: ticks,
-            // 선은 오늘까지만 잇는다. 아직 오지 않은 요일의 0 이 급락처럼
-            // 보이면 안 된다.
-            todayIndex: _todayIndexIn(dates),
-            replayKey: label,
-            goalLabel: '${l.clientPeriodGoal}\n${format(goal)}',
-            formatTick: (double v) => format(v),
+          Builder(
+            builder: (BuildContext context) {
+              final days = <String>[
+                for (final DateTime d in dates) _weekdayLabel(l, d),
+              ];
+              final today = _todayIndexIn(dates);
+              return MetricTrendChart(
+                values: values,
+                dayLabels: days,
+                goal: goal,
+                ticks: ticks,
+                // 선은 오늘까지만 잇는다. 아직 오지 않은 요일의 0 이 급락처럼
+                // 보이면 안 된다.
+                todayIndex: today,
+                replayKey: label,
+                // 카드 머리의 지표 이름으로 시작한다 — 음성 안내에서도 이
+                // 그래프가 무엇의 것인지가 먼저 들린다(#972).
+                semanticsLabel: chartSemanticsLabel(
+                  l,
+                  title: label,
+                  points: chartSeriesPoints(
+                    l,
+                    values: values,
+                    dayLabels: days,
+                    format: (double v) => '${format(v)} $unit',
+                    upTo: today,
+                  ),
+                ),
+                goalLabel: '${l.clientPeriodGoal}\n${format(goal)}',
+                formatTick: (double v) => format(v),
+              );
+            },
           )
         else ...<Widget>[
           _PeriodBars(
@@ -418,74 +438,97 @@ class _PeriodBars extends StatelessWidget {
     final bool hasGoal = goal > 0;
     // 달(30칸)에서도 라벨이 겹치지 않도록 몇 칸에 하나만 적는다.
     final int labelStep = values.length > 10 ? (values.length / 6).ceil() : 1;
+    // 기록이 하나도 없는 달은 막대마다 `기록 없음` 을 서른 번 읽히는 대신 비어
+    // 있다고 한 번만 말한다(#972).
+    final bool empty = logged.every((bool it) => !it);
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        SizedBox(
-          height: chartHeight,
-          child: Stack(
-            children: <Widget>[
-              if (hasGoal)
-                Positioned(
-                  left: 0,
-                  right: 0,
-                  bottom: chartHeight * (goal / maxValue).clamp(0.0, 1.0),
-                  child: const Divider(
-                    height: 1,
-                    thickness: 1,
-                    color: AppColors.borderStrong,
-                  ),
-                ),
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.end,
+    return Semantics(
+      container: true,
+      label: empty
+          ? chartSemanticsLabel(l, title: label, points: const <String>[])
+          : null,
+      child: ExcludeSemantics(
+        excluding: empty,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            SizedBox(
+              height: chartHeight,
+              child: Stack(
                 children: <Widget>[
-                  for (int i = 0; i < values.length; i++)
-                    Expanded(
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 1.5),
-                        child: Tooltip(
-                          key: Key('client-diet-bar-$i'),
-                          message: _tip(l, i),
-                          child: _MacroBar(
-                            height:
-                                chartHeight *
-                                (values[i] / maxValue).clamp(0.0, 1.0),
-                            day: _dayAt(i),
-                            logged: logged[i],
-                            // 목표를 넘긴 날은 한 색(경고)으로 칠한다. 쌓은
-                            // 막대까지 빨갛게 물들이면 무엇이 얼마인지가
-                            // 사라지므로, 탄단지가 있는 날은 쌓은 색을 지키고
-                            // 초과는 목표선과 툴팁이 말한다.
-                            over: hasGoal && values[i] > goal,
-                          ),
-                        ),
+                  if (hasGoal)
+                    Positioned(
+                      left: 0,
+                      right: 0,
+                      bottom: chartHeight * (goal / maxValue).clamp(0.0, 1.0),
+                      child: const Divider(
+                        height: 1,
+                        thickness: 1,
+                        color: AppColors.borderStrong,
                       ),
                     ),
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: <Widget>[
+                      for (int i = 0; i < values.length; i++)
+                        Expanded(
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 1.5,
+                            ),
+                            // 툴팁은 올려야 보인다. 같은 내용을 시맨틱 라벨로도
+                            // 준다 — 막대 하나가 며칠 얼마인지는 이 노드 말고는
+                            // 음성 안내에 나올 데가 없다(#972).
+                            child: Semantics(
+                              label: _tip(l, i)
+                                  .split('\n')
+                                  .map((String s) => s.trim())
+                                  .join(', '),
+                              child: Tooltip(
+                                key: Key('client-diet-bar-$i'),
+                                message: _tip(l, i),
+                                child: _MacroBar(
+                                  height:
+                                      chartHeight *
+                                      (values[i] / maxValue).clamp(0.0, 1.0),
+                                  day: _dayAt(i),
+                                  logged: logged[i],
+                                  // 목표를 넘긴 날은 한 색(경고)으로 칠한다. 쌓은
+                                  // 막대까지 빨갛게 물들이면 무엇이 얼마인지가
+                                  // 사라지므로, 탄단지가 있는 날은 쌓은 색을 지키고
+                                  // 초과는 목표선과 툴팁이 말한다.
+                                  over: hasGoal && values[i] > goal,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                    ],
+                  ),
                 ],
               ),
-            ],
-          ),
-        ),
-        const SizedBox(height: 5),
-        Row(
-          children: <Widget>[
-            for (int i = 0; i < dates.length; i++)
-              Expanded(
-                child: Text(
-                  i % labelStep == 0 ? '${dates[i].day}' : '',
-                  textAlign: TextAlign.center,
-                  maxLines: 1,
-                  style: const TextStyle(
-                    fontSize: 9.5,
-                    fontWeight: FontWeight.w600,
-                    color: AppColors.mutedForeground,
+            ),
+            const SizedBox(height: 5),
+            Row(
+              children: <Widget>[
+                for (int i = 0; i < dates.length; i++)
+                  Expanded(
+                    child: Text(
+                      i % labelStep == 0 ? '${dates[i].day}' : '',
+                      textAlign: TextAlign.center,
+                      maxLines: 1,
+                      style: const TextStyle(
+                        fontSize: 9.5,
+                        fontWeight: FontWeight.w600,
+                        color: AppColors.mutedForeground,
+                      ),
+                    ),
                   ),
-                ),
-              ),
+              ],
+            ),
           ],
         ),
-      ],
+      ),
     );
   }
 

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_exercise_status_card.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_exercise_status_card.dart
@@ -161,6 +161,7 @@ class _Range extends StatelessWidget {
         ),
         const SizedBox(height: AppSpacing.md),
         ActivityBarChart(
+          title: l.clientTrendTitle,
           bars: <ActivityBar>[
             for (final ClientExerciseDay d in days)
               if (d.hasTypeSplit)

--- a/frontend/flutter_trainer/lib/features/coaching/presentation/pages/coaching_page.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/pages/coaching_page.dart
@@ -1269,6 +1269,7 @@ class _WeekCompletionBars extends StatelessWidget {
         else
           BarSeriesChart(
             key: const ValueKey<String>('program-week-completion-chart'),
+            title: l.reportsCompletionByDay,
             values: week,
             labels: weekdayLabels(l),
             maxValue: 100,

--- a/frontend/flutter_trainer/lib/features/coaching/presentation/widgets/program_template_dialog.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/widgets/program_template_dialog.dart
@@ -292,6 +292,7 @@ class _ExerciseRow extends StatelessWidget {
                 ),
               ),
               IconButton(
+                tooltip: l.a11yRemoveExercise,
                 onPressed: onRemove,
                 icon: const Icon(Icons.remove_circle_outline),
                 color: AppColors.mutedForeground,

--- a/frontend/flutter_trainer/lib/features/consultations/presentation/widgets/consultation_inbox_sheet.dart
+++ b/frontend/flutter_trainer/lib/features/consultations/presentation/widgets/consultation_inbox_sheet.dart
@@ -46,6 +46,9 @@ class ConsultationInboxSheet extends ConsumerWidget {
                     ),
                   ),
                   IconButton(
+                    tooltip: MaterialLocalizations.of(
+                      context,
+                    ).closeButtonTooltip,
                     onPressed: () => Navigator.of(context).pop(),
                     icon: const Icon(Icons.close),
                   ),

--- a/frontend/flutter_trainer/lib/features/my/presentation/pages/my_page.dart
+++ b/frontend/flutter_trainer/lib/features/my/presentation/pages/my_page.dart
@@ -1118,12 +1118,19 @@ class _CertsCard extends StatelessWidget {
                     ),
                   ),
                   if (editing)
-                    GestureDetector(
-                      onTap: () => onRemove(i),
-                      child: const Icon(
-                        Icons.close,
-                        size: 14,
-                        color: AppColors.subtleForeground,
+                    // `GestureDetector` 는 버튼으로 인식되지 않고, 안에 있는
+                    // 것은 X 아이콘 하나뿐이라 무엇을 지우는지 말할 데가
+                    // 없다(#972).
+                    Semantics(
+                      button: true,
+                      label: l.a11yRemoveCertification,
+                      child: GestureDetector(
+                        onTap: () => onRemove(i),
+                        child: const Icon(
+                          Icons.close,
+                          size: 14,
+                          color: AppColors.subtleForeground,
+                        ),
                       ),
                     ),
                 ],

--- a/frontend/flutter_trainer/lib/features/reports/presentation/widgets/client_report_view.dart
+++ b/frontend/flutter_trainer/lib/features/reports/presentation/widgets/client_report_view.dart
@@ -155,6 +155,7 @@ class ClientReportView extends StatelessWidget {
               // 어디든 같은 규칙으로 그린다(#752).
               if (report.weekCompletion.length == weekdayCount)
                 BarSeriesChart(
+                  title: l.reportsCompletionByDay,
                   values: report.weekCompletion,
                   labels: weekdayLabels(AppLocalizations.of(context)),
                   maxValue: 100,

--- a/frontend/flutter_trainer/lib/features/reports/presentation/widgets/metric_trend_section.dart
+++ b/frontend/flutter_trainer/lib/features/reports/presentation/widgets/metric_trend_section.dart
@@ -9,6 +9,7 @@ import 'package:oncare_trainer/features/reports/domain/weekly_report.dart';
 import 'package:oncare_trainer/features/reports/presentation/widgets/four_week_metric_trend.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 import 'package:oncare_trainer/shared/models/trainer_client.dart';
+import 'package:oncare_trainer/shared/widgets/chart_semantics.dart';
 import 'package:oncare_trainer/shared/widgets/metric_trend_chart.dart';
 import 'package:oncare_trainer/shared/widgets/section_card.dart';
 
@@ -39,6 +40,14 @@ class _MetricTrendSectionState extends State<MetricTrendSection> {
     _TrendMetric.calories => l.metricCalories,
     _TrendMetric.sodium => l.metricSodium,
     _TrendMetric.sugar => l.metricSugar,
+  };
+
+  /// 고른 지표의 단위. 4주 추이 막대와 시맨틱 라벨이 **같은 것**을 써야
+  /// 그래프와 음성 안내가 서로 다른 단위를 말하지 않는다.
+  String _unit(AppLocalizations l) => switch (_metric) {
+    _TrendMetric.calories => l.unitKcal,
+    _TrendMetric.sodium => l.unitMg,
+    _TrendMetric.sugar => l.unitGram,
   };
 
   /// 선택한 지표의 요일별 값. 계열이 7일이 아니면(구버전 응답) 비워 둔다.
@@ -118,6 +127,23 @@ class _MetricTrendSectionState extends State<MetricTrendSection> {
             // 지표를 바꾸면 선을 처음부터 다시 그려 값이 바뀐 것을 눈으로
             // 따라가게 한다.
             replayKey: _metric,
+            // 화면 위 제목과 같은 문구로 시작한다 — 음성 안내에서도 이 그래프가
+            // 어느 지표의 것인지가 먼저 들린다(#972).
+            semanticsLabel: chartSemanticsLabel(
+              l,
+              title: l.reportsMetricTrend(_label(l, _metric)),
+              points: chartSeriesPoints(
+                l,
+                values: values,
+                dayLabels: weekdayLabels(l),
+                format: (double v) => '${metricTrendNumber(v)}${_unit(l)}',
+                // 이번 주 선은 오늘까지만 잇는다. 아직 오지 않은 요일을 읽으면
+                // 화면에 없는 값을 말하게 된다.
+                upTo: widget.report.isCurrentWeek
+                    ? elapsedWeekdays(nowKst()) - 1
+                    : weekdayCount - 1,
+              ),
+            ),
             goalLabel: l.chartGoalLabel(metricTrendNumber(_goal)),
             formatTick: metricTrendNumber,
           ),
@@ -131,11 +157,7 @@ class _MetricTrendSectionState extends State<MetricTrendSection> {
             _TrendMetric.sugar => r.sugarWeek,
           },
           goal: _goal,
-          unit: switch (_metric) {
-            _TrendMetric.calories => 'kcal',
-            _TrendMetric.sodium => 'mg',
-            _TrendMetric.sugar => 'g',
-          },
+          unit: _unit(l),
         ),
       ],
     );

--- a/frontend/flutter_trainer/lib/features/reports/presentation/widgets/week_comparison.dart
+++ b/frontend/flutter_trainer/lib/features/reports/presentation/widgets/week_comparison.dart
@@ -160,6 +160,7 @@ class _ComparisonMetric extends StatelessWidget {
           ),
           const SizedBox(height: 3),
           BarSeriesChart(
+            title: label,
             values: <int>[previous ?? 0, current ?? 0],
             labels: <String>[previousLabel, currentLabel],
             maxValue: maxValue,

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/schedule_date_nav_bar.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/schedule_date_nav_bar.dart
@@ -39,7 +39,11 @@ class ScheduleDateNavBar extends StatelessWidget {
   Widget build(BuildContext context) {
     final AppLocalizations l = AppLocalizations.of(context);
     final nav = <Widget>[
-      _ChevronButton(icon: Icons.chevron_left, onTap: () => onShift(-1)),
+      _ChevronButton(
+        icon: Icons.chevron_left,
+        tooltip: l.a11yPrevDay,
+        onTap: () => onShift(-1),
+      ),
       const SizedBox(width: AppSpacing.sm),
       Text(
         l.dateRange(
@@ -53,7 +57,11 @@ class ScheduleDateNavBar extends StatelessWidget {
         ),
       ),
       const SizedBox(width: AppSpacing.sm),
-      _ChevronButton(icon: Icons.chevron_right, onTap: () => onShift(1)),
+      _ChevronButton(
+        icon: Icons.chevron_right,
+        tooltip: l.a11yNextDay,
+        onTap: () => onShift(1),
+      ),
     ];
 
     return LayoutBuilder(
@@ -77,7 +85,14 @@ class ScheduleDateNavBar extends StatelessWidget {
 }
 
 class _ChevronButton extends StatelessWidget {
-  const _ChevronButton({required this.icon, required this.onTap});
+  const _ChevronButton({
+    required this.icon,
+    required this.tooltip,
+    required this.onTap,
+  });
+
+  /// 화살표 하나뿐이라 어느 쪽으로 가는지 말할 데가 툴팁뿐이다(#972).
+  final String tooltip;
 
   final IconData icon;
   final VoidCallback onTap;
@@ -93,7 +108,10 @@ class _ChevronButton extends StatelessWidget {
         clipBehavior: Clip.antiAlias,
         child: InkWell(
           onTap: onTap,
-          child: Icon(icon, size: 20, color: AppColors.mutedForeground),
+          child: Tooltip(
+            message: tooltip,
+            child: Icon(icon, size: 20, color: AppColors.mutedForeground),
+          ),
         ),
       ),
     );

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
@@ -5521,6 +5521,78 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'No feedback'**
   String get reportsPdfNoFeedback;
+
+  /// No description provided for @a11yChartSummary.
+  ///
+  /// In en, this message translates to:
+  /// **'{title}. {detail}'**
+  String a11yChartSummary(String title, String detail);
+
+  /// No description provided for @a11yChartEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'{title}. No records yet'**
+  String a11yChartEmpty(String title);
+
+  /// No description provided for @a11yChartPoint.
+  ///
+  /// In en, this message translates to:
+  /// **'{day} {value}'**
+  String a11yChartPoint(String day, String value);
+
+  /// No description provided for @a11yShowPassword.
+  ///
+  /// In en, this message translates to:
+  /// **'Show password'**
+  String get a11yShowPassword;
+
+  /// No description provided for @a11yHidePassword.
+  ///
+  /// In en, this message translates to:
+  /// **'Hide password'**
+  String get a11yHidePassword;
+
+  /// No description provided for @unitMg.
+  ///
+  /// In en, this message translates to:
+  /// **'mg'**
+  String get unitMg;
+
+  /// No description provided for @unitGram.
+  ///
+  /// In en, this message translates to:
+  /// **'g'**
+  String get unitGram;
+
+  /// No description provided for @a11yRemoveExercise.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove exercise'**
+  String get a11yRemoveExercise;
+
+  /// No description provided for @a11yRemoveCertification.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove certification'**
+  String get a11yRemoveCertification;
+
+  /// No description provided for @a11yPrevDay.
+  ///
+  /// In en, this message translates to:
+  /// **'Previous day'**
+  String get a11yPrevDay;
+
+  /// No description provided for @a11yNextDay.
+  ///
+  /// In en, this message translates to:
+  /// **'Next day'**
+  String get a11yNextDay;
+
+  /// No description provided for @a11ySendMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'Send message'**
+  String get a11ySendMessage;
 }
 
 class _AppLocalizationsDelegate

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
@@ -3142,4 +3142,46 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get reportsPdfNoFeedback => 'No feedback';
+
+  @override
+  String a11yChartSummary(String title, String detail) {
+    return '$title. $detail';
+  }
+
+  @override
+  String a11yChartEmpty(String title) {
+    return '$title. No records yet';
+  }
+
+  @override
+  String a11yChartPoint(String day, String value) {
+    return '$day $value';
+  }
+
+  @override
+  String get a11yShowPassword => 'Show password';
+
+  @override
+  String get a11yHidePassword => 'Hide password';
+
+  @override
+  String get unitMg => 'mg';
+
+  @override
+  String get unitGram => 'g';
+
+  @override
+  String get a11yRemoveExercise => 'Remove exercise';
+
+  @override
+  String get a11yRemoveCertification => 'Remove certification';
+
+  @override
+  String get a11yPrevDay => 'Previous day';
+
+  @override
+  String get a11yNextDay => 'Next day';
+
+  @override
+  String get a11ySendMessage => 'Send message';
 }

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
@@ -3021,4 +3021,46 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get reportsPdfNoFeedback => '피드백 없음';
+
+  @override
+  String a11yChartSummary(String title, String detail) {
+    return '$title. $detail';
+  }
+
+  @override
+  String a11yChartEmpty(String title) {
+    return '$title. 기록이 없어요';
+  }
+
+  @override
+  String a11yChartPoint(String day, String value) {
+    return '$day $value';
+  }
+
+  @override
+  String get a11yShowPassword => '비밀번호 표시';
+
+  @override
+  String get a11yHidePassword => '비밀번호 숨기기';
+
+  @override
+  String get unitMg => 'mg';
+
+  @override
+  String get unitGram => 'g';
+
+  @override
+  String get a11yRemoveExercise => '운동 지우기';
+
+  @override
+  String get a11yRemoveCertification => '자격증 지우기';
+
+  @override
+  String get a11yPrevDay => '이전 날';
+
+  @override
+  String get a11yNextDay => '다음 날';
+
+  @override
+  String get a11ySendMessage => '메시지 보내기';
 }

--- a/frontend/flutter_trainer/lib/l10n/app_en.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_en.arb
@@ -1619,5 +1619,20 @@
   "reportsPdfAttendance": "{done}/{booked} ({rate}%)",
   "@reportsPdfAttendance": {"placeholders": {"done": {"type": "String"}, "booked": {"type": "String"}, "rate": {"type": "String"}}},
   "reportsPdfNoData": "Not measured",
-  "reportsPdfNoFeedback": "No feedback"
+  "reportsPdfNoFeedback": "No feedback",
+  "a11yChartSummary": "{title}. {detail}",
+  "@a11yChartSummary": {"placeholders": {"title": {"type": "String"}, "detail": {"type": "String"}}},
+  "a11yChartEmpty": "{title}. No records yet",
+  "@a11yChartEmpty": {"placeholders": {"title": {"type": "String"}}},
+  "a11yChartPoint": "{day} {value}",
+  "@a11yChartPoint": {"placeholders": {"day": {"type": "String"}, "value": {"type": "String"}}},
+  "a11yShowPassword": "Show password",
+  "a11yHidePassword": "Hide password",
+  "unitMg": "mg",
+  "unitGram": "g",
+  "a11yRemoveExercise": "Remove exercise",
+  "a11yRemoveCertification": "Remove certification",
+  "a11yPrevDay": "Previous day",
+  "a11yNextDay": "Next day",
+  "a11ySendMessage": "Send message"
 }

--- a/frontend/flutter_trainer/lib/l10n/app_ko.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_ko.arb
@@ -965,5 +965,20 @@
   "reportsPdfAttendance": "{done}/{booked}회 ({rate}%)",
   "@reportsPdfAttendance": {"placeholders": {"done": {"type": "String"}, "booked": {"type": "String"}, "rate": {"type": "String"}}},
   "reportsPdfNoData": "미집계",
-  "reportsPdfNoFeedback": "피드백 없음"
+  "reportsPdfNoFeedback": "피드백 없음",
+  "a11yChartSummary": "{title}. {detail}",
+  "@a11yChartSummary": {"placeholders": {"title": {"type": "String"}, "detail": {"type": "String"}}},
+  "a11yChartEmpty": "{title}. 기록이 없어요",
+  "@a11yChartEmpty": {"placeholders": {"title": {"type": "String"}}},
+  "a11yChartPoint": "{day} {value}",
+  "@a11yChartPoint": {"placeholders": {"day": {"type": "String"}, "value": {"type": "String"}}},
+  "a11yShowPassword": "비밀번호 표시",
+  "a11yHidePassword": "비밀번호 숨기기",
+  "unitMg": "mg",
+  "unitGram": "g",
+  "a11yRemoveExercise": "운동 지우기",
+  "a11yRemoveCertification": "자격증 지우기",
+  "a11yPrevDay": "이전 날",
+  "a11yNextDay": "다음 날",
+  "a11ySendMessage": "메시지 보내기"
 }

--- a/frontend/flutter_trainer/lib/shared/widgets/activity_charts.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/activity_charts.dart
@@ -27,6 +27,7 @@ import 'package:oncare_trainer/design_system/tokens/elevation.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
+import 'package:oncare_trainer/shared/widgets/chart_semantics.dart';
 
 /// 도넛 한 조각 / 범례 한 줄.
 class ActivitySeg {
@@ -79,37 +80,53 @@ class ActivityDonut extends StatelessWidget {
             SizedBox(
               width: 116,
               height: 116,
-              child: Stack(
-                alignment: Alignment.center,
-                children: <Widget>[
-                  CustomPaint(
-                    size: const Size.square(116),
-                    painter: _DonutPainter(segs),
-                  ),
-                  Column(
-                    mainAxisSize: MainAxisSize.min,
+              // 도넛은 `CustomPaint` 라 시맨틱 트리에 아무 노드도 남기지 않고,
+              // 가운데 숫자는 `45` 와 `분` 두 조각으로 흩어져 읽힌다. 한
+              // 덩어리로 묶어 무엇의 몇 분인지 한 문장으로 말한다(#972).
+              // 유형별 내역은 오른쪽 범례가 이어서 읽어 준다.
+              child: Semantics(
+                container: true,
+                label: chartSemanticsLabel(
+                  l,
+                  title: title,
+                  points: total == 0
+                      ? const <String>[]
+                      : <String>[l.minutesShort(total)],
+                ),
+                child: ExcludeSemantics(
+                  child: Stack(
+                    alignment: Alignment.center,
                     children: <Widget>[
-                      Text(
-                        '$total',
-                        style: const TextStyle(
-                          fontSize: 24,
-                          fontWeight: FontWeight.w800,
-                          color: AppColors.foreground,
-                          height: 1,
-                          letterSpacing: -0.5,
-                        ),
+                      CustomPaint(
+                        size: const Size.square(116),
+                        painter: _DonutPainter(segs),
                       ),
-                      Text(
-                        l.unitMinutes,
-                        style: const TextStyle(
-                          fontSize: 12.5,
-                          fontWeight: FontWeight.w600,
-                          color: AppColors.mutedForeground,
-                        ),
+                      Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: <Widget>[
+                          Text(
+                            '$total',
+                            style: const TextStyle(
+                              fontSize: 24,
+                              fontWeight: FontWeight.w800,
+                              color: AppColors.foreground,
+                              height: 1,
+                              letterSpacing: -0.5,
+                            ),
+                          ),
+                          Text(
+                            l.unitMinutes,
+                            style: const TextStyle(
+                              fontSize: 12.5,
+                              fontWeight: FontWeight.w600,
+                              color: AppColors.mutedForeground,
+                            ),
+                          ),
+                        ],
                       ),
                     ],
                   ),
-                ],
+                ),
               ),
             ),
             const SizedBox(width: 40),
@@ -248,13 +265,32 @@ class ActivityBarChart extends StatelessWidget {
     required this.bars,
     required this.dayLabels,
     required this.todayIndex,
+    required this.title,
   });
 
   final List<ActivityBar> bars;
   final List<String> dayLabels;
 
+  /// 그래프가 무엇을 그린 것인지 — 기록이 하나도 없는 기간에 비어 있다고
+  /// 말할 때 이 이름으로 부른다(#972).
+  final String title;
+
   /// 오늘에 해당하는 칸. 범위 밖이면 -1.
   final int todayIndex;
+
+  /// 툴팁과 **같은 내용**을 시맨틱 라벨로. 색 사각형(`WidgetSpan`)은 빼고
+  /// 줄바꿈은 쉼표로 바꾼다 — 음성 안내는 줄을 나누어 읽지 않는다. 어느 날의
+  /// 막대인지 먼저 말해야 하므로 요일을 앞에 붙인다(#972).
+  String _barSemantics(AppLocalizations l, int i) => chartPointLabel(
+    l,
+    dayLabels[i],
+    TextSpan(children: _tipSpans(l, i))
+        .toPlainText(includePlaceholders: false)
+        .split('\n')
+        .map((String line) => line.trim())
+        .where((String line) => line.isNotEmpty)
+        .join(', '),
+  );
 
   /// 막대 하나의 툴팁 — `[색] 유형   N분` 을 줄마다.
   List<InlineSpan> _tipSpans(AppLocalizations l, int i) {
@@ -294,86 +330,103 @@ class ActivityBarChart extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations l = AppLocalizations.of(context);
-    return Column(
-      children: <Widget>[
-        SizedBox(
-          height: 150,
-          width: double.infinity,
-          child: Stack(
-            children: <Widget>[
-              Positioned.fill(
-                child: CustomPaint(
-                  painter: _StackedBarPainter(
-                    bars: bars,
-                    dayLabels: dayLabels,
-                    todayIndex: todayIndex,
-                    todayLabel: l.labelToday,
-                  ),
-                ),
-              ),
-              // 막대 위에 겹치는 투명한 hover 영역. painter 의 칸과 자리를
-              // 맞춘다(왼쪽 눈금 24, 아래 라벨 24).
-              Positioned.fill(
-                child: Padding(
-                  padding: const EdgeInsets.only(left: 24, bottom: 24),
-                  child: Row(
-                    children: <Widget>[
-                      for (int i = 0; i < bars.length; i++)
-                        Expanded(
-                          child: Tooltip(
-                            key: Key('activity-bar-$i'),
-                            richMessage: TextSpan(
-                              style: const TextStyle(
-                                fontSize: 12.5,
-                                fontWeight: FontWeight.w600,
-                                color: AppColors.foreground,
-                                height: 1.15,
-                              ),
-                              children: _tipSpans(l, i),
-                            ),
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 10,
-                              vertical: 8,
-                            ),
-                            decoration: BoxDecoration(
-                              color: AppColors.inputBackground,
-                              borderRadius: BorderRadius.circular(10),
-                              border: Border.all(color: AppColors.borderStrong),
-                              boxShadow: kCardShadow,
-                            ),
-                            child: const SizedBox.expand(),
-                          ),
-                        ),
-                    ],
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ),
-        const SizedBox(height: AppSpacing.xs),
-        // 범례 셋은 좁아지면 다음 줄로 넘긴다. 한 줄에 붙여 두면 라벨을 줄여야
-        // 하고, 그러면 무슨 색이 무엇인지가 사라진다.
-        Wrap(
-          alignment: WrapAlignment.center,
-          spacing: AppSpacing.md,
-          runSpacing: AppSpacing.xs,
+    // 한 칸도 기록이 없는 기간은 막대마다 `기록 없음` 을 서른 번 읽히는 대신
+    // 비어 있다고 한 번만 말한다(#972).
+    final bool empty = bars.every((ActivityBar b) => b.total <= 0);
+    return Semantics(
+      container: true,
+      label: empty
+          ? chartSemanticsLabel(l, title: title, points: const <String>[])
+          : null,
+      child: ExcludeSemantics(
+        excluding: empty,
+        child: Column(
           children: <Widget>[
-            ActivityLegend(
-              color: AppColors.chartCardio,
-              label: l.routineTypeCardio,
+            SizedBox(
+              height: 150,
+              width: double.infinity,
+              child: Stack(
+                children: <Widget>[
+                  Positioned.fill(
+                    child: CustomPaint(
+                      painter: _StackedBarPainter(
+                        bars: bars,
+                        dayLabels: dayLabels,
+                        todayIndex: todayIndex,
+                        todayLabel: l.labelToday,
+                      ),
+                    ),
+                  ),
+                  // 막대 위에 겹치는 투명한 hover 영역. painter 의 칸과 자리를
+                  // 맞춘다(왼쪽 눈금 24, 아래 라벨 24).
+                  Positioned.fill(
+                    child: Padding(
+                      padding: const EdgeInsets.only(left: 24, bottom: 24),
+                      child: Row(
+                        children: <Widget>[
+                          for (int i = 0; i < bars.length; i++)
+                            Expanded(
+                              child: Semantics(
+                                label: _barSemantics(l, i),
+                                child: Tooltip(
+                                  key: Key('activity-bar-$i'),
+                                  richMessage: TextSpan(
+                                    style: const TextStyle(
+                                      fontSize: 12.5,
+                                      fontWeight: FontWeight.w600,
+                                      color: AppColors.foreground,
+                                      height: 1.15,
+                                    ),
+                                    children: _tipSpans(l, i),
+                                  ),
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 10,
+                                    vertical: 8,
+                                  ),
+                                  decoration: BoxDecoration(
+                                    color: AppColors.inputBackground,
+                                    borderRadius: BorderRadius.circular(10),
+                                    border: Border.all(
+                                      color: AppColors.borderStrong,
+                                    ),
+                                    boxShadow: kCardShadow,
+                                  ),
+                                  child: const SizedBox.expand(),
+                                ),
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
             ),
-            ActivityLegend(
-              color: AppColors.chartStrength,
-              label: l.routineTypeStrength,
-            ),
-            ActivityLegend(
-              color: AppColors.chartStretching,
-              label: l.routineTypeStretching,
+            const SizedBox(height: AppSpacing.xs),
+            // 범례 셋은 좁아지면 다음 줄로 넘긴다. 한 줄에 붙여 두면 라벨을 줄여야
+            // 하고, 그러면 무슨 색이 무엇인지가 사라진다.
+            Wrap(
+              alignment: WrapAlignment.center,
+              spacing: AppSpacing.md,
+              runSpacing: AppSpacing.xs,
+              children: <Widget>[
+                ActivityLegend(
+                  color: AppColors.chartCardio,
+                  label: l.routineTypeCardio,
+                ),
+                ActivityLegend(
+                  color: AppColors.chartStrength,
+                  label: l.routineTypeStrength,
+                ),
+                ActivityLegend(
+                  color: AppColors.chartStretching,
+                  label: l.routineTypeStretching,
+                ),
+              ],
             ),
           ],
         ),
-      ],
+      ),
     );
   }
 }

--- a/frontend/flutter_trainer/lib/shared/widgets/chart_semantics.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/chart_semantics.dart
@@ -1,0 +1,48 @@
+/// `CustomPaint` 로 그린 그래프를 스크린리더에 읽히게 하는 라벨 조립기. (#972)
+///
+/// `CustomPaint` 는 픽셀만 그리고 시맨틱 트리에는 아무 노드도 남기지 않는다.
+/// 감싸는 위젯이 라벨을 주지 않으면 그 그래프는 음성 안내에서 **통째로 존재하지
+/// 않는 영역**이 된다. 이 앱이 다루는 것이 혈압·혈당 위험군의 건강 지표라,
+/// 숫자를 눈으로만 읽을 수 있게 두면 안 된다.
+///
+/// 두 앱은 패키지가 갈라져 있어 코드를 공유할 수 없다 — `metric_trend_chart`
+/// 와 같은 방식으로 규칙을 양쪽에 같은 모양으로 둔다.
+library;
+
+import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
+
+/// 요일(또는 날짜) 한 칸을 `월 300kcal` 처럼 읽는 한 조각으로.
+String chartPointLabel(AppLocalizations l, String day, String value) =>
+    l.a11yChartPoint(day, value);
+
+/// 그래프 하나를 한 문장으로. [points] 가 비면 비어 있다고 말한다 — 빈 그래프를
+/// 말없이 두면 "값이 0" 인지 "아직 기록이 없는지"를 구분할 수 없다.
+String chartSemanticsLabel(
+  AppLocalizations l, {
+  required String title,
+  required List<String> points,
+}) => points.isEmpty
+    ? l.a11yChartEmpty(title)
+    : l.a11yChartSummary(title, points.join(', '));
+
+/// 값이 있는 날만 골라 [chartPointLabel] 조각으로 만든다.
+///
+/// 0 은 건너뛴다. 이 앱의 그래프에서 0 은 "그날 0 만큼 했다"가 아니라 **기록이
+/// 없다**는 뜻이라(빈 트랙·회색 그루터기로 그린다), 0 을 읽어 주면 측정된 값처럼
+/// 들린다. 하루도 남지 않으면 빈 목록이 되어 위 함수가 비어 있다고 말한다.
+///
+/// [upTo] 는 그래프가 실제로 그리는 마지막 칸이다. 이번 주 꺾은선은 오늘까지만
+/// 잇는데, 아직 오지 않은 요일까지 읽으면 화면에 없는 값을 말하게 된다.
+List<String> chartSeriesPoints(
+  AppLocalizations l, {
+  required List<double> values,
+  required List<String> dayLabels,
+  required String Function(double) format,
+  int? upTo,
+}) {
+  final last = upTo ?? values.length - 1;
+  return <String>[
+    for (var i = 0; i <= last && i < values.length && i < dayLabels.length; i++)
+      if (values[i] != 0) chartPointLabel(l, dayLabels[i], format(values[i])),
+  ];
+}

--- a/frontend/flutter_trainer/lib/shared/widgets/metric_trend_chart.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/metric_trend_chart.dart
@@ -64,6 +64,7 @@ class MetricTrendChart extends StatelessWidget {
     required this.ticks,
     required this.todayIndex,
     required this.replayKey,
+    required this.semanticsLabel,
     this.goalLabel,
     required this.formatTick,
     this.markToday = true,
@@ -94,6 +95,11 @@ class MetricTrendChart extends StatelessWidget {
   /// 바뀌면 진입 애니메이션을 처음부터 다시 그린다.
   final Object replayKey;
 
+  /// 그래프가 말하는 내용 한 문장. `CustomPaint` 는 시맨틱 트리에 아무 노드도
+  /// 남기지 않아, 이게 없으면 그래프가 음성 안내에서 통째로 사라진다(#972).
+  /// `chartSemanticsLabel` 로 만든다 — 지표 이름과 단위는 부르는 쪽만 안다.
+  final String semanticsLabel;
+
   /// 목표선 문구 포맷.
   /// 목표선에 붙는 문구(예: `목표 2,000`). null 이면 선만 그린다. 문구를 밖에서
   /// 받는 것은 두 앱의 로케일 자원이 갈라져 있어서다.
@@ -112,91 +118,97 @@ class MetricTrendChart extends StatelessWidget {
       goal: goal,
     );
     final still = MediaQuery.maybeDisableAnimationsOf(context) ?? false;
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        // 목표선의 실제 높이에 맞춰 라벨 하나. 칸은 목표가 없어도 자리를
-        // 지킨다 — 지표를 바꿀 때 그래프 폭이 흔들리지 않는다.
-        //
-        // 폭은 눈금 라벨이 쓰던 38 그대로다. `목표 2,000` 을 한 줄로 두면 이
-        // 칸이 넓어져야 하는데, 그러면 360px 영어 로케일에서 요일 라벨 줄이
-        // 넘친다. 두 줄로 접어 폭을 지킨다.
-        SizedBox(
-          width: 38,
-          height: height,
-          child: Stack(
-            children: <Widget>[
-              if (goalLabel != null && goal > 0 && goal >= lo && goal <= hi)
-                Positioned(
-                  right: 0,
-                  top: (height - ((goal - lo) / (hi - lo)) * height - 13).clamp(
-                    0.0,
-                    height - 26,
-                  ),
-                  child: SizedBox(
-                    height: 26,
-                    child: Center(child: _AxisLabel(goalLabel!)),
-                  ),
-                ),
-            ],
-          ),
-        ),
-        const SizedBox(width: 6),
-        Expanded(
-          child: Column(
-            children: <Widget>[
-              SizedBox(
-                height: height,
-                child: still
-                    ? _paint(1, lo, hi)
-                    : TweenAnimationBuilder<double>(
-                        // 키가 바뀌면 tween 이 0부터 다시 시작한다.
-                        key: ValueKey<Object>(replayKey),
-                        tween: Tween<double>(begin: 0, end: 1),
-                        duration: const Duration(milliseconds: 620),
-                        curve: Curves.easeOutCubic,
-                        builder: (context, t, _) => _paint(t, lo, hi),
-                      ),
-              ),
-              const SizedBox(height: 6),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+    // 눈금·요일 라벨은 낱개로 읽어 봐야 `월` `화` 뿐이라 그래프가 무슨 값을
+    // 말하는지 알 수 없다. 한 덩어리로 묶고 요약 한 문장만 읽힌다.
+    return Semantics(
+      container: true,
+      label: semanticsLabel,
+      child: ExcludeSemantics(
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            // 목표선의 실제 높이에 맞춰 라벨 하나. 칸은 목표가 없어도 자리를
+            // 지킨다 — 지표를 바꿀 때 그래프 폭이 흔들리지 않는다.
+            //
+            // 폭은 눈금 라벨이 쓰던 38 그대로다. `목표 2,000` 을 한 줄로 두면 이
+            // 칸이 넓어져야 하는데, 그러면 360px 영어 로케일에서 요일 라벨 줄이
+            // 넘친다. 두 줄로 접어 폭을 지킨다.
+            SizedBox(
+              width: 38,
+              height: height,
+              child: Stack(
                 children: <Widget>[
-                  for (var i = 0; i < dayLabels.length; i++)
-                    if (i == todayIndex && markToday)
-                      // 오늘: 브랜드색 원 안에 흰 글씨.
-                      Container(
-                        width: 18,
-                        height: 18,
-                        alignment: Alignment.center,
-                        decoration: const BoxDecoration(
-                          color: AppColors.primary,
-                          shape: BoxShape.circle,
-                        ),
-                        child: Text(
-                          dayLabels[i],
-                          style: const TextStyle(
-                            fontSize: 11.5,
-                            fontWeight: FontWeight.w700,
-                            color: AppColors.primaryForeground,
-                          ),
-                        ),
-                      )
-                    else
-                      Text(
-                        dayLabels[i],
-                        style: const TextStyle(
-                          fontSize: 11.5,
-                          fontWeight: FontWeight.w600,
-                          color: AppColors.mutedForeground,
-                        ),
+                  if (goalLabel != null && goal > 0 && goal >= lo && goal <= hi)
+                    Positioned(
+                      right: 0,
+                      top: (height - ((goal - lo) / (hi - lo)) * height - 13)
+                          .clamp(0.0, height - 26),
+                      child: SizedBox(
+                        height: 26,
+                        child: Center(child: _AxisLabel(goalLabel!)),
                       ),
+                    ),
                 ],
               ),
-            ],
-          ),
+            ),
+            const SizedBox(width: 6),
+            Expanded(
+              child: Column(
+                children: <Widget>[
+                  SizedBox(
+                    height: height,
+                    child: still
+                        ? _paint(1, lo, hi)
+                        : TweenAnimationBuilder<double>(
+                            // 키가 바뀌면 tween 이 0부터 다시 시작한다.
+                            key: ValueKey<Object>(replayKey),
+                            tween: Tween<double>(begin: 0, end: 1),
+                            duration: const Duration(milliseconds: 620),
+                            curve: Curves.easeOutCubic,
+                            builder: (context, t, _) => _paint(t, lo, hi),
+                          ),
+                  ),
+                  const SizedBox(height: 6),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: <Widget>[
+                      for (var i = 0; i < dayLabels.length; i++)
+                        if (i == todayIndex && markToday)
+                          // 오늘: 브랜드색 원 안에 흰 글씨.
+                          Container(
+                            width: 18,
+                            height: 18,
+                            alignment: Alignment.center,
+                            decoration: const BoxDecoration(
+                              color: AppColors.primary,
+                              shape: BoxShape.circle,
+                            ),
+                            child: Text(
+                              dayLabels[i],
+                              style: const TextStyle(
+                                fontSize: 11.5,
+                                fontWeight: FontWeight.w700,
+                                color: AppColors.primaryForeground,
+                              ),
+                            ),
+                          )
+                        else
+                          Text(
+                            dayLabels[i],
+                            style: const TextStyle(
+                              fontSize: 11.5,
+                              fontWeight: FontWeight.w600,
+                              color: AppColors.mutedForeground,
+                            ),
+                          ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
         ),
-      ],
+      ),
     );
   }
 

--- a/frontend/flutter_trainer/lib/shared/widgets/mini_charts.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/mini_charts.dart
@@ -3,6 +3,7 @@ import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
+import 'package:oncare_trainer/shared/widgets/chart_semantics.dart';
 
 /// A compact labelled bar series (주간 이행률, 세션 수 …).
 ///
@@ -17,6 +18,7 @@ class BarSeriesChart extends StatelessWidget {
     super.key,
     required this.values,
     required this.labels,
+    required this.title,
     this.height = 96,
     this.maxValue,
     this.highlightIndex,
@@ -32,6 +34,11 @@ class BarSeriesChart extends StatelessWidget {
 
   /// X-axis labels, one per value.
   final List<String> labels;
+
+  /// 그래프가 무엇을 그린 것인지. 막대는 높이로만 값을 말하고 [showValues] 가
+  /// 꺼져 있으면 숫자가 화면 어디에도 없어, 음성 안내는 이 이름과 아래에서
+  /// 만드는 요약 문장에 기댄다(#972).
+  final String title;
 
   /// Plot height (excluding labels).
   final double height;
@@ -71,61 +78,83 @@ class BarSeriesChart extends StatelessWidget {
       1,
     ].reduce((a, b) => a > b ? a : b);
 
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: <Widget>[
-        SizedBox(
-          height: height,
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.end,
-            children: <Widget>[
-              for (var i = 0; i < values.length; i++)
-                Expanded(
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 2.5),
-                    child: _Bar(
-                      value: values[i],
-                      ceiling: ceiling,
-                      color: _colorFor(i),
-                      label: showValues
-                          ? missingIndices.contains(i)
-                                ? AppLocalizations.of(context).chartNoRecord
-                                : '${values[i]}$valueSuffix'
-                          : null,
-                      pending: i >= pendingFrom,
-                      missing: missingIndices.contains(i),
+    // 기록이 없는 칸(`missingIndices`)과 아직 오지 않은 칸은 읽지 않는다 —
+    // 빈 트랙을 `0` 으로 읽으면 측정된 0 과 구분되지 않는다.
+    final points = <String>[
+      for (var i = 0; i < values.length && i < labels.length; i++)
+        if (i < pendingFrom && !missingIndices.contains(i))
+          chartPointLabel(
+            AppLocalizations.of(context),
+            labels[i],
+            '${values[i]}$valueSuffix',
+          ),
+    ];
+
+    return Semantics(
+      container: true,
+      label: chartSemanticsLabel(
+        AppLocalizations.of(context),
+        title: title,
+        points: points,
+      ),
+      child: ExcludeSemantics(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            SizedBox(
+              height: height,
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: <Widget>[
+                  for (var i = 0; i < values.length; i++)
+                    Expanded(
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 2.5),
+                        child: _Bar(
+                          value: values[i],
+                          ceiling: ceiling,
+                          color: _colorFor(i),
+                          label: showValues
+                              ? missingIndices.contains(i)
+                                    ? AppLocalizations.of(context).chartNoRecord
+                                    : '${values[i]}$valueSuffix'
+                              : null,
+                          pending: i >= pendingFrom,
+                          missing: missingIndices.contains(i),
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            Row(
+              children: <Widget>[
+                for (var i = 0; i < labels.length; i++)
+                  Expanded(
+                    child: Text(
+                      labels[i],
+                      textAlign: TextAlign.center,
+                      maxLines: 1,
+                      overflow: TextOverflow.clip,
+                      style: TextStyle(
+                        fontSize: 11,
+                        fontWeight: highlightIndex == i
+                            ? FontWeight.w800
+                            : FontWeight.w500,
+                        color: highlightIndex == i
+                            ? AppColors.primary
+                            : i >= pendingFrom
+                            ? AppColors.disabledForeground
+                            : AppColors.subtleForeground,
+                      ),
                     ),
                   ),
-                ),
-            ],
-          ),
-        ),
-        const SizedBox(height: AppSpacing.xs),
-        Row(
-          children: <Widget>[
-            for (var i = 0; i < labels.length; i++)
-              Expanded(
-                child: Text(
-                  labels[i],
-                  textAlign: TextAlign.center,
-                  maxLines: 1,
-                  overflow: TextOverflow.clip,
-                  style: TextStyle(
-                    fontSize: 11,
-                    fontWeight: highlightIndex == i
-                        ? FontWeight.w800
-                        : FontWeight.w500,
-                    color: highlightIndex == i
-                        ? AppColors.primary
-                        : i >= pendingFrom
-                        ? AppColors.disabledForeground
-                        : AppColors.subtleForeground,
-                  ),
-                ),
-              ),
+              ],
+            ),
           ],
         ),
-      ],
+      ),
     );
   }
 

--- a/frontend/flutter_trainer/test/shared/widgets/chart_semantics_test.dart
+++ b/frontend/flutter_trainer/test/shared/widgets/chart_semantics_test.dart
@@ -1,0 +1,195 @@
+/// `CustomPaint` 로 그린 그래프가 스크린리더에 무엇을 말하는지. (#972)
+///
+/// 회원 앱의 같은 이름 테스트와 짝이다 — 두 앱이 같은 그림을 그리므로 음성
+/// 안내도 같은 말을 해야 한다.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
+import 'package:oncare_trainer/shared/widgets/activity_charts.dart';
+import 'package:oncare_trainer/shared/widgets/chart_semantics.dart';
+import 'package:oncare_trainer/shared/widgets/metric_trend_chart.dart';
+import 'package:oncare_trainer/shared/widgets/mini_charts.dart';
+
+Future<Map<String, String>> _perLocale(
+  WidgetTester tester,
+  String Function(AppLocalizations l) body,
+) async {
+  final out = <String, String>{};
+  for (final code in <String>['ko', 'en']) {
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: Locale(code),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) {
+            out[code] = body(AppLocalizations.of(context));
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+  return out;
+}
+
+Future<void> _pump(WidgetTester tester, Widget child, {String locale = 'ko'}) {
+  return tester.pumpWidget(
+    MaterialApp(
+      locale: Locale(locale),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: SizedBox(width: 360, child: child)),
+    ),
+  );
+}
+
+/// [needle] 을 담은 시맨틱 노드를 찾는 finder.
+Finder _labelled(String needle) =>
+    find.bySemanticsLabel(RegExp(RegExp.escape(needle)));
+
+/// 그 노드가 실제로 읽어 주는 문장.
+String _label(WidgetTester tester, String needle) =>
+    tester.getSemantics(_labelled(needle)).label;
+
+void main() {
+  testWidgets('요일별 값을 한 문장으로 모으고 0 은 읽지 않는다', (tester) async {
+    final labels = await _perLocale(
+      tester,
+      (l) => chartSemanticsLabel(
+        l,
+        title: '나트륨 추이',
+        points: chartSeriesPoints(
+          l,
+          values: const <double>[1800, 0, 2100],
+          dayLabels: const <String>['월', '화', '수'],
+          format: (v) => '${v.round()}mg',
+        ),
+      ),
+    );
+
+    for (final label in labels.values) {
+      expect(label, contains('나트륨 추이'));
+      expect(label, contains('월 1800mg'));
+      expect(label, contains('수 2100mg'));
+      // 0 은 이 앱에서 `기록 없음` 이다 — 측정된 0 처럼 읽히면 안 된다.
+      expect(label, isNot(contains('화')));
+    }
+  });
+
+  testWidgets('기록이 없으면 두 로케일 모두 비어 있다고 말한다', (tester) async {
+    final labels = await _perLocale(
+      tester,
+      (l) => chartSemanticsLabel(l, title: '당류', points: const <String>[]),
+    );
+
+    expect(labels['ko'], '당류. 기록이 없어요');
+    expect(labels['en'], '당류. No records yet');
+  });
+
+  testWidgets('꺾은선은 요약 한 문장만 남기고 요일 낱글자는 감춘다', (tester) async {
+    final handle = tester.ensureSemantics();
+    await _pump(
+      tester,
+      const MetricTrendChart(
+        values: <double>[1800, 1900, 2100, 0, 0, 0, 0],
+        dayLabels: <String>['월', '화', '수', '목', '금', '토', '일'],
+        goal: 2000,
+        ticks: <double>[0, 1750, 3500],
+        todayIndex: 2,
+        replayKey: 'sodium',
+        semanticsLabel: '나트륨 주간 추이. 월 1800mg',
+        formatTick: metricTrendNumber,
+      ),
+    );
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(find.bySemanticsLabel('나트륨 주간 추이. 월 1800mg'), findsOneWidget);
+    expect(find.bySemanticsLabel('월'), findsNothing);
+    handle.dispose();
+  });
+
+  testWidgets('막대 계열은 요일과 값을 함께 읽고 없는 칸은 건너뛴다', (tester) async {
+    final handle = tester.ensureSemantics();
+    await _pump(
+      tester,
+      BarSeriesChart(
+        title: '주간 운동 이행률',
+        values: const <int>[80, 0, 70],
+        labels: const <String>['월', '화', '수'],
+        maxValue: 100,
+        valueSuffix: '%',
+        missingIndices: const <int>{1},
+      ),
+    );
+
+    final label = _label(tester, '주간 운동 이행률');
+    expect(label, contains('월 80%'));
+    expect(label, contains('수 70%'));
+    // 기록이 없는 날은 0% 가 아니다.
+    expect(label, isNot(contains('화')));
+    handle.dispose();
+  });
+
+  testWidgets('누적 막대는 막대마다 그날의 유형별 시간을 읽는다', (tester) async {
+    final handle = tester.ensureSemantics();
+    await _pump(
+      tester,
+      const ActivityBarChart(
+        title: '운동 현황',
+        bars: <ActivityBar>[ActivityBar(30, 20, 0), ActivityBar(0, 0, 0)],
+        dayLabels: <String>['월', '화'],
+        todayIndex: 0,
+      ),
+    );
+
+    expect(
+      _labelled('월'),
+      findsOneWidget,
+      reason: '막대가 시맨틱 트리에 아무것도 남기지 않았습니다.',
+    );
+    final label = _label(tester, '월');
+    expect(label, contains('30'));
+    expect(label, contains('20'));
+    handle.dispose();
+  });
+
+  testWidgets('한 칸도 기록이 없는 기간은 비어 있다고 한 번만 말한다', (tester) async {
+    final handle = tester.ensureSemantics();
+    await _pump(
+      tester,
+      const ActivityBarChart(
+        title: '운동 현황',
+        bars: <ActivityBar>[ActivityBar(0, 0, 0), ActivityBar(0, 0, 0)],
+        dayLabels: <String>['월', '화'],
+        todayIndex: 0,
+      ),
+    );
+
+    expect(_labelled('기록이 없어요'), findsOneWidget);
+    handle.dispose();
+  });
+
+  testWidgets('도넛은 가운데 숫자를 한 덩어리로 읽는다', (tester) async {
+    final handle = tester.ensureSemantics();
+    await _pump(
+      tester,
+      const ActivityDonut(
+        title: '오늘 총 운동 시간',
+        segs: <ActivitySeg>[
+          ActivitySeg('유산소', 30, Color(0xFF000000)),
+          ActivitySeg('근력', 20, Color(0xFF111111)),
+        ],
+      ),
+    );
+
+    // 도넛 오른쪽 열 머리글에도 같은 문구가 있다 — 합계까지 함께 읽는 노드를
+    // 지목한다.
+    expect(_labelled('오늘 총 운동 시간. 50'), findsOneWidget);
+    handle.dispose();
+  });
+}

--- a/frontend/flutter_trainer/test/shared/widgets/metric_trend_chart_test.dart
+++ b/frontend/flutter_trainer/test/shared/widgets/metric_trend_chart_test.dart
@@ -25,6 +25,7 @@ void main() {
           ticks: const <double>[0, 1750, 3500],
           todayIndex: 5,
           replayKey: 'sodium',
+          semanticsLabel: '나트륨 주간 추이',
           goalLabel: goalLabel,
           formatTick: metricTrendNumber,
         ),
@@ -59,7 +60,12 @@ void main() {
   test('눈금은 그리지 않아도 축의 위아래를 정한다', () {
     // `ticks` 를 지우면 세 지표의 축이 서로 다르게 움직인다. 당류처럼 바닥이
     // 0 에 고정되는 성질이 여기서 나온다.
-    for (final (String name, List<double> values, List<double> ticks, double goal)
+    for (final (
+          String name,
+          List<double> values,
+          List<double> ticks,
+          double goal,
+        )
         in <(String, List<double>, List<double>, double)>[
           ('칼로리', <double>[1710, 1830, 1560], <double>[0, 1500, 2500], 2000),
           ('나트륨', <double>[2200, 1900, 2050], <double>[0, 1750, 3500], 2000),

--- a/frontend/flutter_trainer/test/shared/widgets/mini_charts_test.dart
+++ b/frontend/flutter_trainer/test/shared/widgets/mini_charts_test.dart
@@ -13,6 +13,7 @@ void main() {
         supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(
           body: BarSeriesChart(
+            title: '주간 이행률',
             values: const <int>[100, 80, 60, 40, 20, 10, 5],
             labels: const <String>['월', '화', '수', '목', '금', '토', '일'],
             maxValue: 100,
@@ -63,6 +64,7 @@ void main() {
           supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
             body: BarSeriesChart(
+              title: '주간 이행률',
               // Fri/Sat/Sun are over the threshold in the source data but
               // haven't happened; painting their track red would report a
               // bad day the member could not have had yet.
@@ -95,6 +97,7 @@ void main() {
           supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
             body: BarSeriesChart(
+              title: '주간 이행률',
               values: const <int>[0, 75],
               labels: const <String>['지난 주', '이번 주'],
               maxValue: 100,


### PR DESCRIPTION
Closes #972

## Summary

두 앱의 주간·기간 그래프는 전부 `CustomPaint` 라 시맨틱 트리에 아무 노드도 남기지 않았다. 홈의 주간 열량 그래프, 운동 수행률, 나트륨·당류 추이, 리포트의 주간 이행률이 음성 안내에서는 통째로 존재하지 않는 영역이었다. 이 앱이 다루는 것이 고혈압·당뇨 위험군의 건강 지표라는 점을 생각하면, 숫자를 눈으로만 읽을 수 있게 둔 셈이다.

그래프마다 그것이 말하는 내용을 한 문장으로 만들어 읽히게 하고, 아이콘만 있는 버튼과 `GestureDetector` 로 만든 탭 영역에도 이름과 역할을 붙였다.

## Changes

### 차트
- 두 앱에 같은 모양의 `shared/widgets/chart_semantics.dart` 를 뒀다 — 패키지가 갈라져 코드를 공유할 수 없으므로 `metric_trend_chart` 와 같은 방식으로 규칙을 양쪽에 둔다.
- 감싼 그래프: 주간 추이 꺾은선(두 앱), 홈 주간 소모 칼로리 막대, 운동 탭 도넛·누적 막대(회원), 식단 기간 막대(회원), `ActivityDonut`·`ActivityBarChart`·`BarSeriesChart`·회원 식단 기간 막대(트레이너).
- 눈금·요일 라벨은 낱개로는 `월` `화` 뿐이라 `ExcludeSemantics` 로 감추고 요약 한 문장만 남긴다.
- **0 은 읽지 않는다.** 이 앱의 그래프에서 0 은 "그날 0 만큼 했다"가 아니라 기록이 없다는 뜻이라(빈 트랙·회색 그루터기로 그린다), 읽어 주면 측정된 값처럼 들린다. 아직 오지 않은 요일도 건너뛴다 — 선은 오늘까지만 그린다.
- 한 칸도 기록이 없는 기간은 막대마다 `기록 없음` 을 서른 번 읽히는 대신 비어 있다고 한 번만 말한다.

### 데이터 포인트
- 툴팁이 있는 막대(회원 식단 기간·운동 현황, 트레이너 운동 현황·식단 기간)는 **같은 내용**을 막대마다 시맨틱 라벨로도 준다. 툴팁은 올려야 보인다. 색 사각형(`WidgetSpan`)은 빼고 줄바꿈은 쉼표로 바꾼다 — 음성 안내는 줄을 나누어 읽지 않는다.

### 버튼과 탭 영역
- 아이콘만 있는 버튼에 툴팁이나 라벨: 비밀번호 표시/숨기기, 시트·다이얼로그 닫기, 뒤로 가기, 달·주·날짜 이동, 메시지 보내기, 음식·운동·자격증 지우기, 알림·달력 열기, 온이 FAB, 검색어 지우기.
- `GestureDetector` 로 만든 탭 영역 스물넷을 `Semantics(button: true)` 로 감쌌다. 탭·요일 셀·지표 칩처럼 켜고 끄는 자리는 `selected` 까지 붙여, 지금 어느 기간·어느 지표를 보고 있는지가 음성 안내에도 나온다.

### 문구
- 새 문구는 한국어·영어 arb 양쪽에 넣었다.
- 닫기·뒤로·달 이동은 새 키를 만들지 않고 플랫폼이 이미 제 언어로 부르는 이름(`MaterialLocalizations`)을 쓴다.

## Notes

- `FigmaCircleButton` 의 `tooltip` 은 선택이다. 부르는 쪽이 밖에서 `Semantics` 로 이름을 붙인 경우(트레이너 채팅 헤더 버튼)에는 비워 둬야 같은 말을 두 번 읽지 않는다.
- 트레이너 리포트의 4주 추이(`FourWeekMetricTrend`)와 `WeekTrendBar` 는 값과 라벨이 이미 `Text` 라 그대로 뒀다.
- 온이 얼굴·지도 배경처럼 장식용 `CustomPaint` 는 라벨을 붙이지 않았다. 읽을 내용이 없다.

## Verification

- 두 앱에 `chart_semantics_test` 를 새로 뒀다 — 요약 문장 조립, 0·미래 요일 제외, 빈 그래프 문구(한국어·영어), 요일 낱글자가 시맨틱 트리에 남지 않는지, 막대별 라벨, 도넛 합계.
- 회원 앱은 홈 화면을 실제로 띄워 시맨틱 트리를 확인하는 `home_chart_semantics_test` 를 더했다 — 영어 로케일에서 빈 그래프 문구가 영어인지도 함께 본다.
- `flutter analyze` 두 앱 무결. `flutter test` 회원 828개 · 트레이너 913개 전부 통과.
