### PR TITLE
fix(schedule): 주 이동 화살표의 원형 타깃과 색 적용

### DIFF
--- a/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/schedule_date_nav_bar.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/schedule_date_nav_bar.dart
@@ -45,15 +45,25 @@ class ScheduleDateNavBar extends StatelessWidget {
         onTap: () => onShift(-1),
       ),
       const SizedBox(width: AppSpacing.sm),
-      Text(
-        l.dateRange(
-          l.dateMonthDay(start.month, start.day),
-          l.dateMonthDay(end.month, end.day),
-        ),
-        style: const TextStyle(
-          fontSize: 14,
-          fontWeight: FontWeight.w800,
-          color: AppColors.foreground,
+      // 날짜 범위가 줄을 넘기지 않게 이쪽이 먼저 줄어든다. 화살표는 손이 닿는
+      // 크기가 있어야 해서 줄일 수 없고, 날짜는 통째로 작게 그려도 읽힌다 —
+      // 좁은 폭(360)에 큰 글자 배율(1.3)이 겹치면 그 차이가 69px 이다(#1009).
+      Flexible(
+        child: FittedBox(
+          fit: BoxFit.scaleDown,
+          alignment: Alignment.centerLeft,
+          child: Text(
+            l.dateRange(
+              l.dateMonthDay(start.month, start.day),
+              l.dateMonthDay(end.month, end.day),
+            ),
+            maxLines: 1,
+            style: const TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w800,
+              color: AppColors.foreground,
+            ),
+          ),
         ),
       ),
       const SizedBox(width: AppSpacing.sm),
@@ -97,20 +107,44 @@ class _ChevronButton extends StatelessWidget {
   final IconData icon;
   final VoidCallback onTap;
 
+  /// 원의 지름. 손가락이 닿는 최소치(44)보다 작지만, 날짜 행이 한 줄에 들어가야
+  /// 해서 이 값이 상한이다. 대신 [_tapPadding] 으로 탭 영역을 넓혀 둔다.
+  static const double _diameter = 30;
+
+  /// 원 바깥으로 넓히는 탭 영역. 보이는 원은 30 이지만 실제로 눌리는 범위는
+  /// 44 다 — 작은 원을 정확히 겨누게 만들 이유가 없다.
+  static const double _tapPadding = 7;
+
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      width: 28,
-      height: 44,
-      child: Material(
-        color: Colors.transparent,
-        shape: const CircleBorder(),
-        clipBehavior: Clip.antiAlias,
-        child: InkWell(
+    // 색을 아이콘이 아니라 **원 영역**에 준다. 배경 없는 회색 아이콘이던 때에는
+    // 어디까지가 눌리는 범위인지 형태로 알 수 없었고, 주변 글씨와 같은 계열이라
+    // "누르는 것" 으로 읽히지도 않았다(#1009).
+    //
+    // 주 이동에는 제한이 없다 — 앞뒤 어느 쪽으로든 갈 수 있어야 하므로 비활성
+    // 상태를 만들지 않는다.
+    return Tooltip(
+      message: tooltip,
+      child: Semantics(
+        button: true,
+        label: tooltip,
+        excludeSemantics: true,
+        child: InkResponse(
           onTap: onTap,
-          child: Tooltip(
-            message: tooltip,
-            child: Icon(icon, size: 20, color: AppColors.mutedForeground),
+          radius: _diameter / 2 + _tapPadding,
+          child: Padding(
+            padding: const EdgeInsets.all(_tapPadding),
+            child: Container(
+              key: ValueKey<String>('schedule-week-arrow-${icon.codePoint}'),
+              width: _diameter,
+              height: _diameter,
+              alignment: Alignment.center,
+              decoration: const BoxDecoration(
+                shape: BoxShape.circle,
+                color: AppColors.primary,
+              ),
+              child: Icon(icon, size: 18, color: AppColors.primaryForeground),
+            ),
           ),
         ),
       ),

--- a/frontend/flutter_trainer/test/features/schedule/schedule_week_arrows_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/schedule_week_arrows_test.dart
@@ -1,0 +1,86 @@
+/// 주 이동 화살표. (#1009)
+///
+/// 배경 없는 회색 아이콘이던 때에는 어디까지가 눌리는 범위인지 형태로 알 수
+/// 없었고, 주변 글씨와 같은 계열이라 "누르는 것" 으로 읽히지도 않았다. 색을
+/// 아이콘이 아니라 **원 영역**에 준다는 것이 여기서 재는 계약이다.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare_trainer/app/router/routes.dart';
+import 'package:oncare_trainer/design_system/tokens/colors.dart';
+
+import '../../helpers/pump_app.dart';
+
+void main() {
+  Future<void> openSchedule(WidgetTester tester, {Size? size}) async {
+    tester.view.physicalSize = size ?? const Size(1440, 1200);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await pumpTrainerApp(
+      tester,
+      token: 'demo-trainer-token',
+      at: AppRoutes.schedule,
+    );
+  }
+
+  Finder arrow(IconData icon) =>
+      find.byKey(ValueKey<String>('schedule-week-arrow-${icon.codePoint}'));
+
+  ({Color? color, BoxShape shape}) circle(WidgetTester tester, IconData icon) {
+    final decoration =
+        tester.widget<Container>(arrow(icon)).decoration! as BoxDecoration;
+    return (color: decoration.color, shape: decoration.shape);
+  }
+
+  testWidgets('화살표가 색이 있는 원형 타깃으로 그려진다', (tester) async {
+    await openSchedule(tester);
+
+    for (final icon in <IconData>[Icons.chevron_left, Icons.chevron_right]) {
+      final drawn = circle(tester, icon);
+      expect(drawn.shape, BoxShape.circle, reason: '$icon 이 원이어야 한다');
+      expect(drawn.color, AppColors.primary, reason: '색은 아이콘이 아니라 원 영역에 있다');
+    }
+
+    // 두 원의 크기가 같다 — 한쪽만 커 보이면 두 방향의 무게가 달라 보인다.
+    expect(
+      tester.getSize(arrow(Icons.chevron_left)),
+      tester.getSize(arrow(Icons.chevron_right)),
+    );
+
+    // 아이콘은 원 안에서 대비되는 색으로 남는다.
+    final Icon glyph = tester.widget<Icon>(
+      find.descendant(
+        of: arrow(Icons.chevron_right),
+        matching: find.byIcon(Icons.chevron_right),
+      ),
+    );
+    expect(glyph.color, AppColors.primaryForeground);
+  });
+
+  testWidgets('눌러서 지난 주·다음 주로 오간다', (tester) async {
+    await openSchedule(tester);
+    expect(find.text('김민수'), findsWidgets); // 오늘이 보이는 주
+
+    await tester.tap(arrow(Icons.chevron_right));
+    await settle(tester);
+    expect(find.text('김민수'), findsNothing, reason: '다음 주에는 시드가 없다');
+
+    await tester.tap(arrow(Icons.chevron_left));
+    await settle(tester);
+    expect(find.text('김민수'), findsWidgets);
+  });
+
+  testWidgets('좁은 폭과 큰 글자 배율에서도 날짜 행이 넘치지 않는다', (tester) async {
+    tester.platformDispatcher.textScaleFactorTestValue = 1.3;
+    addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
+
+    await openSchedule(tester, size: const Size(360, 720));
+
+    expect(arrow(Icons.chevron_left), findsOneWidget);
+    expect(arrow(Icons.chevron_right), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
## Summary

* 주 이동 화살표를 **색 있는 원형 타깃**으로 바꿨습니다. 색이 아이콘이 아니라 원 영역에 있어, 어디까지가 눌리는 범위인지 형태로 보입니다.
* 보이는 원은 지름 30 이지만 실제 탭 범위는 44 입니다.
* 주 이동에는 제한이 없으므로 비활성 상태는 만들지 않았습니다.

---

## Changes

### ✨ Features

* 없음

### 🔧 Improvements

* 날짜 범위 글씨가 화살표보다 먼저 줄어듭니다(`FittedBox`). 화살표는 손이 닿는 크기가 있어야 해서 줄일 수 없고, 날짜는 통째로 작게 그려도 읽힙니다.

### 🎨 UI/UX

* `_ChevronButton` 이 브랜드 남색 원 + 흰색 화살표가 됐습니다. 툴팁(`이전 주`·`다음 주`)과 시맨틱스는 그대로입니다.

### 📝 Docs

* 왜 색을 원 영역에 주는지, 왜 비활성 상태를 만들지 않는지 문서 주석에 남겼습니다.

### 🐛 Fixes

* 폭 360 · 글자 배율 1.3 에서 날짜 행이 69px 넘치던 문제를 함께 고쳤습니다(원이 커지며 드러난 값입니다).

---

## Notes

* **비활성(회색) 상태는 넣지 않았습니다.** 처음 이슈에는 "이동 가능할 때 파랑, 불가능할 때 회색" 이 있었는데, 주 이동을 미래 쪽으로 막지 않기로 해서 회색이 나올 조건이 없어졌습니다. 조건 없는 비활성 표현을 미리 만들어 두면 쓰이지 않는 분기만 남습니다.
* 탭 범위를 `InkResponse(radius:)` + `Padding` 으로 원 바깥까지 넓혔습니다. 물결도 원보다 크게 번집니다.
* 화살표를 `find.byIcon` 으로 찾던 기존 테스트는 그대로 통과합니다 — 아이콘 위젯이 원 안에 남아 있습니다.

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 데모 모드로 스케줄 탭을 엽니다.
2. 날짜 행 양쪽 화살표가 남색 원으로 보이는지 확인합니다.
3. 원 바깥 살짝 떨어진 지점을 눌러도 주가 넘어가는지 확인합니다.
4. 창을 360px 까지 좁히고 글자 배율을 키워 날짜 행이 넘치지 않는지 확인합니다.

---

## Related Issues

Closes #1009

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인
