### PR TITLE
chore(demo): 데모 픽스처 기준 사용자·트레이너 데이터 일관성 확보

### DIFF
--- a/backend/app/db/demo_fixture.py
+++ b/backend/app/db/demo_fixture.py
@@ -94,7 +94,7 @@ class FixtureMeal:
 @dataclass(frozen=True)
 class FixtureExercise:
     name: str
-    #: `cardio` | `strength` | `stretching`.
+    #: `cardio` | `strength` | `flexibility` — 표준 어휘 (#996, #997).
     type: str
     minutes: int
     calories: int

--- a/backend/app/db/demo_fixture_data.json
+++ b/backend/app/db/demo_fixture_data.json
@@ -332,19 +332,19 @@
           "name": "레그프레스 3세트",
           "type": "strength",
           "minutes": 25,
-          "calories": 125,
+          "calories": 150,
           "done": true
         },
         {
           "name": "레그컬 3세트",
           "type": "strength",
           "minutes": 20,
-          "calories": 100,
+          "calories": 120,
           "done": true
         },
         {
           "name": "하체 스트레칭 15분",
-          "type": "stretching",
+          "type": "flexibility",
           "minutes": 15,
           "calories": 45,
           "done": true
@@ -383,19 +383,19 @@
           "name": "저강도 유산소 (걷기) 30분",
           "type": "cardio",
           "minutes": 30,
-          "calories": 225,
+          "calories": 270,
           "done": true
         },
         {
           "name": "코어 강화 10분",
           "type": "strength",
           "minutes": 10,
-          "calories": 50,
+          "calories": 60,
           "done": true
         },
         {
           "name": "하체 스트레칭 15분",
-          "type": "stretching",
+          "type": "flexibility",
           "minutes": 15,
           "calories": 45,
           "done": false
@@ -436,19 +436,19 @@
           "name": "저강도 유산소 (걷기) 30분",
           "type": "cardio",
           "minutes": 30,
-          "calories": 225,
+          "calories": 270,
           "done": true
         },
         {
           "name": "코어 강화 10분",
           "type": "strength",
           "minutes": 10,
-          "calories": 50,
+          "calories": 60,
           "done": true
         },
         {
           "name": "하체 스트레칭 15분",
-          "type": "stretching",
+          "type": "flexibility",
           "minutes": 15,
           "calories": 45,
           "done": true
@@ -490,19 +490,19 @@
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -529,12 +529,12 @@
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -581,19 +581,19 @@
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": false
@@ -623,12 +623,12 @@
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -655,19 +655,19 @@
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": true
@@ -697,12 +697,12 @@
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -735,19 +735,19 @@
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -774,12 +774,12 @@
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -826,19 +826,19 @@
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -868,12 +868,12 @@
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -900,19 +900,19 @@
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": true
@@ -939,12 +939,12 @@
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -980,19 +980,19 @@
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -1022,12 +1022,12 @@
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": false
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -1074,19 +1074,19 @@
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": false
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": false
@@ -1116,12 +1116,12 @@
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -1151,19 +1151,19 @@
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": false
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": false
@@ -1193,12 +1193,12 @@
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -1231,19 +1231,19 @@
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -1270,12 +1270,12 @@
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -1322,19 +1322,19 @@
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -1364,12 +1364,12 @@
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -1396,19 +1396,19 @@
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": false
@@ -1438,12 +1438,12 @@
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -1476,19 +1476,19 @@
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -1515,12 +1515,12 @@
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -1567,19 +1567,19 @@
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -1609,12 +1609,12 @@
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -1641,19 +1641,19 @@
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": true
@@ -1683,12 +1683,12 @@
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -1721,19 +1721,19 @@
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -1760,12 +1760,12 @@
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": false
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -1809,19 +1809,19 @@
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": false
@@ -1848,12 +1848,12 @@
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -1880,19 +1880,19 @@
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": true
@@ -1919,12 +1919,12 @@
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -1960,19 +1960,19 @@
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": false
@@ -2021,19 +2021,19 @@
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": false
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": false
@@ -2062,19 +2062,19 @@
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": false
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": false
@@ -2104,12 +2104,12 @@
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -2142,19 +2142,19 @@
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -2181,12 +2181,12 @@
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -2233,19 +2233,19 @@
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": false
@@ -2275,12 +2275,12 @@
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -2307,19 +2307,19 @@
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": true
@@ -2349,12 +2349,12 @@
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -2387,19 +2387,19 @@
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -2426,12 +2426,12 @@
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -2478,19 +2478,19 @@
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -2520,12 +2520,12 @@
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -2552,19 +2552,19 @@
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": true
@@ -2591,12 +2591,12 @@
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -2632,19 +2632,19 @@
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -2674,12 +2674,12 @@
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": false
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -2726,19 +2726,19 @@
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": false
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": false
@@ -2768,12 +2768,12 @@
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -2803,19 +2803,19 @@
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": false
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": false
@@ -2845,12 +2845,12 @@
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -2883,19 +2883,19 @@
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -2922,12 +2922,12 @@
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -2974,19 +2974,19 @@
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -3016,12 +3016,12 @@
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -3048,19 +3048,19 @@
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": false
@@ -3090,12 +3090,12 @@
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -3128,19 +3128,19 @@
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -3167,12 +3167,12 @@
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -3219,19 +3219,19 @@
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -3261,12 +3261,12 @@
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -3293,19 +3293,19 @@
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": true
@@ -3335,12 +3335,12 @@
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false

--- a/backend/tests/test_demo_fixture.py
+++ b/backend/tests/test_demo_fixture.py
@@ -8,6 +8,8 @@ from datetime import date
 from pathlib import Path
 
 from app.db.demo_fixture import FIXTURE_PATH, load_fixture
+from app.services import exercise_types
+from app.services.exercise_service import estimate_calories
 
 #: Flutter 두 앱이 읽는 원본. 백엔드 이미지는 `backend/` 만 담아서 같은 파일을
 #: 한 벌 더 갖고 있다 — 두 파일이 어긋나면 두 앱과 백엔드의 숫자가 갈라진다.
@@ -57,3 +59,24 @@ def test_the_fixture_covers_twelve_weeks_without_gaps():
     assert fixture.history_weeks == 12
     assert len(days) == 84
     assert len({d.iso for d in days}) == 84
+
+
+def test_exercise_calories_match_the_app_estimate():
+    """픽스처의 칼로리는 앱·서버가 쓰는 추정표와 같은 값이어야 한다. (#997)
+
+    예전에는 픽스처만 분당 7.5·5 로 낮았다. 그래서 데모의 30분 유산소는
+    225kcal 인데, 같은 운동을 회원이 직접 기록하면 270kcal 이 나왔다 — 같은
+    사람의 같은 운동이 어느 경로로 들어왔는지에 따라 다른 숫자가 됐다.
+    """
+    for day in load_fixture().days_for(date(2026, 8, 16)):
+        for exercise in day.exercises:
+            assert exercise.calories == estimate_calories(
+                exercise.type, exercise.minutes, "moderate"
+            ), f"{day.iso} {exercise.name}"
+
+
+def test_exercise_types_use_the_standard_vocabulary():
+    """유형은 표준 네 가지로만 적는다 — 옛 이름이 픽스처에 다시 들어오지 않게. (#996)"""
+    for day in load_fixture().days_for(date(2026, 8, 16)):
+        for exercise in day.exercises:
+            assert exercise.type in exercise_types.CANONICAL_TYPES, exercise.type

--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -867,6 +867,9 @@ class LocalApiInterceptor extends Interceptor {
     final perDayStretching = <String, int>{
       for (final l in _weekdayLabels) l: 0,
     };
+    // 기타는 유산소에 얹지 않는다 — 서버가 그렇게 세지 않는다 (#996). 목업이
+    // 서버와 다르게 세면 데모(목업)와 실 API 화면의 그래프가 갈라진다. (#997)
+    final perDayOther = <String, int>{for (final l in _weekdayLabels) l: 0};
     int totalMinutes = 0;
     int totalCalories = 0;
     final sessionsJson = <Map<String, Object?>>[];
@@ -887,8 +890,8 @@ class LocalApiInterceptor extends Interceptor {
       final bucket = switch (r.type) {
         'cardio' || 'walking' => perDayCardio,
         'strength' => perDayStrength,
-        'yoga' || 'stretching' => perDayStretching,
-        _ => perDayCardio,
+        'yoga' || 'stretching' || 'flexibility' => perDayStretching,
+        _ => perDayOther,
       };
       bucket.update(
         r.dayLabel,
@@ -931,6 +934,9 @@ class LocalApiInterceptor extends Interceptor {
     final stretchingSeries = <num>[
       for (final l in _weekdayLabels) perDayStretching[l] ?? 0,
     ];
+    final otherSeries = <num>[
+      for (final l in _weekdayLabels) perDayOther[l] ?? 0,
+    ];
 
     final streak = _longestActiveStreak(dailyMinutes);
 
@@ -940,7 +946,11 @@ class LocalApiInterceptor extends Interceptor {
       'daily_calories': dailyCalories,
       'cardio_minutes': cardioSeries,
       'strength_minutes': strengthSeries,
+      // 서버와 같은 이름으로 함께 내려준다 — flexibility 가 표준이고
+      // stretching 은 옮겨 가는 동안의 옛 이름이다. (#996)
+      'flexibility_minutes': stretchingSeries,
       'stretching_minutes': stretchingSeries,
+      'other_minutes': otherSeries,
       'day_labels': _weekdayLabels,
       'total_minutes': totalMinutes,
       'total_calories': totalCalories,
@@ -993,7 +1003,7 @@ class LocalApiInterceptor extends Interceptor {
   String _defaultTimeLabel(String type) => switch (type) {
     'cardio' => '07:30',
     'strength' => '18:00',
-    'yoga' || 'stretching' => '20:00',
+    'yoga' || 'stretching' || 'flexibility' => '20:00',
     'walking' => '12:00',
     _ => '15:00',
   };
@@ -1001,7 +1011,7 @@ class LocalApiInterceptor extends Interceptor {
   List<String> _defaultItems(String type) => switch (type) {
     'cardio' => const <String>['러닝머신 30분'],
     'strength' => const <String>['스쿼트 3세트', '데드리프트 3세트'],
-    'yoga' || 'stretching' => const <String>['전신 스트레칭 20분'],
+    'yoga' || 'stretching' || 'flexibility' => const <String>['전신 스트레칭 20분'],
     'walking' => const <String>['공원 산책'],
     _ => const <String>[],
   };

--- a/frontend/flutter/lib/features/exercise/data/repositories/mock_exercise_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/mock_exercise_repository.dart
@@ -106,13 +106,14 @@ class MockExerciseRepository implements ExerciseRepository {
     return out;
   }
 
-  /// 픽스처의 종류 문자열(`cardio`|`strength`|`stretching`) → [ExerciseType].
+  /// 픽스처의 종류 문자열(`cardio`|`strength`|`flexibility`) → [ExerciseType].
+  ///
+  /// 옛 값(`walking`·`yoga`·`stretching`)도 읽어 준다 — 픽스처는 표준 어휘로
+  /// 옮겼지만(#997) 손으로 고친 사본이나 예전 캐시가 남아 있을 수 있다.
   ExerciseType _typeOf(FixtureExercise e) => switch (e.type) {
-    'cardio' => ExerciseType.cardio,
-    'walking' => ExerciseType.walking,
+    'cardio' || 'walking' => ExerciseType.cardio,
     'strength' => ExerciseType.strength,
-    'stretching' => ExerciseType.stretching,
-    'yoga' => ExerciseType.yoga,
+    'flexibility' || 'stretching' || 'yoga' => ExerciseType.stretching,
     _ => ExerciseType.other,
   };
 

--- a/frontend/flutter/lib/features/exercise/domain/entities/exercise_week.dart
+++ b/frontend/flutter/lib/features/exercise/domain/entities/exercise_week.dart
@@ -209,7 +209,11 @@ class ExerciseWeek {
       dailyCalories: dailyCalories,
       cardioMinutes: parseDoubleList('cardio_minutes'),
       strengthMinutes: parseDoubleList('strength_minutes'),
-      stretchingMinutes: parseDoubleList('stretching_minutes'),
+      // 표준 이름을 먼저 본다. 옛 이름은 서버가 아직 함께 내려주는 동안의
+      // 다리다 — 둘 다 없으면 빈 목록이라 그래프가 그 줄기만 비운다. (#997)
+      stretchingMinutes: parseDoubleList('flexibility_minutes').isNotEmpty
+          ? parseDoubleList('flexibility_minutes')
+          : parseDoubleList('stretching_minutes'),
     );
   }
 }

--- a/shared/demo_fixture/assets/kim_minsu.json
+++ b/shared/demo_fixture/assets/kim_minsu.json
@@ -332,19 +332,19 @@
           "name": "레그프레스 3세트",
           "type": "strength",
           "minutes": 25,
-          "calories": 125,
+          "calories": 150,
           "done": true
         },
         {
           "name": "레그컬 3세트",
           "type": "strength",
           "minutes": 20,
-          "calories": 100,
+          "calories": 120,
           "done": true
         },
         {
           "name": "하체 스트레칭 15분",
-          "type": "stretching",
+          "type": "flexibility",
           "minutes": 15,
           "calories": 45,
           "done": true
@@ -383,19 +383,19 @@
           "name": "저강도 유산소 (걷기) 30분",
           "type": "cardio",
           "minutes": 30,
-          "calories": 225,
+          "calories": 270,
           "done": true
         },
         {
           "name": "코어 강화 10분",
           "type": "strength",
           "minutes": 10,
-          "calories": 50,
+          "calories": 60,
           "done": true
         },
         {
           "name": "하체 스트레칭 15분",
-          "type": "stretching",
+          "type": "flexibility",
           "minutes": 15,
           "calories": 45,
           "done": false
@@ -436,19 +436,19 @@
           "name": "저강도 유산소 (걷기) 30분",
           "type": "cardio",
           "minutes": 30,
-          "calories": 225,
+          "calories": 270,
           "done": true
         },
         {
           "name": "코어 강화 10분",
           "type": "strength",
           "minutes": 10,
-          "calories": 50,
+          "calories": 60,
           "done": true
         },
         {
           "name": "하체 스트레칭 15분",
-          "type": "stretching",
+          "type": "flexibility",
           "minutes": 15,
           "calories": 45,
           "done": true
@@ -490,19 +490,19 @@
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -529,12 +529,12 @@
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -581,19 +581,19 @@
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": false
@@ -623,12 +623,12 @@
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -655,19 +655,19 @@
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": true
@@ -697,12 +697,12 @@
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -735,19 +735,19 @@
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -774,12 +774,12 @@
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -826,19 +826,19 @@
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -868,12 +868,12 @@
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -900,19 +900,19 @@
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": true
@@ -939,12 +939,12 @@
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -980,19 +980,19 @@
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -1022,12 +1022,12 @@
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": false
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -1074,19 +1074,19 @@
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": false
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": false
@@ -1116,12 +1116,12 @@
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -1151,19 +1151,19 @@
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": false
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": false
@@ -1193,12 +1193,12 @@
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -1231,19 +1231,19 @@
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -1270,12 +1270,12 @@
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -1322,19 +1322,19 @@
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -1364,12 +1364,12 @@
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -1396,19 +1396,19 @@
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": false
@@ -1438,12 +1438,12 @@
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -1476,19 +1476,19 @@
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -1515,12 +1515,12 @@
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -1567,19 +1567,19 @@
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -1609,12 +1609,12 @@
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -1641,19 +1641,19 @@
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": true
@@ -1683,12 +1683,12 @@
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -1721,19 +1721,19 @@
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -1760,12 +1760,12 @@
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": false
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -1809,19 +1809,19 @@
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": false
@@ -1848,12 +1848,12 @@
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -1880,19 +1880,19 @@
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": true
@@ -1919,12 +1919,12 @@
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -1960,19 +1960,19 @@
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": false
@@ -2021,19 +2021,19 @@
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": false
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": false
@@ -2062,19 +2062,19 @@
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": false
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": false
@@ -2104,12 +2104,12 @@
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -2142,19 +2142,19 @@
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -2181,12 +2181,12 @@
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -2233,19 +2233,19 @@
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": false
@@ -2275,12 +2275,12 @@
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -2307,19 +2307,19 @@
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": true
@@ -2349,12 +2349,12 @@
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -2387,19 +2387,19 @@
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -2426,12 +2426,12 @@
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -2478,19 +2478,19 @@
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -2520,12 +2520,12 @@
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -2552,19 +2552,19 @@
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": true
@@ -2591,12 +2591,12 @@
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -2632,19 +2632,19 @@
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -2674,12 +2674,12 @@
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": false
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -2726,19 +2726,19 @@
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": false
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": false
@@ -2768,12 +2768,12 @@
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -2803,19 +2803,19 @@
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": false
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": false
@@ -2845,12 +2845,12 @@
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -2883,19 +2883,19 @@
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -2922,12 +2922,12 @@
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -2974,19 +2974,19 @@
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -3016,12 +3016,12 @@
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -3048,19 +3048,19 @@
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": false
@@ -3090,12 +3090,12 @@
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -3128,19 +3128,19 @@
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -3167,12 +3167,12 @@
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -3219,19 +3219,19 @@
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -3261,12 +3261,12 @@
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -3293,19 +3293,19 @@
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": true
@@ -3335,12 +3335,12 @@
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false

--- a/shared/demo_fixture/lib/src/fixture_json.g.dart
+++ b/shared/demo_fixture/lib/src/fixture_json.g.dart
@@ -340,19 +340,19 @@ const String kimMinsuFixtureJson = r'''
           "name": "레그프레스 3세트",
           "type": "strength",
           "minutes": 25,
-          "calories": 125,
+          "calories": 150,
           "done": true
         },
         {
           "name": "레그컬 3세트",
           "type": "strength",
           "minutes": 20,
-          "calories": 100,
+          "calories": 120,
           "done": true
         },
         {
           "name": "하체 스트레칭 15분",
-          "type": "stretching",
+          "type": "flexibility",
           "minutes": 15,
           "calories": 45,
           "done": true
@@ -391,19 +391,19 @@ const String kimMinsuFixtureJson = r'''
           "name": "저강도 유산소 (걷기) 30분",
           "type": "cardio",
           "minutes": 30,
-          "calories": 225,
+          "calories": 270,
           "done": true
         },
         {
           "name": "코어 강화 10분",
           "type": "strength",
           "minutes": 10,
-          "calories": 50,
+          "calories": 60,
           "done": true
         },
         {
           "name": "하체 스트레칭 15분",
-          "type": "stretching",
+          "type": "flexibility",
           "minutes": 15,
           "calories": 45,
           "done": false
@@ -444,19 +444,19 @@ const String kimMinsuFixtureJson = r'''
           "name": "저강도 유산소 (걷기) 30분",
           "type": "cardio",
           "minutes": 30,
-          "calories": 225,
+          "calories": 270,
           "done": true
         },
         {
           "name": "코어 강화 10분",
           "type": "strength",
           "minutes": 10,
-          "calories": 50,
+          "calories": 60,
           "done": true
         },
         {
           "name": "하체 스트레칭 15분",
-          "type": "stretching",
+          "type": "flexibility",
           "minutes": 15,
           "calories": 45,
           "done": true
@@ -498,19 +498,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -537,12 +537,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -589,19 +589,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": false
@@ -631,12 +631,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -663,19 +663,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": true
@@ -705,12 +705,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -743,19 +743,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -782,12 +782,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -834,19 +834,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -876,12 +876,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -908,19 +908,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": true
@@ -947,12 +947,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -988,19 +988,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -1030,12 +1030,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": false
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -1082,19 +1082,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": false
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": false
@@ -1124,12 +1124,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -1159,19 +1159,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": false
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": false
@@ -1201,12 +1201,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -1239,19 +1239,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -1278,12 +1278,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -1330,19 +1330,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -1372,12 +1372,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -1404,19 +1404,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": false
@@ -1446,12 +1446,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -1484,19 +1484,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -1523,12 +1523,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -1575,19 +1575,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -1617,12 +1617,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -1649,19 +1649,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": true
@@ -1691,12 +1691,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -1729,19 +1729,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -1768,12 +1768,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": false
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -1817,19 +1817,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": false
@@ -1856,12 +1856,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -1888,19 +1888,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": true
@@ -1927,12 +1927,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -1968,19 +1968,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": false
@@ -2029,19 +2029,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": false
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": false
@@ -2070,19 +2070,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": false
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": false
@@ -2112,12 +2112,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -2150,19 +2150,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -2189,12 +2189,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -2241,19 +2241,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": false
@@ -2283,12 +2283,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -2315,19 +2315,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": true
@@ -2357,12 +2357,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -2395,19 +2395,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -2434,12 +2434,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -2486,19 +2486,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -2528,12 +2528,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -2560,19 +2560,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": true
@@ -2599,12 +2599,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -2640,19 +2640,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -2682,12 +2682,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": false
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -2734,19 +2734,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": false
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": false
@@ -2776,12 +2776,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -2811,19 +2811,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": false
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": false
@@ -2853,12 +2853,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -2891,19 +2891,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -2930,12 +2930,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -2982,19 +2982,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -3024,12 +3024,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -3056,19 +3056,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": false
@@ -3098,12 +3098,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -3136,19 +3136,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 30분",
               "type": "cardio",
               "minutes": 30,
-              "calories": 225,
+              "calories": 270,
               "done": true
             },
             {
               "name": "코어 강화 10분",
               "type": "strength",
               "minutes": 10,
-              "calories": 50,
+              "calories": 60,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -3175,12 +3175,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 40분",
               "type": "cardio",
               "minutes": 40,
-              "calories": 300,
+              "calories": 360,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false
@@ -3227,19 +3227,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 35분",
               "type": "cardio",
               "minutes": 35,
-              "calories": 262,
+              "calories": 315,
               "done": true
             },
             {
               "name": "코어 강화 20분",
               "type": "strength",
               "minutes": 20,
-              "calories": 100,
+              "calories": 120,
               "done": true
             },
             {
               "name": "하체 스트레칭 5분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 5,
               "calories": 15,
               "done": true
@@ -3269,12 +3269,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 45분",
               "type": "cardio",
               "minutes": 45,
-              "calories": 338,
+              "calories": 405,
               "done": true
             },
             {
               "name": "어깨 관절 보호 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": true
@@ -3301,19 +3301,19 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 25분",
               "type": "cardio",
               "minutes": 25,
-              "calories": 188,
+              "calories": 225,
               "done": true
             },
             {
               "name": "코어 강화 30분",
               "type": "strength",
               "minutes": 30,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 15분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 15,
               "calories": 45,
               "done": true
@@ -3343,12 +3343,12 @@ const String kimMinsuFixtureJson = r'''
               "name": "저강도 유산소 (걷기) 20분",
               "type": "cardio",
               "minutes": 20,
-              "calories": 150,
+              "calories": 180,
               "done": true
             },
             {
               "name": "하체 스트레칭 10분",
-              "type": "stretching",
+              "type": "flexibility",
               "minutes": 10,
               "calories": 30,
               "done": false

--- a/tool/gen_demo_fixture.py
+++ b/tool/gen_demo_fixture.py
@@ -150,25 +150,30 @@ MEALS: dict[str, tuple[str, str, str, str, list[str]]] = {
 ROUTINE: dict[int, list[tuple[str, str, int]]] = {
     0: [("저강도 유산소 (걷기) 30분", "cardio", 30),
         ("코어 강화 10분", "strength", 10),
-        ("하체 스트레칭 5분", "stretching", 5)],
+        ("하체 스트레칭 5분", "flexibility", 5)],
     1: [("저강도 유산소 (걷기) 40분", "cardio", 40),
-        ("하체 스트레칭 10분", "stretching", 10)],
+        ("하체 스트레칭 10분", "flexibility", 10)],
     2: [],
     3: [("저강도 유산소 (걷기) 35분", "cardio", 35),
         ("코어 강화 20분", "strength", 20),
-        ("하체 스트레칭 5분", "stretching", 5)],
+        ("하체 스트레칭 5분", "flexibility", 5)],
     4: [("저강도 유산소 (걷기) 45분", "cardio", 45),
-        ("어깨 관절 보호 스트레칭 10분", "stretching", 10)],
+        ("어깨 관절 보호 스트레칭 10분", "flexibility", 10)],
     5: [("저강도 유산소 (걷기) 25분", "cardio", 25),
         ("코어 강화 30분", "strength", 30),
-        ("하체 스트레칭 15분", "stretching", 15)],
+        ("하체 스트레칭 15분", "flexibility", 15)],
     6: [("저강도 유산소 (걷기) 20분", "cardio", 20),
-        ("하체 스트레칭 10분", "stretching", 10)],
+        ("하체 스트레칭 10분", "flexibility", 10)],
 }
 
 #: 분당 칼로리. 종류마다 다르다 — 걷기와 스트레칭을 같은 값으로 두면 주간 활동
 #: 그래프의 스택이 실제 운동 강도와 어긋난다.
-KCAL_PER_MIN = {"cardio": 7.5, "strength": 5, "stretching": 3}
+#:
+#: 값은 앱·백엔드의 추정표와 **같아야 한다**(`_estimateCalories`,
+#: `exercise_service._KCAL_PER_MIN`). 예전에는 여기만 7.5·5 로 낮아, 데모의 30분
+#: 유산소는 225kcal 인데 같은 운동을 회원이 직접 기록하면 270kcal 이 나왔다.
+#: 같은 사람의 같은 운동이 기록 경로에 따라 다른 숫자가 되는 셈이다. (#997)
+KCAL_PER_MIN = {"cardio": 9, "strength": 6, "flexibility": 3}
 
 # ── 주별 이야기 ────────────────────────────────────────────────────────────
 # 12주를 7가지 주로 돌려 채운다. 예전에는 주마다 계수 하나를 곱해 흔들었는데,
@@ -316,7 +321,7 @@ RECENT: list[dict] = [
         "exercises": [
             ("레그프레스 3세트", "strength", 25, True),
             ("레그컬 3세트", "strength", 20, True),
-            ("하체 스트레칭 15분", "stretching", 15, True),
+            ("하체 스트레칭 15분", "flexibility", 15, True),
         ],
         "meals": [
             (B_EGG, "seed-diet-breakfast", "08:20",
@@ -337,7 +342,7 @@ RECENT: list[dict] = [
         "exercises": [
             ("저강도 유산소 (걷기) 30분", "cardio", 30, True),
             ("코어 강화 10분", "strength", 10, True),
-            ("하체 스트레칭 15분", "stretching", 15, False),
+            ("하체 스트레칭 15분", "flexibility", 15, False),
         ],
         "meals": [
             (B_OAT, "seed-diet-yesterday-breakfast", "08:10",
@@ -358,7 +363,7 @@ RECENT: list[dict] = [
         "exercises": [
             ("저강도 유산소 (걷기) 30분", "cardio", 30, True),
             ("코어 강화 10분", "strength", 10, True),
-            ("하체 스트레칭 15분", "stretching", 15, True),
+            ("하체 스트레칭 15분", "flexibility", 15, True),
         ],
         "meals": [
             (B_YOG, "seed-diet-two-days-ago-breakfast", "08:35",


### PR DESCRIPTION
## Summary

사용자앱과 트레이너웹이 같은 김민수를 **같은 숫자로** 보여 주게 맞춘다. 수정사항 반영의 선행 세 가지 중 마지막이다(#1000, #1002에 이어).

두 앱은 이미 `shared/demo_fixture` 를 단일 원본으로 읽고 있었다. 어긋난 것은 픽스처 **안의 값**이었다.

Closes #997

## Changes

**칼로리 표를 앱·서버와 같게**

픽스처만 분당 칼로리가 7.5·5 로 낮았다. 데모의 30분 유산소는 225kcal 인데, 같은 운동을 회원이 직접 기록하면 앱이 270kcal 로 계산했다 — 같은 사람의 같은 운동이 어느 경로로 들어왔는지에 따라 다른 숫자가 됐고, 두 앱을 나란히 놓는 시연에서 그대로 드러난다. 앱(`_estimateCalories`)·서버(`exercise_service._KCAL_PER_MIN`)가 쓰는 9·6·3 에 맞췄다.

**운동 유형을 표준 어휘로**

픽스처의 `stretching` 을 `flexibility` 로 옮긴다(#996의 네 가지). 픽스처는 세 곳이 함께 읽는 단일 원본이라, 여기가 옛 이름을 쓰면 세 곳이 각자 매핑을 들고 있어야 한다. 읽는 쪽은 옛 이름도 계속 받아 준다 — 손으로 고친 사본이나 예전 캐시가 있을 수 있다.

**목업 집계를 서버와 같게**

목업이 '기타' 운동을 유산소에 얹어 세고 있었다. 서버는 기타를 자기 칸으로 센다(#996). 같은 기록인데 데모와 실 API 의 그래프가 갈라진다. 주간 응답도 서버와 같은 이름으로 `flexibility_minutes`·`other_minutes` 를 함께 내려주고, 읽는 쪽은 표준 이름을 먼저 본다.

**다시 갈라지지 않게 잠금**

픽스처의 각 운동 칼로리가 서버 추정표의 결과와 같은지, 유형이 표준 네 가지인지 검사한다. 이번에 고친 것이 조용히 되돌아가는 걸 막는 자리다.

## Notes

- 김민수의 식단·운동 수치는 원래도 양쪽 모두 픽스처에서 온다(트레이너웹 `seed_clients.dart` 에 "김민수의 수치는 여기에 없다"고 적혀 있다). 그래서 시드 파일을 손댈 필요가 없었고, 결과적으로 열려 있는 #1001 과 겹치는 파일이 하나도 없다.
- 백엔드 전체 테스트, 두 앱 전체 테스트, 공유 픽스처 패키지 테스트 모두 통과.
- '기타' 시간을 그래프에 별도 줄기로 보여 주는 것과 배정 루틴 카드에 예상 칼로리를 싣는 것은 화면 작업이라 운동 탭 개편(수정사항 A 파트)에서 붙인다. 계약과 데이터는 이 PR 로 준비됐다.
