### PR TITLE
fix(schedule): 상담 요청 버튼 알림 배지 위치 조정

### DIFF
--- a/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/consultation_inbox_action.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/consultation_inbox_action.dart
@@ -3,7 +3,7 @@ import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 
-/// 상담 요청 인박스로 가는 헤더 액션. (#858, #882)
+/// 상담 요청 인박스로 가는 헤더 액션. (#858, #882, #987)
 ///
 /// 처음에는 화면 폭 전체를 쓰는 남색 그라디언트 카드였다. 면적은 제일 큰데
 /// 정작 몇 건 밀렸는지가 눈에 꽂히지 않았고 — 알림이 아니라 배너로 읽혔다 —
@@ -14,6 +14,13 @@ import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 /// 라벨을 함께 두면 영어 로케일·큰 글자 배율에서 줄 전체가 넘친다 — #849
 /// 관문이 폭 1024·en·배율 1.3 에서 그것을 잡았다. 이름은 툴팁과 시맨틱스로
 /// 남는다.
+///
+/// 배지가 감싸는 것은 **아이콘이 아니라 아이콘을 담은 네모**다(#987). 배지는
+/// 자식의 오른쪽 위 모서리에 붙는데, 17px 아이콘을 감싸면 지름 16px 짜리 빨간
+/// 원이 아이콘의 절반 가까이를 덮어 무슨 버튼인지 형태로 알아볼 수 없었다.
+/// 네모를 감싸면 같은 규약(오른쪽 위 모서리)을 지키면서 아이콘이 온전히 남는다.
+/// 모서리 밖으로 나가는 만큼은 바깥 여백으로 미리 자리를 비워 둔다 — 헤더
+/// 액션 줄에서 옆 버튼을 침범하지 않기 위해서다.
 ///
 /// 빨강은 처리할 것이 있을 때만 뜬다: 0건이거나 아직 못 읽었으면([pending] 이
 /// null) 배지 없이 조용한 버튼으로 남는다.
