### PR TITLE
fix(messages): 통증어·부정어 매칭의 낱말 경계와 활용형 보강

### DIFF
--- a/frontend/flutter_trainer/lib/features/messages/domain/chat_context_insight.dart
+++ b/frontend/flutter_trainer/lib/features/messages/domain/chat_context_insight.dart
@@ -45,7 +45,7 @@ class ChatContextInsightDetector {
     final text = message.body.toLowerCase();
 
     final part = _bodyPartIn(text);
-    if (_discomfortTerms.any(text.contains)) {
+    if (_matches(_discomfortPatterns, text)) {
       return ChatContextInsight(
         id: '${message.id}:discomfort',
         messageId: message.id,
@@ -55,7 +55,7 @@ class ChatContextInsightDetector {
       );
     }
 
-    if (_negativeTerms.any(text.contains)) {
+    if (_matches(_negativePatterns, text)) {
       return ChatContextInsight(
         id: '${message.id}:negative',
         messageId: message.id,
@@ -65,6 +65,9 @@ class ChatContextInsightDetector {
     }
     return null;
   }
+
+  static bool _matches(List<RegExp> patterns, String text) =>
+      patterns.any((RegExp p) => p.hasMatch(text));
 
   /// 문장이 가리키는 신체 부위. 짚을 것이 없으면 null 이고, 그때 배너는
   /// 부위 없는 문구로 뜬다.
@@ -107,37 +110,61 @@ class ChatContextInsightDetector {
     ),
   ];
 
-  static const List<String> _discomfortTerms = <String>[
-    '아프',
-    '통증',
-    '당기',
-    '불편',
-    '저리',
-    '쑤',
-    '붓',
-    // 영어 쪽 `stiff` 와 짝이 없어 비어 있던 자리.
-    '뻐근',
-    'pain',
-    'hurt',
-    'sore',
-    'discomfort',
-    'stiff',
+  /// 통증을 말하는 표현. 부위와 **같은 규칙**을 쓴다(#963) — 어간을 부분
+  /// 문자열로 찾으면 `아프리카` 의 `아프` 까지 통증이 되고, 어간 하나만 두면
+  /// `아프네요` 는 잡으면서 한국어에서 가장 흔한 `아파요` 를 지나친다. 활용형과
+  /// 경계 규칙은 함께 가야 한다(#975).
+  ///
+  /// 앞 음절이 한글이면 다른 낱말의 꼬리로 본다(`(?<![가-힣])`). 뒤쪽은 조사와
+  /// 어미가 붙어야 하므로 한글을 막을 수 없어, 그 음절로 시작하는 **다른
+  /// 낱말**을 명시해 배제한다.
+  static final List<RegExp> _discomfortPatterns = <RegExp>[
+    // 아프다·아파요·아팠어요·아픈·아픔·아픕니다.
+    // `아파트` 와 `아프리카` 는 통증이 아니다.
+    RegExp(r'(?<![가-힣])아(?:프(?!리카|리칸|간)|파(?!트)|팠|픈|픔|픕)'),
+    // 앞을 막지 않는 유일한 한국어 항목이다 — `근육통증`·`관절통증` 처럼 다른
+    // 낱말 뒤에 붙어도 뜻이 그대로다.
+    RegExp(r'통증'),
+    // 당기다·당겨요·당겼어요·당김.
+    RegExp(r'(?<![가-힣])당(?:기|겨|겼|김)'),
+    RegExp(r'(?<![가-힣])불편'),
+    // 저리다·저려요·저렸어요·저릿하다. `저리 가` 는 통증이 아니라 방향이다.
+    RegExp(r'(?<![가-힣])저(?:리(?!\s*가)|려|렸|릿)'),
+    // 쑤시다·쑤셔요. 어간 `쑤` 만 두면 다른 낱말의 첫 음절까지 걸린다.
+    RegExp(r'(?<![가-힣])쑤(?:시|셔|셨|신)'),
+    // 붓다·부어요·부었어요·붓기.
+    RegExp(r'(?<![가-힣])(?:붓|부어|부었|부기)'),
+    RegExp(r'(?<![가-힣])뻐근'),
+    // 영어는 낱말 경계로 가른다. 부위의 `back` 과 달리 이 낱말들은 문맥 없이도
+    // 통증을 뜻한다.
+    RegExp(r'\bpain(?:s|ful|fully)?\b'),
+    RegExp(r'\bhurt(?:s|ing)?\b'),
+    RegExp(r'\bsore(?:s|ness)?\b'),
+    RegExp(r'\bdiscomforts?\b'),
+    RegExp(r'\bstiff(?:ness)?\b'),
+    // 부위 규칙이 `back ache` 를 부위로 읽으면서도 통증어 목록에는 없어,
+    // `my back aches` 가 아무 신호도 만들지 않고 있었다.
+    RegExp(r'\bach(?:e|es|ed|ing|y)\b'),
   ];
 
-  static const List<String> _negativeTerms = <String>[
-    '너무 힘들',
-    '못 ',
-    '못 했',
-    '못했',
-    '포기',
-    '별로',
-    '무리',
-    '부담',
-    '지쳐',
-    'too hard',
-    'couldn\'t',
-    'cannot',
-    'gave up',
-    'exhausted',
+  /// 운동을 못 했다는 보고. 같은 경계 규칙을 쓴다.
+  static final List<RegExp> _negativePatterns = <RegExp>[
+    RegExp(r'너무\s*힘들'),
+    // 못 갔어요·못했어요·못하겠어요. `연못 근처` 의 꼬리는 아니다.
+    RegExp(r'(?<![가-힣])못(?:\s|했|하|해)'),
+    RegExp(r'(?<![가-힣])포기'),
+    RegExp(r'(?<![가-힣])별로'),
+    // 프로그램이 준비운동·본운동·마무리로 나뉘어 있어(#934) `마무리` 는 이
+    // 대화에서 흔한 말이다. 그 꼬리를 무리로 읽으면 **잘 마쳤다는 보고가
+    // 경고 배너로 뜬다**. `아무리` 도 같은 이유로 걸러진다.
+    RegExp(r'(?<![가-힣])무리(?!수)'),
+    RegExp(r'(?<![가-힣])부담'),
+    // 지쳐요·지쳤어요. `지침`(안내)은 지친 것이 아니다.
+    RegExp(r'(?<![가-힣])지(?:쳐|쳤)'),
+    RegExp(r'\btoo hard\b'),
+    RegExp(r"\bcouldn'?t\b"),
+    RegExp(r'\bcannot\b'),
+    RegExp(r'\bgave up\b'),
+    RegExp(r'\bexhausted\b'),
   ];
 }

--- a/frontend/flutter_trainer/test/features/messages/chat_context_insight_test.dart
+++ b/frontend/flutter_trainer/test/features/messages/chat_context_insight_test.dart
@@ -83,6 +83,89 @@ void main() {
     });
   });
 
+  group('통증어·부정어도 낱말 경계에서 끊는다 (#975)', () {
+    test('마무리 운동 보고는 아무 신호도 만들지 않는다', () {
+      // 프로그램이 준비운동·본운동·마무리로 나뉘어 있어(#934) `마무리` 는 이
+      // 대화에서 흔한 말이다. 잘 마쳤다는 보고가 경고 배너로 뜨면 안 된다.
+      expect(detector.detect(message('마무리 운동까지 다 했어요')), isNull);
+    });
+
+    test('아무리 해도 라는 말이 무리로 읽히지 않는다', () {
+      expect(detector.detect(message('아무리 해도 재밌네요')), isNull);
+    });
+
+    test('무리했다는 보고는 그대로 잡는다', () {
+      expect(
+        detector.detect(message('어제 좀 무리했어요'))?.kind,
+        ChatInsightKind.negativeFeedback,
+      );
+    });
+
+    test('아프리카는 통증이 아니다', () {
+      expect(detector.detect(message('아프리카 다큐 보면서 걸었어요')), isNull);
+    });
+
+    test('아파트는 통증이 아니다', () {
+      expect(detector.detect(message('아파트 계단으로 올라갔어요')), isNull);
+    });
+
+    test('연못은 못 갔다는 말이 아니다', () {
+      expect(detector.detect(message('연못 근처를 한 바퀴 걸었어요')), isNull);
+    });
+
+    test('가장 흔한 통증 활용형을 모두 잡는다', () {
+      // 어간 하나만 두면 `아프네요` 는 잡으면서 `아파요` 를 지나친다.
+      for (final (String body, String? part) in <(String, String?)>[
+        ('무릎이 아파요', '무릎'),
+        ('어제부터 아팠어요', null),
+        ('어깨가 저려요', '어깨'),
+        ('허리가 당겨요', '허리'),
+        ('발목이 부었어요', '발목'),
+        ('종아리가 쑤셔요', null),
+        ('오늘은 좀 아픔이 있어요', null),
+      ]) {
+        final insight = detector.detect(message(body));
+        expect(
+          insight?.kind,
+          ChatInsightKind.discomfort,
+          reason: '`$body` 를 통증으로 읽지 못했습니다.',
+        );
+        expect(insight?.bodyPart, part, reason: body);
+      }
+    });
+
+    test('예전부터 잡히던 표현은 그대로 잡힌다', () {
+      for (final (String body, ChatInsightKind kind)
+          in <(String, ChatInsightKind)>[
+            ('무릎이 아프네요', ChatInsightKind.discomfort),
+            ('어깨가 불편해요', ChatInsightKind.discomfort),
+            ('통증이 좀 있어요', ChatInsightKind.discomfort),
+            ('목이 뻐근해요', ChatInsightKind.discomfort),
+            ('운동을 못 갔어요', ChatInsightKind.negativeFeedback),
+            ('오늘은 못했어요', ChatInsightKind.negativeFeedback),
+            ('너무 힘들어서 포기했어요', ChatInsightKind.negativeFeedback),
+            ('별로였어요', ChatInsightKind.negativeFeedback),
+            ('오늘은 지쳤어요', ChatInsightKind.negativeFeedback),
+            ('계단이 좀 부담돼요', ChatInsightKind.negativeFeedback),
+          ]) {
+        expect(detector.detect(message(body))?.kind, kind, reason: body);
+      }
+    });
+
+    test('영어 통증어도 낱말 경계에서 끊는다', () {
+      // `painting`·`sorely` 처럼 통증과 무관한 낱말에 어간이 들어 있다.
+      expect(detector.detect(message('did some painting today')), isNull);
+      expect(
+        detector.detect(message('my knee hurts'))?.kind,
+        ChatInsightKind.discomfort,
+      );
+      expect(
+        detector.detect(message('my back aches since monday'))?.bodyPart,
+        'Back',
+      );
+    });
+  });
+
   group('english body parts need real word context', () {
     test('coming back to the gym is not the back', () {
       final insight = detector.detect(


### PR DESCRIPTION
Closes #975

## Summary

#963 이 신체 부위 매칭에 넣은 낱말 경계 규칙을 같은 파일의 통증어·부정어 목록에도 적용했다. 두 목록이 `contains` 그대로라 양쪽으로 틀리고 있었다.

**틀리게 잡던 쪽** — `마무리 운동까지 다 했어요` 가 `마무리` 안의 `무리` 때문에 부정 피드백으로, `아프리카 다큐 보면서 걸었어요` 가 `아프` 때문에 통증으로 떴다. 프로그램이 준비운동·본운동·마무리로 나뉘어 있어(#934) `마무리` 는 이 대화에서 흔한 말이다. 잘 마쳤다는 보고가 경고 배너가 되고 있었다.

**놓치던 쪽** — 목록이 어간 하나씩만 갖고 있어 `아파요`·`아팠어요`·`저려요`·`당겨요`·`부었어요` 가 전부 빠졌다. `아프` 는 `아프네요` 만 잡고 `아파요` 를 못 잡는다. 통증을 알아채자고 만든 기능이 한국어에서 가장 흔한 통증 표현을 지나쳤다.

## Changes

- 통증어·부정어를 `List<String>` 에서 `List<RegExp>` 로 옮기고, 어간마다 **활용형을 담은 패턴**을 만들었다 — `아프|아파|아팠|아픈|아픔|아픕`, `저리|저려|저렸|저릿`, `당기|당겨|당겼|당김`, `붓|부어|부었|부기`, `쑤시|쑤셔`, `지쳐|지쳤`.
- 앞 음절이 한글이면 다른 낱말의 꼬리로 본다(`(?<![가-힣])`). `마무리`·`아무리` 의 `무리`, `연못` 의 `못`, `아프리카` 의 `아프` 가 이것으로 걸러진다.
- 뒤쪽은 조사·어미가 붙어야 해서 한글을 막을 수 없으므로, 그 음절로 시작하는 다른 낱말을 명시해 배제했다 — `아파트`, `아프리카`, `무리수`, 방향을 가리키는 `저리 가`, 안내를 뜻하는 `지침`.
- `통증` 은 앞을 막지 않는 유일한 한국어 항목이다. `근육통증`·`관절통증` 처럼 다른 낱말 뒤에 붙어도 뜻이 그대로다.
- 영어는 낱말 경계로 가르고 흔한 활용형을 함께 담았다(`painful`, `hurting`, `soreness`, `stiffness`). 부위의 `back` 과 달리 이 낱말들은 문맥 없이도 통증을 뜻해 추가 조건이 필요 없다.

## Notes

- 통증어에 `ache` 를 더했다. 부위 규칙이 `back ache` 를 부위로 읽으면서도 통증어 목록에는 그 낱말이 없어, `my back aches` 가 부위만 짚고 아무 신호도 만들지 않던 상태였다.
- 이 파일은 실 insight API 가 붙기 전까지 쓰는 결정적 폴백이다. 판정 근거를 회원 메시지에서 그대로 짚을 수 있게 두는 성격은 바뀌지 않았다.

## Verification

- 이슈의 표에 있는 사례를 전부 회귀 테스트로 고정했다 — `마무리`·`아무리`·`아프리카`·`아파트`·`연못` 오탐, `아파요`·`아팠어요`·`저려요`·`당겨요`·`부었어요`·`쑤셔요`·`아픔` 탐지와 각 부위, 그리고 예전부터 잡히던 표현 열 가지가 그대로 잡히는지.
- `flutter analyze` 무결, `flutter test` 922개 전부 통과.
