### PR TITLE
fix(a11y): 글씨 확대 후 두 앱의 문구 잘림 정리

### DIFF
--- a/frontend/flutter/lib/design_system/figma/figma_kit.dart
+++ b/frontend/flutter/lib/design_system/figma/figma_kit.dart
@@ -358,15 +358,21 @@ class FigmaTabHeader extends StatelessWidget {
         children: <Widget>[
           if (leading != null) ...<Widget>[leading!, const SizedBox(width: 6)],
           Expanded(
-            child: Text(
-              title,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: const TextStyle(
-                fontSize: 20,
-                fontWeight: FontWeight.w800,
-                color: FigmaColors.ink,
-                letterSpacing: -0.5,
+            // 말줄임이 아니라 축소다 (#1004). 서비스 이름이 `On - Ca…` 가 되면
+            // 헤더가 무엇을 가리키는지 사라진다 — 글씨를 키운 뒤로 좁은 폰에서
+            // 실제로 그렇게 됐다.
+            child: FittedBox(
+              fit: BoxFit.scaleDown,
+              alignment: AlignmentDirectional.centerStart,
+              child: Text(
+                title,
+                maxLines: 1,
+                style: const TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.w800,
+                  color: FigmaColors.ink,
+                  letterSpacing: -0.5,
+                ),
               ),
             ),
           ),

--- a/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
@@ -1734,6 +1734,10 @@ class _RecMealCard extends StatelessWidget {
                     ),
                     child: Text(
                       meal.tag,
+                      // 영어 태그는 길어서 두 줄이 되고, 그만큼 설명이 눌려
+                      // 사라진다 — 태그는 한 줄로 못 박는다. (#1004)
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
                       style: TextStyle(
                         fontSize: 12,
                         fontWeight: FontWeight.w700,
@@ -1966,14 +1970,19 @@ class _ChartLegend extends StatelessWidget {
     return Row(
       children: <Widget>[
         Expanded(
-          child: Text(
-            title,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: const TextStyle(
-              fontSize: 14.5,
-              fontWeight: FontWeight.w700,
-              color: FigmaColors.ink,
+          // 그래프 제목은 그 그래프가 무슨 지표인지를 말한다 — 줄임표가 되면
+          // (`Weekly Calories tre…`) 그 역할이 사라진다. 좁으면 줄인다. (#1004)
+          child: FittedBox(
+            fit: BoxFit.scaleDown,
+            alignment: AlignmentDirectional.centerStart,
+            child: Text(
+              title,
+              maxLines: 1,
+              style: const TextStyle(
+                fontSize: 14.5,
+                fontWeight: FontWeight.w700,
+                color: FigmaColors.ink,
+              ),
             ),
           ),
         ),

--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -667,8 +667,10 @@ class _DayCell extends StatelessWidget {
             ),
             const SizedBox(height: 3),
             Container(
-              width: 30,
-              height: 30,
+              // 알약도 글씨 배율을 따라간다 — 30 으로 박아 두면 날짜 숫자가
+              // 상자에 눌린다. (#1004)
+              width: 30 * MediaQuery.textScalerOf(context).scale(1),
+              height: 30 * MediaQuery.textScalerOf(context).scale(1),
               alignment: Alignment.center,
               decoration: BoxDecoration(
                 color: isSelected ? FigmaColors.primary : Colors.transparent,

--- a/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
@@ -796,8 +796,10 @@ class _WeekDay extends StatelessWidget {
             ),
             const SizedBox(height: 3),
             Container(
-              width: 30,
-              height: 30,
+              // 알약도 글씨 배율을 따라간다 — 30 으로 박아 두면 날짜 숫자가
+              // 상자에 눌린다. (#1004)
+              width: 30 * MediaQuery.textScalerOf(context).scale(1),
+              height: 30 * MediaQuery.textScalerOf(context).scale(1),
               alignment: Alignment.center,
               decoration: BoxDecoration(
                 color: isSelected ? FigmaColors.primary : Colors.transparent,

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/gym_tab.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/gym_tab.dart
@@ -577,10 +577,11 @@ class _TrainerChatButton extends StatelessWidget {
             // 배지가 붙으면 라벨과 함께 버튼 폭을 넘는다 — 글씨를 키운 뒤로는
             // 배지가 없어도 빠듯하다. 문구 쪽이 줄어든다. (#995)
             Flexible(
-              child: Text(
-                l.coachChatWithTrainer,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
+              // 줄임표가 되면 무슨 버튼인지 사라진다 — 좁으면 글씨를 줄인다.
+              // (#1004)
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Text(l.coachChatWithTrainer, maxLines: 1),
               ),
             ),
             if (unread > 0) ...<Widget>[

--- a/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_card.dart
+++ b/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_card.dart
@@ -658,14 +658,18 @@ class _ChatButton extends StatelessWidget {
               // 큰 글자 배율에서 라벨이 버튼을 넘겼다. 안 읽은 개수 배지는
               // 접지 않는다 — 몇 건인지가 이 버튼을 누를 이유다(#766).
               Flexible(
-                child: Text(
-                  l.coachChatWithTrainer,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(
-                    fontSize: 14,
-                    fontWeight: FontWeight.w700,
-                    color: FigmaColors.primary,
+                // 줄임표 대신 축소다 — `Chat with train…` 이 되면 버튼이 무슨
+                // 버튼인지 사라진다. (#1004)
+                child: FittedBox(
+                  fit: BoxFit.scaleDown,
+                  child: Text(
+                    l.coachChatWithTrainer,
+                    maxLines: 1,
+                    style: const TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w700,
+                      color: FigmaColors.primary,
+                    ),
                   ),
                 ),
               ),

--- a/frontend/flutter/lib/shared/widgets/metric_trend_chart.dart
+++ b/frontend/flutter/lib/shared/widgets/metric_trend_chart.dart
@@ -136,23 +136,41 @@ class MetricTrendChart extends StatelessWidget {
             // 폭은 눈금 라벨이 쓰던 38 그대로다. `목표 2,000` 을 한 줄로 두면 이
             // 칸이 넓어져야 하는데, 그러면 360px 영어 로케일에서 요일 라벨 줄이
             // 넘친다. 두 줄로 접어 폭을 지킨다.
-            SizedBox(
-              width: 38,
-              height: height,
-              child: Stack(
-                children: <Widget>[
-                  if (goalLabel != null && goal > 0 && goal >= lo && goal <= hi)
-                    Positioned(
-                      right: 0,
-                      top: (height - ((goal - lo) / (hi - lo)) * height - 13)
-                          .clamp(0.0, height - 26),
-                      child: SizedBox(
-                        height: 26,
-                        child: Center(child: _AxisLabel(goalLabel!)),
-                      ),
-                    ),
-                ],
-              ),
+            Builder(
+              builder: (BuildContext context) {
+                // 칸도 글씨 배율을 따라간다 (#1004). 38·26 으로 박아 두면 배율이
+                // 올라간 순간 `목표` 아래 줄(`2,000`)이 상자에 눌려 반만 보인다.
+                final TextScaler ts = MediaQuery.textScalerOf(context);
+                final double labelWidth = 38 * ts.scale(1);
+                // 두 줄(`목표` / 값)이 들어갈 높이를 글씨에서 잰다. 상수로 두면
+                // 배율이 오른 순간 아랫줄이 잘린다. (#1004)
+                final double labelHeight = ts.scale(_axisLabelSize) * 1.35 * 2;
+                return SizedBox(
+                  width: labelWidth,
+                  height: height,
+                  child: Stack(
+                    children: <Widget>[
+                      if (goalLabel != null &&
+                          goal > 0 &&
+                          goal >= lo &&
+                          goal <= hi)
+                        Positioned(
+                          right: 0,
+                          top:
+                              (height -
+                                      ((goal - lo) / (hi - lo)) * height -
+                                      labelHeight / 2)
+                                  .clamp(0.0, height - labelHeight),
+                          child: SizedBox(
+                            key: chartGoalLabelKey,
+                            height: labelHeight,
+                            child: Center(child: _AxisLabel(goalLabel!)),
+                          ),
+                        ),
+                    ],
+                  ),
+                );
+              },
             ),
             const SizedBox(width: 6),
             Expanded(
@@ -221,6 +239,12 @@ class MetricTrendChart extends StatelessWidget {
   }
 }
 
+/// 목표선 라벨 칸. 높이가 글씨 배율을 따라 달라져서, 크기로 찾을 수 없다.
+const Key chartGoalLabelKey = ValueKey<String>('chart-goal-label');
+
+/// 축 라벨 글씨 크기. 라벨 칸 높이를 이 값에서 재므로 한 곳에 둔다. (#1004)
+const double _axisLabelSize = 10;
+
 class _AxisLabel extends StatelessWidget {
   const _AxisLabel(this.text);
 
@@ -232,7 +256,8 @@ class _AxisLabel extends StatelessWidget {
     textAlign: TextAlign.right,
     maxLines: 2,
     style: const TextStyle(
-      fontSize: 10,
+      fontSize: _axisLabelSize,
+      height: 1.35,
       fontWeight: FontWeight.w600,
       color: AppColors.mutedForeground,
     ),

--- a/frontend/flutter/test/app/text_not_clipped_test.dart
+++ b/frontend/flutter/test/app/text_not_clipped_test.dart
@@ -1,0 +1,93 @@
+/// 글씨를 키운 뒤 문구가 잘리던 자리들 (#1004).
+///
+/// 세로로 넘치는 것은 예외로 드러나지만 **가로로 줄임표가 되거나 상자에 눌려
+/// 잘리는 것은 조용하다.** 서비스 이름과 그래프 목표 라벨은 잘리면 그 자리가
+/// 무엇인지가 사라지는 곳이라, 여기서 못 박아 둔다.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
+
+import 'package:oncare/app/app.dart';
+import 'package:oncare/app/session_feature_reset.dart';
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/core/logging/app_logger.dart';
+import 'package:oncare/features/dashboard/data/repositories/mock_dashboard_repository.dart';
+import 'package:oncare/features/dashboard/domain/repositories/dashboard_repository.dart';
+import 'package:oncare/features/dashboard/presentation/controllers/dashboard_controller.dart';
+import 'package:oncare/features/diet/domain/repositories/diet_repository.dart';
+import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
+import 'package:oncare/features/exercise/data/repositories/mock_exercise_repository.dart';
+import 'package:oncare/features/exercise/domain/repositories/exercise_repository.dart';
+import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
+
+import '../helpers/fake_diet_repository.dart';
+
+bool _isClipped(WidgetTester tester, String contains) {
+  bool clipped = false;
+  bool found = false;
+  void visit(Element el) {
+    final RenderObject? ro = el.renderObject;
+    if (ro is RenderParagraph && ro.hasSize) {
+      if (ro.text.toPlainText().contains(contains)) {
+        found = true;
+        if (ro.didExceedMaxLines ||
+            ro.getMinIntrinsicHeight(ro.size.width) > ro.size.height + 0.5) {
+          clipped = true;
+        }
+      }
+    }
+    el.visitChildren(visit);
+  }
+
+  visit(tester.binding.rootElement!);
+  expect(found, isTrue, reason: '"$contains" 를 그리는 문단을 못 찾았다');
+  return clipped;
+}
+
+void main() {
+  testWidgets('헤더의 서비스 이름과 그래프 목표 라벨이 잘리지 않는다', (WidgetTester tester) async {
+    // 폰이 기준이다.
+    tester.view.physicalSize = const Size(390, 1600);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    const AppConfig config = AppConfig(
+      environment: Environment.dev,
+      apiBaseUrl: 'https://dev.api.test',
+      useMockApi: true,
+    );
+    final FakeDietRepository diet = FakeDietRepository();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          appConfigProvider.overrideWithValue(config),
+          appLoggerProvider.overrideWithValue(Logger(level: Level.off)),
+          dietRepositoryProvider.overrideWithValue(diet as DietRepository),
+          exerciseRepositoryProvider.overrideWithValue(
+            MockExerciseRepository() as ExerciseRepository,
+          ),
+          dashboardRepositoryProvider.overrideWithValue(
+            MockDashboardRepository(diet) as DashboardRepository,
+          ),
+          sessionFeatureResetOverride(),
+        ],
+        child: const OncareApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+    final Finder demo = find.byKey(const Key('demoEnterButton'));
+    await tester.ensureVisible(demo);
+    await tester.pumpAndSettle();
+    await tester.tap(demo);
+    await tester.pumpAndSettle();
+
+    expect(_isClipped(tester, 'On - Care'), isFalse);
+    // 주간 추이 그래프의 목표 라벨 — `목표` 아래 줄(값)이 상자에 눌려 잘렸다.
+    expect(_isClipped(tester, 'Goal'), isFalse);
+  });
+}

--- a/frontend/flutter/test/features/dashboard/home_nutrition_axis_test.dart
+++ b/frontend/flutter/test/features/dashboard/home_nutrition_axis_test.dart
@@ -100,9 +100,9 @@ void main() {
   List<({String text, Rect rect})> axisLabels(WidgetTester tester) {
     final Finder slots = find.descendant(
       of: axis,
-      matching: find.byWidgetPredicate(
-        (Widget w) => w is SizedBox && w.height == 26,
-      ),
+      // 칸 높이는 글씨 배율을 따라 달라진다 — 크기가 아니라 이름으로 찾는다.
+      // (#1004)
+      matching: find.byKey(chartGoalLabelKey),
     );
     return <({String text, Rect rect})>[
       for (final Element e in slots.evaluate())

--- a/frontend/flutter_trainer/lib/app/shell/app_sidebar.dart
+++ b/frontend/flutter_trainer/lib/app/shell/app_sidebar.dart
@@ -230,24 +230,32 @@ class _Brand extends StatelessWidget {
                 logo,
                 const SizedBox(width: AppSpacing.sm),
                 Expanded(
-                  child: Text.rich(
-                    TextSpan(
-                      children: <InlineSpan>[
-                        const TextSpan(
-                          text: 'On-Care ',
-                          style: TextStyle(color: AppColors.foreground),
+                  // 서비스 이름이 `On-Care 트레…` 가 되면 이 콘솔이 무엇인지가
+                  // 사라진다 — 좁으면 글씨를 줄인다. (#1004)
+                  child: FittedBox(
+                    fit: BoxFit.scaleDown,
+                    alignment: AlignmentDirectional.centerStart,
+                    child: Text.rich(
+                      TextSpan(
+                        children: <InlineSpan>[
+                          const TextSpan(
+                            text: 'On-Care ',
+                            style: TextStyle(color: AppColors.foreground),
+                          ),
+                          TextSpan(
+                            text: AppLocalizations.of(
+                              context,
+                            ).appWordmarkTrainer,
+                            style: const TextStyle(color: AppColors.primary),
+                          ),
+                        ],
+                        style: const TextStyle(
+                          fontSize: 19,
+                          fontWeight: FontWeight.w800,
                         ),
-                        TextSpan(
-                          text: AppLocalizations.of(context).appWordmarkTrainer,
-                          style: const TextStyle(color: AppColors.primary),
-                        ),
-                      ],
-                      style: const TextStyle(
-                        fontSize: 19,
-                        fontWeight: FontWeight.w800,
                       ),
+                      maxLines: 1,
                     ),
-                    overflow: TextOverflow.ellipsis,
                   ),
                 ),
               ],

--- a/frontend/flutter_trainer/lib/features/search/presentation/widgets/client_search_bar.dart
+++ b/frontend/flutter_trainer/lib/features/search/presentation/widgets/client_search_bar.dart
@@ -269,7 +269,7 @@ class _ClientSearchBarState extends ConsumerState<ClientSearchBar> {
                 child: TapRegion(
                   groupId: this,
                   onTapOutside: (_) => _close(),
-                  child: _field(l, facts),
+                  child: _field(l, facts, width),
                 ),
               ),
             ),
@@ -279,7 +279,15 @@ class _ClientSearchBarState extends ConsumerState<ClientSearchBar> {
     );
   }
 
-  Widget _field(AppLocalizations l, ClientSearchFacts facts) {
+  /// 긴 검색 범위 안내가 들어갈 만한 폭. 이보다 좁으면 짧은 안내로 바꾼다 —
+  /// 줄임표로 끝이 잘리면(`…마지막 루틴 전송…`) 무엇까지 찾아 주는지가 사라진다.
+  /// 글씨를 키운 뒤 1280 폭에서 실제로 그렇게 됐다. (#1004)
+  static const double _longHintMinWidth = 460;
+
+  Widget _field(AppLocalizations l, ClientSearchFacts facts, double width) {
+    final String hint = width >= _longHintMinWidth
+        ? l.searchClientsHint
+        : l.searchClients;
     return CallbackShortcuts(
       // The same keys the dropdown implies: ↑/↓ walk the rows, Esc backs
       // out. Enter is the field's own submit.
@@ -302,7 +310,7 @@ class _ClientSearchBarState extends ConsumerState<ClientSearchBar> {
           isDense: true,
           filled: true,
           fillColor: AppColors.inputBackground,
-          hintText: l.searchClientsHint,
+          hintText: hint,
           hintStyle: const TextStyle(
             fontSize: 13,
             color: AppColors.subtleForeground,

--- a/frontend/flutter_trainer/lib/shared/widgets/metric_trend_chart.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/metric_trend_chart.dart
@@ -133,23 +133,38 @@ class MetricTrendChart extends StatelessWidget {
             // 폭은 눈금 라벨이 쓰던 38 그대로다. `목표 2,000` 을 한 줄로 두면 이
             // 칸이 넓어져야 하는데, 그러면 360px 영어 로케일에서 요일 라벨 줄이
             // 넘친다. 두 줄로 접어 폭을 지킨다.
-            SizedBox(
-              width: 38,
-              height: height,
-              child: Stack(
-                children: <Widget>[
-                  if (goalLabel != null && goal > 0 && goal >= lo && goal <= hi)
-                    Positioned(
-                      right: 0,
-                      top: (height - ((goal - lo) / (hi - lo)) * height - 13)
-                          .clamp(0.0, height - 26),
-                      child: SizedBox(
-                        height: 26,
-                        child: Center(child: _AxisLabel(goalLabel!)),
-                      ),
-                    ),
-                ],
-              ),
+            Builder(
+              builder: (BuildContext context) {
+                // 칸도 글씨 배율을 따라간다 (#1004). 38·26 으로 박아 두면 배율이
+                // 올라간 순간 `목표` 아래 줄(`2,000`)이 상자에 눌려 반만 보인다.
+                final TextScaler ts = MediaQuery.textScalerOf(context);
+                final double labelWidth = 38 * ts.scale(1);
+                final double labelHeight = ts.scale(_axisLabelSize) * 1.35 * 2;
+                return SizedBox(
+                  width: labelWidth,
+                  height: height,
+                  child: Stack(
+                    children: <Widget>[
+                      if (goalLabel != null &&
+                          goal > 0 &&
+                          goal >= lo &&
+                          goal <= hi)
+                        Positioned(
+                          right: 0,
+                          top:
+                              (height -
+                                      ((goal - lo) / (hi - lo)) * height -
+                                      labelHeight / 2)
+                                  .clamp(0.0, height - labelHeight),
+                          child: SizedBox(
+                            height: labelHeight,
+                            child: Center(child: _AxisLabel(goalLabel!)),
+                          ),
+                        ),
+                    ],
+                  ),
+                );
+              },
             ),
             const SizedBox(width: 6),
             Expanded(
@@ -226,6 +241,9 @@ class MetricTrendChart extends StatelessWidget {
   );
 }
 
+/// 축 라벨 글씨 크기. 라벨 칸 높이를 이 값에서 재므로 한 곳에 둔다. (#1004)
+const double _axisLabelSize = 10;
+
 class _AxisLabel extends StatelessWidget {
   const _AxisLabel(this.text);
 
@@ -237,7 +255,8 @@ class _AxisLabel extends StatelessWidget {
     textAlign: TextAlign.right,
     maxLines: 2,
     style: const TextStyle(
-      fontSize: 10,
+      fontSize: _axisLabelSize,
+      height: 1.35,
       fontWeight: FontWeight.w600,
       color: AppColors.mutedForeground,
     ),

--- a/frontend/flutter_trainer/lib/shared/widgets/page_scaffold.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/page_scaffold.dart
@@ -129,13 +129,20 @@ class _Header extends StatelessWidget {
                   mainAxisAlignment: MainAxisAlignment.center,
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: <Widget>[
-                    Text(
-                      title,
-                      overflow: TextOverflow.ellipsis,
-                      style: const TextStyle(
-                        fontSize: 18,
-                        fontWeight: FontWeight.w800,
-                        color: AppColors.foreground,
+                    // 화면 이름은 줄임표로 줄이지 않는다 — `My prof…` 이 되면
+                    // 지금 어느 화면인지가 사라진다. 액션이 많은 화면에서 자리가
+                    // 모자라면 글씨를 줄인다. (#1004)
+                    FittedBox(
+                      fit: BoxFit.scaleDown,
+                      alignment: AlignmentDirectional.centerStart,
+                      child: Text(
+                        title,
+                        maxLines: 1,
+                        style: const TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.w800,
+                          color: AppColors.foreground,
+                        ),
                       ),
                     ),
                     if (subtitle != null)

--- a/frontend/flutter_trainer/lib/shared/widgets/section_card.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/section_card.dart
@@ -68,13 +68,19 @@ class SectionCard extends StatelessWidget {
                   const SizedBox(width: AppSpacing.xs),
                 ],
                 Expanded(
-                  child: Text(
-                    title,
-                    overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(
-                      fontSize: 14.5,
-                      fontWeight: FontWeight.w800,
-                      color: AppColors.foreground,
+                  // 카드 제목도 줄임표 대신 축소다 — 옆의 버튼 줄이 길어지면
+                  // 제목이 먼저 잘렸다. (#1004)
+                  child: FittedBox(
+                    fit: BoxFit.scaleDown,
+                    alignment: AlignmentDirectional.centerStart,
+                    child: Text(
+                      title,
+                      maxLines: 1,
+                      style: const TextStyle(
+                        fontSize: 14.5,
+                        fontWeight: FontWeight.w800,
+                        color: AppColors.foreground,
+                      ),
                     ),
                   ),
                 ),

--- a/frontend/flutter_trainer/test/app/text_not_clipped_test.dart
+++ b/frontend/flutter_trainer/test/app/text_not_clipped_test.dart
@@ -1,0 +1,76 @@
+/// 글씨를 키운 뒤 문구가 잘리던 자리들 (#1004).
+///
+/// 세로로 넘치는 것은 예외로 드러나지만 **가로로 줄임표가 되거나 상자에 눌려
+/// 잘리는 것은 조용하다.** 화면 이름·서비스 이름·그래프 목표 라벨은 잘리면
+/// 그 자리가 무엇인지가 사라지는 곳이라, 여기서 못 박아 둔다.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare_trainer/app/router/routes.dart';
+
+import '../helpers/pump_app.dart';
+
+/// [text] 를 그리는 문단이 잘렸는가 — 줄임표가 걸렸거나 상자보다 큰가.
+bool _isClipped(WidgetTester tester, String contains) {
+  bool clipped = false;
+  bool found = false;
+  void visit(Element el) {
+    final RenderObject? ro = el.renderObject;
+    if (ro is RenderParagraph && ro.hasSize) {
+      final String text = ro.text.toPlainText();
+      if (text.contains(contains)) {
+        found = true;
+        if (ro.didExceedMaxLines ||
+            ro.getMinIntrinsicHeight(ro.size.width) > ro.size.height + 0.5) {
+          clipped = true;
+        }
+      }
+    }
+    el.visitChildren(visit);
+  }
+
+  visit(tester.binding.rootElement!);
+  expect(found, isTrue, reason: '"$contains" 를 그리는 문단을 못 찾았다');
+  return clipped;
+}
+
+void main() {
+  testWidgets('사이드바 서비스 이름이 줄임표로 잘리지 않는다', (WidgetTester tester) async {
+    // 사이드바가 라벨을 펴는 폭.
+    tester.view.physicalSize = const Size(1440, 1000);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await pumpTrainerApp(
+      tester,
+      token: 'demo-trainer-token',
+      at: AppRoutes.dashboard,
+    );
+    await settle(tester);
+
+    expect(_isClipped(tester, 'On-Care'), isFalse);
+  });
+
+  testWidgets('화면 이름이 줄임표로 잘리지 않는다 — 액션이 많은 내 정보', (
+    WidgetTester tester,
+  ) async {
+    tester.view.physicalSize = const Size(1280, 1000);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await pumpTrainerApp(
+      tester,
+      token: 'demo-trainer-token',
+      at: AppRoutes.my,
+      locale: const Locale('en'),
+    );
+    await settle(tester);
+
+    expect(_isClipped(tester, 'My profile'), isFalse);
+  });
+}


### PR DESCRIPTION
## Summary

글씨를 키우고 서체를 바꾼 뒤(#1000) 두 앱에서 문구가 잘리던 자리들을 정리한다. 사이드바가 `On-Care 트레…` 로 줄고, 사용자앱 주간 칼로리 그래프의 목표 라벨은 아랫줄이 눌려 값이 반만 보였다.

세로로 넘치는 것은 예외로 드러나 이미 잡았지만, **가로로 줄임표가 되거나 상자에 눌리는 것은 조용하다.** 그래서 화면을 하나씩 눈으로 보는 대신, 그려진 문단이 실제로 잘렸는지 보는 잣대를 만들어 두 앱의 주요 화면을 돌았다. 글씨 배율 1.0 과 1.1 의 결과를 견줘 **이번 변경으로 새로 생긴 것만** 골라 고쳤다.

Closes #1004

## Changes

**이름은 줄임표 대신 축소로**

끝이 잘리면 그 자리가 무엇인지 사라지는 문구들이다. 좁으면 글씨를 줄여서라도 끝까지 보인다.

- 트레이너 사이드바의 서비스 이름, 사용자앱 헤더의 서비스 이름
- 페이지 제목(액션이 많은 화면에서 먼저 잘렸다), 카드·그래프 제목
- 트레이너 채팅 버튼(회원앱 두 곳)

반대로 고객 이름·목표처럼 사람마다 길이가 다른 값은 줄임표가 맞아 그대로 뒀다.

**글씨가 차지하는 자리는 배율을 따라**

- 주간 추이 그래프의 목표 라벨: 26px 칸에 두 줄을 넣던 자리라 아랫줄이 잘렸다. 라벨 높이를 글씨에서 재고, 줄 높이를 못 박아 서체가 바뀌어도 어긋나지 않게 했다. 두 앱 모두.
- 주간 달력의 날짜 알약도 같은 이유로 배율을 따라간다.

**그 밖에**

- 트레이너 통합 검색: 좁은 헤더에서 긴 안내(`고객·목표·최근 메시지·마지막 루틴 전송일 검색`)가 잘려 무엇까지 찾아 주는지 사라졌다. 폭이 모자라면 짧은 안내로 바꾼다.
- 추천 식단 카드: 영어 태그가 두 줄이 되면서 설명을 밀어냈다. 태그를 한 줄로 못 박는다.

**검사**

문단이 실제로 잘렸는지 보고 판정하는 검사를 두 앱에 하나씩 뒀다. 고친 코드를 되돌리면 둘 다 실패하는 것을 확인했다.

## Notes

- 훑고 남은 것은 의도한 축약뿐이다: 추천 식단 카드의 음식 이름·태그(카드 폭이 고정), 고객 목표 문자열.
- 두 앱 `flutter analyze` 무경고, 전체 테스트 통과.
- 목표 라벨 칸을 크기(`height == 26`)로 찾던 기존 검사는 이름으로 찾게 바꿨다 — 칸 높이가 이제 배율을 따라 달라진다.