@@ -29,6 +36,11 @@ class ConsultationInboxAction extends StatelessWidget {
 
   final VoidCallback onTap;
 
+  /// 배지가 네모 밖으로 나가는 양. [Padding] 과 [Badge.offset] 이 같은 값을
+  /// 써야 배지가 예약된 자리에 정확히 앉는다.
+  static const double _badgeOverflowTop = 6;
+  static const double _badgeOverflowRight = 5;
+
   @override
   Widget build(BuildContext context) {
     final AppLocalizations l = AppLocalizations.of(context);
@@ -38,36 +50,46 @@ class ConsultationInboxAction extends StatelessWidget {
     return Tooltip(
       message: l.consultTitle,
       child: Semantics(
+        // 키는 액션 전체에 둔다 — 배지가 탭 대상(InkWell)의 바깥이라, 키가
+        // 안쪽에 있으면 배지를 이 액션의 자손으로 찾을 수 없다.
+        key: const Key('consult-inbox-entry'),
         button: true,
         label: l.consultTitle,
-        child: Material(
-          color: Colors.transparent,
-          borderRadius: const BorderRadius.all(AppRadius.md),
-          child: InkWell(
-            key: const Key('consult-inbox-entry'),
-            onTap: onTap,
-            borderRadius: const BorderRadius.all(AppRadius.md),
-            child: Container(
-              height: 36,
-              width: 40,
-              alignment: Alignment.center,
-              decoration: BoxDecoration(
+        child: Padding(
+          padding: const EdgeInsets.only(
+            top: _badgeOverflowTop,
+            right: _badgeOverflowRight,
+          ),
+          child: Badge(
+            isLabelVisible: waiting,
+            alignment: Alignment.topRight,
+            offset: const Offset(_badgeOverflowRight, -_badgeOverflowTop),
+            backgroundColor: AppColors.destructive,
+            textColor: AppColors.destructiveForeground,
+            label: Text('$count'),
+            child: Material(
+              color: Colors.transparent,
+              borderRadius: const BorderRadius.all(AppRadius.md),
+              child: InkWell(
+                onTap: onTap,
                 borderRadius: const BorderRadius.all(AppRadius.md),
-                border: Border.all(
-                  color: waiting
-                      ? AppColors.destructive.withValues(alpha: 0.45)
-                      : AppColors.primary.withValues(alpha: 0.45),
-                ),
-              ),
-              child: Badge(
-                isLabelVisible: waiting,
-                backgroundColor: AppColors.destructive,
-                textColor: AppColors.destructiveForeground,
-                label: Text('$count'),
-                child: const Icon(
-                  Icons.mark_email_unread_outlined,
-                  size: 17,
-                  color: AppColors.primary,
+                child: Container(
+                  height: 36,
+                  width: 40,
+                  alignment: Alignment.center,
+                  decoration: BoxDecoration(
+                    borderRadius: const BorderRadius.all(AppRadius.md),
+                    border: Border.all(
+                      color: waiting
+                          ? AppColors.destructive.withValues(alpha: 0.45)
+                          : AppColors.primary.withValues(alpha: 0.45),
+                    ),
+                  ),
+                  child: const Icon(
+                    Icons.mark_email_unread_outlined,
+                    size: 17,
+                    color: AppColors.primary,
+                  ),
                 ),
               ),
             ),

--- a/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
@@ -500,6 +500,41 @@ void main() {
       );
     });
 
+    testWidgets('빨간 배지가 아이콘을 가리지 않고 네모 모서리에 붙는다 (#987)', (tester) async {
+      // 배지가 아이콘을 감싸던 때에는 지름 16px 짜리 원이 17px 아이콘의 절반을
+      // 덮어, 남는 것이 빨간 원뿐이었다. 배지는 숫자를 **더하는** 표시이지
+      // 아이콘을 대체하는 표시가 아니다.
+      await openSchedule(tester);
+
+      final Finder entry = find.byKey(const Key('consult-inbox-entry'));
+      final Rect icon = tester.getRect(
+        find.descendant(
+          of: entry,
+          matching: find.byIcon(Icons.mark_email_unread_outlined),
+        ),
+      );
+      final Rect label = tester.getRect(
+        find.descendant(of: entry, matching: find.text('1')),
+      );
+      // 배지 원(지름 16)은 라벨을 가운데 두므로, 원 전체를 아이콘 오른쪽
+      // 바깥에서 재려면 라벨이 아니라 원의 왼쪽 끝을 봐야 한다.
+      final double badgeLeft = label.center.dx - 8;
+
+      expect(
+        badgeLeft,
+        greaterThanOrEqualTo(icon.right),
+        reason: '배지가 아이콘 오른쪽 바깥에 있어야 한다',
+      );
+      final Rect box = tester.getRect(
+        find.descendant(of: entry, matching: find.byType(InkWell)).first,
+      );
+      expect(
+        label.center.dy,
+        lessThan(box.top + 8),
+        reason: '배지는 네모의 위쪽 모서리에 걸친다',
+      );
+    });
+
     testWidgets('대기 건이 없으면 빨간 배지를 달지 않는다', (tester) async {
       // 빨강은 처리할 것이 있을 때만 뜬다 — 0건에도 뜨면 몇 번 겪고 나서
       // 아무도 안 보게 된다.


### PR DESCRIPTION
## Summary

* 스케줄 탭 헤더의 상담 요청 진입점에서 대기 건수 배지가 아이콘 자체를 덮던 문제를 고쳤습니다.
* 배지가 감싸는 대상을 `Icon` 에서 **아이콘을 담은 테두리 네모**로 옮겨, 오른쪽 위 모서리라는 알림 배지의 통상 규약을 지키면서 아이콘이 온전히 보이게 했습니다.
* 배지가 네모 밖으로 나가는 만큼을 바깥 여백으로 미리 잡아 헤더 액션 줄에서 옆 버튼을 침범하지 않게 했습니다.
* 배지와 아이콘이 겹치지 않는다는 것을 좌표로 확인하는 회귀 테스트를 추가했습니다.

---

## Changes

### ✨ Features

* 없음

### 🔧 Improvements

* 액션의 `Key('consult-inbox-entry')` 를 탭 대상(`InkWell`)에서 액션 전체로 올렸습니다. 배지가 탭 대상 바깥으로 나가면서, 키가 안쪽에 있으면 배지를 이 액션의 자손으로 찾을 수 없기 때문입니다.

### 🎨 UI/UX

* 대기 건수 배지가 `mark_email_unread_outlined` 아이콘 위가 아니라 40×36 테두리 네모의 오른쪽 위 모서리에 붙습니다.
* 배지가 뜨는 조건(대기 1건 이상)과 색(`AppColors.destructive`), 0건·미조회 시 조용한 버튼으로 남는 규칙은 그대로입니다.

### 📝 Docs

* `ConsultationInboxAction` 의 문서 주석에 배지를 아이콘이 아니라 네모에 붙이는 이유를 남겼습니다.

### 🐛 Fixes

* 지름 16px 배지가 17px 아이콘의 절반 가까이를 덮어 무슨 버튼인지 형태로 알아볼 수 없던 문제를 고쳤습니다.

---

## Commits

1. `54e7d69e` fix(schedule): 상담 요청 버튼 알림 배지를 아이콘 밖 네모 모서리로

---

## Notes

* `Badge` 는 `Positioned.fill` + `Clip.none` 으로 라벨을 그리므로 자식 경계 밖으로 나가도 잘리지 않습니다. 다만 그대로 두면 헤더 액션 줄의 8px 간격을 침범하므로, 넘치는 양(`위 6`, `오른쪽 5`)만큼을 `Padding` 으로 예약해 두었습니다. 두 값은 `Badge.offset` 과 같은 상수를 씁니다.
* 배지 원의 왼쪽 끝이 아이콘의 오른쪽 끝보다 바깥에 오도록 오프셋을 잡았습니다 — 원이 라벨보다 크므로 라벨 좌표만 보면 겹침을 놓칩니다. 테스트도 라벨 중심에서 반지름을 빼 원의 왼쪽 끝을 재도록 했습니다.
* 기존 배지 테스트 3건(대기 건수 표시 / 0건이면 배지 없음 / 좁은 폭 오버플로 없음)은 수정 없이 그대로 통과합니다.

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 데모 계정으로 스케줄 탭에 들어갑니다.
2. 헤더 오른쪽 상담 요청 버튼에서 메일 아이콘 형태가 온전히 보이는지, 빨간 배지가 네모 오른쪽 위 모서리에 걸쳐 있는지 확인합니다.
3. 대기 건이 0건인 상태(상담 요청을 모두 처리)에서 배지가 사라지고 테두리가 조용한 색으로 돌아오는지 확인합니다.
4. 창 폭을 360px 까지 좁혀 헤더 액션 줄이 넘치지 않는지 확인합니다.

---

## Related Issues

Closes #987

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인
