### PR TITLE
feat(backend): 예약·상담·로스터 목록 엔드포인트 페이지네이션

### DIFF
--- a/backend/API_CONTRACT.md
+++ b/backend/API_CONTRACT.md
@@ -14,6 +14,18 @@
 - **인증**: `Authorization: Bearer <token>` (JWT). `auth_interceptor` 가 붙인다. 자세한 것은 아래 "인증" 절.
 - **에러**: `{ "code": "...", "message": "..." }` 형태. 4xx/5xx 는 DioException 으로 처리됨.
 - **사용자 id**: **문자열** (`"user-demo"`). 정수 아님.
+- **목록 페이지네이션**: 계속 자라는 목록은 **한 쪽**만 돌려줍니다. 파라미터 없이 부르면
+  기본 50건이라 기존 클라이언트는 그대로 동작합니다. 커서 모양은 한 가지입니다 —
+  받은 마지막 항목의 `(정렬키, id)` 를 `(before, before_id)` 로 되돌려 줍니다
+  (`limit` 은 1~100, 벗어나면 **422**. `before` 파싱 실패도 422이고, 오프셋 없는 값은
+  UTC 로 읽습니다).
+  적용된 곳: 채팅 스레드(`/me/coach/chat`, `/trainer/clients/{id}/chat`),
+  알림(`/notifications`, #965), 예약(`/reservations/me`), 상담(`/consultations/me`,
+  `/trainer/consultations`), 로스터(`/trainer/clients`) — 뒤의 넷은 #980.
+  **로스터만 커서가 다릅니다**(아래 트레이너 도메인 문서 참고) — 정렬키가 시각이 아니라
+  트레이너가 정한 순서라 마지막 카드의 `after_id` 하나만 넘깁니다.
+  집계 값(`/notifications/unread-count`, `/trainer/consultations/pending-count` 등)은
+  쪽 나눔과 무관하게 **전체 기준**입니다.
 
 ## 프론트에 실제 구현된 엔드포인트 (이번에 완성할 대상)
 
@@ -191,7 +203,7 @@ category: medical|fitness|healthy_food|pharmacy (생략 가능)
 |---|---|---|
 | GET | `/trainers/{trainer_id}/slots` | `[{ id, trainer_id, starts_at, capacity, remaining, is_closed }]` |
 | POST | `/reservations` | 입력 `{ slot_id }` → `{ id, slot_id, schedule_id, status, created_at }` |
-| GET | `/reservations/me` | `[{ id, slot_id, trainer_id, starts_at, cancellable }]` — 내 예약 |
+| GET | `/reservations/me` | `[{ id, slot_id, trainer_id, starts_at, cancellable }]` — 내 예약 (다가오는 것부터, 기본 50건·커서) |
 | DELETE | `/reservations/{id}` | 취소 → `{ status: "cancelled" }` |
 
 - **예약은 트레이너 일정을 만듭니다.** 확정 시 `trainer_schedule` 에 `1:1 PT` 세션이 생기고, 취소하면 그 일정과 좌석이 함께 돌아갑니다. 회원 탈퇴 경로와 **같은 함수**(`reservation_service._release`)를 씁니다. (#502)
@@ -199,6 +211,42 @@ category: medical|fitness|healthy_food|pharmacy (생략 가능)
 - **남의 예약·없는 예약은 404** 로 같습니다. 존재 여부조차 드러내지 않습니다(상담 요청과 같은 규칙).
 - `cancellable` 은 **서버 판단**입니다. 앱이 자기 시계로 다시 계산하면 시각이 어긋난 기기에서 버튼은 눌리는데 서버가 409 를 주는 상태가 됩니다.
 - 취소는 트레이너에게 알림 행을 남깁니다(`notifications`). 트레이너는 `/trainer/notifications` 로 읽습니다(#503).
+
+#### 목록 페이지네이션과 순서 (#980)
+
+`GET /reservations/me` 는 **한 쪽**만 돌려줍니다. 파라미터 없이 부르면 50건입니다.
+
+| 파라미터 | 기본 | 설명 |
+|---|---|---|
+| `limit` | 50 | 1~100. 범위를 벗어나면 **422** |
+| `before` | — | 다음 쪽 커서. 받은 마지막 예약의 `starts_at`(ISO) |
+| `before_id` | — | 복합 커서 tie-break. 받은 마지막 예약의 `id` |
+
+- **순서가 `starts_at` 내림차순으로 바뀌었습니다.** 예약은 취소해도 이력이 남아야 해
+  계정마다 계속 쌓이는데, 예전의 오름차순에 상한만 씌우면 첫 쪽이 **가장 오래된 지난
+  예약**으로 차서 정작 다가오는 예약이 화면에서 사라집니다. 내림차순이면 첫 쪽이 항상
+  예정된 예약이고, 지난 예약은 이어 받는 쪽으로 밀립니다.
+- 지난 예약을 여전히 숨기지 않습니다 — "내가 그 시간에 예약했었나" 를 확인하는
+  자리이기도 합니다. `cancellable` 로 취소 가능 여부만 서버가 갈라 줍니다.
+- 한 트레이너가 같은 시각에 슬롯을 여러 개 열 수 있어 동시각이 실제로 나옵니다.
+  시각만으로 자르면 그 경계에서 예약이 빠지거나 겹쳐 `(starts_at, id)` 복합 커서를 씁니다.
+
+### 상담 요청 (회원 → 트레이너)
+
+| Method | Path | 응답 |
+|---|---|---|
+| POST | `/consultations` | 입력 `{ trainer_id, exercise_goal, health_purpose_type, preferred_date, preferred_time_slot, message? }` |
+| GET | `/consultations/me` | 내가 보낸 요청 (최신순, 기본 50건·커서) |
+| GET | `/consultations/{id}` | 단건(남의 것·없는 것 404) |
+
+- 같은 트레이너에게 **대기 중인 요청은 한 건**입니다(`uq_consultation_requests_pending_trainer`,
+  중복은 409). 그래서 목록이 자라는 쪽은 처리된 지난 요청입니다 — 상태 필터가 없어
+  그대로 함께 쌓이고, 그 때문에 상한이 필요합니다. (#980)
+- 커서는 `(created_at, id)` 로 알림과 같은 모양입니다(`before`·`before_id`).
+- 트레이너 인박스(`GET /trainer/consultations`)도 같은 파라미터를 받습니다. 기본값인
+  `status=pending` 은 처리하는 만큼 줄지만 `status=all` 은 그 트레이너에게 들어온 요청
+  전체입니다. 미처리 배지(`/trainer/consultations/pending-count`)는 **쪽 나눔과 무관하게**
+  전체를 셉니다.
 
 ### 트레이너 알림함
 

--- a/backend/app/api/v1/consultations.py
+++ b/backend/app/api/v1/consultations.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
 from app.api.deps import RequireMember
+from app.core.pagination import DEFAULT_PAGE, MAX_PAGE, parse_before
 from app.db.session import get_db
 from app.schemas.consultation_api import ConsultationCreate, ConsultationOut
 from app.services import consultation_service
@@ -37,8 +38,28 @@ def create_consultation(
 def list_my_consultations(
     member: RequireMember,
     db: Annotated[Session, Depends(get_db)],
+    limit: int = Query(
+        DEFAULT_PAGE, ge=1, le=MAX_PAGE, description="한 번에 가져올 요청 수"
+    ),
+    before: str | None = Query(
+        None, description="ISO datetime 커서(다음 쪽) — 받은 마지막 요청의 created_at"
+    ),
+    before_id: str | None = Query(
+        None, description="복합 커서 tie-break — 받은 마지막 요청의 id"
+    ),
 ) -> list[ConsultationOut]:
-    return consultation_service.list_my_consultations(db, member.id)
+    """내가 보낸 상담 요청 한 쪽(최신순, 기본 50건). (#980)
+
+    필터가 없어 승인·거절된 지난 요청까지 함께 자란다. 파라미터 없이 부르면 최신
+    50건이고, 그보다 오래된 요청은 커서로 이어 받는다.
+    """
+    return consultation_service.list_my_consultations(
+        db,
+        member.id,
+        limit=limit,
+        before=parse_before(before),
+        before_id=before_id,
+    )
 
 
 @router.get(

--- a/backend/app/api/v1/notifications.py
+++ b/backend/app/api/v1/notifications.py
@@ -9,7 +9,6 @@
 """
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -17,6 +16,7 @@ from sqlalchemy import func, select, tuple_, update
 from sqlalchemy.orm import Session
 
 from app.api.deps import CurrentUser, RequireMember
+from app.core.pagination import DEFAULT_PAGE, MAX_PAGE, parse_before
 from app.db.session import get_db
 from app.models.models import Notification
 from app.schemas.misc_api import NotificationAction, NotificationOut
@@ -62,7 +62,9 @@ _time_ago = notification_service.time_ago
 def list_notifications(
     current_user: CurrentUser,
     db: Annotated[Session, Depends(get_db)],
-    limit: int = Query(50, ge=1, le=100, description="한 번에 가져올 최신 알림 수"),
+    limit: int = Query(
+        DEFAULT_PAGE, ge=1, le=MAX_PAGE, description="한 번에 가져올 최신 알림 수"
+    ),
     before: str | None = Query(
         None, description="ISO datetime 커서(다음 쪽) — 받은 마지막 알림의 created_at"
     ),
@@ -83,17 +85,8 @@ def list_notifications(
     파라미터 없이 부르면 최신 50건이다. 기존 클라이언트는 그대로 동작한다.
     """
     query = select(Notification).where(Notification.user_id == current_user.id)
-    if before is not None:
-        try:
-            cursor = datetime.fromisoformat(before)
-        except ValueError as exc:
-            raise HTTPException(
-                status_code=422, detail="before 는 ISO datetime 이어야 합니다."
-            ) from exc
-        if cursor.tzinfo is None:
-            # 오프셋 없이 온 커서는 UTC 로 읽는다. created_at 은 UTC 로 저장되므로
-            # (`app.core.clock`), 서버 로컬 타임존에 맡기면 쪽 경계가 밀린다.
-            cursor = cursor.replace(tzinfo=timezone.utc)
+    cursor = parse_before(before)
+    if cursor is not None:
         if before_id is not None:
             query = query.where(
                 tuple_(Notification.created_at, Notification.id) < (cursor, before_id)

--- a/backend/app/api/v1/reservations.py
+++ b/backend/app/api/v1/reservations.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from app.api.deps import RequireMember, RequireTrainer
+from app.core.pagination import DEFAULT_PAGE, MAX_PAGE, parse_before
 from app.db.session import get_db
 from app.schemas.reservation_api import (
     MyReservationOut,
@@ -67,12 +68,31 @@ def create_reservation(
 def my_reservations(
     member: RequireMember,
     db: Annotated[Session, Depends(get_db)],
+    limit: int = Query(
+        DEFAULT_PAGE, ge=1, le=MAX_PAGE, description="한 번에 가져올 예약 수"
+    ),
+    before: str | None = Query(
+        None, description="ISO datetime 커서(다음 쪽) — 받은 마지막 예약의 starts_at"
+    ),
+    before_id: str | None = Query(
+        None, description="복합 커서 tie-break — 받은 마지막 예약의 id"
+    ),
 ) -> list[MyReservationOut]:
-    """회원의 예약 목록. 앱이 '내가 잡은 자리'를 표시하고 취소를 걸 자리다. (#502)
+    """회원의 예약 목록 한 쪽. 앱이 '내가 잡은 자리'를 표시하고 취소를 걸 자리다. (#502)
+
+    예약은 취소해도 이력이 남아야 해 계정마다 계속 쌓인다. 상한 없이 전부 돌려주던
+    시절에는 예약할 때마다 이 응답이 한 건씩 길어졌다 — 다가오는 예약부터 기본 50건씩
+    주고, 지난 예약은 커서로 이어 받는다. (#980)
 
     `/reservations/{id}` 보다 먼저 선언해야 "me" 가 id 로 잡히지 않는다.
     """
-    return reservation_service.list_member_reservations(db, member.id)
+    return reservation_service.list_member_reservations(
+        db,
+        member.id,
+        limit=limit,
+        before=parse_before(before),
+        before_id=before_id,
+    )
 
 
 @router.delete("/reservations/{reservation_id}", status_code=200)

--- a/backend/app/api/v1/trainer.py
+++ b/backend/app/api/v1/trainer.py
@@ -22,6 +22,7 @@ from sqlalchemy.orm import Session
 
 from app.api.deps import RequireTrainer
 from app.core.config import get_settings
+from app.core.pagination import DEFAULT_PAGE, MAX_PAGE, parse_before
 from app.core.rate_limit import limiter, rate_limit
 from app.core.security import hash_password, verify_password
 from app.db.session import get_db
@@ -284,10 +285,30 @@ def trainer_update_settings(
 def trainer_clients(
     trainer: RequireTrainer,
     db: Annotated[Session, Depends(get_db)],
+    limit: int = Query(
+        DEFAULT_PAGE, ge=1, le=MAX_PAGE, description="한 번에 가져올 고객 수"
+    ),
+    after_id: str | None = Query(
+        None, description="다음 쪽 커서 — 받은 마지막 고객의 id(회원 id)"
+    ),
 ) -> list[TrainerClientOut]:
-    """담당 고객 로스터. 각 카드의 오늘 영양소와 나트륨 추세는
-    회원의 실제 식단 기록(DietEntry)에서 집계한다 — 트레이너↔회원 실데이터 공유."""
-    return trainer_service.build_roster(db, trainer.id)
+    """담당 고객 로스터 한 쪽. 각 카드의 오늘 영양소와 나트륨 추세는
+    회원의 실제 식단 기록(DietEntry)에서 집계한다 — 트레이너↔회원 실데이터 공유.
+
+    로스터는 트레이너 한 명이 감당하는 인원만큼만 자라 급하지 않지만, 상한이 없으면
+    카드마다 붙는 집계까지 인원수에 비례해 커진다. (#980)
+
+    커서가 다른 목록과 다르다 — 정렬키가 시각이 아니라 트레이너가 정한 순서
+    (`sort_order`)이고 그 값은 카드에 실리지 않으므로, 받은 마지막 카드의 **id 하나**만
+    넘기면 서버가 그 자리를 찾아 이어 준다. 명단에 없는 id 는 422 다(조용히 첫 쪽을
+    돌려주면 이어 받기가 제자리를 돈다).
+    """
+    try:
+        return trainer_service.build_roster(
+            db, trainer.id, limit=limit, after_id=after_id
+        )
+    except trainer_service.RosterCursorNotFound as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
 
 
 @router.put(
@@ -2036,9 +2057,29 @@ def trainer_consultations(
     trainer: RequireTrainer,
     db: Annotated[Session, Depends(get_db)],
     status: Annotated[ConsultationStatusFilter, Query()] = "pending",
+    limit: int = Query(
+        DEFAULT_PAGE, ge=1, le=MAX_PAGE, description="한 번에 가져올 요청 수"
+    ),
+    before: str | None = Query(
+        None, description="ISO datetime 커서(다음 쪽) — 받은 마지막 요청의 created_at"
+    ),
+    before_id: str | None = Query(
+        None, description="복합 커서 tie-break — 받은 마지막 요청의 id"
+    ),
 ) -> list[TrainerConsultationOut]:
-    """나를 지정한 상담 요청. 기본은 미처리만."""
-    return consultation_service.list_for_trainer(db, trainer.id, status)
+    """나를 지정한 상담 요청 한 쪽. 기본은 미처리만, 최신 50건. (#980)
+
+    미처리 배지(`/trainer/consultations/pending-count`)는 이 쪽 나눔과 무관하게
+    전체를 센다 — 배지가 첫 쪽 안에서만 세어지면 인박스가 길어질수록 조용히 줄어든다.
+    """
+    return consultation_service.list_for_trainer(
+        db,
+        trainer.id,
+        status,
+        limit=limit,
+        before=parse_before(before),
+        before_id=before_id,
+    )
 
 
 @router.get("/trainer/consultations/pending-count", response_model=dict[str, int])

--- a/backend/app/core/pagination.py
+++ b/backend/app/core/pagination.py
@@ -1,0 +1,39 @@
+"""목록 엔드포인트가 공유하는 커서 파싱. (#980)
+
+이 저장소의 목록 커서는 한 가지 모양이다 — 받은 마지막 항목의 `(정렬키, id)` 를
+`(before, before_id)` 로 되돌려 준다. 시각만으로 자르면 같은 정렬키를 가진 항목이
+여러 건일 때 그 경계에서 항목이 빠지거나 겹치므로 id 를 tie-break 로 함께 쓴다.
+
+파싱 규칙이 엔드포인트마다 복사돼 있으면 오프셋 없는 커서의 해석 같은 세부가 한쪽만
+고쳐진다. 규칙은 여기 한 곳에 둔다.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import HTTPException
+
+#: 목록 한 쪽의 기본 건수. 채팅 스레드·알림과 같은 값이다.
+DEFAULT_PAGE = 50
+
+#: 한 번에 받아 갈 수 있는 최대 건수.
+MAX_PAGE = 100
+
+
+def parse_before(before: str | None) -> datetime | None:
+    """ISO datetime 커서를 읽는다. 값이 없으면 첫 쪽(None).
+
+    오프셋 없이 온 커서는 **UTC** 로 읽는다 — 정렬키는 UTC 로 저장되므로
+    (`app.core.clock`), 서버 로컬 타임존에 맡기면 쪽 경계가 밀린다.
+    """
+    if not before:
+        return None
+    try:
+        cursor = datetime.fromisoformat(before)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=422, detail="before 는 ISO datetime 이어야 합니다."
+        ) from exc
+    if cursor.tzinfo is None:
+        return cursor.replace(tzinfo=timezone.utc)
+    return cursor

--- a/backend/app/services/consultation_service.py
+++ b/backend/app/services/consultation_service.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import uuid
 from datetime import date, datetime, timezone
 
-from sqlalchemy import func, select
+from sqlalchemy import func, select, tuple_
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.core import clock
+from app.core.pagination import DEFAULT_PAGE
 from app.models.models import (
     ConsultationRequest,
     MemberGym,
@@ -180,15 +181,45 @@ def attach_target_names(db: Session, rows: list[ConsultationRequest]) -> list[Co
     return out
 
 
-def list_my_consultations(db: Session, member_id: str) -> list[ConsultationOut]:
+def _apply_cursor(query, before: datetime | None, before_id: str | None):
+    """`(created_at, id)` 복합 커서를 건다. (#980)
+
+    시각만으로 자르지 않는 이유는 알림과 같다 — 같은 `created_at` 이 여러 건이면 그
+    경계에서 요청이 빠지거나 겹친다. 상담은 회원이 여러 트레이너에게 연달아 보내는
+    일이 있어 초 단위 동시각이 실제로 나온다.
+    """
+    if before is None:
+        return query
+    if before_id is not None:
+        return query.where(
+            tuple_(ConsultationRequest.created_at, ConsultationRequest.id)
+            < (before, before_id)
+        )
+    return query.where(ConsultationRequest.created_at < before)
+
+
+def list_my_consultations(
+    db: Session,
+    member_id: str,
+    *,
+    limit: int = DEFAULT_PAGE,
+    before: datetime | None = None,
+    before_id: str | None = None,
+) -> list[ConsultationOut]:
+    """내가 보낸 상담 요청 한 쪽(최신순). 기본 50건, 다음 쪽은 커서로 이어 받는다."""
+    query = _apply_cursor(
+        select(ConsultationRequest).where(
+            ConsultationRequest.member_id == member_id
+        ),
+        before,
+        before_id,
+    )
     rows = list(
         db.scalars(
-            select(ConsultationRequest)
-            .where(ConsultationRequest.member_id == member_id)
-            .order_by(
+            query.order_by(
                 ConsultationRequest.created_at.desc(),
                 ConsultationRequest.id.desc(),
-            )
+            ).limit(limit)
         ).all()
     )
     return attach_target_names(db, rows)
@@ -282,11 +313,24 @@ def _to_trainer_out(
 
 
 def list_for_trainer(
-    db: Session, trainer_id: str, status: ConsultationStatusFilter = "pending"
+    db: Session,
+    trainer_id: str,
+    status: ConsultationStatusFilter = "pending",
+    *,
+    limit: int = DEFAULT_PAGE,
+    before: datetime | None = None,
+    before_id: str | None = None,
 ) -> list[TrainerConsultationOut]:
-    """트레이너 인박스. 기본은 미처리(`pending`)만, 최신 요청이 위로 온다."""
-    query = select(ConsultationRequest).where(
-        _inbox_scope(trainer_id)
+    """트레이너 인박스 한 쪽. 기본은 미처리(`pending`)만, 최신 요청이 위로 온다.
+
+    기본값인 `pending` 은 처리하는 만큼 줄어 실무상 짧지만, `status=all` 은 그
+    트레이너에게 들어온 요청 **전체**라 담당 기간에 비례해 자란다. 목록 쪽 나눔과
+    무관하게 배지 수는 [pending_count_for_trainer] 가 DB 에서 따로 센다. (#980)
+    """
+    query = _apply_cursor(
+        select(ConsultationRequest).where(_inbox_scope(trainer_id)),
+        before,
+        before_id,
     )
     if status != "all":
         query = query.where(ConsultationRequest.status == status)
@@ -295,7 +339,7 @@ def list_for_trainer(
             query.order_by(
                 ConsultationRequest.created_at.desc(),
                 ConsultationRequest.id.desc(),
-            )
+            ).limit(limit)
         ).all()
     )
     return _to_trainer_out(db, rows)

--- a/backend/app/services/reservation_service.py
+++ b/backend/app/services/reservation_service.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import func, select
+from sqlalchemy import func, select, tuple_
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.core.clock import SEOUL
+from app.core.pagination import DEFAULT_PAGE
 from app.models.models import (
     TrainerClient,
     TrainerReservation,
@@ -349,22 +350,49 @@ def reserve(
 
 
 def list_member_reservations(
-    db: Session, member_id: str, *, now: datetime | None = None
+    db: Session,
+    member_id: str,
+    *,
+    now: datetime | None = None,
+    limit: int = DEFAULT_PAGE,
+    before: datetime | None = None,
+    before_id: str | None = None,
 ) -> list[MyReservationOut]:
-    """회원의 예약 목록(예정된 것 먼저). 지난 예약도 함께 준다.
+    """회원의 예약 목록 한 쪽(다가오는 것부터). 지난 예약도 함께 준다.
 
     지난 것을 숨기지 않는 이유: 회원이 "내가 그 시간에 예약했었나" 를 확인하는
     자리이기도 하다. 대신 `cancellable` 로 취소 가능 여부를 서버가 판단해 준다.
+
+    **순서가 늦은 것부터로 바뀌었다(#980).** 예약은 한 건씩 영구히 쌓이는데 예전에는
+    상한 없이 `starts_at` 오름차순으로 전부 돌려줬다 — 여기에 상한만 씌우면 첫 쪽이
+    **가장 오래된 지난 예약**으로 채워져, 정작 다가오는 예약이 화면에서 사라진다.
+    내림차순이면 첫 쪽이 항상 예정된 예약이고, 지난 예약은 이어 받는 쪽으로 밀린다.
+
+    커서는 알림·채팅 스레드와 같은 모양이다 — 받은 마지막 예약의
+    `(starts_at, id)` 를 `(before, before_id)` 로 넘긴다. 한 트레이너가 같은 시각에
+    슬롯을 여러 개 열어 둘 수 있어 동시각이 실제로 나오므로 복합 커서를 쓴다.
     """
     current = now or datetime.now(timezone.utc)
-    rows = db.execute(
+    query = (
         select(TrainerReservation, TrainerReservationSlot)
         .join(
             TrainerReservationSlot,
             TrainerReservationSlot.id == TrainerReservation.slot_id,
         )
         .where(TrainerReservation.member_id == member_id)
-        .order_by(TrainerReservationSlot.starts_at)
+    )
+    if before is not None:
+        if before_id is not None:
+            query = query.where(
+                tuple_(TrainerReservationSlot.starts_at, TrainerReservation.id)
+                < (before, before_id)
+            )
+        else:
+            query = query.where(TrainerReservationSlot.starts_at < before)
+    rows = db.execute(
+        query.order_by(
+            TrainerReservationSlot.starts_at.desc(), TrainerReservation.id.desc()
+        ).limit(limit)
     ).all()
     return [
         MyReservationOut(

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import Session
 from pydantic import ValidationError
 
 from app.core import clock
+from app.core.pagination import DEFAULT_PAGE
 from app.models.models import (
     ChatMessage, DietEntry, ExerciseSession, GymProfile, HealthProfile, Place, RoutineHistory,
     TrainerClient, TrainerClientMemo, TrainerProfile, TrainerProgramDraft,
@@ -270,16 +271,46 @@ def _roster_active(link: TrainerClient) -> bool:
     return link.active and not link.dormant
 
 
-def build_roster(db: Session, trainer_id: str) -> list[TrainerClientOut]:
-    """트레이너의 담당 고객 로스터. 각 카드의 영양 지표는 회원 실데이터에서 집계.
+class RosterCursorNotFound(Exception):
+    """로스터 커서가 가리키는 회원이 그 트레이너의 명단에 없음 — 라우터가 422 로 옮긴다."""
+
+
+def build_roster(
+    db: Session,
+    trainer_id: str,
+    *,
+    limit: int = DEFAULT_PAGE,
+    after_id: str | None = None,
+) -> list[TrainerClientOut]:
+    """트레이너의 담당 고객 로스터 한 쪽. 각 카드의 영양 지표는 회원 실데이터에서 집계.
 
     쿼리는 고객 수와 무관하게 상수개(배치)로 유지하고, 식단/기록은 필요한 창(최근 7일 /
-    이번 주)만 로드한다(N+1·무제한 이력 로드 방지, 리뷰 PR 250-#3).
+    이번 주)만 로드한다(N+1·무제한 이력 로드 방지, 리뷰 PR 250-#3). 쿼리 수는 상수라도
+    **한 쿼리가 읽는 양**은 인원수만큼 자라므로 한 번에 주는 건수에 상한을 둔다. (#980)
+
+    커서는 트레이너가 정한 순서를 그대로 따라 오름차순이고, 받은 마지막 카드의 **회원
+    id** 하나다(`after_id`) — 정렬키인 `sort_order` 는 카드에 실리지 않으므로 그 자리를
+    여기서 찾는다. 명단에 없는 id 면 [RosterCursorNotFound].
+
+    tie-break 를 `created_at` 이 아니라 회원 id 로 둔다 — `sort_order` 가 같은 링크
+    사이의 순서만 바뀌며, 담당 링크는 만들 때마다 `max(sort_order) + 1` 을 받아 같은
+    값이 겹치는 일 자체가 드물다.
     """
+    query = select(TrainerClient).where(TrainerClient.trainer_id == trainer_id)
+    if after_id is not None:
+        anchor = db.execute(
+            select(TrainerClient.sort_order, TrainerClient.member_id).where(
+                TrainerClient.trainer_id == trainer_id,
+                TrainerClient.member_id == after_id,
+            )
+        ).first()
+        if anchor is None:
+            raise RosterCursorNotFound("이어 받을 자리를 찾을 수 없습니다.")
+        query = query.where(
+            tuple_(TrainerClient.sort_order, TrainerClient.member_id) > tuple(anchor)
+        )
     links = db.scalars(
-        select(TrainerClient)
-        .where(TrainerClient.trainer_id == trainer_id)
-        .order_by(TrainerClient.sort_order, TrainerClient.created_at)
+        query.order_by(TrainerClient.sort_order, TrainerClient.member_id).limit(limit)
     ).all()
     if not links:
         return []

--- a/backend/docs/TRAINER_DOMAIN.md
+++ b/backend/docs/TRAINER_DOMAIN.md
@@ -107,7 +107,7 @@
 | POST | `/trainer/me/password` | 비밀번호 변경(현재 비밀번호 확인) |
 | GET | `/trainer/me/settings` | 알림 수신 설정 |
 | PUT | `/trainer/me/settings` | 알림 수신 설정 부분 수정 |
-| GET | `/trainer/clients` | 고객 로스터(회원 실데이터 집계) |
+| GET | `/trainer/clients` | 고객 로스터(회원 실데이터 집계) — 기본 50명, `after_id` 로 이어 받기 (#980) |
 | PUT | `/trainer/clients/{member_id}/status` | 활성/휴면 전환(담당 관계는 유지, #707) |
 | GET | `/trainer/clients/{member_id}/diet?date=` | 해당 회원의 실제 식단 기록 |
 | GET | `/trainer/clients/{member_id}/history` | 해당 회원 운동 기록(최신순) |
@@ -289,6 +289,14 @@ O2O 코칭의 재등록 고리. 세션 수·완료 수는 `trainer_schedule`, �
   '오늘/어제'가 어긋난다. 운영은 `TZ=Asia/Seoul`.
 - 채팅 스레드는 `(created_at, id)` **복합 커서**(`before`/`before_id`)로 페이지네이션 —
   같은 `created_at`이 여러 건이어도 안정적으로 끊어 읽는다.
+- **로스터도 한 쪽만 준다**(기본 50명, `limit` 1~100). 쿼리 수는 인원과 무관하게
+  상수지만 *한 쿼리가 읽는 양*은 인원만큼 자라고, 카드마다 붙는 집계도 함께 커진다. (#980)
+- 로스터 커서는 다른 목록과 모양이 다르다 — 정렬키가 시각이 아니라 트레이너가 정한
+  순서(`sort_order`)이고 그 값은 카드에 실리지 않아서, 받은 마지막 카드의 **회원 id**
+  하나(`after_id`)만 넘기면 서버가 그 자리를 찾아 이어 준다. 명단에 없는 id 는 **422** 다
+  — 조용히 첫 쪽을 돌려주면 이어 받기가 제자리를 돈다. 정렬 tie-break 는
+  `created_at` 이 아니라 회원 id 이며(같은 `sort_order` 안에서만 차이), 담당 링크는
+  만들 때마다 `max(sort_order) + 1` 을 받아 값이 겹치는 일 자체가 드물다.
 
 ## 5. 예약 → 수업 → 기록 루프
 

--- a/backend/tests/test_list_pagination.py
+++ b/backend/tests/test_list_pagination.py
@@ -1,0 +1,398 @@
+"""예약·상담·로스터 목록의 상한과 커서. (#980) DB 필요.
+
+알림(#965)과 같은 문제가 남아 있던 목록들이다 — 계정을 오래 쓸수록 응답이 선형으로
+길어지는데, 알림과 달리 **지우는 것이 답이 아니다**(예약·상담은 이력이고, 로스터는
+담당 관계다). 그래서 상한과 커서만 씌운다.
+
+여기서 확인하는 것:
+  1. 기본 상한이 있고, 커서로 다음 쪽을 빠짐없이·겹치지 않게 이어 받는다.
+  2. 파라미터 없이 부르던 기존 클라이언트가 깨지지 않는다.
+  3. 첫 쪽에 **지금 쓸모 있는 것**이 온다 — 예약은 다가오는 것부터다.
+  4. 미처리 상담 배지는 쪽 나눔과 무관하게 전체 기준이다.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+
+from app.core.security import hash_password
+from app.models.models import (
+    ConsultationRequest,
+    TrainerClient,
+    TrainerProfile,
+    TrainerReservation,
+    TrainerReservationSlot,
+    TrainerSchedule,
+    User,
+)
+
+EMAIL_PREFIX = "page-test-"
+PASSWORD = "page-pw-1234!"
+
+#: 기본 상한(50)의 경계를 보려면 그보다 많아야 한다.
+_TOTAL = 120
+
+#: 로스터는 인원수만큼만 자라 120명까지 쌓아 볼 일이 없다 — 상한만 넘기면 된다.
+_ROSTER_TOTAL = 60
+
+_BASE = datetime(2026, 3, 1, 9, 0, tzinfo=timezone.utc)
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _login(client, email: str) -> str:
+    res = client.post("/v1/auth/login", data={"username": email, "password": PASSWORD})
+    assert res.status_code == 200, res.text
+    return res.json()["access_token"]
+
+
+@pytest.fixture()
+def member(client) -> dict:
+    """예약·상담이 하나도 없는 새 회원. 시드 계정은 다른 테스트가 건드려 수가 흔들린다."""
+    email = f"{EMAIL_PREFIX}member-{uuid4().hex[:8]}@oncare.com"
+    created = client.post(
+        "/v1/auth/register",
+        json={"email": email, "password": PASSWORD, "name": "페이지 회원"},
+    )
+    assert created.status_code == 201, created.text
+    return {"id": created.json()["id"], "token": _login(client, email)}
+
+
+@pytest.fixture()
+def trainer(client, db_session) -> dict:
+    """담당 고객도 상담 요청도 없는 새 트레이너."""
+    suffix = uuid4().hex[:8]
+    email = f"{EMAIL_PREFIX}trainer-{suffix}@oncare.com"
+    row = User(
+        id=f"page-trainer-{suffix}",
+        email=email,
+        name="페이지 트레이너",
+        hashed_password=hash_password(PASSWORD),
+        role="trainer",
+        is_active=True,
+    )
+    db_session.add(row)
+    db_session.flush()
+    db_session.add(TrainerProfile(trainer_id=row.id))
+    db_session.commit()
+    return {"id": row.id, "token": _login(client, email)}
+
+
+def _get(client, token: str, path: str, **params) -> list[dict]:
+    res = client.get(f"/v1/{path}", params=params, headers=_auth(token))
+    assert res.status_code == 200, res.text
+    return res.json()
+
+
+def _walk(client, token: str, path: str, cursor_keys: tuple[str, str], key, **params):
+    """커서를 따라 목록 전체를 훑는다. 받은 id 를 순서대로 돌려준다.
+
+    쪽 크기를 기본값보다 작게 잡아 경계를 여러 번 지나게 한다 — 한 쪽에 다 들어가면
+    커서가 실제로 동작하는지 알 수 없다.
+    """
+    before_key, before_id_key = cursor_keys
+    seen: list[str] = []
+    cursor: dict[str, object] = {}
+    for _ in range(30):  # 넉넉한 상한 — 커서가 멈추지 않아도 매달리지 않게.
+        rows = _get(client, token, path, limit=25, **params, **cursor)
+        if not rows:
+            break
+        seen.extend(r["id"] for r in rows)
+        cursor = {before_key: key(rows[-1]), before_id_key: rows[-1]["id"]}
+    return seen
+
+
+# ---------------------------------------------------------------------------
+# GET /reservations/me
+# ---------------------------------------------------------------------------
+def _seed_reservations(db, member_id: str, trainer_id: str, count: int) -> None:
+    """이른 시각부터 `count` 건. 마지막 두 건은 **같은 시각**이다.
+
+    한 트레이너가 같은 시각에 슬롯을 여러 개 열어 둘 수 있어 동시각이 실제로 나온다.
+    시각만으로 자르는 커서라면 그 경계에서 예약이 빠지거나 겹친다.
+    """
+    for i in range(count):
+        starts_at = _BASE + timedelta(hours=min(i, count - 2))
+        slot = TrainerReservationSlot(
+            id=f"slot-page-{i:04d}-{uuid4().hex[:6]}",
+            trainer_id=trainer_id,
+            starts_at=starts_at,
+            capacity=1,
+            remaining=0,
+        )
+        schedule = TrainerSchedule(
+            id=f"sched-page-{i:04d}-{uuid4().hex[:6]}",
+            trainer_id=trainer_id,
+            member_id=member_id,
+            date=starts_at.date().isoformat(),
+            time=starts_at.strftime("%H:%M"),
+            client_name="페이지 회원",
+            type="1:1 PT",
+            duration_minutes=50,
+            status="예정",
+            note="",
+            program_json="[]",
+            sort_order=0,
+        )
+        db.add_all([slot, schedule])
+        # 슬롯·일정을 **먼저** 내보낸다 — 모델에 relationship 이 없어 ORM 이 예약과의
+        # 의존을 모르고, 한 번에 flush 하면 예약이 먼저 나가 FK 위반이 된다.
+        db.flush()
+        db.add(
+            TrainerReservation(
+                id=f"resv-page-{i:04d}-{uuid4().hex[:6]}",
+                member_id=member_id,
+                slot_id=slot.id,
+                schedule_id=schedule.id,
+                status="booked",
+            )
+        )
+    db.commit()
+
+
+def test_reservations_default_page_is_capped_and_upcoming_first(
+    client, db_session, member, trainer
+):
+    """파라미터 없는 호출은 그대로 동작하되, 늦은 예약부터 50건까지만 준다.
+
+    순서가 중요하다 — 오름차순 그대로 상한만 씌우면 첫 쪽이 **가장 오래된 지난
+    예약**으로 차서, 정작 다가오는 예약이 화면에서 사라진다.
+    """
+    _seed_reservations(db_session, member["id"], trainer["id"], _TOTAL)
+
+    rows = _get(client, member["token"], "reservations/me")
+
+    assert len(rows) == 50
+    times = [r["starts_at"] for r in rows]
+    assert times == sorted(times, reverse=True)
+
+
+def test_reservations_limit_is_bounded(client, member):
+    """채팅 스레드·알림과 같은 규약(1~100)."""
+    assert len(_get(client, member["token"], "reservations/me", limit=1)) <= 1
+    for bad in (0, 101):
+        res = client.get(
+            "/v1/reservations/me",
+            params={"limit": bad},
+            headers=_auth(member["token"]),
+        )
+        assert res.status_code == 422
+
+
+def test_reservations_cursor_walks_the_whole_list(client, db_session, member, trainer):
+    """쪽을 이어 받으면 전체가 정확히 한 번씩 나온다 — 동시각 경계 포함."""
+    _seed_reservations(db_session, member["id"], trainer["id"], _TOTAL)
+
+    seen = _walk(
+        client,
+        member["token"],
+        "reservations/me",
+        ("before", "before_id"),
+        key=lambda r: r["starts_at"],
+    )
+
+    assert len(seen) == _TOTAL
+    assert len(set(seen)) == _TOTAL
+
+
+def test_reservations_bad_cursor_is_rejected(client, member):
+    """커서를 파싱할 수 없으면 422 — 조용히 첫 쪽을 주면 무한 루프가 된다."""
+    res = client.get(
+        "/v1/reservations/me",
+        params={"before": "어제"},
+        headers=_auth(member["token"]),
+    )
+    assert res.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /consultations/me · GET /trainer/consultations
+# ---------------------------------------------------------------------------
+def _consultation(member_id: str, trainer_id: str, i: int, count: int, status: str):
+    """상담 요청 한 건. 마지막 두 건은 같은 `created_at` 이다.
+
+    같은 시각이 실제로 나온다 — 인박스는 회원 여러 명의 요청이 몰리는 자리다. 시각만으로
+    자르는 커서라면 그 경계에서 요청이 빠지거나 겹친다.
+    """
+    return ConsultationRequest(
+        id=f"consult-page-{i:04d}-{uuid4().hex[:6]}",
+        member_id=member_id,
+        target_type="trainer",
+        trainer_id=trainer_id,
+        exercise_goal="fitness",
+        health_purpose_type="general",
+        preferred_date="2026-04-01",
+        preferred_time_slot="morning",
+        status=status,
+        created_at=_BASE + timedelta(minutes=min(i, count - 2)),
+    )
+
+
+def _seed_my_consultations(db, member_id: str, trainer_id: str, count: int) -> None:
+    """한 회원이 쌓은 상담 이력 `count` 건.
+
+    대기 중인 요청은 **한 건뿐**이다 — `uq_consultation_requests_pending_trainer` 가
+    같은 트레이너에게 보낸 대기 요청을 하나로 막는다. 나머지는 처리된 지난 요청이고,
+    회원 목록에는 상태 필터가 없어 그대로 함께 자란다(그래서 상한이 필요하다).
+    """
+    for i in range(count):
+        status = "pending" if i == count - 1 else ("accepted" if i % 2 else "rejected")
+        db.add(_consultation(member_id, trainer_id, i, count, status))
+    db.commit()
+
+
+def _seed_inbox(db, trainer_id: str, count: int) -> None:
+    """트레이너 인박스에 회원 `count` 명의 미처리 요청을 쌓는다.
+
+    회원마다 한 건씩인 것이 실제 모양이다 — 한 회원이 같은 트레이너에게 대기 요청을
+    여러 건 보낼 수는 없다.
+    """
+    password = hash_password(PASSWORD)  # 한 번만 해싱한다 — 회원 수만큼 돌리면 느리다.
+    for i in range(count):
+        suffix = uuid4().hex[:8]
+        member = User(
+            id=f"page-asker-{i:04d}-{suffix}",
+            email=f"{EMAIL_PREFIX}asker-{i:04d}-{suffix}@oncare.com",
+            name=f"문의 회원 {i}",
+            hashed_password=password,
+            role="member",
+            is_active=True,
+        )
+        db.add(member)
+        db.flush()
+        db.add(_consultation(member.id, trainer_id, i, count, "pending"))
+    db.commit()
+
+
+def test_my_consultations_default_page_is_capped(client, db_session, member, trainer):
+    """필터가 없어 지난 요청까지 함께 자란다 — 최신 50건."""
+    _seed_my_consultations(db_session, member["id"], trainer["id"], _TOTAL)
+
+    rows = _get(client, member["token"], "consultations/me")
+
+    assert len(rows) == 50
+    created = [r["created_at"] for r in rows]
+    assert created == sorted(created, reverse=True)
+
+
+def test_my_consultations_cursor_walks_the_whole_list(
+    client, db_session, member, trainer
+):
+    _seed_my_consultations(db_session, member["id"], trainer["id"], _TOTAL)
+
+    seen = _walk(
+        client,
+        member["token"],
+        "consultations/me",
+        ("before", "before_id"),
+        key=lambda r: r["created_at"],
+    )
+
+    assert len(seen) == _TOTAL
+    assert len(set(seen)) == _TOTAL
+
+
+def test_trainer_inbox_is_capped_and_walkable(client, db_session, trainer):
+    """`status=all` 은 그 트레이너에게 들어온 요청 전체다 — 여기가 가장 크게 자란다."""
+    _seed_inbox(db_session, trainer["id"], _TOTAL)
+
+    first = _get(client, trainer["token"], "trainer/consultations", status="all")
+    assert len(first) == 50
+
+    seen = _walk(
+        client,
+        trainer["token"],
+        "trainer/consultations",
+        ("before", "before_id"),
+        key=lambda r: r["created_at"],
+        status="all",
+    )
+    assert len(seen) == _TOTAL
+    assert len(set(seen)) == _TOTAL
+
+
+def test_pending_count_ignores_pagination(client, db_session, trainer):
+    """배지는 DB 에서 센다 — 첫 쪽 안에서 세면 인박스가 길어질수록 조용히 줄어든다."""
+    _seed_inbox(db_session, trainer["id"], _TOTAL)
+
+    res = client.get(
+        "/v1/trainer/consultations/pending-count", headers=_auth(trainer["token"])
+    )
+    assert res.status_code == 200, res.text
+    assert res.json()["count"] == _TOTAL
+
+
+# ---------------------------------------------------------------------------
+# GET /trainer/clients
+# ---------------------------------------------------------------------------
+def _seed_roster(db, trainer_id: str, count: int) -> list[str]:
+    """담당 회원 `count` 명. 트레이너가 정한 순서(`sort_order`)대로 넣는다."""
+    member_ids: list[str] = []
+    for i in range(count):
+        suffix = uuid4().hex[:8]
+        member = User(
+            id=f"page-roster-{i:04d}-{suffix}",
+            email=f"{EMAIL_PREFIX}roster-{i:04d}-{suffix}@oncare.com",
+            name=f"회원 {i}",
+            hashed_password=hash_password(PASSWORD),
+            role="member",
+            is_active=True,
+        )
+        db.add(member)
+        db.flush()
+        db.add(
+            TrainerClient(
+                id=f"tc-page-{i:04d}-{suffix}",
+                trainer_id=trainer_id,
+                member_id=member.id,
+                goal="체력 증진",
+                active=True,
+                sort_order=i,
+            )
+        )
+        member_ids.append(member.id)
+    db.commit()
+    return member_ids
+
+
+def test_roster_default_page_is_capped_and_keeps_trainer_order(
+    client, db_session, trainer
+):
+    """상한을 넘겨도 트레이너가 정한 순서 그대로 앞에서부터 준다."""
+    member_ids = _seed_roster(db_session, trainer["id"], _ROSTER_TOTAL)
+
+    rows = _get(client, trainer["token"], "trainer/clients")
+
+    assert len(rows) == 50
+    assert [r["id"] for r in rows] == member_ids[:50]
+
+
+def test_roster_cursor_walks_the_whole_list(client, db_session, trainer):
+    """이어 받으면 담당 회원이 한 명도 빠지지 않는다 — 상한이 곧 명단 잘림이면 안 된다."""
+    member_ids = _seed_roster(db_session, trainer["id"], _ROSTER_TOTAL)
+
+    seen: list[str] = []
+    cursor: dict[str, object] = {}
+    for _ in range(10):
+        rows = _get(client, trainer["token"], "trainer/clients", limit=25, **cursor)
+        if not rows:
+            break
+        seen.extend(r["id"] for r in rows)
+        # 커서는 마지막 카드의 id 하나 — 정렬키(sort_order)는 서버가 찾는다.
+        cursor = {"after_id": rows[-1]["id"]}
+
+    assert seen == member_ids
+
+
+def test_roster_unknown_cursor_is_rejected(client, trainer):
+    """명단에 없는 id 로 이어 받으려 하면 422 — 첫 쪽을 다시 주면 제자리를 돈다."""
+    res = client.get(
+        "/v1/trainer/clients",
+        params={"after_id": "no-such-member"},
+        headers=_auth(trainer["token"]),
+    )
+    assert res.status_code == 422

--- a/frontend/flutter/lib/features/exercise/data/repositories/dio_consultation_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/dio_consultation_repository.dart
@@ -33,8 +33,13 @@ class DioConsultationRepository implements ConsultationRepository {
   }
 
   @override
-  Future<List<ConsultationRequest>> fetchMine() async {
-    final res = await _dio.get<List<Object?>>('/consultations/me');
+  Future<List<ConsultationRequest>> fetchMine({
+    int limit = consultationPageSize,
+  }) async {
+    final res = await _dio.get<List<Object?>>(
+      '/consultations/me',
+      queryParameters: <String, Object?>{'limit': limit},
+    );
     return (res.data ?? const <Object?>[])
         .cast<Map<String, Object?>>()
         .map(consultationFromJson)
@@ -59,6 +64,7 @@ class MockConsultationRepository implements ConsultationRepository {
 
   /// 데모에는 서버가 없으므로 복원할 것도 없다.
   @override
-  Future<List<ConsultationRequest>> fetchMine() async =>
-      const <ConsultationRequest>[];
+  Future<List<ConsultationRequest>> fetchMine({
+    int limit = consultationPageSize,
+  }) async => const <ConsultationRequest>[];
 }

--- a/frontend/flutter/lib/features/exercise/data/repositories/dio_gym_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/dio_gym_repository.dart
@@ -111,7 +111,10 @@ class DioGymRepository implements GymRepository {
     try {
       final res = await _dio.get<Map<String, Object?>>(
         '/me/gym',
-        queryParameters: <String, Object?>{'lat': kGymSearchLat, 'lng': kGymSearchLng},
+        queryParameters: <String, Object?>{
+          'lat': kGymSearchLat,
+          'lng': kGymSearchLng,
+        },
       );
       if (res.data != null) return _gym(res.data!);
     } on DioException catch (e) {
@@ -142,8 +145,21 @@ class DioGymRepository implements GymRepository {
       _list('/trainers/$trainerId/slots', _slot);
 
   @override
-  Future<List<MyReservation>> fetchMyReservations() =>
-      _list('/reservations/me', MyReservation.fromJson);
+  Future<List<MyReservation>> fetchMyReservations({
+    int limit = reservationPageSize,
+    DateTime? before,
+    String? beforeId,
+  }) => _list(
+    '/reservations/me',
+    MyReservation.fromJson,
+    query: <String, Object?>{
+      'limit': limit,
+      // 커서는 서버가 준 시각 그대로여야 한다 — 엔티티는 화면용으로 로컬 시각을
+      // 들고 있으므로 UTC 로 되돌려 보낸다.
+      if (before != null) 'before': before.toUtc().toIso8601String(),
+      'before_id': ?beforeId,
+    },
+  );
 
   @override
   Future<void> cancelReservation(String reservationId) async {

--- a/frontend/flutter/lib/features/exercise/data/repositories/mock_gym_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/mock_gym_repository.dart
@@ -87,7 +87,8 @@ class MockGymRepository implements GymRepository {
       role: '재활 트레이너',
       reason: '무릎·허리 통증 관리 다수 경험',
       career: '11년',
-      intro: '수술 후 회복과 만성 통증 관리를 주로 맡습니다. 무리하지 않는 범위에서 '
+      intro:
+          '수술 후 회복과 만성 통증 관리를 주로 맡습니다. 무리하지 않는 범위에서 '
           '가동 범위를 조금씩 넓혀 갑니다.',
       certifications: <String>['물리치료사', '재활 트레이닝 NASM-CES'],
     ),
@@ -98,7 +99,8 @@ class MockGymRepository implements GymRepository {
       role: '그룹 PT 트레이너',
       reason: '2~4인 소그룹 수업 운영',
       career: '4년',
-      intro: '2~4인 소그룹 수업을 진행합니다. 혼자서는 운동을 이어 가기 어려운 회원에게 '
+      intro:
+          '2~4인 소그룹 수업을 진행합니다. 혼자서는 운동을 이어 가기 어려운 회원에게 '
           '적합한 방식입니다.',
       certifications: <String>['생활스포츠지도사 2급'],
     ),
@@ -109,7 +111,8 @@ class MockGymRepository implements GymRepository {
       role: '퍼스널 트레이너',
       reason: '교대근무 일정 맞춤 설계',
       career: '5년',
-      intro: '불규칙한 근무 일정에 맞춘 운동 설계를 주로 합니다. 짧은 시간에 집중도를 '
+      intro:
+          '불규칙한 근무 일정에 맞춘 운동 설계를 주로 합니다. 짧은 시간에 집중도를 '
           '높이는 근력 프로그램을 구성합니다.',
       certifications: <String>['건강운동관리사', '퍼스널트레이닝 CPT'],
     ),
@@ -120,7 +123,8 @@ class MockGymRepository implements GymRepository {
       role: '근력 전문 트레이너',
       reason: '기초 근력부터 단계별 지도',
       career: '8년',
-      intro: '기초 근력부터 파워리프팅까지 단계를 나눠 지도합니다. 현재 들 수 있는 '
+      intro:
+          '기초 근력부터 파워리프팅까지 단계를 나눠 지도합니다. 현재 들 수 있는 '
           '무게를 확인한 뒤 다음 단계를 정합니다.',
       certifications: <String>['퍼스널트레이닝 CPT'],
     ),
@@ -131,13 +135,10 @@ class MockGymRepository implements GymRepository {
       role: '퍼스널 트레이너',
       reason: '초심자용 간단 루틴 구성',
       career: '9년',
-      intro: '운동을 처음 시작하는 회원을 오래 지도했습니다. 식단 상담을 함께 진행해 '
+      intro:
+          '운동을 처음 시작하는 회원을 오래 지도했습니다. 식단 상담을 함께 진행해 '
           '생활 습관부터 조정합니다.',
-      certifications: <String>[
-        '생활스포츠지도사 2급',
-        '스포츠 영양사',
-        '재활 트레이닝 NASM-CES',
-      ],
+      certifications: <String>['생활스포츠지도사 2급', '스포츠 영양사', '재활 트레이닝 NASM-CES'],
     ),
     Trainer(
       id: 'trainer-cho',
@@ -146,7 +147,8 @@ class MockGymRepository implements GymRepository {
       role: '시니어 운동 트레이너',
       reason: '고령 회원 균형 운동 장기 지도',
       career: '12년',
-      intro: '60대 이상 회원 수업을 오래 맡았습니다. 균형 잡기와 낙상 예방 동작부터 '
+      intro:
+          '60대 이상 회원 수업을 오래 맡았습니다. 균형 잡기와 낙상 예방 동작부터 '
           '시작해 천천히 강도를 올립니다.',
       certifications: <String>['건강운동관리사', '노인스포츠지도사'],
     ),
@@ -160,7 +162,8 @@ class MockGymRepository implements GymRepository {
       role: '퍼스널 트레이너',
       reason: '감량 정체기 식사·운동량 재조정',
       career: '6년',
-      intro: '체중이 멈춘 시점에 식사량과 운동량을 다시 맞추는 일을 자주 합니다. '
+      intro:
+          '체중이 멈춘 시점에 식사량과 운동량을 다시 맞추는 일을 자주 합니다. '
           '몸무게보다 둘레와 체성분 변화를 기준으로 판단합니다.',
       certifications: <String>['생활스포츠지도사 2급'],
     ),
@@ -171,7 +174,8 @@ class MockGymRepository implements GymRepository {
       role: '체형 교정 트레이너',
       reason: '장시간 착석형 목·어깨 교정',
       career: '4년',
-      intro: '오래 앉아 생긴 목과 어깨 불편을 주로 다룹니다. 스트레칭과 가벼운 근력 '
+      intro:
+          '오래 앉아 생긴 목과 어깨 불편을 주로 다룹니다. 스트레칭과 가벼운 근력 '
           '운동을 번갈아 배치해 한 시간을 구성합니다.',
       certifications: <String>['필라테스 지도자', '생활스포츠지도사 2급'],
     ),
@@ -182,7 +186,8 @@ class MockGymRepository implements GymRepository {
       role: '퍼스널 트레이너',
       reason: '기구 입문자 눈높이 지도',
       career: '3년',
-      intro: '기구 사용법부터 하나씩 익히는 수업입니다. 무게를 올리기 전에 자세가 '
+      intro:
+          '기구 사용법부터 하나씩 익히는 수업입니다. 무게를 올리기 전에 자세가 '
           '자리를 잡을 때까지 시간을 들입니다.',
       certifications: <String>['퍼스널트레이닝 CPT'],
     ),
@@ -193,7 +198,8 @@ class MockGymRepository implements GymRepository {
       role: '그룹 PT 트레이너',
       reason: '3~5인 그룹 수업 출석 관리',
       career: '5년',
-      intro: '3~5인 그룹 수업을 맡습니다. 서로 속도를 맞추는 구성이라 혼자 할 때보다 '
+      intro:
+          '3~5인 그룹 수업을 맡습니다. 서로 속도를 맞추는 구성이라 혼자 할 때보다 '
           '출석이 안정적으로 유지됩니다.',
       certifications: <String>['생활스포츠지도사 2급'],
     ),
@@ -204,7 +210,8 @@ class MockGymRepository implements GymRepository {
       role: '재활 전문 트레이너',
       reason: '병원 재활 이후 복귀 단계 관리',
       career: '10년',
-      intro: '병원 재활이 끝난 뒤 일상 운동으로 넘어가는 구간을 담당합니다. 통증 기록을 '
+      intro:
+          '병원 재활이 끝난 뒤 일상 운동으로 넘어가는 구간을 담당합니다. 통증 기록을 '
           '함께 남기며 주 단위로 강도를 조절합니다.',
       certifications: <String>['물리치료사', '건강운동관리사'],
     ),
@@ -215,7 +222,8 @@ class MockGymRepository implements GymRepository {
       role: '퍼스널 트레이너',
       reason: '스쿼트·데드리프트 영상 자세 교정',
       career: '7년',
-      intro: '스쿼트와 데드리프트 자세 교정을 주로 합니다. 수행 장면을 영상으로 남겨 '
+      intro:
+          '스쿼트와 데드리프트 자세 교정을 주로 합니다. 수행 장면을 영상으로 남겨 '
           '회차별로 달라진 점을 함께 확인합니다.',
       certifications: <String>['퍼스널트레이닝 CPT'],
     ),
@@ -226,7 +234,8 @@ class MockGymRepository implements GymRepository {
       role: '퍼스널 트레이너',
       reason: '주간 식단 기록 점검',
       career: '7년',
-      intro: '1:1 수업만 진행합니다. 매주 식사 기록을 함께 보고 다음 주에 바꿀 항목을 '
+      intro:
+          '1:1 수업만 진행합니다. 매주 식사 기록을 함께 보고 다음 주에 바꿀 항목을 '
           '한 가지씩 정합니다.',
       certifications: <String>['스포츠 영양사', '생활스포츠지도사 2급'],
     ),
@@ -237,7 +246,8 @@ class MockGymRepository implements GymRepository {
       role: '러닝 코치',
       reason: '무릎 부담 적은 러닝 자세 교정',
       career: '5년',
-      intro: '달리기 자세와 호흡을 함께 점검합니다. 무릎에 부담이 덜 가는 보폭을 찾는 '
+      intro:
+          '달리기 자세와 호흡을 함께 점검합니다. 무릎에 부담이 덜 가는 보폭을 찾는 '
           '데 수업 시간을 많이 배정합니다.',
       certifications: <String>['생활스포츠지도사 2급'],
     ),
@@ -464,9 +474,28 @@ class MockGymRepository implements GymRepository {
   final List<MyReservation> _reservations = <MyReservation>[];
 
   @override
-  Future<List<MyReservation>> fetchMyReservations() async {
+  Future<List<MyReservation>> fetchMyReservations({
+    int limit = reservationPageSize,
+    DateTime? before,
+    String? beforeId,
+  }) async {
     await Future<void>.delayed(const Duration(milliseconds: 40));
-    return List<MyReservation>.unmodifiable(_reservations);
+    // 서버와 같은 순서·상한을 흉내 낸다(#980) — 데모에서만 순서가 다르면 패널이
+    // 실모드와 다르게 보인다. 데모 예약은 한 줌이라 커서가 실제로 쓰이지는 않는다.
+    final List<MyReservation> ordered = <MyReservation>[..._reservations]
+      ..sort(
+        (MyReservation a, MyReservation b) => b.startsAt.compareTo(a.startsAt),
+      );
+    final Iterable<MyReservation> page = before == null
+        ? ordered
+        : ordered.where(
+            (MyReservation r) =>
+                r.startsAt.isBefore(before) ||
+                (r.startsAt == before &&
+                    beforeId != null &&
+                    r.id.compareTo(beforeId) < 0),
+          );
+    return List<MyReservation>.unmodifiable(page.take(limit));
   }
 
   @override
@@ -483,7 +512,9 @@ class MockGymRepository implements GymRepository {
       throw StateError('reservation no longer cancellable: $reservationId');
     }
     // 좌석을 되돌린다 — 실서버와 같은 결과가 화면에 보여야 한다.
-    final int s = _slots.indexWhere((TrainerSlot slot) => slot.id == reservation.slotId);
+    final int s = _slots.indexWhere(
+      (TrainerSlot slot) => slot.id == reservation.slotId,
+    );
     if (s >= 0) {
       _slots[s] = _slots[s].copyWith(
         remaining: (_slots[s].remaining + 1).clamp(0, _slots[s].capacity),

--- a/frontend/flutter/lib/features/exercise/domain/repositories/consultation_repository.dart
+++ b/frontend/flutter/lib/features/exercise/domain/repositories/consultation_repository.dart
@@ -1,14 +1,22 @@
 import 'package:oncare/features/exercise/domain/entities/consultation_draft.dart';
 import 'package:oncare/features/exercise/domain/entities/consultation_request.dart';
 
+/// 상담 목록 한 쪽의 건수. 서버 기본값과 같다(#980).
+const int consultationPageSize = 50;
+
 /// 상담 신청 접수·조회. (#327)
 abstract class ConsultationRepository {
   /// 접수된 상담 id. 같은 대상에 이미 대기 중이면 [DuplicatePendingConsultation].
   Future<String> create(ConsultationDraft draft);
 
-  /// 내가 낸 상담 전부. 앱을 다시 열어도 대기 중 신청이 화면에 남아야 한다 —
-  /// 목록이 비면 `hasPending` 이 false 라 같은 대상에 다시 눌러 409 를 받는다(#327).
-  Future<List<ConsultationRequest>> fetchMine();
+  /// 내가 낸 상담 **최근 [limit] 건**(최신순). 앱을 다시 열어도 대기 중 신청이 화면에
+  /// 남아야 한다 — 목록이 비면 `hasPending` 이 false 라 같은 대상에 다시 눌러 409 를
+  /// 받는다(#327).
+  ///
+  /// 서버가 한 쪽만 준다(#980). 화면이 쓰는 것은 대기 중인 신청뿐이고 그것은 대개 가장
+  /// 최근 건이라 첫 쪽으로 충분하다. 그보다 오래된 대기 신청이 남아 있는 드문 경우는
+  /// 접수 시 서버가 409 로 알려 주고, 컨트롤러가 그 응답으로 목록을 채운다.
+  Future<List<ConsultationRequest>> fetchMine({int limit});
 }
 
 /// 서버가 409 로 거절한 경우 — 같은 헬스장/트레이너에 대기 중인 신청이 이미 있다.

--- a/frontend/flutter/lib/features/exercise/domain/repositories/gym_repository.dart
+++ b/frontend/flutter/lib/features/exercise/domain/repositories/gym_repository.dart
@@ -5,6 +5,12 @@ import 'package:oncare/features/exercise/domain/entities/trainer_slot.dart';
 
 /// Gym + trainer directory, plus the user's own two links. Both live here
 /// because the links are coupled: leaving a gym also drops its trainer.
+/// 예약 목록 한 쪽의 건수. 서버 기본값과 같다(#980).
+///
+/// 한 화면에 다 그리는 패널이라 알림함(30)보다 크게 잡는다 — 회원 한 명이 잡아 둔
+/// 예약은 트레이너별로 갈라 보이고, 첫 쪽에 다가오는 예약이 모두 들어와야 한다.
+const int reservationPageSize = 50;
+
 abstract class GymRepository {
   /// User's current gym (one). `null` until they register one.
   Future<Gym?> fetchMyGym();
@@ -46,8 +52,15 @@ abstract class GymRepository {
   /// stale screen cannot silently overbook.
   Future<void> reserve(String slotId);
 
-  /// 내가 잡아 둔 예약들. 예약 패널이 '내 자리'를 표시하고 취소를 걸 근거다. (#502)
-  Future<List<MyReservation>> fetchMyReservations();
+  /// 내가 잡아 둔 예약 한 쪽. 예약 패널이 '내 자리'를 표시하고 취소를 걸 근거다. (#502)
+  ///
+  /// **다가오는 예약부터** 온다. 서버가 한 번에 주는 건수에 상한이 있어(#980), 더 과거를
+  /// 보려면 받은 마지막 예약의 `startsAt`·`id` 를 [before]·[beforeId] 로 넘긴다.
+  Future<List<MyReservation>> fetchMyReservations({
+    int limit,
+    DateTime? before,
+    String? beforeId,
+  });
 
   /// 예약 취소. 좌석과 트레이너 일정이 함께 돌아간다.
   ///

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/gym_tab.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/gym_tab.dart
@@ -731,7 +731,16 @@ class _ReservationPanelState extends ConsumerState<_ReservationPanel> {
         (ref.watch(myReservationsProvider).valueOrNull ??
                 const <MyReservation>[])
             .where((MyReservation r) => r.trainerId == widget.trainer.id)
-            .toList();
+            .toList()
+          // 서버는 늦은 예약부터 준다(#980) — 쪽을 나누려면 그 순서여야 한다. 화면은
+          // 다르다: **곧 다가오는 자리가 맨 위**여야 하고, 지난 예약은 최근 것부터
+          // 아래에 남는다. 취소 가능 여부(`cancellable`)가 곧 예정/지난 판단이다.
+          ..sort((MyReservation a, MyReservation b) {
+            if (a.cancellable != b.cancellable) return a.cancellable ? -1 : 1;
+            return a.cancellable
+                ? a.startsAt.compareTo(b.startsAt)
+                : b.startsAt.compareTo(a.startsAt);
+          });
     final bool busy = _reserving != null || _cancelling != null;
     return Container(
       width: double.infinity,

--- a/frontend/flutter/test/features/auth/session_reset_account_scope_test.dart
+++ b/frontend/flutter/test/features/auth/session_reset_account_scope_test.dart
@@ -20,6 +20,7 @@ import 'package:oncare/core/config/app_config.dart';
 import 'package:oncare/core/session/session_feature_reset.dart';
 import 'package:oncare/features/exercise/data/repositories/mock_gym_repository.dart';
 import 'package:oncare/features/exercise/domain/entities/my_reservation.dart';
+import 'package:oncare/features/exercise/domain/repositories/gym_repository.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
 import 'package:oncare/features/notification/data/repositories/notification_settings_repository.dart';
 
@@ -40,7 +41,11 @@ class _CountingGymRepository extends MockGymRepository {
   String accountId = 'account-a';
 
   @override
-  Future<List<MyReservation>> fetchMyReservations() async {
+  Future<List<MyReservation>> fetchMyReservations({
+    int limit = reservationPageSize,
+    DateTime? before,
+    String? beforeId,
+  }) async {
     fetchReservationsCalls++;
     return <MyReservation>[
       MyReservation(

--- a/frontend/flutter/test/features/exercise/consultation_restore_test.dart
+++ b/frontend/flutter/test/features/exercise/consultation_restore_test.dart
@@ -30,8 +30,9 @@ class _RestoringRepository implements ConsultationRepository {
   Future<String> create(ConsultationDraft draft) async => 'new-id';
 
   @override
-  Future<List<ConsultationRequest>> fetchMine() async =>
-      <ConsultationRequest>[consultationFromJson(_serverRow)];
+  Future<List<ConsultationRequest>> fetchMine({
+    int limit = consultationPageSize,
+  }) async => <ConsultationRequest>[consultationFromJson(_serverRow)];
 }
 
 class _FailingRepository implements ConsultationRepository {
@@ -39,8 +40,9 @@ class _FailingRepository implements ConsultationRepository {
   Future<String> create(ConsultationDraft draft) async => 'new-id';
 
   @override
-  Future<List<ConsultationRequest>> fetchMine() async =>
-      throw StateError('network down');
+  Future<List<ConsultationRequest>> fetchMine({
+    int limit = consultationPageSize,
+  }) async => throw StateError('network down');
 }
 
 void main() {
@@ -73,10 +75,7 @@ void main() {
 
     expect(c.state, hasLength(1));
     // 복원이 없으면 목록이 비어 같은 대상에 다시 눌러 409 를 받는다.
-    expect(
-      c.hasPending(trainerId: 'trainer-demo'),
-      isTrue,
-    );
+    expect(c.hasPending(trainerId: 'trainer-demo'), isTrue);
   });
 
   test('복원 실패는 화면을 깨뜨리지 않는다', () async {

--- a/frontend/flutter/test/features/exercise/dio_gym_repository_test.dart
+++ b/frontend/flutter/test/features/exercise/dio_gym_repository_test.dart
@@ -5,16 +5,19 @@ import 'package:oncare/features/exercise/data/repositories/dio_gym_repository.da
 import 'package:oncare/features/exercise/domain/entities/gym.dart';
 import 'package:oncare/features/exercise/domain/entities/gym_search_area.dart';
 import 'package:oncare/features/exercise/domain/entities/trainer.dart';
+import 'package:oncare/features/exercise/domain/repositories/gym_repository.dart';
 
 /// 백엔드 실응답을 그대로 돌려주는 어댑터. 필드명이 어긋나면 여기서 걸린다.
 class _StubAdapter implements HttpClientAdapter {
   _StubAdapter(this.routes);
   final Map<String, Object?> routes;
   final List<String> calls = <String>[];
-  final Map<String, Map<String, dynamic>> queries = <String, Map<String, dynamic>>{};
+  final Map<String, Map<String, dynamic>> queries =
+      <String, Map<String, dynamic>>{};
 
   /// 경로에 실제로 실려 나간 query parameter.
-  Map<String, dynamic> queryOf(String path) => queries[path] ?? <String, dynamic>{};
+  Map<String, dynamic> queryOf(String path) =>
+      queries[path] ?? <String, dynamic>{};
 
   @override
   Future<ResponseBody> fetch(RequestOptions options, _, _) async {
@@ -22,15 +25,21 @@ class _StubAdapter implements HttpClientAdapter {
     queries[options.path] = Map<String, dynamic>.from(options.queryParameters);
     final body = routes[options.path];
     if (body == null) {
-      return ResponseBody.fromString('{"detail":"not found"}', 404,
-          headers: <String, List<String>>{
-            Headers.contentTypeHeader: <String>[Headers.jsonContentType],
-          });
-    }
-    return ResponseBody.fromString(_encode(body), 200,
+      return ResponseBody.fromString(
+        '{"detail":"not found"}',
+        404,
         headers: <String, List<String>>{
           Headers.contentTypeHeader: <String>[Headers.jsonContentType],
-        });
+        },
+      );
+    }
+    return ResponseBody.fromString(
+      _encode(body),
+      200,
+      headers: <String, List<String>>{
+        Headers.contentTypeHeader: <String>[Headers.jsonContentType],
+      },
+    );
   }
 
   static String _encode(Object? v) {
@@ -63,6 +72,14 @@ const String _trainersJson = '''
   "role":"퍼스널 트레이너","reason":"혈압 관리와 운동 병행 지도","career":"7년",
   "intro":"혈압 관리와 체중 감량을 함께 다루는 퍼스널 트레이너입니다.",
   "certifications":["생활스포츠지도사 2급","퍼스널트레이닝 CPT"]}]
+''';
+
+/// `GET /v1/reservations/me` 실응답 — 늦은 예약부터(#980).
+const String _reservationsJson = '''
+[{"id":"resv-2","slot_id":"slot-2","trainer_id":"trainer-demo",
+  "starts_at":"2026-03-02T02:00:00+00:00","cancellable":true},
+ {"id":"resv-1","slot_id":"slot-1","trainer_id":"trainer-demo",
+  "starts_at":"2026-03-02T01:00:00+00:00","cancellable":false}]
 ''';
 
 Dio _dio(_StubAdapter adapter) =>
@@ -133,6 +150,41 @@ void main() {
     expect(q['lng'], kGymSearchLng);
   });
 
+  group('내 예약 목록 (#980)', () {
+    test('첫 쪽은 상한만 싣고 커서는 싣지 않는다', () async {
+      final adapter = _StubAdapter(<String, Object?>{
+        '/reservations/me': _reservationsJson,
+      });
+
+      final list = await DioGymRepository(_dio(adapter)).fetchMyReservations();
+
+      expect(list.first.id, 'resv-2');
+      final Map<String, dynamic> q = adapter.queryOf('/reservations/me');
+      expect(q['limit'], reservationPageSize);
+      expect(q.containsKey('before'), isFalse);
+      expect(q.containsKey('before_id'), isFalse);
+    });
+
+    test('이어 받기는 마지막 예약의 (starts_at, id) 를 UTC 로 넘긴다', () async {
+      // 엔티티는 화면용 로컬 시각을 들고 있다. 그대로 보내면 서버가 UTC 로 읽어
+      // 쪽 경계가 시간대만큼 밀린다.
+      final adapter = _StubAdapter(<String, Object?>{
+        '/reservations/me': _reservationsJson,
+      });
+
+      await DioGymRepository(_dio(adapter)).fetchMyReservations(
+        limit: 10,
+        before: DateTime.utc(2026, 3, 2, 1).toLocal(),
+        beforeId: 'resv-1',
+      );
+
+      final Map<String, dynamic> q = adapter.queryOf('/reservations/me');
+      expect(q['limit'], 10);
+      expect(q['before'], '2026-03-02T01:00:00.000Z');
+      expect(q['before_id'], 'resv-1');
+    });
+  });
+
   test('헬스장 해제는 DELETE /me/coach, 트레이너 해제는 DELETE /me/coach/trainer', () async {
     // 두 휴지통이 같은 엔드포인트로 나가면 트레이너만 끊어도 헬스장이 사라진다.
     final adapter = _StubAdapter(<String, Object?>{
@@ -144,6 +196,9 @@ void main() {
     await repo.disconnectMyGym();
     await repo.disconnectMyTrainer();
 
-    expect(adapter.calls, <String>['DELETE /me/coach', 'DELETE /me/coach/trainer']);
+    expect(adapter.calls, <String>[
+      'DELETE /me/coach',
+      'DELETE /me/coach/trainer',
+    ]);
   });
 }

--- a/frontend/flutter/test/features/exercise/gym_tab_action_test.dart
+++ b/frontend/flutter/test/features/exercise/gym_tab_action_test.dart
@@ -9,6 +9,7 @@ import 'package:oncare/core/config/app_config.dart';
 import 'package:oncare/features/exercise/domain/entities/consultation_draft.dart';
 import 'package:oncare/features/exercise/domain/entities/consultation_request.dart';
 import 'package:oncare/features/exercise/domain/entities/gym.dart';
+import 'package:oncare/features/exercise/domain/entities/my_reservation.dart';
 import 'package:oncare/features/exercise/domain/entities/trainer.dart';
 import 'package:oncare/features/exercise/presentation/controllers/consultation_request_controller.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
@@ -90,6 +91,7 @@ void main() {
     Trainer? trainer = _trainer,
     MemberCoach? coach,
     int unread = 0,
+    List<MyReservation> reservations = const <MyReservation>[],
   }) async {
     await tester.binding.setSurfaceSize(const Size(390, 844));
     addTearDown(() => tester.binding.setSurfaceSize(null));
@@ -138,6 +140,7 @@ void main() {
           ),
           memberCoachProvider.overrideWith((ref) async => coach),
           coachUnreadProvider.overrideWith((ref) async => unread),
+          myReservationsProvider.overrideWith((ref) async => reservations),
         ],
         child: MaterialApp.router(
           routerConfig: router,
@@ -165,6 +168,57 @@ void main() {
       scrollable: find.byType(Scrollable).first,
     );
   }
+
+  testWidgets('예약 패널은 다가오는 자리를 위에, 지난 예약을 아래에 둔다', (WidgetTester tester) async {
+    // 서버는 늦은 예약부터 준다(#980) — 쪽을 나누려면 그 순서여야 한다. 그대로
+    // 그리면 다음 주 자리가 내일 자리보다 위에 오고, 지난 예약이 그 사이에 섞인다.
+    await pumpGymTab(
+      tester,
+      reservations: <MyReservation>[
+        MyReservation(
+          id: 'far',
+          slotId: 'slot-far',
+          trainerId: _trainer.id,
+          startsAt: DateTime(2026, 9, 30, 10),
+          cancellable: true,
+        ),
+        MyReservation(
+          id: 'past',
+          slotId: 'slot-past',
+          trainerId: _trainer.id,
+          startsAt: DateTime(2026, 8, 1, 10),
+          cancellable: false,
+        ),
+        MyReservation(
+          id: 'soon',
+          slotId: 'slot-soon',
+          trainerId: _trainer.id,
+          startsAt: DateTime(2026, 9, 1, 10),
+          cancellable: true,
+        ),
+      ],
+    );
+    await tester.scrollUntilVisible(
+      reservationPanel(),
+      250,
+      scrollable: find.byType(Scrollable).first,
+    );
+
+    final AppLocalizations l = AppLocalizations.of(
+      tester.element(find.byType(Scaffold).first),
+    );
+    double y(Finder finder) => tester.getTopLeft(finder).dy;
+
+    expect(
+      y(find.byKey(const ValueKey<String>('cancel-reservation-soon'))),
+      lessThan(y(find.byKey(const ValueKey<String>('cancel-reservation-far')))),
+    );
+    // 지난 예약은 취소 버튼 대신 그 사실이 적히고, 예정된 자리 아래로 밀린다.
+    expect(
+      y(find.byKey(const ValueKey<String>('cancel-reservation-far'))),
+      lessThan(y(find.text(l.exReservationPast))),
+    );
+  });
 
   testWidgets('legacy footer actions and their trailing space are removed', (
     WidgetTester tester,
@@ -383,9 +437,7 @@ void main() {
   // "거절됨" 배지만으로는 다시 신청해도 되는지, 다른 트레이너를 찾아야 하는지
   // 알 수 없다. 사유가 결과 전달의 본체다.
 
-  testWidgets('거절된 요청은 트레이너가 남긴 사유를 보여준다', (
-    WidgetTester tester,
-  ) async {
+  testWidgets('거절된 요청은 트레이너가 남긴 사유를 보여준다', (WidgetTester tester) async {
     await pumpGymTab(
       tester,
       consultation: _consultation(
@@ -417,9 +469,7 @@ void main() {
     expect(find.text(l.exConsultRejectedReasonLabel), findsNothing);
   });
 
-  testWidgets('승인된 요청은 채팅으로 이어지는 안내를 보여준다', (
-    WidgetTester tester,
-  ) async {
+  testWidgets('승인된 요청은 채팅으로 이어지는 안내를 보여준다', (WidgetTester tester) async {
     await pumpGymTab(
       tester,
       consultation: _consultation(ConsultationStatus.accepted),

--- a/frontend/flutter/test/features/my_health/my_health_gym_section_test.dart
+++ b/frontend/flutter/test/features/my_health/my_health_gym_section_test.dart
@@ -18,8 +18,11 @@ class _FailingGymRepository implements GymRepository {
   const _FailingGymRepository();
 
   @override
-  Future<List<MyReservation>> fetchMyReservations() async =>
-      const <MyReservation>[];
+  Future<List<MyReservation>> fetchMyReservations({
+    int limit = reservationPageSize,
+    DateTime? before,
+    String? beforeId,
+  }) async => const <MyReservation>[];
 
   @override
   Future<void> cancelReservation(String reservationId) async {}

--- a/frontend/flutter_trainer/lib/features/clients/data/repositories/dio_client_repository.dart
+++ b/frontend/flutter_trainer/lib/features/clients/data/repositories/dio_client_repository.dart
@@ -14,6 +14,13 @@ import 'package:oncare_trainer/features/clients/domain/repositories/client_data_
 import 'package:oncare_trainer/shared/models/trainer_client.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
 
+/// 로스터 한 쪽의 인원. 서버 기본값과 같다(#980).
+const int rosterPageSize = 50;
+
+/// 이어 받을 쪽 수의 상한 — 담당 회원 2,500명이면 어떤 트레이너의 명단도 덮는다.
+/// 서버가 같은 쪽을 계속 돌려주는 상황에서 고리가 멈추지 않는 것만 막는다.
+const int _rosterPageLimit = 50;
+
 /// Reads a trainer's clients + their diet/history from the FastAPI backend.
 /// Selected when `USE_MOCK_API=false` (see [clientRepositoryProvider]).
 ///
@@ -178,8 +185,30 @@ class DioClientRepository implements ClientRepository, ClientDataRefresher {
     }
   }
 
-  Future<List<TrainerClient>> _fetchClients() =>
-      _getList('/trainer/clients', trainerClientFromJson);
+  /// 로스터 전체. 서버가 한 쪽씩 주므로(#980) 명단이 끝날 때까지 이어 받는다.
+  ///
+  /// 화면에 "더 보기" 를 두지 않는 이유: 담당 회원 목록은 사이드바 개수·검색·차트가
+  /// 모두 **전체**를 전제로 읽는 자리라, 절반만 들고 있으면 트레이너가 명단이 잘린 줄
+  /// 모른 채 빠진 회원을 찾게 된다. 상한은 한 응답이 인원수만큼 커지는 것을 막는
+  /// 장치이고, 여기서는 그 쪽들을 이어 붙여 같은 목록을 만든다. 트레이너 한 명이
+  /// 감당하는 인원만큼만 도는 고리다.
+  Future<List<TrainerClient>> _fetchClients() async {
+    final List<TrainerClient> all = <TrainerClient>[];
+    String? afterId;
+    // 명단 길이에 상한을 두지 않되, 서버가 같은 쪽을 계속 주는 상황에서 매달리지는
+    // 않도록 쪽 수를 넉넉히 제한한다.
+    for (int page = 0; page < _rosterPageLimit; page++) {
+      final List<TrainerClient> rows = await _getList(
+        '/trainer/clients',
+        trainerClientFromJson,
+        query: <String, Object?>{'limit': rosterPageSize, 'after_id': ?afterId},
+      );
+      all.addAll(rows);
+      if (rows.length < rosterPageSize) break;
+      afterId = rows.last.id;
+    }
+    return List<TrainerClient>.unmodifiable(all);
+  }
 
   Future<List<ClientDietEntry>> _fetchDiet(String clientId) => _getList(
     '/trainer/clients/${Uri.encodeComponent(clientId)}/diet',
@@ -246,10 +275,11 @@ class DioClientRepository implements ClientRepository, ClientDataRefresher {
   /// surface as a typed [AppError].
   Future<List<T>> _getList<T>(
     String path,
-    T Function(Map<String, Object?>) fromJson,
-  ) async {
+    T Function(Map<String, Object?>) fromJson, {
+    Map<String, Object?>? query,
+  }) async {
     try {
-      final res = await _dio.get<List<dynamic>>(path);
+      final res = await _dio.get<List<dynamic>>(path, queryParameters: query);
       final data = res.data ?? const <dynamic>[];
       return data
           .map((item) {

--- a/frontend/flutter_trainer/lib/features/consultations/data/dtos/consultation_dtos.dart
+++ b/frontend/flutter_trainer/lib/features/consultations/data/dtos/consultation_dtos.dart
@@ -55,6 +55,7 @@ ConsultationRequest consultationRequestFromJson(Map<String, Object?> json) {
     message: _nullable(json['message']),
     status: _str(json['status']),
     decisionNote: _nullable(json['decision_note']),
+    createdAt: DateTime.tryParse(_str(json['created_at'])),
   );
 }
 

--- a/frontend/flutter_trainer/lib/features/consultations/data/repositories/consultation_repository.dart
+++ b/frontend/flutter_trainer/lib/features/consultations/data/repositories/consultation_repository.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:oncare_trainer/core/config/app_config.dart';
@@ -27,11 +29,25 @@ abstract interface class ConsultationRepository {
   bool get supportsInbox;
 
   /// Pending requests, newest first. `status` may be `pending` or `all`.
-  Future<List<ConsultationRequest>> fetch({String status = 'pending'});
+  ///
+  /// 서버가 한 쪽만 준다(#980). 더 오래된 요청은 받은 마지막 요청의 `createdAt`·`id` 를
+  /// [before]·[beforeId] 로 넘겨 이어 받는다.
+  Future<List<ConsultationRequest>> fetch({
+    String status = 'pending',
+    int limit,
+    DateTime? before,
+    String? beforeId,
+  });
 
   /// Subscribes to the inbox for [status] — the open screen keeps up with
   /// requests that arrive while the trainer is looking at it. (#917)
-  Stream<List<ConsultationRequest>> watch({String status = 'pending'});
+  ///
+  /// **첫 쪽만** 흘려보낸다. 이어 받아 둔 과거 요청까지 매번 다시 읽으면 폴링이
+  /// 인박스 길이에 비례해 무거워진다 — 과거 요청은 바뀌지 않으므로 한 번 받으면 된다.
+  Stream<List<ConsultationRequest>> watch({
+    String status = 'pending',
+    int limit,
+  });
 
   /// Number of undecided requests — the sidebar badge.
   Future<int> pendingCount();
@@ -90,16 +106,29 @@ class DemoConsultationRepository implements ConsultationRepository {
   bool get supportsInbox => true;
 
   @override
-  Future<List<ConsultationRequest>> fetch({String status = 'pending'}) async =>
-      status == 'all'
-      ? List<ConsultationRequest>.unmodifiable(_requests)
-      : _requests.where((request) => request.status == status).toList();
+  Future<List<ConsultationRequest>> fetch({
+    String status = 'pending',
+    int limit = consultationPageSize,
+    DateTime? before,
+    String? beforeId,
+  }) async {
+    // 데모 인박스는 한 줌이라 커서가 실제로 쓰일 일이 없다 — 상한만 지킨다.
+    if (before != null) return const <ConsultationRequest>[];
+    final Iterable<ConsultationRequest> rows = status == 'all'
+        ? _requests
+        : _requests.where((request) => request.status == status);
+    return List<ConsultationRequest>.unmodifiable(rows.take(limit));
+  }
 
   /// 데모의 인박스는 메모리에 있다. 폴링해도 같은 값을 다시 세는 것뿐이라
   /// 한 번 내고 끝내고, 수락·거절 뒤의 갱신은 지금처럼 invalidate 가 맡는다.
   @override
-  Stream<List<ConsultationRequest>> watch({String status = 'pending'}) =>
-      Stream<List<ConsultationRequest>>.fromFuture(fetch(status: status));
+  Stream<List<ConsultationRequest>> watch({
+    String status = 'pending',
+    int limit = consultationPageSize,
+  }) => Stream<List<ConsultationRequest>>.fromFuture(
+    fetch(status: status, limit: limit),
+  );
 
   @override
   Future<int> pendingCount() async =>
@@ -162,11 +191,22 @@ class DioConsultationRepository implements ConsultationRepository {
   bool get supportsInbox => true;
 
   @override
-  Future<List<ConsultationRequest>> fetch({String status = 'pending'}) async {
+  Future<List<ConsultationRequest>> fetch({
+    String status = 'pending',
+    int limit = consultationPageSize,
+    DateTime? before,
+    String? beforeId,
+  }) async {
     try {
       final res = await _dio.get<List<dynamic>>(
         '/trainer/consultations',
-        queryParameters: <String, Object?>{'status': status},
+        queryParameters: <String, Object?>{
+          'status': status,
+          'limit': limit,
+          // 커서는 서버가 준 시각 그대로여야 한다 — 엔티티는 로컬 시각을 들고 있다.
+          if (before != null) 'before': before.toUtc().toIso8601String(),
+          'before_id': ?beforeId,
+        },
       );
       return (res.data ?? const <dynamic>[])
           .whereType<Map<String, Object?>>()
@@ -178,11 +218,13 @@ class DioConsultationRepository implements ConsultationRepository {
   }
 
   @override
-  Stream<List<ConsultationRequest>> watch({String status = 'pending'}) =>
-      activePollingStream<List<ConsultationRequest>>(
-        load: () => fetch(status: status),
-        interval: pollInterval,
-      );
+  Stream<List<ConsultationRequest>> watch({
+    String status = 'pending',
+    int limit = consultationPageSize,
+  }) => activePollingStream<List<ConsultationRequest>>(
+    load: () => fetch(status: status, limit: limit),
+    interval: pollInterval,
+  );
 
   @override
   Stream<int> watchPendingCount() =>
@@ -269,11 +311,146 @@ final consultationFilterProvider = StateProvider<String>(
   name: 'consultationFilter',
 );
 
+/// 인박스 한 쪽의 건수. 서버 기본값과 같다(#980).
+const int consultationPageSize = 50;
+
+/// 인박스 화면 상태 — 목록과 "더 있는가".
+class ConsultationInboxState {
+  /// Creates the inbox state.
+  const ConsultationInboxState({
+    this.requests = const AsyncValue<List<ConsultationRequest>>.loading(),
+    this.loadingMore = false,
+    this.hasMore = false,
+  });
+
+  /// 첫 쪽 + 이어 받은 과거 요청. 화면은 이 값만 그린다.
+  final AsyncValue<List<ConsultationRequest>> requests;
+
+  /// 다음 쪽을 받는 중인가 — 버튼이 두 번 눌리는 것을 막는다.
+  final bool loadingMore;
+
+  /// 더 받을 것이 남았는가. 마지막 쪽이 상한만큼 왔으면 남았다고 본다.
+  final bool hasMore;
+
+  /// Copies with the given fields replaced.
+  ConsultationInboxState copyWith({
+    AsyncValue<List<ConsultationRequest>>? requests,
+    bool? loadingMore,
+    bool? hasMore,
+  }) => ConsultationInboxState(
+    requests: requests ?? this.requests,
+    loadingMore: loadingMore ?? this.loadingMore,
+    hasMore: hasMore ?? this.hasMore,
+  );
+}
+
+/// 인박스 목록 — 폴링하는 첫 쪽 위에 이어 받은 과거 요청을 붙여 둔다. (#980)
+///
+/// 두 갈래를 나눠 두는 이유: 폴링은 **새로 들어온 요청**을 보려는 것이라 첫 쪽만
+/// 다시 읽으면 되고, 이어 받은 과거 요청은 이미 처리된 이력이라 바뀌지 않는다.
+/// 매번 전체를 다시 읽으면 인박스가 길어질수록 폴링이 그만큼 무거워진다.
+class ConsultationInboxController
+    extends StateNotifier<ConsultationInboxState> {
+  /// Subscribes to the first page for [status].
+  ConsultationInboxController(this._repository, this._status)
+    : super(const ConsultationInboxState()) {
+    _subscription = _repository
+        .watch(status: _status, limit: consultationPageSize)
+        .listen(_onFirstPage, onError: _onError);
+  }
+
+  final ConsultationRepository _repository;
+  final String _status;
+  late final StreamSubscription<List<ConsultationRequest>> _subscription;
+
+  /// 이어 받아 둔 과거 요청(오래된 쪽).
+  List<ConsultationRequest> _older = const <ConsultationRequest>[];
+
+  void _onFirstPage(List<ConsultationRequest> page) {
+    if (!mounted) return;
+    // 첫 쪽에 다시 나타난 요청은 이어 받아 둔 목록에서 뺀다 — 같은 요청이 두 줄로
+    // 그려지면 트레이너는 요청이 두 건 온 것으로 읽는다.
+    final Set<String> ids = page.map((r) => r.id).toSet();
+    _older = _older
+        .where((ConsultationRequest r) => !ids.contains(r.id))
+        .toList(growable: false);
+    state = state.copyWith(
+      requests: AsyncValue<List<ConsultationRequest>>.data(
+        <ConsultationRequest>[...page, ..._older],
+      ),
+      // 이어 받은 쪽이 있으면 "더 있는가" 는 그 마지막 쪽이 이미 답했다.
+      hasMore: _older.isEmpty ? page.length >= consultationPageSize : null,
+    );
+  }
+
+  void _onError(Object error, StackTrace stack) {
+    if (!mounted) return;
+    // 이미 받아 둔 목록이 있으면 지우지 않는다 — 폴링 한 번 실패했다고 인박스를
+    // 오류 화면으로 덮을 일은 아니다.
+    if (state.requests.hasValue) return;
+    state = state.copyWith(
+      requests: AsyncValue<List<ConsultationRequest>>.error(error, stack),
+    );
+  }
+
+  /// 과거 요청을 한 쪽 더 이어 붙인다.
+  Future<void> loadMore() async {
+    if (!state.hasMore || state.loadingMore) return;
+    final List<ConsultationRequest> shown =
+        state.requests.valueOrNull ?? const <ConsultationRequest>[];
+    final ConsultationRequest? last = shown.isEmpty ? null : shown.last;
+    // 커서를 만들 수 없으면 이어 받지 않는다 — 커서 없이 다시 부르면 첫 쪽이 또 온다.
+    if (last?.createdAt == null) {
+      state = state.copyWith(hasMore: false);
+      return;
+    }
+
+    state = state.copyWith(loadingMore: true);
+    try {
+      final List<ConsultationRequest> page = await _repository.fetch(
+        status: _status,
+        limit: consultationPageSize,
+        before: last!.createdAt,
+        beforeId: last.id,
+      );
+      if (!mounted) return;
+      final Set<String> seen = shown.map((r) => r.id).toSet();
+      final List<ConsultationRequest> fresh = page
+          .where((ConsultationRequest r) => seen.add(r.id))
+          .toList(growable: false);
+      _older = <ConsultationRequest>[..._older, ...fresh];
+      state = state.copyWith(
+        requests: AsyncValue<List<ConsultationRequest>>.data(
+          <ConsultationRequest>[...shown, ...fresh],
+        ),
+        loadingMore: false,
+        hasMore: page.length >= consultationPageSize,
+      );
+    } on Object {
+      // 이어 받기 실패는 보고 있는 목록을 건드리지 않는다. 다시 누르면 또 시도한다.
+      if (!mounted) return;
+      state = state.copyWith(loadingMore: false);
+    }
+  }
+
+  @override
+  void dispose() {
+    _subscription.cancel();
+    super.dispose();
+  }
+}
+
 /// The inbox list for the active filter.
 final consultationsProvider =
-    StreamProvider.autoDispose<List<ConsultationRequest>>((ref) {
+    StateNotifierProvider.autoDispose<
+      ConsultationInboxController,
+      ConsultationInboxState
+    >((ref) {
       final status = ref.watch(consultationFilterProvider);
-      return ref.watch(consultationRepositoryProvider).watch(status: status);
+      return ConsultationInboxController(
+        ref.watch(consultationRepositoryProvider),
+        status,
+      );
     }, name: 'consultations');
 
 /// Pending count for the sidebar badge.

--- a/frontend/flutter_trainer/lib/features/consultations/domain/entities/consultation_request.dart
+++ b/frontend/flutter_trainer/lib/features/consultations/domain/entities/consultation_request.dart
@@ -18,6 +18,7 @@ class ConsultationRequest {
     this.message,
     this.purposeDetail,
     this.decisionNote,
+    this.createdAt,
   });
 
   /// Server id — the path segment for accept / reject.
@@ -55,6 +56,12 @@ class ConsultationRequest {
 
   /// Rejection reason, once decided.
   final String? decisionNote;
+
+  /// 요청이 접수된 시각. 인박스가 이어 받을 때 커서로 쓴다(#980).
+  ///
+  /// 목록 정렬키라 서버 응답에는 항상 실려 오지만, 데모 인박스는 메모리 목록이라
+  /// 값이 없다 — 그쪽은 이어 받을 것도 없다.
+  final DateTime? createdAt;
 
   /// Whether this request is still waiting on a decision.
   bool get isPending => status == 'pending';

--- a/frontend/flutter_trainer/lib/features/consultations/presentation/pages/consultations_page.dart
+++ b/frontend/flutter_trainer/lib/features/consultations/presentation/pages/consultations_page.dart
@@ -35,7 +35,7 @@ class ConsultationsPage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final AppLocalizations l = AppLocalizations.of(context);
     final filter = ref.watch(consultationFilterProvider);
-    final requests = ref.watch(consultationsProvider);
+    final inbox = ref.watch(consultationsProvider);
     final pending = ref.watch(consultationPendingCountProvider).valueOrNull;
 
     return PageScaffold(
@@ -51,7 +51,7 @@ class ConsultationsPage extends ConsumerWidget {
               filter == 'pending' ? 'all' : 'pending',
         ),
       ],
-      child: requests.when(
+      child: inbox.requests.when(
         loading: () => const Padding(
           padding: EdgeInsets.only(top: AppSpacing.xxl),
           child: Center(child: CircularProgressIndicator()),
@@ -87,6 +87,21 @@ class ConsultationsPage extends ConsumerWidget {
                     ),
                     const SizedBox(height: AppSpacing.md),
                   ],
+                  // 서버는 한 쪽만 준다(#980). 상한에 닿았을 때만 버튼을 띄운다 —
+                  // 늘 보이면 더 없는데도 누를 것이 있는 것처럼 읽힌다.
+                  if (inbox.hasMore)
+                    Align(
+                      child: ActionButton(
+                        key: const ValueKey<String>('consultation-load-more'),
+                        label: l.consultLoadMore,
+                        icon: Icons.history,
+                        onPressed: inbox.loadingMore
+                            ? null
+                            : () => ref
+                                  .read(consultationsProvider.notifier)
+                                  .loadMore(),
+                      ),
+                    ),
                 ],
               ),
       ),
@@ -267,7 +282,10 @@ class _RejectDialogState extends State<_RejectDialog> {
         children: <Widget>[
           Text(
             l.consultRejectNotice,
-            style: const TextStyle(fontSize: 13.5, color: AppColors.mutedForeground),
+            style: const TextStyle(
+              fontSize: 13.5,
+              color: AppColors.mutedForeground,
+            ),
           ),
           const SizedBox(height: AppSpacing.md),
           TextField(

--- a/frontend/flutter_trainer/lib/features/consultations/presentation/widgets/consultation_inbox_sheet.dart
+++ b/frontend/flutter_trainer/lib/features/consultations/presentation/widgets/consultation_inbox_sheet.dart
@@ -25,7 +25,7 @@ class ConsultationInboxSheet extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l = AppLocalizations.of(context);
-    final requests = ref.watch(consultationsProvider);
+    final requests = ref.watch(consultationsProvider).requests;
     return SafeArea(
       child: SizedBox(
         height: MediaQuery.sizeOf(context).height * .82,

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
@@ -1634,6 +1634,12 @@ abstract class AppLocalizations {
   /// **'Pending only'**
   String get consultShowPending;
 
+  /// No description provided for @consultLoadMore.
+  ///
+  /// In en, this message translates to:
+  /// **'Load earlier requests'**
+  String get consultLoadMore;
+
   /// No description provided for @consultLoadFailed.
   ///
   /// In en, this message translates to:

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
@@ -876,6 +876,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get consultShowPending => 'Pending only';
 
   @override
+  String get consultLoadMore => 'Load earlier requests';
+
+  @override
   String get consultLoadFailed => 'Couldn\'t load consultation requests';
 
   @override

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
@@ -841,6 +841,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get consultShowPending => '대기 중만';
 
   @override
+  String get consultLoadMore => '지난 요청 더 보기';
+
+  @override
   String get consultLoadFailed => '상담 요청을 불러오지 못했어요';
 
   @override

--- a/frontend/flutter_trainer/lib/l10n/app_en.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_en.arb
@@ -392,6 +392,7 @@
   "consultNoPending": "No pending requests",
   "consultShowAll": "All",
   "consultShowPending": "Pending only",
+  "consultLoadMore": "Load earlier requests",
   "consultLoadFailed": "Couldn't load consultation requests",
   "consultRetryLater": "Please try again in a moment",
   "consultEmptyPending": "No pending consultation requests",

--- a/frontend/flutter_trainer/lib/l10n/app_ko.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_ko.arb
@@ -264,6 +264,7 @@
   "consultNoPending": "대기 중인 요청이 없어요",
   "consultShowAll": "전체 보기",
   "consultShowPending": "대기 중만",
+  "consultLoadMore": "지난 요청 더 보기",
   "consultLoadFailed": "상담 요청을 불러오지 못했어요",
   "consultRetryLater": "잠시 후 다시 시도해 주세요",
   "consultEmptyPending": "대기 중인 상담 요청이 없어요",

--- a/frontend/flutter_trainer/test/features/clients/client_repository_provider_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_repository_provider_test.dart
@@ -224,7 +224,12 @@ void main() {
       'exactly one GET /trainer/clients in real-API mode (review: the two '
       'providers used to each fetch independently)', () async {
     final dio = _MockDio();
-    when(() => dio.get<List<dynamic>>('/trainer/clients')).thenAnswer(
+    when(
+      () => dio.get<List<dynamic>>(
+        '/trainer/clients',
+        queryParameters: any(named: 'queryParameters'),
+      ),
+    ).thenAnswer(
       (_) async => Response<List<dynamic>>(
         requestOptions: RequestOptions(path: '/trainer/clients'),
         statusCode: 200,
@@ -244,7 +249,12 @@ void main() {
     // future to await.
     final prioritized = container.read(prioritizedClientsProvider).valueOrNull;
 
-    verify(() => dio.get<List<dynamic>>('/trainer/clients')).called(1);
+    verify(
+      () => dio.get<List<dynamic>>(
+        '/trainer/clients',
+        queryParameters: any(named: 'queryParameters'),
+      ),
+    ).called(1);
     expect(clients.map((c) => c.id), <String>['a', 'b']);
     expect(prioritized!.map((c) => c.id), <String>['a', 'b']); // a is over
   });

--- a/frontend/flutter_trainer/test/features/clients/dio_client_repository_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/dio_client_repository_test.dart
@@ -41,7 +41,12 @@ void main() {
   });
 
   test('watchClients parses the roster', () async {
-    when(() => dio.get<List<dynamic>>('/trainer/clients')).thenAnswer(
+    when(
+      () => dio.get<List<dynamic>>(
+        '/trainer/clients',
+        queryParameters: any(named: 'queryParameters'),
+      ),
+    ).thenAnswer(
       (_) async => _okList(<dynamic>[
         <String, Object?>{'id': 'm1', 'name': '김민수', 'sodium_mg': 2100},
         <String, Object?>{'id': 'm2', 'name': '이지수', 'sodium_mg': 1500},
@@ -53,8 +58,48 @@ void main() {
     expect(clients.first.sodiumOverBudget, isTrue);
   });
 
+  test('로스터는 명단이 끝날 때까지 쪽을 이어 받는다 (#980)', () async {
+    // 서버가 한 쪽만 준다고 화면의 명단이 잘리면 안 된다 — 사이드바 개수·검색이
+    // 모두 전체를 전제로 읽는 자리라, 트레이너는 빠진 회원을 찾아 헤매게 된다.
+    final List<Map<String, Object?>> full = <Map<String, Object?>>[
+      for (int i = 0; i < rosterPageSize; i++)
+        <String, Object?>{'id': 'm$i', 'name': '회원 $i'},
+    ];
+    final List<Object?> cursors = <Object?>[];
+    when(
+      () => dio.get<List<dynamic>>(
+        '/trainer/clients',
+        queryParameters: any(named: 'queryParameters'),
+      ),
+    ).thenAnswer((invocation) async {
+      final Map<Object?, Object?> query =
+          invocation.namedArguments[#queryParameters] as Map<Object?, Object?>;
+      cursors.add(query['after_id']);
+      return _okList(
+        query['after_id'] == null
+            ? full
+            : <dynamic>[
+                <String, Object?>{'id': 'last', 'name': '마지막 회원'},
+              ],
+        '/trainer/clients',
+      );
+    });
+
+    final clients = await repo.watchClients().first;
+
+    // 첫 쪽은 커서 없이, 다음 쪽은 받은 마지막 회원의 id 로 이어 받는다.
+    expect(cursors, <Object?>[null, 'm${rosterPageSize - 1}']);
+    expect(clients, hasLength(rosterPageSize + 1));
+    expect(clients.map((c) => c.id), contains('last'));
+  });
+
   test('the roster ordering puts the over-target client first', () async {
-    when(() => dio.get<List<dynamic>>('/trainer/clients')).thenAnswer(
+    when(
+      () => dio.get<List<dynamic>>(
+        '/trainer/clients',
+        queryParameters: any(named: 'queryParameters'),
+      ),
+    ).thenAnswer(
       (_) async => _okList(<dynamic>[
         <String, Object?>{'id': 'ok', 'name': 'A', 'sodium_mg': 1500},
         <String, Object?>{'id': 'over', 'name': 'B', 'sodium_mg': 2500},
@@ -125,9 +170,12 @@ void main() {
   test('the roster re-reads itself so a change made elsewhere lands without a '
       'manual refresh (#918)', () async {
     var calls = 0;
-    when(() => dio.get<List<dynamic>>('/trainer/clients')).thenAnswer((
-      _,
-    ) async {
+    when(
+      () => dio.get<List<dynamic>>(
+        '/trainer/clients',
+        queryParameters: any(named: 'queryParameters'),
+      ),
+    ).thenAnswer((_) async {
       calls += 1;
       return _okList(<dynamic>[
         <String, Object?>{'id': 'm$calls', 'name': '김민수'},
@@ -174,9 +222,12 @@ void main() {
 
   test('the roster stops re-reading once nothing listens', () async {
     var calls = 0;
-    when(() => dio.get<List<dynamic>>('/trainer/clients')).thenAnswer((
-      _,
-    ) async {
+    when(
+      () => dio.get<List<dynamic>>(
+        '/trainer/clients',
+        queryParameters: any(named: 'queryParameters'),
+      ),
+    ).thenAnswer((_) async {
       calls += 1;
       return _okList(const <dynamic>[], '/trainer/clients');
     });
@@ -244,7 +295,12 @@ void main() {
       var calls = 0;
       final Completer<void> firstValue = Completer<void>();
       final Completer<void> refreshAttempted = Completer<void>();
-      when(() => dio.get<List<dynamic>>(path)).thenAnswer((_) async {
+      when(
+        () => dio.get<List<dynamic>>(
+          path,
+          queryParameters: any(named: 'queryParameters'),
+        ),
+      ).thenAnswer((_) async {
         calls += 1;
         if (calls == 1) {
           return _okList(<dynamic>[
@@ -336,7 +392,12 @@ void main() {
   });
 
   test('malformed list entries fail instead of being silently dropped', () {
-    when(() => dio.get<List<dynamic>>('/trainer/clients')).thenAnswer(
+    when(
+      () => dio.get<List<dynamic>>(
+        '/trainer/clients',
+        queryParameters: any(named: 'queryParameters'),
+      ),
+    ).thenAnswer(
       (_) async => _okList(<dynamic>[
         <String, Object?>{'id': 'm1'},
         'not-an-object',
@@ -400,7 +461,12 @@ void main() {
     test('a confirmed change re-fetches the roster so the badge follows the '
         'server, not the tap', () async {
       var rosterActive = true;
-      when(() => dio.get<List<dynamic>>('/trainer/clients')).thenAnswer(
+      when(
+        () => dio.get<List<dynamic>>(
+          '/trainer/clients',
+          queryParameters: any(named: 'queryParameters'),
+        ),
+      ).thenAnswer(
         (_) async => _okList(<dynamic>[
           <String, Object?>{'id': 'm1', 'name': 'A', 'active': rosterActive},
         ], '/trainer/clients'),
@@ -431,7 +497,12 @@ void main() {
 
     test('a rejected change surfaces a typed error and does not refresh the '
         'roster — the badge keeps the state the server still has', () async {
-      when(() => dio.get<List<dynamic>>('/trainer/clients')).thenAnswer(
+      when(
+        () => dio.get<List<dynamic>>(
+          '/trainer/clients',
+          queryParameters: any(named: 'queryParameters'),
+        ),
+      ).thenAnswer(
         (_) async => _okList(<dynamic>[
           <String, Object?>{'id': 'm1', 'name': 'A', 'active': true},
         ], '/trainer/clients'),

--- a/frontend/flutter_trainer/test/features/consultations/consultations_page_test.dart
+++ b/frontend/flutter_trainer/test/features/consultations/consultations_page_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -18,6 +19,7 @@ ConsultationRequest _request({
   String name = '김민수',
   String status = 'pending',
   String? message = '상담 부탁드립니다.',
+  DateTime? createdAt,
 }) => ConsultationRequest(
   id: id,
   memberId: 'user-$id',
@@ -28,6 +30,7 @@ ConsultationRequest _request({
   preferredTimeCode: 'evening',
   message: message,
   status: status,
+  createdAt: createdAt,
 );
 
 /// A stand-in inbox that reports itself enabled (so the nav row renders)
@@ -47,17 +50,47 @@ class _FakeConsultationRepository implements ConsultationRepository {
   @override
   bool get supportsInbox => true;
 
+  /// 이어 받기 요청으로 들어온 커서 — 인박스가 무엇을 넘겼는지 확인한다(#980).
+  final List<(DateTime?, String?)> cursors = <(DateTime?, String?)>[];
+
   @override
-  Future<List<ConsultationRequest>> fetch({String status = 'pending'}) async {
+  Future<List<ConsultationRequest>> fetch({
+    String status = 'pending',
+    int limit = consultationPageSize,
+    DateTime? before,
+    String? beforeId,
+  }) async {
     if (failure != null) throw failure!;
-    return status == 'pending'
-        ? requests.where((r) => r.isPending).toList()
-        : requests;
+    // 서버와 같은 순서로 준다 — 최신 요청이 먼저다. 이 순서가 아니면 커서가 가리키는
+    // '받은 마지막 요청'이 가장 오래된 것이 아니게 되어 이어 받기가 성립하지 않는다.
+    final List<ConsultationRequest> rows =
+        (status == 'pending' ? requests.where((r) => r.isPending) : requests)
+            .toList()
+          ..sort((ConsultationRequest a, ConsultationRequest b) {
+            final DateTime? x = a.createdAt;
+            final DateTime? y = b.createdAt;
+            if (x == null || y == null) return 0;
+            return y.compareTo(x);
+          });
+    if (before == null) return rows.take(limit).toList();
+    cursors.add((before, beforeId));
+    // 커서보다 오래된 것만 — 서버와 같은 규칙이다.
+    return rows
+        .where(
+          (ConsultationRequest r) =>
+              r.createdAt != null && r.createdAt!.isBefore(before),
+        )
+        .take(limit)
+        .toList();
   }
 
   @override
-  Stream<List<ConsultationRequest>> watch({String status = 'pending'}) =>
-      Stream<List<ConsultationRequest>>.fromFuture(fetch(status: status));
+  Stream<List<ConsultationRequest>> watch({
+    String status = 'pending',
+    int limit = consultationPageSize,
+  }) => Stream<List<ConsultationRequest>>.fromFuture(
+    fetch(status: status, limit: limit),
+  );
 
   @override
   Future<int> pendingCount() async => requests.where((r) => r.isPending).length;
@@ -116,9 +149,7 @@ void main() {
   ) async {
     await _pumpInbox(
       tester,
-      _FakeConsultationRepository(
-        requests: <ConsultationRequest>[_request()],
-      ),
+      _FakeConsultationRepository(requests: <ConsultationRequest>[_request()]),
     );
 
     // 요청은 트레이너 한 사람 앞으로만 온다 — "헬스장 문의" 갈래는 없어졌다.
@@ -186,6 +217,45 @@ void main() {
         expect(find.text(navLabel(_ko, destination.label)), findsWidgets);
       }
     });
+  });
+
+  testWidgets('상한에 닿은 인박스는 지난 요청을 이어 받는다 (#980)', (tester) async {
+    // 서버는 한 쪽만 준다. 버튼이 없으면 트레이너는 첫 쪽 너머의 요청을 볼 길이 없고,
+    // 목록이 잘렸다는 사실조차 화면에 남지 않는다.
+    final repo = _FakeConsultationRepository(
+      requests: <ConsultationRequest>[
+        for (int i = 0; i < consultationPageSize; i++)
+          _request(
+            id: 'consult-new-$i',
+            name: '최근 $i',
+            createdAt: DateTime.utc(2026, 8, 19, 9).add(Duration(minutes: i)),
+          ),
+        _request(
+          id: 'consult-old',
+          name: '지난 요청',
+          createdAt: DateTime.utc(2026, 8, 1, 9),
+        ),
+      ],
+    );
+
+    await _pumpInbox(tester, repo);
+
+    // 첫 쪽에는 오래된 요청이 없다.
+    expect(find.text('지난 요청'), findsNothing);
+
+    final Finder more = find.byKey(
+      const ValueKey<String>('consultation-load-more'),
+    );
+    await tester.scrollUntilVisible(more, 400);
+    await tester.tap(more);
+    await tester.pumpAndSettle();
+
+    // 커서는 받은 쪽의 **가장 오래된** 요청이다 — 최신순 목록의 마지막 줄.
+    expect(repo.cursors.single.$2, 'consult-new-0');
+    await tester.scrollUntilVisible(find.text('지난 요청'), 400);
+    expect(find.text('지난 요청'), findsOneWidget);
+    // 다 받았으면 버튼은 사라진다 — 남아 있으면 눌러도 아무 일이 없다.
+    expect(more, findsNothing);
   });
 
   testWidgets('the real-API console also keeps the separate row hidden', (

--- a/frontend/flutter_trainer/test/features/consultations/dio_consultation_repository_test.dart
+++ b/frontend/flutter_trainer/test/features/consultations/dio_consultation_repository_test.dart
@@ -87,6 +87,41 @@ void main() {
       expect(captured['status'], 'pending');
     });
 
+    test('첫 쪽은 상한만 싣고, 이어 받기는 (created_at, id) 를 UTC 로 넘긴다 (#980)', () async {
+      when(
+        () => dio.get<List<dynamic>>(
+          '/trainer/consultations',
+          queryParameters: any(named: 'queryParameters'),
+        ),
+      ).thenAnswer(
+        (_) async =>
+            _ok<List<dynamic>>(const <dynamic>[], '/trainer/consultations'),
+      );
+
+      await repo.fetch();
+      await repo.fetch(
+        status: 'all',
+        before: DateTime.utc(2026, 8, 19, 9).toLocal(),
+        beforeId: 'consult-1',
+      );
+
+      final captured = verify(
+        () => dio.get<List<dynamic>>(
+          '/trainer/consultations',
+          queryParameters: captureAny(named: 'queryParameters'),
+        ),
+      ).captured.cast<Map<String, Object?>>();
+
+      // 첫 쪽에는 커서를 싣지 않는다 — 실으면 첫 쪽이 한 칸 밀린다.
+      expect(captured.first['limit'], consultationPageSize);
+      expect(captured.first.containsKey('before'), isFalse);
+      expect(captured.first.containsKey('before_id'), isFalse);
+      // 엔티티는 로컬 시각을 들고 있다. 그대로 보내면 쪽 경계가 시간대만큼 밀린다.
+      expect(captured.last['status'], 'all');
+      expect(captured.last['before'], '2026-08-19T09:00:00.000Z');
+      expect(captured.last['before_id'], 'consult-1');
+    });
+
     test('fetch skips malformed elements instead of throwing', () async {
       when(
         () => dio.get<List<dynamic>>(
@@ -330,7 +365,10 @@ void main() {
       when(
         () => dio.get<List<dynamic>>(
           '/trainer/consultations',
-          queryParameters: <String, Object?>{'status': 'pending'},
+          queryParameters: <String, Object?>{
+            'status': 'pending',
+            'limit': consultationPageSize,
+          },
         ),
       ).thenAnswer((_) async {
         calls += 1;


### PR DESCRIPTION
Closes #980

## Summary

계속 자라는데 상한이 없던 목록 넷에 기본 상한과 커서를 넣었습니다. 알림(#965)과 같은 문제이지만 **지우는 것이 답이 아닌** 자리들입니다 — 예약·상담은 이력이고, 로스터는 담당 관계입니다.

파라미터 없이 부르던 기존 클라이언트는 그대로 동작합니다(기본 50건). 커서 모양은 채팅 스레드·알림과 같습니다 — 받은 마지막 항목의 `(정렬키, id)` 를 `(before, before_id)` 로 되돌려 줍니다.

## Changes

**백엔드 — 예약**

- `GET /reservations/me` 에 `limit`(기본 50, 1~100)·`before`·`before_id` 를 추가했습니다. 커서는 `(starts_at, id)` 복합입니다 — 한 트레이너가 같은 시각에 슬롯을 여러 개 열 수 있어 동시각이 실제로 나오고, 시각만으로 자르면 그 경계에서 예약이 빠지거나 겹칩니다.
- **순서를 `starts_at` 내림차순으로 바꿨습니다.** 예약은 취소해도 이력이 남아야 해 계정마다 계속 쌓이는데, 기존 오름차순에 상한만 씌우면 첫 쪽이 **가장 오래된 지난 예약**으로 차서 정작 다가오는 예약이 화면에서 사라집니다. 이슈가 "커서 설계를 먼저 정해야 한다" 고 짚은 부분입니다. 지난 예약을 숨기지 않는 것은 그대로입니다.

**백엔드 — 상담**

- `GET /consultations/me` 와 `GET /trainer/consultations` 에 같은 파라미터를 넣었습니다. 커서는 `(created_at, id)` 입니다.
- 회원 쪽은 필터가 없어 처리된 지난 요청까지 함께 자랍니다(같은 트레이너에게 보낸 대기 요청은 부분 유니크 인덱스가 한 건으로 막습니다). 트레이너 쪽은 기본 `pending` 이 처리하는 만큼 줄지만 `status=all` 이 그 트레이너에게 들어온 요청 전체입니다.
- 미처리 배지(`/trainer/consultations/pending-count`)는 DB 집계라 쪽 나눔과 무관하게 전체 기준입니다.

**백엔드 — 로스터**

- `GET /trainer/clients` 에 상한을 넣었습니다. 쿼리 수는 인원과 무관하게 상수지만 *한 쿼리가 읽는 양*과 카드마다 붙는 집계는 인원만큼 자랍니다.
- **커서 모양이 다릅니다.** 정렬키가 시각이 아니라 트레이너가 정한 순서(`sort_order`)이고 그 값은 카드에 실리지 않으므로, 받은 마지막 카드의 회원 id 하나(`after_id`)만 넘기면 서버가 그 자리를 찾아 이어 줍니다. 명단에 없는 id 는 **422** 입니다 — 조용히 첫 쪽을 돌려주면 이어 받기가 제자리를 돕니다.
- 정렬 tie-break 를 `created_at` 에서 회원 id 로 옮겼습니다. 같은 `sort_order` 안에서만 차이가 나며, 담당 링크는 만들 때마다 `max(sort_order) + 1` 을 받아 값이 겹치는 일 자체가 드뭅니다.

**백엔드 — 공통**

- 커서 파싱 규칙(파싱 실패 422, 오프셋 없는 값은 UTC)을 `app.core.pagination` 한 곳에 두고 알림 라우터도 그것을 쓰게 했습니다. 규칙이 엔드포인트마다 복사돼 있으면 한쪽만 고쳐지는 날이 옵니다.

**회원 앱**

- 예약·상담 조회가 상한과 커서를 싣습니다. 엔티티는 화면용 로컬 시각을 들고 있어 커서는 UTC 로 되돌려 보냅니다 — 그대로 보내면 쪽 경계가 시간대만큼 밀립니다.
- 예약 패널은 서버 순서를 그대로 그리지 않고 **다가오는 자리를 위에**, 지난 예약을 최근 것부터 아래에 둡니다. 쪽을 나누는 순서와 읽는 순서는 다릅니다.
- 상담 복원은 첫 쪽으로 충분합니다 — 화면이 보는 것은 대기 중인 신청이고 그것은 대개 가장 최근 건입니다. 그보다 오래된 대기 건이 남아 있는 드문 경우는 접수 때 서버가 409 로 알려 주고, 컨트롤러가 그 응답으로 목록을 채우는 경로가 이미 있습니다.

**트레이너 웹**

- 인박스는 **첫 쪽만 폴링**하고 이어 받은 지난 요청은 그 아래에 붙여 둡니다. 폴링은 새로 들어온 요청을 보려는 것이고 과거 요청은 바뀌지 않는데, 매번 전체를 다시 읽으면 폴링이 인박스 길이만큼 무거워집니다. 첫 쪽에 다시 나타난 요청은 id 로 걸러 한 번만 그립니다.
- 상한에 닿았을 때만 '지난 요청 더 보기' 가 뜹니다. 늘 보이면 더 없는데도 누를 것이 있는 것처럼 읽힙니다.
- 로스터는 명단이 끝날 때까지 쪽을 이어 받아 같은 목록을 만듭니다 — 사이드바 개수·검색·차트가 모두 전체를 전제로 읽는 자리라, 절반만 들고 있으면 트레이너가 명단이 잘린 줄 모른 채 빠진 회원을 찾게 됩니다.

**문서**

- `backend/API_CONTRACT.md` 공통 규약에 목록 페이지네이션 규칙과 적용된 엔드포인트를 적고, 예약·상담 절을 갱신했습니다. 로스터 커서는 `backend/docs/TRAINER_DOMAIN.md` 에 적었습니다.

## Commits

- `feat(backend): 예약·상담·로스터 목록 엔드포인트 페이지네이션` — 라우터·서비스·공통 커서·테스트·문서
- `feat(frontend): 예약·상담·로스터 목록의 쪽 나눔 반영` — 회원 앱 · 트레이너 웹

## Notes

- AC 의 "화면들이 추가 로딩으로 과거 항목을 이어 본다" 는 **트레이너 인박스**에만 눈에 보이는 버튼으로 넣었습니다. 로스터는 위 이유로 화면이 전체를 받아야 해 저장소가 대신 이어 받고, 회원 앱의 두 곳은 목록으로 그려지는 화면이 아닙니다(예약 패널은 트레이너별로 걸러 보이고, 상담은 `hasPending` 판정에만 쓰입니다) — 버튼을 달아도 눌러서 얻을 것이 없습니다.
- 채팅 스레드 두 곳(`/me/coach/chat`, `/trainer/clients/{id}/chat`)의 커서 파싱은 이번 범위 밖이라 그대로 뒀습니다. 오프셋 없는 커서를 UTC 로 읽는 규칙만 새 공통 함수와 다릅니다.
- 검증: 백엔드 전체 pytest 통과(신규 `test_list_pagination.py` 포함), 두 앱 모두 `flutter analyze` 클린 · `flutter test` 전체 통과.
