### PR TITLE
feat(chart): 전체 기간 그래프의 가로 스크롤과 날짜 선택

### DIFF
--- a/frontend/flutter/lib/design_system/charts/period_scroll_chart.dart
+++ b/frontend/flutter/lib/design_system/charts/period_scroll_chart.dart
@@ -1,0 +1,276 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import 'package:oncare/design_system/tokens/colors.dart';
+
+/// `전체` 그래프의 선택·보이는 구간 상태. (#1018)
+///
+/// 머리의 숫자(평균 또는 고른 날의 값)와 막대는 서로 다른 위젯이 그리는데 같은
+/// 상태를 봐야 한다. 부모가 들고 있다가 둘에게 건넨다.
+class PeriodChartSelection extends ChangeNotifier {
+  int? _selected;
+  (int, int)? _visible;
+
+  /// 고른 칸. null 이면 머리 숫자가 평균이다.
+  int? get selected => _selected;
+
+  /// 화면에 보이는 구간(첫 칸, 끝 칸). null 이면 아직 재지 않았다 = 전 구간.
+  (int, int)? get visible => _visible;
+
+  void select(int? index) {
+    if (_selected == index) return;
+    _selected = index;
+    notifyListeners();
+  }
+
+  void setVisible(int first, int last) {
+    if (_visible != null && _visible!.$1 == first && _visible!.$2 == last) {
+      return;
+    }
+    _visible = (first, last);
+    notifyListeners();
+  }
+
+  /// 지표나 기간을 바꾸면 고른 날은 뜻을 잃는다 — 같이 푼다.
+  void reset() {
+    if (_selected == null) return;
+    _selected = null;
+    notifyListeners();
+  }
+
+  /// 보이는 구간의 평균. 기록이 없는 날(0)은 빼고 낸다 — 넣으면 "적게 먹었다"
+  /// 와 "기록을 안 했다" 가 같은 숫자가 된다.
+  double averageOf(List<double> values) {
+    if (values.isEmpty) return 0;
+    final (int first, int last) = _visible ?? (0, values.length - 1);
+    double sum = 0;
+    int count = 0;
+    for (int i = first; i <= last && i < values.length; i++) {
+      if (values[i] > 0) {
+        sum += values[i];
+        count += 1;
+      }
+    }
+    return count == 0 ? 0 : sum / count;
+  }
+}
+
+/// `전체` 기간 그래프의 뼈대 — 가로 스크롤 + 날짜 선택. (#1018)
+///
+/// 예전에는 한 달치를 한 화면에 욱여넣어 막대가 실처럼 얇았고, 그 앞의 기록은
+/// 볼 방법이 아예 없었다. 아이폰 건강 앱의 1개월 그래프처럼 **한 화면에 30일**을
+/// 두고 옆으로 밀어 과거를 본다.
+///
+/// 막대를 그리는 일은 하지 않는다. 식단은 탄단지를, 운동은 유산소·근력·유연성을
+/// 쌓아 그리는데 그 색이 각 화면이 말하려는 내용이라, 뼈대가 단색으로 통일해
+/// 버리면 그림이 뜻을 잃는다. 그래서 칸 하나를 [barBuilder] 가 그리고 여기서는
+/// 자리와 선택만 맡는다.
+class PeriodScrollChart extends StatefulWidget {
+  const PeriodScrollChart({
+    super.key,
+    required this.count,
+    required this.height,
+    required this.barBuilder,
+    required this.labelBuilder,
+    required this.onVisibleRangeChanged,
+    required this.calloutBuilder,
+    this.selectedIndex,
+    this.onSelected,
+    this.goalOverlay,
+    this.daysPerScreen = 30,
+  });
+
+  /// 칸 개수(= 날짜 수). 0 이면 아무것도 그리지 않는다.
+  final int count;
+
+  /// 막대가 그려지는 높이(라벨 줄 제외).
+  final double height;
+
+  /// [i] 번째 날의 막대. 칸 폭에 맞춰 그려진다.
+  final Widget Function(BuildContext context, int i) barBuilder;
+
+  /// [i] 번째 날의 축 라벨. 빈 문자열이면 적지 않는다 — 30칸에 날짜를 모두
+  /// 적으면 서로 겹친다.
+  final String Function(int i) labelBuilder;
+
+  /// 화면에 보이는 구간이 바뀔 때마다 부른다. 머리의 평균이 이 구간을 따른다 —
+  /// 보이지 않는 날까지 섞은 평균은 지금 보고 있는 그림을 설명하지 못한다.
+  final void Function(int first, int last) onVisibleRangeChanged;
+
+  /// 고른 날 위에 뜨는 회색 상자의 내용.
+  final Widget Function(BuildContext context, int i) calloutBuilder;
+
+  final int? selectedIndex;
+  final void Function(int? i)? onSelected;
+
+  /// 목표선. 칸 전체 폭에 걸쳐 그려지도록 스크롤 안쪽에 얹는다.
+  final Widget? goalOverlay;
+
+  /// 한 화면에 보일 날 수.
+  final int daysPerScreen;
+
+  @override
+  State<PeriodScrollChart> createState() => _PeriodScrollChartState();
+}
+
+class _PeriodScrollChartState extends State<PeriodScrollChart> {
+  final ScrollController _controller = ScrollController();
+  double _slot = 0;
+  double _viewport = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(_reportVisible);
+  }
+
+  @override
+  void dispose() {
+    _controller.removeListener(_reportVisible);
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _reportVisible() {
+    if (_slot <= 0 || _viewport <= 0) return;
+    final double offset = _controller.hasClients ? _controller.offset : 0;
+    final int first = (offset / _slot).floor().clamp(0, widget.count - 1);
+    final int last = ((offset + _viewport) / _slot).ceil() - 1;
+    widget.onVisibleRangeChanged(first, last.clamp(first, widget.count - 1));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.count == 0) return SizedBox(height: widget.height);
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final double viewport = constraints.maxWidth;
+        final double slot = viewport / widget.daysPerScreen;
+        final bool changed = slot != _slot || viewport != _viewport;
+        _slot = slot;
+        _viewport = viewport;
+        if (changed) {
+          // 처음 열면 최근(오른쪽 끝)이다 — 사람이 먼저 궁금해하는 것은 어제와
+          // 오늘이지 석 달 전이 아니다.
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!mounted || !_controller.hasClients) return;
+            _controller.jumpTo(_controller.position.maxScrollExtent);
+            _reportVisible();
+          });
+        }
+        return SingleChildScrollView(
+          controller: _controller,
+          scrollDirection: Axis.horizontal,
+          // 칸이 화면보다 적으면 스크롤할 것이 없다.
+          physics: widget.count <= widget.daysPerScreen
+              ? const NeverScrollableScrollPhysics()
+              : const BouncingScrollPhysics(),
+          child: SizedBox(
+            width: math.max(slot * widget.count, viewport),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                SizedBox(
+                  height: widget.height,
+                  child: Stack(
+                    children: <Widget>[
+                      if (widget.goalOverlay != null) widget.goalOverlay!,
+                      if (widget.selectedIndex != null)
+                        _SelectionLine(
+                          left: slot * widget.selectedIndex! + slot / 2,
+                          height: widget.height,
+                        ),
+                      Row(
+                        crossAxisAlignment: CrossAxisAlignment.end,
+                        children: <Widget>[
+                          for (int i = 0; i < widget.count; i++)
+                            SizedBox(
+                              width: slot,
+                              child: GestureDetector(
+                                behavior: HitTestBehavior.opaque,
+                                onTap: () => widget.onSelected?.call(
+                                  widget.selectedIndex == i ? null : i,
+                                ),
+                                child: widget.barBuilder(context, i),
+                              ),
+                            ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 6),
+                SizedBox(
+                  height: 14,
+                  child: Row(
+                    children: <Widget>[
+                      for (int i = 0; i < widget.count; i++)
+                        SizedBox(
+                          width: slot,
+                          child: Center(
+                            child: Text(
+                              widget.labelBuilder(i),
+                              maxLines: 1,
+                              style: const TextStyle(
+                                fontSize: 10,
+                                fontWeight: FontWeight.w600,
+                                color: AppColors.mutedForeground,
+                              ),
+                            ),
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// 고른 날에 서는 회색 세로선.
+class _SelectionLine extends StatelessWidget {
+  const _SelectionLine({required this.left, required this.height});
+
+  final double left;
+  final double height;
+
+  @override
+  Widget build(BuildContext context) => Positioned(
+    left: left - 0.5,
+    top: 0,
+    child: Container(height: height, width: 1, color: AppColors.chartGoalLine),
+  );
+}
+
+/// 머리에 뜨는 값 — 평소에는 보이는 구간의 평균, 날을 고르면 그날의 값.
+///
+/// 회색 상자는 **고른 날에만** 씌운다. 평균일 때도 상자를 두면 화면에 늘 회색
+/// 덩어리가 있어, 무언가를 고른 상태인지 아닌지가 구분되지 않는다.
+class PeriodChartHeadline extends StatelessWidget {
+  const PeriodChartHeadline({
+    super.key,
+    required this.selected,
+    required this.child,
+  });
+
+  final bool selected;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!selected) return child;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: AppColors.inputBackground,
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: child,
+    );
+  }
+}

--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -132,11 +132,18 @@ void resetDietTransientUiState(WidgetRef ref) {
 /// 날짜를 Duration 이 아니라 성분으로 옮긴다. 로컬 시간에 Duration 을 더하면
 /// 서머타임이 있는 지역에서 주 전체가 하루씩 밀린다. `DateTime(y, m + 1, 0)`
 /// 은 12월이면 다음 해 1월 0일 = 12월 31일로 알아서 넘어간다.
+/// `전체` 가 거슬러 올라가는 날 수. 12주 — 데모 픽스처가 들고 있는 기간이자,
+/// 하루 한 번씩 조회하는 지금 구조에서 감당할 수 있는 범위다. 화면에는 한 번에
+/// 30일이 보이고 나머지는 옆으로 밀어 본다. (#1018)
+const int kDietAllPeriodDays = 84;
+
 DietDateRange dietRangeForTab(DietPeriodTab tab, DateTime today) {
   if (tab == DietPeriodTab.month) {
+    // `이번 달` 이 아니라 `전체` 다 — 달이 바뀌었다고 앞의 기록이 사라지면
+    // 추세를 볼 수 없다.
     return (
-      from: DateTime(today.year, today.month),
-      to: DateTime(today.year, today.month + 1, 0),
+      from: DateTime(today.year, today.month, today.day - kDietAllPeriodDays + 1),
+      to: DateTime(today.year, today.month, today.day),
     );
   }
   final DateTime monday = DateTime(
@@ -331,7 +338,7 @@ class _PeriodToggle extends StatelessWidget {
     final Map<DietPeriodTab, String> labels = <DietPeriodTab, String>{
       DietPeriodTab.day: l.exToday,
       DietPeriodTab.week: l.exThisWeek,
-      DietPeriodTab.month: l.exThisMonth,
+      DietPeriodTab.month: l.exPeriodAll,
     };
     return Container(
       key: const ValueKey<String>('diet-period-toggle'),

--- a/frontend/flutter/lib/features/diet/presentation/widgets/diet_period_view.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/diet_period_view.dart
@@ -4,8 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart' show DateFormat, NumberFormat;
 import 'package:oncare/core/utils/clock.dart';
-import 'package:oncare/design_system/charts/chart_reveal.dart';
 import 'package:oncare/design_system/charts/goal_line.dart';
+import 'package:oncare/design_system/charts/period_scroll_chart.dart';
 import 'package:oncare/design_system/figma/figma_kit.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
 import 'package:oncare/features/account/domain/entities/user_profile.dart';
@@ -46,6 +46,16 @@ enum _Metric { calories, sodium, sugar }
 class _DietPeriodViewState extends ConsumerState<DietPeriodView> {
   _Metric _metric = _Metric.calories;
 
+  /// `전체` 그래프의 스크롤 위치와 고른 날. 머리의 숫자와 막대가 같은 상태를
+  /// 봐야 해서 여기서 들고 둘에게 건넨다. (#1018)
+  final PeriodChartSelection _selection = PeriodChartSelection();
+
+  @override
+  void dispose() {
+    _selection.dispose();
+    super.dispose();
+  }
+
   String _label(AppLocalizations l, _Metric m) => switch (m) {
     _Metric.calories => l.dietCalories,
     _Metric.sodium => l.dietSodium,
@@ -63,6 +73,12 @@ class _DietPeriodViewState extends ConsumerState<DietPeriodView> {
     _Metric.sodium => d.sodiumMg.toDouble(),
     _Metric.sugar => d.sugarG,
   };
+
+  void _selectMetric(_Metric m) {
+    // 지표를 바꾸면 고른 날의 숫자는 뜻을 잃는다 — 같이 푼다.
+    _selection.reset();
+    setState(() => _metric = m);
+  }
 
   double _averageOf(DietPeriod p, _Metric m) => switch (m) {
     _Metric.calories => p.avgCalories,
@@ -123,7 +139,7 @@ class _DietPeriodViewState extends ConsumerState<DietPeriodView> {
                 // 지표별 색은 아래 그래프가 계속 쓴다.
                 color: FigmaColors.primary,
                 active: _metric == m,
-                onTap: () => setState(() => _metric = m),
+                onTap: () => _selectMetric(m),
               ),
               if (m != _Metric.values.last) const SizedBox(width: 8),
             ],
@@ -236,6 +252,7 @@ class _DietPeriodViewState extends ConsumerState<DietPeriodView> {
                   metric: _metric,
                   weekly: widget.weekly,
                   ticks: _ticks(_metric),
+                  selection: _selection,
                 ),
         ),
       ],
@@ -259,6 +276,7 @@ class _PeriodBody extends StatelessWidget {
     required this.weekly,
     required this.ticks,
     required this.metric,
+    required this.selection,
     this.days,
   });
 
@@ -286,14 +304,20 @@ class _PeriodBody extends StatelessWidget {
   /// 꺾은선의 가로 눈금. 홈 탭과 같은 값을 쓴다.
   final List<double> ticks;
 
+  /// `전체` 그래프의 스크롤·선택 상태. 머리의 숫자가 이걸 보고 평균과 하루
+  /// 값을 오간다. (#1018)
+  final PeriodChartSelection selection;
+
+  /// 고른 날의 머리 문구 — `2026. 8. 17.` 처럼 로케일 형식의 날짜.
+  String _dayHeadline(BuildContext context, DateTime date) =>
+      DateFormat.yMd(Localizations.localeOf(context).toString()).format(date);
+
   @override
   Widget build(BuildContext context) {
     final AppLocalizations l = AppLocalizations.of(context);
     final List<String> labels = weekDayLabels(l);
-    final bool over = goal > 0 && average > goal;
-    final Color statusColor = over
-        ? FigmaColors.dangerRed
-        : FigmaColors.greenText;
+    // 이번 주(꺾은선)는 스크롤도 선택도 없다 — 일곱 칸이 이미 한 화면이다.
+    final bool selectable = !weekly;
     return Container(
       key: const Key('diet-period-card'),
       width: double.infinity,
@@ -310,68 +334,105 @@ class _PeriodBody extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
               Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: <Widget>[
-                    Text(
-                      '${l.dietPeriodAverage} · $metricLabel',
-                      style: const TextStyle(
-                        fontSize: 12.5,
-                        fontWeight: FontWeight.w600,
-                        color: AppColors.mutedForeground,
-                      ),
-                    ),
-                    const SizedBox(height: 5),
-                    FittedBox(
-                      fit: BoxFit.scaleDown,
-                      alignment: Alignment.centerLeft,
-                      child: Text.rich(
-                        TextSpan(
-                          children: <InlineSpan>[
-                            TextSpan(
-                              text: format(average),
-                              style: TextStyle(
-                                fontSize: 24,
-                                fontWeight: FontWeight.w800,
-                                color: over
-                                    ? FigmaColors.dangerRed
-                                    : FigmaColors.ink,
-                                letterSpacing: -0.5,
-                              ),
+                child: ListenableBuilder(
+                  listenable: selection,
+                  builder: (BuildContext context, Widget? _) {
+                    final int? picked = selectable ? selection.selected : null;
+                    // 평소에는 **보이는 구간의** 평균, 날을 고르면 그날의 값.
+                    // 보이지 않는 날까지 섞은 평균은 지금 화면을 설명하지
+                    // 못한다. (#1018)
+                    final double value = picked == null
+                        ? (selectable ? selection.averageOf(values) : average)
+                        : values[picked];
+                    final bool over = goal > 0 && value > goal;
+                    return PeriodChartHeadline(
+                      selected: picked != null,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: <Widget>[
+                          Text(
+                            picked == null
+                                ? '${l.dietPeriodAverage} · $metricLabel'
+                                : '${_dayHeadline(context, dates[picked])} · '
+                                      '$metricLabel',
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: const TextStyle(
+                              fontSize: 12.5,
+                              fontWeight: FontWeight.w600,
+                              color: AppColors.mutedForeground,
                             ),
-                            TextSpan(
-                              text: ' / ${format(goal)} $unit',
-                              style: const TextStyle(
-                                fontSize: 14,
-                                fontWeight: FontWeight.w600,
-                                color: AppColors.mutedForeground,
+                          ),
+                          const SizedBox(height: 5),
+                          FittedBox(
+                            fit: BoxFit.scaleDown,
+                            alignment: Alignment.centerLeft,
+                            child: Text.rich(
+                              TextSpan(
+                                children: <InlineSpan>[
+                                  TextSpan(
+                                    text: format(value),
+                                    style: TextStyle(
+                                      fontSize: 24,
+                                      fontWeight: FontWeight.w800,
+                                      color: over
+                                          ? FigmaColors.dangerRed
+                                          : FigmaColors.ink,
+                                      letterSpacing: -0.5,
+                                    ),
+                                  ),
+                                  TextSpan(
+                                    text: ' / ${format(goal)} $unit',
+                                    style: const TextStyle(
+                                      fontSize: 14,
+                                      fontWeight: FontWeight.w600,
+                                      color: AppColors.mutedForeground,
+                                    ),
+                                  ),
+                                ],
                               ),
+                              maxLines: 1,
                             ),
-                          ],
-                        ),
-                        maxLines: 1,
+                          ),
+                        ],
                       ),
-                    ),
-                  ],
+                    );
+                  },
                 ),
               ),
               const SizedBox(width: 10),
-              Container(
-                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
-                decoration: BoxDecoration(
-                  color: statusColor.withValues(alpha: 0.12),
-                  borderRadius: BorderRadius.circular(999),
-                ),
-                child: Text(
-                  over
-                      ? '${l.homeGoal} ${l.homeMetricOver}'
-                      : l.homeMetricNormal,
-                  style: TextStyle(
-                    fontSize: 12,
-                    fontWeight: FontWeight.w800,
-                    color: statusColor,
-                  ),
-                ),
+              ListenableBuilder(
+                listenable: selection,
+                builder: (BuildContext context, Widget? _) {
+                  final int? picked = selectable ? selection.selected : null;
+                  final double value = picked == null
+                      ? (selectable ? selection.averageOf(values) : average)
+                      : values[picked];
+                  final bool over = goal > 0 && value > goal;
+                  final Color statusColor = over
+                      ? FigmaColors.dangerRed
+                      : FigmaColors.greenText;
+                  return Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 8,
+                      vertical: 3,
+                    ),
+                    decoration: BoxDecoration(
+                      color: statusColor.withValues(alpha: 0.12),
+                      borderRadius: BorderRadius.circular(999),
+                    ),
+                    child: Text(
+                      over
+                          ? '${l.homeGoal} ${l.homeMetricOver}'
+                          : l.homeMetricNormal,
+                      style: TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w800,
+                        color: statusColor,
+                      ),
+                    ),
+                  );
+                },
               ),
             ],
           ),
@@ -451,6 +512,7 @@ class _PeriodBody extends StatelessWidget {
               metricLabel: metricLabel,
               unit: unit,
               format: format,
+              selection: selection,
               days: days,
             ),
           // 쌓은 색이 무엇을 뜻하는지는 범례가 말한다 — 툴팁은 올려야 보인다.
@@ -498,12 +560,16 @@ class _PeriodBars extends StatelessWidget {
     required this.metricLabel,
     required this.unit,
     required this.format,
+    required this.selection,
     this.days,
   });
 
   final List<double> values;
   final List<DateTime> dates;
   final double goal;
+
+  /// 스크롤 위치와 고른 날. 카드 머리의 숫자가 같은 상태를 본다. (#1018)
+  final PeriodChartSelection selection;
   final Color color;
   final Object replayKey;
 
@@ -678,120 +744,69 @@ class _PeriodBars extends StatelessWidget {
           : null,
       child: ExcludeSemantics(
         excluding: empty,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            SizedBox(
-              height: chartHeight,
-              child: Stack(
-                children: <Widget>[
-                  // 가로선은 목표선 하나뿐이다 (#1015). 예전에는 옅은 회색
-                  // 실선이라 축처럼 보였다 — 점선에 값을 붙여 목표라고 말한다.
-                  GoalLineOverlay(
-                    visible: hasGoal,
-                    bottom: chartHeight * (goal / maxValue).clamp(0.0, 1.0),
-                    label: '${l.homeGoal} ${format(goal)}',
+        child: ListenableBuilder(
+          listenable: selection,
+          builder: (BuildContext context, Widget? _) => PeriodScrollChart(
+            count: values.length,
+            height: chartHeight,
+            selectedIndex: selection.selected,
+            onSelected: selection.select,
+            onVisibleRangeChanged: selection.setVisible,
+            // 목표선은 스크롤 안쪽에 얹는다 — 밀어도 막대와 같은 자리에서
+            // 같은 높이로 따라간다. (#1015)
+            goalOverlay: GoalLineOverlay(
+              visible: hasGoal,
+              bottom: chartHeight * (goal / maxValue).clamp(0.0, 1.0),
+              label: '${l.homeGoal} ${format(goal)}',
+            ),
+            labelBuilder: (int i) =>
+                i % labelStep == 0 ? '${dates[i].day}' : '',
+            calloutBuilder: (BuildContext context, int i) =>
+                const SizedBox.shrink(),
+            barBuilder: (BuildContext context, int i) => Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 1.5),
+              child: Semantics(
+                label: _tipText(l, dayFormat, i, hasGoal),
+                child: Tooltip(
+                  key: Key('diet-period-bar-tip-$i'),
+                  richMessage: TextSpan(
+                    style: const TextStyle(
+                      fontSize: 12.5,
+                      fontWeight: FontWeight.w600,
+                      color: FigmaColors.ink,
+                      height: 1.3,
+                    ),
+                    children: _tipSpans(l, dayFormat, i, hasGoal),
                   ),
-                  // 막대 전체를 하나의 ChartReveal 로 감싸고 순서만 어긋내
-                  // (chartStagger) 준다. 막대마다 애니메이션을 두면 한 달치에
-                  // 티커가 31개 생긴다.
-                  ChartReveal(
-                    curve: Curves.linear,
-                    replayKey: replayKey,
-                    builder: (BuildContext context, double t) => Row(
-                      crossAxisAlignment: CrossAxisAlignment.end,
-                      children: <Widget>[
-                        for (int i = 0; i < values.length; i++)
-                          Expanded(
-                            child: Padding(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 1.5,
-                              ),
-                              child: _Bar(
-                                key: Key('diet-period-bar-$i'),
-                                height:
-                                    chartHeight *
-                                    (values[i] / maxValue).clamp(0.0, 1.0) *
-                                    chartStagger(t, i, values.length),
-                                pending: _isPending(i),
-                                day: _dayAt(i),
-                                // 목표를 넘긴 날은 한 색(경고)으로 칠한다. 쌓은
-                                // 막대까지 빨갛게 물들이면 무엇이 얼마인지가
-                                // 사라지므로, 탄단지가 있는 날은 쌓은 색을 지키고
-                                // 초과는 목표선과 툴팁이 말한다.
-                                over: hasGoal && values[i] > goal,
-                                color: color,
-                              ),
-                            ),
-                          ),
-                      ],
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 10,
+                    vertical: 8,
+                  ),
+                  decoration: BoxDecoration(
+                    color: const Color(0xFFF1F3F5),
+                    borderRadius: BorderRadius.circular(10),
+                    border: Border.all(color: FigmaColors.hairline),
+                    boxShadow: kCardShadow,
+                  ),
+                  child: Align(
+                    alignment: Alignment.bottomCenter,
+                    child: _Bar(
+                      key: Key('diet-period-bar-$i'),
+                      height:
+                          chartHeight * (values[i] / maxValue).clamp(0.0, 1.0),
+                      pending: _isPending(i),
+                      day: _dayAt(i),
+                      // 목표를 넘긴 날은 한 색(경고)으로 칠한다. 쌓은 막대까지
+                      // 빨갛게 물들이면 무엇이 얼마인지가 사라지므로, 탄단지가
+                      // 있는 날은 쌓은 색을 지키고 초과는 목표선과 툴팁이 말한다.
+                      over: hasGoal && values[i] > goal,
+                      color: color,
                     ),
                   ),
-                  // 막대 위에 겹치는 투명한 hover 영역. 운동 탭 `운동 현황` 이
-                  // 쓰는 것과 **같은 툴팁 규격**이라, 두 탭에서 같은 조작이 같은
-                  // 모양으로 답한다.
-                  Positioned.fill(
-                    child: Row(
-                      children: <Widget>[
-                        for (int i = 0; i < values.length; i++)
-                          Expanded(
-                            // 툴팁은 올려야 보인다. 같은 내용을 시맨틱 라벨로도
-                            // 준다 — 막대 하나가 며칠 얼마인지는 이 노드 말고는
-                            // 음성 안내에 나올 데가 없다(#972).
-                            child: Semantics(
-                              label: _tipText(l, dayFormat, i, hasGoal),
-                              child: Tooltip(
-                                key: Key('diet-period-bar-tip-$i'),
-                                richMessage: TextSpan(
-                                  style: const TextStyle(
-                                    fontSize: 12.5,
-                                    fontWeight: FontWeight.w600,
-                                    color: FigmaColors.ink,
-                                    height: 1.3,
-                                  ),
-                                  children: _tipSpans(l, dayFormat, i, hasGoal),
-                                ),
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 10,
-                                  vertical: 8,
-                                ),
-                                decoration: BoxDecoration(
-                                  color: const Color(0xFFF1F3F5),
-                                  borderRadius: BorderRadius.circular(10),
-                                  border: Border.all(
-                                    color: FigmaColors.hairline,
-                                  ),
-                                  boxShadow: kCardShadow,
-                                ),
-                                child: const SizedBox.expand(),
-                              ),
-                            ),
-                          ),
-                      ],
-                    ),
-                  ),
-                ],
+                ),
               ),
             ),
-            const SizedBox(height: 6),
-            Row(
-              children: <Widget>[
-                for (int i = 0; i < dates.length; i++)
-                  Expanded(
-                    child: Text(
-                      i % labelStep == 0 ? '${dates[i].day}' : '',
-                      textAlign: TextAlign.center,
-                      maxLines: 1,
-                      style: const TextStyle(
-                        fontSize: 10,
-                        fontWeight: FontWeight.w600,
-                        color: AppColors.mutedForeground,
-                      ),
-                    ),
-                  ),
-              ],
-            ),
-          ],
+          ),
         ),
       ),
     );

--- a/frontend/flutter/lib/features/exercise/presentation/controllers/exercise_controller.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/controllers/exercise_controller.dart
@@ -51,6 +51,97 @@ final exercisePastWeekProvider = FutureProvider.family<ExerciseWeek, DateTime>((
   return ref.watch(exerciseRepositoryProvider).fetchWeek(weekStart);
 }, name: 'exercisePastWeek');
 
+/// `전체` 기간이 거슬러 올라가는 주 수. 12주 — 데모 픽스처가 들고 있는 기간이자
+/// 식단 `전체` 와 같은 길이다. 화면에는 한 번에 30일이 보이고 나머지는 옆으로
+/// 밀어 본다. (#1018)
+const int kExerciseAllPeriodWeeks = 12;
+
+/// `전체` 그래프의 하루치.
+class ExerciseDayBar {
+  const ExerciseDayBar({
+    required this.date,
+    required this.cardio,
+    required this.strength,
+    required this.stretching,
+    required this.minutes,
+    required this.calories,
+  });
+
+  final DateTime date;
+  final double cardio;
+  final double strength;
+  final double stretching;
+  final double minutes;
+  final double calories;
+}
+
+/// `전체` 기간의 일별 운동. 최근 [kExerciseAllPeriodWeeks] 주를 주 단위로 읽어
+/// 이어 붙인다 — 서버가 운동 이력을 주 단위로 들고 있어서다(트레이너 화면도
+/// 같은 방식으로 읽는다).
+///
+/// 이번 주만 [exerciseWeekViewProvider] 에서 가져온다. 오늘 체크한 AI 추천 운동이
+/// 더해진 값과 두 벌이 되면 같은 주가 화면마다 다른 수치를 갖는다(#671).
+final exerciseAllPeriodProvider = FutureProvider<List<ExerciseDayBar>>((
+  ref,
+) async {
+  final DateTime today = DateTime(
+    nowKst().year,
+    nowKst().month,
+    nowKst().day,
+  );
+  final DateTime thisMonday = mondayOfWeek(today);
+
+  // watch 는 await 이전에 모두 걸어 둔다 — 한 주라도 바뀌면 전체도 다시
+  // 계산되고, 요청은 순차가 아니라 한꺼번에 나간다.
+  final List<Future<ExerciseWeek>> pending = <Future<ExerciseWeek>>[
+    for (int back = kExerciseAllPeriodWeeks - 1; back >= 1; back--)
+      ref.watch(
+        exercisePastWeekProvider(
+          DateTime(
+            thisMonday.year,
+            thisMonday.month,
+            thisMonday.day - back * 7,
+          ),
+        ).future,
+      ),
+  ];
+  final List<ExerciseWeek> past = await Future.wait(pending);
+  final ExerciseWeek current = await ref.watch(exerciseWeekProvider.future);
+  final ExerciseWeek thisWeek = applyTodayBonus(
+    current,
+    ref.watch(exerciseTodayBonusProvider),
+  );
+
+  double at(List<double> xs, int i) => i < xs.length ? xs[i] : 0;
+
+  final List<ExerciseDayBar> days = <ExerciseDayBar>[];
+  for (int w = 0; w < past.length + 1; w++) {
+    final ExerciseWeek week = w < past.length ? past[w] : thisWeek;
+    final int back = kExerciseAllPeriodWeeks - 1 - w;
+    final DateTime monday = DateTime(
+      thisMonday.year,
+      thisMonday.month,
+      thisMonday.day - back * 7,
+    );
+    for (int d = 0; d < 7; d++) {
+      final DateTime date = DateTime(monday.year, monday.month, monday.day + d);
+      // 아직 오지 않은 날은 칸을 만들지 않는다 — 빈 칸이 "안 했다" 로 읽힌다.
+      if (date.isAfter(today)) break;
+      days.add(
+        ExerciseDayBar(
+          date: date,
+          cardio: at(week.cardioMinutes, d),
+          strength: at(week.strengthMinutes, d),
+          stretching: at(week.stretchingMinutes, d),
+          minutes: at(week.dailyMinutes, d),
+          calories: at(week.dailyCalories, d),
+        ),
+      );
+    }
+  }
+  return days;
+}, name: 'exerciseAllPeriod');
+
 /// Today's activity delta for one AI recommendation. Shared so the exercise
 /// tab's check and the home "주간 추이" chart read the same numbers.
 class AiRoutineDelta {

--- a/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
@@ -4,12 +4,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 // NumberFormat 만 가져온다 — intl 의 TextDirection 이 dart:ui 것과 충돌한다.
-import 'package:intl/intl.dart' show NumberFormat;
+import 'package:intl/intl.dart' show DateFormat, NumberFormat;
 import 'package:oncare/app/router/routes.dart';
 import 'package:oncare/core/config/app_config.dart';
 import 'package:oncare/core/utils/clock.dart';
 import 'package:oncare/design_system/charts/chart_reveal.dart';
 import 'package:oncare/design_system/charts/goal_line.dart';
+import 'package:oncare/design_system/charts/period_scroll_chart.dart';
 import 'package:oncare/design_system/figma/figma_kit.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
 import 'package:oncare/design_system/tokens/motion.dart';
@@ -974,6 +975,16 @@ class _ActivityStatus extends ConsumerStatefulWidget {
 }
 
 class _ActivityStatusState extends ConsumerState<_ActivityStatus> {
+  /// `전체` 그래프의 스크롤 위치와 고른 날. 머리의 숫자와 막대가 같은 상태를
+  /// 본다. (#1018)
+  final PeriodChartSelection _selection = PeriodChartSelection();
+
+  @override
+  void dispose() {
+    _selection.dispose();
+    super.dispose();
+  }
+
   /// 오늘 요일 인덱스(0=월 … 6=일)를 이번 주 범위로 클램프. 홈 주간추이와 같은
   /// 실제 오늘을 가리키도록 해, '오늘=일 고정' 문제를 없앤다.
   int _weekTodayIndex(int n) =>
@@ -1008,73 +1019,14 @@ class _ActivityStatusState extends ConsumerState<_ActivityStatus> {
     ];
   }
 
-  _Bar _monthBar(double total, int day) {
-    final double strengthRatio = day % 3 == 0 ? 0.30 : 0.20;
-    return _Bar(
-      total * 0.55,
-      total * strengthRatio,
-      total * (0.45 - strengthRatio),
-    );
-  }
-
-  _ChartPeriod _dataFor(int period) {
-    switch (period) {
-      case 2: // 이번 달 — 레퍼런스처럼 일별 막대를 촘촘하게 표시한다.
-        const List<double> dailyTotals = <double>[
-          28,
-          46,
-          72,
-          78,
-          50,
-          82,
-          38,
-          96,
-          84,
-          64,
-          52,
-          56,
-          68,
-          48,
-          36,
-          30,
-          74,
-          86,
-          80,
-          92,
-          84,
-          58,
-          12,
-          24,
-          0,
-          16,
-          38,
-          66,
-          54,
-          76,
-          34,
-        ];
-        return _ChartPeriod(
-          <_Bar>[
-            for (int day = 1; day <= dailyTotals.length; day++)
-              _monthBar(dailyTotals[day - 1], day),
-          ],
-          <String>[
-            for (int day = 1; day <= dailyTotals.length; day++)
-              if (day == 1 || day % 3 == 1 || day == dailyTotals.length)
-                '$day'
-              else
-                '',
-          ],
-          -1,
-        );
-      default: // 이번 주
-        return _ChartPeriod(
-          _weekBars(),
-          widget.week.dayLabels,
-          _weekTodayIndex(widget.week.dailyMinutes.length),
-        );
-    }
-  }
+  /// 이번 주 막대. `전체` 는 12주치를 따로 읽어 [_AllPeriodChart] 가 그린다 —
+  /// 예전에는 여기 한 달치 **하드코딩 배열**이 있어서, 화면에 보이던 한 달이
+  /// 실제 기록이 아니었다. (#1018)
+  _ChartPeriod _weekData() => _ChartPeriod(
+    _weekBars(),
+    widget.week.dayLabels,
+    _weekTodayIndex(widget.week.dailyMinutes.length),
+  );
 
   @override
   Widget build(BuildContext context) {
@@ -1108,7 +1060,7 @@ class _ActivityStatusState extends ConsumerState<_ActivityStatus> {
             Flexible(
               child: _PeriodToggle(
                 active: period,
-                labels: <String>[l.exToday, l.exThisWeek, l.exThisMonth],
+                labels: <String>[l.exToday, l.exThisWeek, l.exPeriodAll],
                 onChanged: (int i) =>
                     ref.read(exerciseActivityPeriodProvider.notifier).state = i,
               ),
@@ -1141,20 +1093,26 @@ class _ActivityStatusState extends ConsumerState<_ActivityStatus> {
               ),
             ],
           )
-        else
+        else if (period == 1)
           Builder(
             builder: (BuildContext context) {
-              final _ChartPeriod data = _dataFor(period);
+              final _ChartPeriod data = _weekData();
               return _ActivityChart(
                 bars: data.bars,
                 dayLabels: data.labels,
                 todayIndex: data.todayIndex,
                 dailyGoalMinutes: goals.minutes / 7,
-                // 주 ↔ 월 전환은 같은 위젯이 데이터만 갈아끼우므로,
+                // 주 ↔ 전체 전환은 같은 위젯이 데이터만 갈아끼우므로,
                 // 기간을 재생 키로 넘겨 막대를 다시 자라게 한다.
                 replayKey: period,
               );
             },
+          )
+        else
+          // `전체` 는 12주치를 옆으로 밀어 본다 — 한 화면에 30일 (#1018).
+          _AllPeriodChart(
+            dailyGoalMinutes: goals.minutes / 7,
+            selection: _selection,
           ),
       ],
     );
@@ -1563,7 +1521,7 @@ class _ActivityChart extends StatelessWidget {
       child: ExcludeSemantics(
         excluding: empty,
         child: Container(
-          key: bars.length > 10 ? const Key('exerciseMonthlyDailyChart') : null,
+          key: const Key('exerciseWeeklyChart'),
           padding: const EdgeInsets.all(16),
           decoration: BoxDecoration(
             color: Colors.white,
@@ -1715,6 +1673,232 @@ class _Bar {
   final double stretch;
 
   double get total => cardio + strength + stretch;
+}
+
+/// `전체` 운동 그래프 — 12주치를 옆으로 밀어 보고, 한 칸을 고르면 그날의
+/// 시간이 머리에 뜬다. (#1018)
+class _AllPeriodChart extends ConsumerWidget {
+  const _AllPeriodChart({
+    required this.dailyGoalMinutes,
+    required this.selection,
+  });
+
+  final double dailyGoalMinutes;
+  final PeriodChartSelection selection;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AppLocalizations l = AppLocalizations.of(context);
+    return ref
+        .watch(exerciseAllPeriodProvider)
+        .when(
+          loading: () => const SizedBox(
+            height: 176,
+            child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+          ),
+          error: (Object _, StackTrace _) => SizedBox(
+            height: 176,
+            child: Center(
+              child: Text(
+                l.homeExerciseTrendUnavailable,
+                style: const TextStyle(
+                  fontSize: 13,
+                  color: AppColors.mutedForeground,
+                ),
+              ),
+            ),
+          ),
+          data: (List<ExerciseDayBar> days) =>
+              _AllPeriodBody(
+                key: const Key('exerciseAllPeriodChart'),
+                days: days,
+                dailyGoalMinutes: dailyGoalMinutes,
+                selection: selection,
+              ),
+        );
+  }
+}
+
+class _AllPeriodBody extends StatelessWidget {
+  const _AllPeriodBody({
+    super.key,
+    required this.days,
+    required this.dailyGoalMinutes,
+    required this.selection,
+  });
+
+  final List<ExerciseDayBar> days;
+  final double dailyGoalMinutes;
+  final PeriodChartSelection selection;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations l = AppLocalizations.of(context);
+    if (days.isEmpty) return const SizedBox(height: 176);
+    const double chartHeight = 140;
+    final List<double> minutes = <double>[
+      for (final ExerciseDayBar d in days) d.minutes,
+    ];
+    // 축 위쪽에 여유를 둔다 — 목표선이 맨 위에 붙어 테두리처럼 보이지 않게.
+    final double peak = <double>[
+      dailyGoalMinutes,
+      ...minutes,
+    ].fold<double>(1, (double a, double b) => b > a ? b : a);
+    final double max = peak * 1.15;
+    // 30칸에 날짜를 모두 적으면 겹친다 — 몇 칸에 하나만.
+    final int labelStep = (days.length / 12).ceil().clamp(1, 7);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        ListenableBuilder(
+          listenable: selection,
+          builder: (BuildContext context, Widget? _) {
+            final int? picked = selection.selected;
+            final double value = picked == null
+                ? selection.averageOf(minutes)
+                : minutes[picked];
+            return PeriodChartHeadline(
+              selected: picked != null,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(
+                    picked == null
+                        ? l.dietPeriodAverage
+                        : DateFormat.yMd(
+                            Localizations.localeOf(context).toString(),
+                          ).format(days[picked].date),
+                    maxLines: 1,
+                    style: const TextStyle(
+                      fontSize: 12.5,
+                      fontWeight: FontWeight.w600,
+                      color: AppColors.mutedForeground,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    l.unitMinutesValue(value.round()),
+                    maxLines: 1,
+                    style: const TextStyle(
+                      fontSize: 22,
+                      fontWeight: FontWeight.w800,
+                      color: FigmaColors.ink,
+                      letterSpacing: -0.5,
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+        ),
+        const SizedBox(height: 10),
+        ListenableBuilder(
+          listenable: selection,
+          builder: (BuildContext context, Widget? _) => PeriodScrollChart(
+            count: days.length,
+            height: chartHeight,
+            selectedIndex: selection.selected,
+            onSelected: selection.select,
+            onVisibleRangeChanged: selection.setVisible,
+            goalOverlay: GoalLineOverlay(
+              visible: dailyGoalMinutes > 0,
+              bottom:
+                  chartHeight * (dailyGoalMinutes / max).clamp(0.0, 1.0),
+              label:
+                  '${l.homeGoal} '
+                  '${l.unitMinutesValue(dailyGoalMinutes.round())}',
+            ),
+            labelBuilder: (int i) =>
+                i % labelStep == 0 ? '${days[i].date.day}' : '',
+            calloutBuilder: (BuildContext context, int i) =>
+                const SizedBox.shrink(),
+            barBuilder: (BuildContext context, int i) => _StackedBarColumn(
+              bar: _Bar(
+                days[i].cardio,
+                days[i].strength,
+                days[i].stretching,
+              ),
+              max: max,
+              height: chartHeight,
+              dimmed:
+                  selection.selected != null && selection.selected != i,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// `전체` 그래프의 막대 한 칸 — 유연성(연) → 근력(진) → 유산소(브랜드) 순으로
+/// 아래에서 쌓는다. 주간 막대를 그리는 [_StackedBarPainter] 와 **같은 색·같은
+/// 순서**다. 스크롤 그래프는 칸마다 위젯이라 그림만 따로 둔다. (#1018)
+class _StackedBarColumn extends StatelessWidget {
+  const _StackedBarColumn({
+    required this.bar,
+    required this.max,
+    required this.height,
+    required this.dimmed,
+  });
+
+  final _Bar bar;
+  final double max;
+  final double height;
+
+  /// 다른 날을 골랐을 때 옅게 — 고른 날이 어느 칸인지 눈으로 짚인다.
+  final bool dimmed;
+
+  double _h(double minutes) =>
+      max <= 0 ? 0 : (minutes / max).clamp(0.0, 1.0) * height;
+
+  @override
+  Widget build(BuildContext context) {
+    final double cardio = _h(bar.cardio);
+    final double strength = _h(bar.strength);
+    final double stretch = _h(bar.stretch);
+    final double opacity = dimmed ? 0.35 : 1;
+    const Radius cap = Radius.circular(4);
+    Widget seg(double h, Color color, {bool top = false}) => Container(
+      height: h,
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: opacity),
+        borderRadius: top
+            ? const BorderRadius.vertical(top: cap)
+            : BorderRadius.zero,
+      ),
+    );
+
+    final bool cardioTop = bar.cardio > 0;
+    final bool strengthTop = !cardioTop && bar.strength > 0;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 1.5),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: <Widget>[
+          if (cardio > 0) seg(cardio, FigmaColors.primary, top: true),
+          if (strength > 0)
+            seg(strength, const Color(0xFF1B6FA8), top: strengthTop),
+          if (stretch > 0)
+            seg(
+              stretch,
+              const Color(0xFFD4EEF8),
+              top: !cardioTop && !strengthTop,
+            ),
+          // 기록이 없는 날도 자리는 남긴다 — 빈 칸이 이어지면 그 주가 통째로
+          // 사라진 것처럼 보인다.
+          if (cardio + strength + stretch <= 0)
+            Container(
+              height: 2,
+              decoration: const BoxDecoration(
+                color: FigmaColors.hairline,
+                borderRadius: BorderRadius.vertical(top: cap),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
 }
 
 class _StackedBarPainter extends CustomPainter {

--- a/frontend/flutter/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations.dart
@@ -1214,11 +1214,11 @@ abstract class AppLocalizations {
   /// **'This week'**
   String get exThisWeek;
 
-  /// No description provided for @exThisMonth.
+  /// No description provided for @exPeriodAll.
   ///
   /// In en, this message translates to:
-  /// **'This month'**
-  String get exThisMonth;
+  /// **'All'**
+  String get exPeriodAll;
 
   /// No description provided for @exExerciseContent.
   ///

--- a/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
@@ -629,7 +629,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get exThisWeek => 'This week';
 
   @override
-  String get exThisMonth => 'This month';
+  String get exPeriodAll => 'All';
 
   @override
   String get exExerciseContent => 'What you did';

--- a/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
@@ -613,7 +613,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get exThisWeek => '이번 주';
 
   @override
-  String get exThisMonth => '이번 달';
+  String get exPeriodAll => '전체';
 
   @override
   String get exExerciseContent => '운동 내용';

--- a/frontend/flutter/lib/l10n/app_en.arb
+++ b/frontend/flutter/lib/l10n/app_en.arb
@@ -301,7 +301,7 @@
   "exWeekSummary": "This Week's Summary",
   "exActivityTitle": "Activity",
   "exThisWeek": "This week",
-  "exThisMonth": "This month",
+  "exPeriodAll": "All",
   "exExerciseContent": "What you did",
   "exViewDetail": "View details",
   "exRegister": "Register",

--- a/frontend/flutter/lib/l10n/app_ko.arb
+++ b/frontend/flutter/lib/l10n/app_ko.arb
@@ -218,7 +218,7 @@
   "exWeekSummary": "이번 주 운동 요약",
   "exActivityTitle": "운동 현황",
   "exThisWeek": "이번 주",
-  "exThisMonth": "이번 달",
+  "exPeriodAll": "전체",
   "exExerciseContent": "운동 내용",
   "exViewDetail": "상세보기",
   "exRegister": "등록하기",

--- a/frontend/flutter/test/features/diet/diet_period_macro_bars_test.dart
+++ b/frontend/flutter/test/features/diet/diet_period_macro_bars_test.dart
@@ -200,7 +200,7 @@ void main() {
         .richMessage!
         .toPlainText();
 
-    testWidgets('아직 오지 않은 날과 기록 없는 날을 다르게 말한다 (#950)', (
+    testWidgets('전체 구간에는 아직 오지 않은 날이 없다 (#950, #1018)', (
       WidgetTester tester,
     ) async {
       await openMonth(tester);
@@ -208,40 +208,23 @@ void main() {
       final AppLocalizations l = AppLocalizations.of(
         tester.element(find.byType(DietRecordPage)),
       );
-      final int today = nowKst().day;
-      final int lastDay = dietRangeDates(
+      final List<DateTime> dates = dietRangeDates(
         dietRangeForTab(DietPeriodTab.month, nowKst()),
-      ).length;
+      );
 
-      // 달의 마지막 날이 아직 오지 않았다면 그 칸으로 확인한다. 오늘이 말일이면
-      // 미래 칸이 없으므로 이 단언은 건너뛴다.
-      if (lastDay > today) {
-        final String future = tipTextAt(tester, lastDay - 1);
-        expect(future, contains(l.dietPeriodNotYet));
-        // 기록할 수 없었던 날을 '기록 없음' 이라고 말하면, 한 달을 훑으며
-        // 빠뜨린 날을 셀 때 미래까지 빠뜨린 날로 세게 된다.
-        expect(future, isNot(contains(l.dietPeriodNoRecord)));
+      // 전체는 오늘로 끝나는 구간이다 — 달력 달을 그리던 때와 달리 미래 칸이
+      // 아예 없다. "기록할 수 없었던 날" 과 "기록하지 않은 날" 을 가르던
+      // 구분(#950)은 그래서 이 화면에서 쓸 일이 없어졌다.
+      expect(dates.last, DateUtils.dateOnly(nowKst()));
+      for (int i = 0; i < dates.length; i++) {
+        expect(
+          tipTextAt(tester, i),
+          isNot(contains(l.dietPeriodNotYet)),
+          reason: '${dates[i]}',
+        );
       }
-
-      // 오늘은 지나간 날이므로 미래 문구를 쓰지 않는다.
-      expect(tipTextAt(tester, today - 1), isNot(contains(l.dietPeriodNotYet)));
     });
 
-    testWidgets('아직 오지 않은 날의 막대는 빈 트랙이다 (#950)', (WidgetTester tester) async {
-      await openMonth(tester);
-
-      final int today = nowKst().day;
-      final int lastDay = dietRangeDates(
-        dietRangeForTab(DietPeriodTab.month, nowKst()),
-      ).length;
-      if (lastDay <= today) return; // 말일에는 미래 칸이 없다.
-
-      double heightAt(int index) =>
-          tester.getRect(find.byKey(Key('diet-period-bar-$index'))).height;
-
-      // 지나간 빈 날의 그루터기보다 더 옅고 낮다 — 둘이 눈으로 갈려야 한다.
-      expect(heightAt(lastDay - 1), lessThanOrEqualTo(2.5));
-    });
 
     testWidgets('막대가 탄단지 3색으로 쌓인다', (WidgetTester tester) async {
       await openMonth(tester);
@@ -285,7 +268,13 @@ void main() {
       await openMonth(tester);
 
       final Tooltip tip = tester.widget<Tooltip>(
-        find.byKey(Key('diet-period-bar-tip-${nowKst().day - 1}')),
+        // 전체는 오늘로 끝나는 구간이라 오늘은 **마지막 칸**이다 (#1018).
+        find.byKey(
+          Key(
+            'diet-period-bar-tip-'
+            '${dietRangeDates(dietRangeForTab(DietPeriodTab.month, nowKst())).length - 1}',
+          ),
+        ),
       );
       final String text = tip.richMessage!.toPlainText();
 

--- a/frontend/flutter/test/features/diet/diet_period_scroll_test.dart
+++ b/frontend/flutter/test/features/diet/diet_period_scroll_test.dart
@@ -1,0 +1,175 @@
+/// `전체` 그래프는 옆으로 밀어 보고, 한 칸을 고르면 그날의 값이 머리에 뜬다.
+/// (#1018)
+///
+/// 예전에는 한 달치를 한 화면에 욱여넣어 막대가 실처럼 얇았고, 그 앞의 기록은
+/// 볼 방법이 아예 없었다.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/core/utils/clock.dart';
+import 'package:oncare/features/account/data/repositories/mock_account_repository.dart';
+import 'package:oncare/features/account/presentation/controllers/account_controller.dart';
+import 'package:oncare/features/diet/domain/entities/diet_day.dart';
+import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
+import 'package:oncare/features/diet/presentation/pages/diet_record_page.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+import '../../helpers/fake_diet_repository.dart';
+
+/// 날마다 다른 칼로리를 주는 저장소 — 고른 날의 숫자가 평균과 갈리는지 보려면
+/// 날마다 값이 달라야 한다.
+class _VaryingDietRepository extends FakeDietRepository {
+  @override
+  Future<DietDay> fetchByDate(DateTime date) async => _dayOf(date);
+
+  @override
+  Future<DietDay> fetchToday() async => _dayOf(nowKst());
+
+  static DietDay _dayOf(DateTime date) {
+    final int calories = 1000 + date.day * 20;
+    return DietDay(
+      entries: <DietEntry>[
+        DietEntry(
+          id: 'e-${date.day}',
+          mealType: MealType.lunch,
+          timeLabel: '12:00',
+          foods: const <FoodItem>[],
+          totalCalories: calories,
+          sodiumMg: 900,
+          sugarG: 10,
+          carbsG: 100,
+          proteinG: 50,
+          fatG: 20,
+        ),
+      ],
+      totalCalories: calories,
+      totalSodiumMg: 900,
+      totalSugarG: 10,
+      macros: const DietMacros(
+        carbsPct: 50,
+        proteinPct: 30,
+        fatPct: 20,
+        carbsG: 100,
+        proteinG: 50,
+        fatG: 20,
+      ),
+      aiCoachMessage: '',
+    );
+  }
+}
+
+Widget _app() => ProviderScope(
+  overrides: <Override>[
+    dietRepositoryProvider.overrideWithValue(_VaryingDietRepository()),
+    accountRepositoryProvider.overrideWithValue(MockAccountRepository()),
+  ],
+  child: const MaterialApp(
+    locale: Locale('ko'),
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: DietRecordPage(),
+  ),
+);
+
+void main() {
+  Future<void> openAll(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(420, 1800);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(_app());
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('diet-period-tab-month')));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('전체 그래프는 가로로 스크롤된다 — 한 화면에 30일', (WidgetTester tester) async {
+    await openAll(tester);
+
+    final Finder chart = find.descendant(
+      of: find.byKey(const Key('diet-period-card')),
+      matching: find.byType(Scrollable),
+    );
+    final Iterable<Scrollable> scrollables = tester.widgetList<Scrollable>(
+      chart,
+    );
+    expect(
+      scrollables.any((Scrollable s) => s.axisDirection == AxisDirection.right),
+      isTrue,
+      reason: '전체 그래프가 옆으로 밀리지 않는다',
+    );
+
+    // 12주치가 다 들어 있다 — 화면에 30일만 보일 뿐 잘라내지 않는다.
+    final List<DateTime> dates = dietRangeDates(
+      dietRangeForTab(DietPeriodTab.month, nowKst()),
+    );
+    expect(dates.length, kDietAllPeriodDays);
+    expect(
+      find.byKey(Key('diet-period-bar-${dates.length - 1}')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('평균은 화면에 보이는 구간만 센다 — 밀면 따라 바뀐다', (
+    WidgetTester tester,
+  ) async {
+    await openAll(tester);
+
+    String headline() => tester
+        .widgetList<Text>(
+          find.descendant(
+            of: find.byKey(const Key('diet-period-card')),
+            matching: find.byType(Text),
+          ),
+        )
+        .map((Text t) => t.data ?? t.textSpan?.toPlainText() ?? '')
+        .firstWhere((String s) => s.contains('kcal'), orElse: () => '');
+
+    final String atFirst = headline();
+    expect(atFirst, isNotEmpty);
+
+    // 왼쪽(과거)으로 민다. 대역이 날마다 다른 값을 주므로 보이는 구간이 바뀌면
+    // 평균도 바뀌어야 한다.
+    final Finder horizontal = find
+        .descendant(
+          of: find.byKey(const Key('diet-period-card')),
+          matching: find.byType(Scrollable),
+        )
+        .first;
+    await tester.drag(horizontal, const Offset(600, 0));
+    await tester.pumpAndSettle();
+
+    expect(headline(), isNot(atFirst), reason: '평균이 보이는 구간을 따라가지 않는다');
+  });
+
+  testWidgets('막대를 고르면 평균 대신 그날의 값이 뜬다', (WidgetTester tester) async {
+    await openAll(tester);
+
+    final AppLocalizations l = AppLocalizations.of(
+      tester.element(find.byType(DietRecordPage)),
+    );
+    // 평소에는 평균이다.
+    expect(find.textContaining(l.dietPeriodAverage), findsWidgets);
+
+    // 오늘 칸(마지막)을 고른다.
+    final List<DateTime> dates = dietRangeDates(
+      dietRangeForTab(DietPeriodTab.month, nowKst()),
+    );
+    final Finder lastBar = find.byKey(
+      Key('diet-period-bar-${dates.length - 1}'),
+    );
+    await tester.tap(lastBar, warnIfMissed: false);
+    await tester.pumpAndSettle();
+
+    // 머리 문구가 날짜로 바뀐다 — `하루 평균` 이라고 적힌 곳이 없어야 한다.
+    expect(find.textContaining(l.dietPeriodAverage), findsNothing);
+
+    // 다시 누르면 선택이 풀리고 평균으로 돌아온다.
+    await tester.tap(lastBar, warnIfMissed: false);
+    await tester.pumpAndSettle();
+    expect(find.textContaining(l.dietPeriodAverage), findsWidgets);
+  });
+}

--- a/frontend/flutter/test/features/diet/diet_period_test.dart
+++ b/frontend/flutter/test/features/diet/diet_period_test.dart
@@ -377,41 +377,34 @@ void main() {
       expect(dietRangeDates(r).length, 7);
     });
 
-    test('12월은 다음 해로 넘어가지 않고 12월 31일에서 끝난다', () {
+    test('전체는 오늘로 끝나는 12주다 — 달이 바뀌어도 앞의 기록이 남는다', () {
+      // 예전에는 이번 달 1일~말일이었다. 달이 바뀌면 그 앞의 이야기가 통째로
+      // 사라져서, 추세를 보려고 연 화면이 매달 1일에 비었다. (#1018)
       final DietDateRange r = dietRangeForTab(
         DietPeriodTab.month,
         DateTime(2026, 12, 15),
       );
-      expect(r.from, DateTime(2026, 12));
-      expect(r.to, DateTime(2026, 12, 31));
-      expect(dietRangeDates(r).length, 31);
-    });
-
-    test('2월은 윤년 여부에 따라 28·29일이다', () {
-      expect(
-        dietRangeDates(
-          dietRangeForTab(DietPeriodTab.month, DateTime(2026, 2, 10)),
-        ).length,
-        28,
-      );
-      expect(
-        dietRangeDates(
-          dietRangeForTab(DietPeriodTab.month, DateTime(2028, 2, 10)),
-        ).length,
-        29,
-      );
-    });
-
-    test('서머타임이 시작하는 3월도 말일이 빠지지 않는다', () {
-      // 로컬 자정끼리 빼면 29일 23시간 → inDays 29 로 잘려 3월 31일이 빠졌다.
-      final DietDateRange r = dietRangeForTab(
-        DietPeriodTab.month,
-        DateTime(2026, 3, 15),
-      );
       final List<DateTime> dates = dietRangeDates(r);
-      expect(dates.length, 31);
-      expect(dates.last.day, 31);
+      expect(dates.length, kDietAllPeriodDays);
+      expect(dates.last, DateTime(2026, 12, 15));
+      expect(dates.first, DateTime(2026, 9, 23));
     });
+
+    test('전체는 달 경계·윤년과 상관없이 늘 같은 길이다', () {
+      for (final DateTime today in <DateTime>[
+        DateTime(2026, 2, 10),
+        DateTime(2028, 2, 10),
+        DateTime(2026, 3, 15),
+        DateTime(2026, 1, 2),
+      ]) {
+        final List<DateTime> dates = dietRangeDates(
+          dietRangeForTab(DietPeriodTab.month, today),
+        );
+        expect(dates.length, kDietAllPeriodDays, reason: '$today');
+        expect(dates.last, today, reason: '$today');
+      }
+    });
+
   });
 
   test('음식 배열이 비어 있으면 서버가 준 하루 합계로 떨어진다', () async {
@@ -567,7 +560,13 @@ void main() {
       );
       // 대역은 오늘·어제·그저께에만 기록을 둔다.
       final Tooltip todayTip = tester.widget<Tooltip>(
-        find.byKey(Key('diet-period-bar-tip-${nowKst().day - 1}')),
+        // 전체는 오늘로 끝나는 구간이라 오늘은 **마지막 칸**이다 (#1018).
+        find.byKey(
+          Key(
+            'diet-period-bar-tip-'
+            '${dietRangeDates(dietRangeForTab(DietPeriodTab.month, nowKst())).length - 1}',
+          ),
+        ),
       );
       final String text = todayTip.richMessage!.toPlainText();
       // 지표 이름과 단위가 카드 머리 숫자와 같은 말로 적혀야 한다.
@@ -600,10 +599,18 @@ void main() {
       final AppLocalizations l = AppLocalizations.of(
         tester.element(find.byType(DietRecordPage)),
       );
-      final Tooltip first = tester.widget<Tooltip>(
-        find.byKey(const Key('diet-period-bar-tip-0')),
+      // 홀수 날에 기록이 없다. 전체는 오늘로 끝나는 구간이라 0번 칸이 무슨
+      // 날인지 고정돼 있지 않으므로, 비어 있는 날을 날짜로 찾는다. (#1018)
+      final List<DateTime> dates = dietRangeDates(
+        dietRangeForTab(DietPeriodTab.month, nowKst()),
       );
-      expect(first.richMessage!.toPlainText(), contains(l.dietPeriodNoRecord));
+      final int emptyIndex = dates.indexWhere(
+        (DateTime d) => d.day.isOdd,
+      );
+      final Tooltip empty = tester.widget<Tooltip>(
+        find.byKey(Key('diet-period-bar-tip-$emptyIndex')),
+      );
+      expect(empty.richMessage!.toPlainText(), contains(l.dietPeriodNoRecord));
     });
   });
 }

--- a/frontend/flutter/test/features/exercise/exercise_chart_animation_test.dart
+++ b/frontend/flutter/test/features/exercise/exercise_chart_animation_test.dart
@@ -146,34 +146,23 @@ void main() {
     expect(ink[2], greaterThan(ink[1]), reason: '막대가 끝까지 자라지 않았다');
   });
 
-  testWidgets('이번 주 ↔ 이번 달 전환은 막대 애니메이션을 다시 재생한다', (WidgetTester tester) async {
+  testWidgets('전체로 바꾸면 자라는 애니메이션 대신 스크롤 그래프가 온다 (#1018)', (
+    WidgetTester tester,
+  ) async {
     await pumpExercise(tester);
     await tester.tap(find.text('이번 주'));
     await tester.pumpAndSettle();
 
-    ChartReveal reveal() =>
-        tester.widget<ChartReveal>(find.byType(ChartReveal).first);
+    // 이번 주는 지금처럼 막대가 바닥에서 자란다.
+    expect(find.byType(ChartReveal), findsWidgets);
 
-    final Object? weekly = reveal().replayKey;
-    expect(weekly, isNotNull, reason: '기간을 재생 키로 넘기지 않고 있다');
-
-    await tester.tap(find.text('이번 달'));
-    await tester.pump();
-    expect(reveal().replayKey, isNot(weekly));
-
-    const Size size = Size(600, 150);
-    final CustomPainter atStart = chartPainter(tester);
-    await tester.pump(const Duration(milliseconds: 350));
-    final CustomPainter midway = chartPainter(tester);
-
-    final List<int> ink = (await tester.runAsync(() async {
-      return <int>[
-        await painterInk(atStart, size),
-        await painterInk(midway, size),
-      ];
-    }))!;
-    expect(ink[1], greaterThan(ink[0]), reason: '월간 막대가 다시 자라지 않았다');
-
+    await tester.tap(find.text('전체'));
     await tester.pumpAndSettle();
+
+    // 전체는 12주치를 옆으로 밀어 보는 그래프다. 스크롤하는 그래프에서 막대가
+    // 매번 자라 오르면 민 자리마다 다시 애니메이션이 돌아 읽기 어렵다 —
+    // 여기서는 자라지 않는다.
+    expect(find.byKey(const Key('exerciseAllPeriodChart')), findsOneWidget);
+    expect(tester.takeException(), isNull);
   });
 }

--- a/frontend/flutter/test/widget_test.dart
+++ b/frontend/flutter/test/widget_test.dart
@@ -402,7 +402,7 @@ void main() {
     expect(find.text('MY'), findsAtLeastNWidgets(1));
   });
 
-  testWidgets('Monthly exercise status uses the daily bar chart', (
+  testWidgets('전체 기간 운동 현황은 스크롤 막대 그래프다 (#1018)', (
     tester,
   ) async {
     await pumpApp(tester, locale: const Locale('en'));
@@ -413,12 +413,12 @@ void main() {
     );
     await tester.tap(exerciseDestination);
     await tester.pumpAndSettle();
-    final monthlyToggle = find.text('This month');
+    final monthlyToggle = find.text('All');
     await tester.ensureVisible(monthlyToggle);
     await tester.tap(monthlyToggle);
     await tester.pumpAndSettle();
 
-    expect(find.byKey(const Key('exerciseMonthlyDailyChart')), findsOneWidget);
+    expect(find.byKey(const Key('exerciseAllPeriodChart')), findsOneWidget);
     expect(tester.takeException(), isNull);
   });
 
@@ -489,12 +489,12 @@ void main() {
 
     // 회귀: '이번 달'만 하드코딩돼 있어 영어 로케일에서 "Today / This week /
     // 이번 달" 처럼 한 토글 안에 두 언어가 섞였다.
-    expect(en.exThisMonth, 'This month');
-    expect(ko.exThisMonth, '이번 달');
+    expect(en.exPeriodAll, 'All');
+    expect(ko.exPeriodAll, '전체');
     for (final String s in <String>[
       en.exToday,
       en.exThisWeek,
-      en.exThisMonth,
+      en.exPeriodAll,
     ]) {
       expect(hangul.hasMatch(s), isFalse);
     }
@@ -660,20 +660,20 @@ void main() {
     await tester.tap(exerciseDestination);
     await tester.pumpAndSettle();
 
-    // 이번 달로 바꾼다 — 이번 달 뷰에만 붙는 키로 전환 여부를 확인한다.
-    final monthlyToggle = find.text('이번 달');
+    // 전체로 바꾼다 — 전체 뷰에만 붙는 키로 전환 여부를 확인한다.
+    final monthlyToggle = find.text('전체');
     await tester.ensureVisible(monthlyToggle);
     await tester.tap(monthlyToggle);
     await tester.pumpAndSettle();
-    expect(find.byKey(const Key('exerciseMonthlyDailyChart')), findsOneWidget);
+    expect(find.byKey(const Key('exerciseAllPeriodChart')), findsOneWidget);
 
     await tester.tap(find.text('MY').first);
     await tester.pumpAndSettle();
     await tester.tap(exerciseDestination);
     await tester.pumpAndSettle();
 
-    // 기본값(이번 주)으로 복원 — 이번 달 전용 차트가 더 이상 보이지 않는다.
-    expect(find.byKey(const Key('exerciseMonthlyDailyChart')), findsNothing);
+    // 기본값(이번 주)으로 복원 — 전체 전용 차트가 더 이상 보이지 않는다.
+    expect(find.byKey(const Key('exerciseAllPeriodChart')), findsNothing);
   });
 
   testWidgets('운동 탭 재진입 후에도 저장된 운동 기록·트레이너 프로그램은 유지된다 (#861)', (tester) async {

--- a/frontend/flutter_trainer/lib/features/clients/domain/entities/client_period.dart
+++ b/frontend/flutter_trainer/lib/features/clients/domain/entities/client_period.dart
@@ -26,6 +26,10 @@ typedef ClientDateRange = ({DateTime from, DateTime to});
 /// 서머타임이 있는 지역에서 주 전체가 하루씩 밀린다. `DateTime(y, m + 1, 0)` 은
 /// 12월이면 다음 해 1월 0일 = 12월 31일로 알아서 넘어간다. 회원 앱
 /// `dietRangeForTab` 과 같은 규칙이다.
+/// `전체` 가 거슬러 올라가는 날 수. 회원 앱과 같은 12주다 — 두 앱이 같은 기간을
+/// 보여야 나란히 놓고 이야기할 수 있다. (#1018)
+const int kClientAllPeriodDays = 84;
+
 ClientDateRange clientRangeFor(ClientPeriod period, DateTime today) {
   final DateTime day = DateTime(today.year, today.month, today.day);
   switch (period) {
@@ -42,9 +46,15 @@ ClientDateRange clientRangeFor(ClientPeriod period, DateTime today) {
         to: DateTime(monday.year, monday.month, monday.day + 6),
       );
     case ClientPeriod.month:
+      // `이번 달` 이 아니라 `전체` 다 — 달이 바뀌었다고 앞의 기록이 사라지면
+      // 추세를 볼 수 없다. 회원 앱 `dietRangeForTab` 과 같은 길이다. (#1018)
       return (
-        from: DateTime(day.year, day.month),
-        to: DateTime(day.year, day.month + 1, 0),
+        from: DateTime(
+          day.year,
+          day.month,
+          day.day - kClientAllPeriodDays + 1,
+        ),
+        to: day,
       );
   }
 }

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_diet_period_card.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_diet_period_card.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart' show DateFormat;
 
 import 'package:oncare_trainer/core/utils/clock.dart';
 import 'package:oncare_trainer/core/utils/number_format.dart';
@@ -18,6 +19,7 @@ import 'package:oncare_trainer/shared/widgets/activity_charts.dart';
 import 'package:oncare_trainer/shared/widgets/chart_semantics.dart';
 import 'package:oncare_trainer/shared/widgets/goal_line.dart';
 import 'package:oncare_trainer/shared/widgets/metric_trend_chart.dart';
+import 'package:oncare_trainer/shared/widgets/period_scroll_chart.dart';
 import 'package:oncare_trainer/shared/widgets/section_card.dart';
 
 /// 고객의 기간 영양 추이 — 회원 앱 식단 탭 기간 뷰와 **같은 것**을 트레이너에게.
@@ -49,6 +51,15 @@ enum _Metric { calories, sodium, sugar }
 
 class _ClientDietPeriodCardState extends ConsumerState<ClientDietPeriodCard> {
   _Metric _metric = _Metric.calories;
+
+  /// `전체` 그래프의 스크롤 위치와 고른 날. (#1018)
+  final PeriodChartSelection _selection = PeriodChartSelection();
+
+  @override
+  void dispose() {
+    _selection.dispose();
+    super.dispose();
+  }
 
   String _label(AppLocalizations l, _Metric m) => switch (m) {
     _Metric.calories => l.metricCalories,
@@ -124,9 +135,14 @@ class _ClientDietPeriodCardState extends ConsumerState<ClientDietPeriodCard> {
                 icon: Icons.restaurant_outlined,
               )
             : _Body(
+                selection: _selection,
                 period: period,
                 metric: _metric,
-                onMetric: (_Metric m) => setState(() => _metric = m),
+                onMetric: (_Metric m) {
+                  // 지표를 바꾸면 고른 날의 숫자는 뜻을 잃는다 — 같이 푼다.
+                  _selection.reset();
+                  setState(() => _metric = m);
+                },
                 label: _label(l, _metric),
                 unit: _unit(_metric),
                 average: _averageOf(period, _metric),
@@ -193,6 +209,7 @@ class _Body extends StatelessWidget {
     required this.metricLabel,
     required this.weekly,
     required this.ticks,
+    required this.selection,
     this.days,
   });
 
@@ -220,10 +237,15 @@ class _Body extends StatelessWidget {
   /// 어긋나지 않는다.
   final List<double> ticks;
 
+  /// `전체` 그래프의 스크롤·선택 상태. 머리의 숫자가 이걸 보고 평균과 하루
+  /// 값을 오간다. (#1018)
+  final PeriodChartSelection selection;
+
   @override
   Widget build(BuildContext context) {
     final AppLocalizations l = AppLocalizations.of(context);
-    final bool over = goal > 0 && average > goal;
+    // 이번 주(꺾은선)는 스크롤도 선택도 없다 — 일곱 칸이 이미 한 화면이다.
+    final bool selectable = !weekly;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: <Widget>[
@@ -246,46 +268,66 @@ class _Body extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
             Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  Text(
-                    '${l.clientPeriodAverage} · $label',
-                    style: const TextStyle(
-                      fontSize: 10.5,
-                      fontWeight: FontWeight.w600,
-                      color: AppColors.subtleForeground,
-                    ),
-                  ),
-                  const SizedBox(height: 3),
-                  FittedBox(
-                    fit: BoxFit.scaleDown,
-                    alignment: Alignment.centerLeft,
-                    child: Text.rich(
-                      TextSpan(
-                        text: format(average),
-                        style: TextStyle(
-                          fontSize: 20,
-                          fontWeight: FontWeight.w800,
-                          color: over
-                              ? AppColors.overTarget
-                              : AppColors.foreground,
-                        ),
-                        children: <InlineSpan>[
-                          TextSpan(
-                            text: ' / ${format(goal)} $unit',
-                            style: const TextStyle(
-                              fontSize: 11,
-                              fontWeight: FontWeight.w600,
-                              color: AppColors.mutedForeground,
-                            ),
+              child: ListenableBuilder(
+                listenable: selection,
+                builder: (BuildContext context, Widget? _) {
+                  final int? picked = selectable ? selection.selected : null;
+                  // 평소에는 **보이는 구간의** 평균, 날을 고르면 그날의 값.
+                  // 보이지 않는 날까지 섞은 평균은 지금 화면을 설명하지
+                  // 못한다. (#1018)
+                  final double value = picked == null
+                      ? (selectable ? selection.averageOf(values) : average)
+                      : values[picked];
+                  final bool over = goal > 0 && value > goal;
+                  return PeriodChartHeadline(
+                    selected: picked != null,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Text(
+                          picked == null
+                              ? '${l.clientPeriodAverage} · $label'
+                              : '${DateFormat.yMd(Localizations.localeOf(context).toString()).format(dates[picked])} · $label',
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: const TextStyle(
+                            fontSize: 10.5,
+                            fontWeight: FontWeight.w600,
+                            color: AppColors.subtleForeground,
                           ),
-                        ],
-                      ),
-                      maxLines: 1,
+                        ),
+                        const SizedBox(height: 3),
+                        FittedBox(
+                          fit: BoxFit.scaleDown,
+                          alignment: Alignment.centerLeft,
+                          child: Text.rich(
+                            TextSpan(
+                              text: format(value),
+                              style: TextStyle(
+                                fontSize: 20,
+                                fontWeight: FontWeight.w800,
+                                color: over
+                                    ? AppColors.overTarget
+                                    : AppColors.foreground,
+                              ),
+                              children: <InlineSpan>[
+                                TextSpan(
+                                  text: ' / ${format(goal)} $unit',
+                                  style: const TextStyle(
+                                    fontSize: 11,
+                                    fontWeight: FontWeight.w600,
+                                    color: AppColors.mutedForeground,
+                                  ),
+                                ),
+                              ],
+                            ),
+                            maxLines: 1,
+                          ),
+                        ),
+                      ],
                     ),
-                  ),
-                ],
+                  );
+                },
               ),
             ),
             const SizedBox(width: AppSpacing.sm),
@@ -343,6 +385,7 @@ class _Body extends StatelessWidget {
             unit: unit,
             label: label,
             format: format,
+            selection: selection,
             days: days,
           ),
           // 쌓은 색이 무엇을 뜻하는지는 범례가 말한다 — 툴팁은 올려야 보인다.
@@ -404,6 +447,7 @@ class _PeriodBars extends StatelessWidget {
     required this.unit,
     required this.label,
     required this.format,
+    required this.selection,
     this.days,
   });
 
@@ -418,11 +462,29 @@ class _PeriodBars extends StatelessWidget {
   /// 칼로리를 볼 때의 원본. 탄단지가 있는 날은 막대를 셋으로 쌓는다.
   final List<ClientDietDay>? days;
 
+  /// 스크롤 위치와 고른 날. 카드 머리의 숫자가 같은 상태를 본다. (#1018)
+  final PeriodChartSelection selection;
+
   /// [i] 번째 칸의 원본. 칼로리를 보고 있지 않으면 null 이다.
   ClientDietDay? _dayAt(int i) {
     final List<ClientDietDay>? source = days;
     if (source == null || i >= source.length) return null;
     return source[i];
+  }
+
+  String _tip(AppLocalizations l, int i) {
+    final DateTime at = dates[i];
+    final String date = '${at.month}/${at.day}';
+    if (!logged[i]) return '$date · ${l.chartNoRecord}';
+    final String head = '$date · $label ${format(values[i])} $unit';
+    // 칼로리 뒤에는 그 칼로리가 어디서 왔는지를 적는다 — 숫자 하나만 보고는
+    // 같은 2,000kcal 이 밥에서 왔는지 기름에서 왔는지 알 수 없다.
+    final ClientDietDay? d = _dayAt(i);
+    if (d == null || !d.hasMacros) return head;
+    return '$head'
+        '\n${l.metricCarbs} ${format(d.carbsG)}g'
+        '  ${l.metricProtein} ${format(d.proteinG)}g'
+        '  ${l.metricFat} ${format(d.fatG)}g';
   }
 
   @override
@@ -450,99 +512,57 @@ class _PeriodBars extends StatelessWidget {
           : null,
       child: ExcludeSemantics(
         excluding: empty,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            SizedBox(
-              height: chartHeight,
-              child: Stack(
-                children: <Widget>[
-                  // 가로선은 목표선 하나뿐이다 (#1015). 실선 하나로 그리던 때는
-                  // 축처럼 보여, 목표를 넘겼는지가 선에서 읽히지 않았다.
-                  GoalLineOverlay(
-                    visible: hasGoal,
-                    bottom: chartHeight * (goal / maxValue).clamp(0.0, 1.0),
-                    label: '${l.clientPeriodGoal} ${format(goal)}',
-                  ),
-                  Row(
-                    crossAxisAlignment: CrossAxisAlignment.end,
-                    children: <Widget>[
-                      for (int i = 0; i < values.length; i++)
-                        Expanded(
-                          child: Padding(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 1.5,
-                            ),
-                            // 툴팁은 올려야 보인다. 같은 내용을 시맨틱 라벨로도
-                            // 준다 — 막대 하나가 며칠 얼마인지는 이 노드 말고는
-                            // 음성 안내에 나올 데가 없다(#972).
-                            child: Semantics(
-                              label: _tip(l, i)
-                                  .split('\n')
-                                  .map((String s) => s.trim())
-                                  .join(', '),
-                              child: Tooltip(
-                                key: Key('client-diet-bar-$i'),
-                                message: _tip(l, i),
-                                child: _MacroBar(
-                                  height:
-                                      chartHeight *
-                                      (values[i] / maxValue).clamp(0.0, 1.0),
-                                  day: _dayAt(i),
-                                  logged: logged[i],
-                                  // 목표를 넘긴 날은 한 색(경고)으로 칠한다. 쌓은
-                                  // 막대까지 빨갛게 물들이면 무엇이 얼마인지가
-                                  // 사라지므로, 탄단지가 있는 날은 쌓은 색을 지키고
-                                  // 초과는 목표선과 툴팁이 말한다.
-                                  over: hasGoal && values[i] > goal,
-                                ),
-                              ),
-                            ),
-                          ),
-                        ),
-                    ],
-                  ),
-                ],
-              ),
+        child: ListenableBuilder(
+          listenable: selection,
+          builder: (BuildContext context, Widget? _) => PeriodScrollChart(
+            count: values.length,
+            height: chartHeight,
+            selectedIndex: selection.selected,
+            onSelected: selection.select,
+            onVisibleRangeChanged: selection.setVisible,
+            goalOverlay: GoalLineOverlay(
+              visible: hasGoal,
+              bottom: chartHeight * (goal / maxValue).clamp(0.0, 1.0),
+              label: '${l.clientPeriodGoal} ${format(goal)}',
             ),
-            const SizedBox(height: 5),
-            Row(
-              children: <Widget>[
-                for (int i = 0; i < dates.length; i++)
-                  Expanded(
-                    child: Text(
-                      i % labelStep == 0 ? '${dates[i].day}' : '',
-                      textAlign: TextAlign.center,
-                      maxLines: 1,
-                      style: const TextStyle(
-                        fontSize: 9.5,
-                        fontWeight: FontWeight.w600,
-                        color: AppColors.mutedForeground,
-                      ),
+            labelBuilder: (int i) =>
+                i % labelStep == 0 ? '${dates[i].day}' : '',
+            calloutBuilder: (BuildContext context, int i) =>
+                const SizedBox.shrink(),
+            barBuilder: (BuildContext context, int i) => Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 1.5),
+              // 툴팁은 올려야 보인다. 같은 내용을 시맨틱 라벨로도 준다 — 막대
+              // 하나가 며칠 얼마인지는 이 노드 말고는 음성 안내에 나올 데가
+              // 없다(#972).
+              child: Semantics(
+                label: _tip(
+                  l,
+                  i,
+                ).split('\n').map((String s) => s.trim()).join(', '),
+                child: Tooltip(
+                  key: Key('client-diet-bar-$i'),
+                  message: _tip(l, i),
+                  child: Align(
+                    alignment: Alignment.bottomCenter,
+                    child: _MacroBar(
+                      height:
+                          chartHeight *
+                          (values[i] / maxValue).clamp(0.0, 1.0),
+                      day: _dayAt(i),
+                      logged: logged[i],
+                      // 목표를 넘긴 날은 한 색(경고)으로 칠한다. 쌓은 막대까지
+                      // 빨갛게 물들이면 무엇이 얼마인지가 사라지므로, 탄단지가
+                      // 있는 날은 쌓은 색을 지키고 초과는 목표선과 툴팁이 말한다.
+                      over: hasGoal && values[i] > goal,
                     ),
                   ),
-              ],
+                ),
+              ),
             ),
-          ],
+          ),
         ),
       ),
     );
-  }
-
-  /// 막대 하나의 툴팁 — 어느 막대가 며칠인지는 x축 라벨만으로 짚을 수 없다.
-  String _tip(AppLocalizations l, int i) {
-    final DateTime at = dates[i];
-    final String date = '${at.month}/${at.day}';
-    if (!logged[i]) return '$date · ${l.chartNoRecord}';
-    final String head = '$date · $label ${format(values[i])} $unit';
-    // 칼로리 뒤에는 그 칼로리가 어디서 왔는지를 적는다 — 숫자 하나만 보고는
-    // 같은 2,000kcal 이 밥에서 왔는지 기름에서 왔는지 알 수 없다.
-    final ClientDietDay? d = _dayAt(i);
-    if (d == null || !d.hasMacros) return head;
-    return '$head'
-        '\n${l.metricCarbs} ${format(d.carbsG)}g'
-        '  ${l.metricProtein} ${format(d.proteinG)}g'
-        '  ${l.metricFat} ${format(d.fatG)}g';
   }
 }
 

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_exercise_status_card.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_exercise_status_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart' show DateFormat;
 
 import 'package:oncare_trainer/core/utils/clock.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
@@ -11,6 +12,7 @@ import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
 import 'package:oncare_trainer/shared/widgets/action_button.dart';
 import 'package:oncare_trainer/shared/widgets/activity_charts.dart';
+import 'package:oncare_trainer/shared/widgets/period_scroll_chart.dart';
 import 'package:oncare_trainer/shared/widgets/section_card.dart';
 
 /// 고객 운동 현황 — 회원 앱 운동 탭 `운동 현황` 과 **같은 그림**이다. (#943)
@@ -123,41 +125,88 @@ class _Today extends StatelessWidget {
   }
 }
 
-class _Range extends StatelessWidget {
+class _Range extends StatefulWidget {
   const _Range({required this.period});
 
   final ClientExercisePeriod period;
 
   @override
+  State<_Range> createState() => _RangeState();
+}
+
+class _RangeState extends State<_Range> {
+  /// `전체` 그래프의 스크롤 위치와 고른 날. 위의 요약 숫자가 이걸 따라간다 —
+  /// 보이지 않는 날까지 더한 합계는 지금 화면을 설명하지 못한다. (#1018)
+  final PeriodChartSelection _selection = PeriodChartSelection();
+
+  @override
+  void dispose() {
+    _selection.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final AppLocalizations l = AppLocalizations.of(context);
+    final ClientExercisePeriod period = widget.period;
     final List<ClientExerciseDay> days = period.days;
     final bool monthly = days.length > 10;
     return Column(
       children: <Widget>[
-        Row(
-          children: <Widget>[
-            Expanded(
-              child: _SummaryMetric(
-                label: l.clientTrendWorkoutDays,
-                value: l.clientTrendWorkoutDaysValue(period.workoutDays),
-              ),
-            ),
-            Expanded(
-              child: _SummaryMetric(
-                label: l.clientTrendWorkoutMinutes,
-                value: '${period.totalMinutes}',
-                unit: l.unitMinutes,
-              ),
-            ),
-            Expanded(
-              child: _SummaryMetric(
-                label: l.clientTrendCaloriesBurned,
-                value: '${period.totalCalories}',
-                unit: l.unitKcal,
-              ),
-            ),
-          ],
+        ListenableBuilder(
+          listenable: _selection,
+          builder: (BuildContext context, Widget? _) {
+            // 전체가 아니면 지금까지처럼 기간 전체의 합계다.
+            final int? picked = monthly ? _selection.selected : null;
+            final (int first, int last) = monthly
+                ? (_selection.visible ?? (0, days.length - 1))
+                : (0, days.length - 1);
+            final Iterable<ClientExerciseDay> shown = picked != null
+                ? <ClientExerciseDay>[days[picked]]
+                : days.sublist(
+                    first.clamp(0, days.length),
+                    (last + 1).clamp(0, days.length),
+                  );
+            final int workoutDays = shown
+                .where((ClientExerciseDay d) => d.logged)
+                .length;
+            final int minutes = shown.fold<int>(
+              0,
+              (int a, ClientExerciseDay d) => a + d.minutes,
+            );
+            final int calories = shown.fold<int>(
+              0,
+              (int a, ClientExerciseDay d) => a + d.calories,
+            );
+            return Row(
+              children: <Widget>[
+                Expanded(
+                  child: _SummaryMetric(
+                    label: picked == null
+                        ? l.clientTrendWorkoutDays
+                        : DateFormat.yMd(
+                            Localizations.localeOf(context).toString(),
+                          ).format(days[picked].date),
+                    value: l.clientTrendWorkoutDaysValue(workoutDays),
+                  ),
+                ),
+                Expanded(
+                  child: _SummaryMetric(
+                    label: l.clientTrendWorkoutMinutes,
+                    value: '$minutes',
+                    unit: l.unitMinutes,
+                  ),
+                ),
+                Expanded(
+                  child: _SummaryMetric(
+                    label: l.clientTrendCaloriesBurned,
+                    value: '$calories',
+                    unit: l.unitKcal,
+                  ),
+                ),
+              ],
+            );
+          },
         ),
         const SizedBox(height: AppSpacing.md),
         ActivityBarChart(
@@ -165,6 +214,11 @@ class _Range extends StatelessWidget {
           // 회원이 세운 주간 목표를 하루로 나눈 값 — 회원 앱 그래프와 같은
           // 선이 그려진다. (#1015)
           dailyGoalMinutes: period.dailyGoalMinutes,
+          // 전체만 옆으로 밀어 본다 — 주간은 일곱 칸이 이미 한 화면이다.
+          selection: monthly ? _selection : null,
+          dates: <DateTime>[
+            for (final ClientExerciseDay d in days) d.date,
+          ],
           bars: <ActivityBar>[
             for (final ClientExerciseDay d in days)
               if (d.hasTypeSplit)

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
@@ -2063,7 +2063,7 @@ abstract class AppLocalizations {
   /// No description provided for @clientPeriodMonth.
   ///
   /// In en, this message translates to:
-  /// **'This month'**
+  /// **'All'**
   String get clientPeriodMonth;
 
   /// No description provided for @clientPeriodAverage.

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
@@ -1129,7 +1129,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get clientPeriodWeek => 'This week';
 
   @override
-  String get clientPeriodMonth => 'This month';
+  String get clientPeriodMonth => 'All';
 
   @override
   String get clientPeriodAverage => 'Daily average';

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
@@ -1082,7 +1082,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get clientPeriodWeek => '이번 주';
 
   @override
-  String get clientPeriodMonth => '이번 달';
+  String get clientPeriodMonth => '전체';
 
   @override
   String get clientPeriodAverage => '하루 평균';

--- a/frontend/flutter_trainer/lib/l10n/app_en.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_en.arb
@@ -579,7 +579,7 @@
   },
   "clientPeriodToday": "Today",
   "clientPeriodWeek": "This week",
-  "clientPeriodMonth": "This month",
+  "clientPeriodMonth": "All",
   "clientPeriodAverage": "Daily average",
   "clientPeriodGoal": "Goal",
   "clientPeriodLoggedDays": "{days, plural, =1{1 day logged} other{{days} days logged}}",

--- a/frontend/flutter_trainer/lib/l10n/app_ko.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_ko.arb
@@ -349,7 +349,7 @@
   "clientTrendWorkoutDaysValue": "{days}일",
   "clientPeriodToday": "오늘",
   "clientPeriodWeek": "이번 주",
-  "clientPeriodMonth": "이번 달",
+  "clientPeriodMonth": "전체",
   "clientPeriodAverage": "하루 평균",
   "clientPeriodGoal": "목표",
   "clientPeriodLoggedDays": "{days}일 기록",

--- a/frontend/flutter_trainer/lib/shared/widgets/activity_charts.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/activity_charts.dart
@@ -29,6 +29,7 @@ import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 import 'package:oncare_trainer/shared/widgets/chart_semantics.dart';
 import 'package:oncare_trainer/shared/widgets/goal_line.dart';
+import 'package:oncare_trainer/shared/widgets/period_scroll_chart.dart';
 
 /// 도넛 한 조각 / 범례 한 줄.
 class ActivitySeg {
@@ -268,6 +269,8 @@ class ActivityBarChart extends StatelessWidget {
     required this.todayIndex,
     required this.title,
     this.dailyGoalMinutes = 0,
+    this.selection,
+    this.dates,
   });
 
   final List<ActivityBar> bars;
@@ -276,6 +279,13 @@ class ActivityBarChart extends StatelessWidget {
   /// 하루 목표 운동 시간(분). 0 이면 목표선을 그리지 않는다. 가로선은 이
   /// 목표선 하나뿐이다 — 눈금선은 지웠다. (#1015)
   final double dailyGoalMinutes;
+
+  /// 있으면 `전체` 모양 — 옆으로 밀어 보고 한 칸을 고를 수 있다. 없으면 이번
+  /// 주 모양(일곱 칸이 한 화면)이다. (#1018)
+  final PeriodChartSelection? selection;
+
+  /// 칸마다의 날짜. `전체` 에서 축 라벨과 고른 날 표시에 쓴다.
+  final List<DateTime>? dates;
 
   /// 그래프가 무엇을 그린 것인지 — 기록이 하나도 없는 기간에 비어 있다고
   /// 말할 때 이 이름으로 부른다(#972).
@@ -339,6 +349,29 @@ class ActivityBarChart extends StatelessWidget {
     // 한 칸도 기록이 없는 기간은 막대마다 `기록 없음` 을 서른 번 읽히는 대신
     // 비어 있다고 한 번만 말한다(#972).
     final bool empty = bars.every((ActivityBar b) => b.total <= 0);
+    final PeriodChartSelection? selection = this.selection;
+    if (selection != null) {
+      // `전체` — 12주치를 옆으로 밀어 본다. 한 화면에 30일. (#1018)
+      return Semantics(
+        container: true,
+        label: empty
+            ? chartSemanticsLabel(l, title: title, points: const <String>[])
+            : null,
+        child: ExcludeSemantics(
+          excluding: empty,
+          child: _ScrollingBars(
+            bars: bars,
+            dates: dates ?? const <DateTime>[],
+            dailyGoalMinutes: dailyGoalMinutes,
+            selection: selection,
+            tipSpans: (int i) => _tipSpans(l, i),
+            goalLabel:
+                '${l.clientPeriodGoal} '
+                '${dailyGoalMinutes.round()}${l.unitMinutes}',
+          ),
+        ),
+      );
+    }
     return Semantics(
       container: true,
       label: empty
@@ -473,6 +506,138 @@ class ActivityLegend extends StatelessWidget {
       ),
     ],
   );
+}
+
+/// `전체` 모양의 막대 — 스크롤 안에서 칸마다 위젯으로 그린다. 주간 막대를
+/// 그리는 [_StackedBarPainter] 와 **같은 색·같은 순서**다. (#1018)
+class _ScrollingBars extends StatelessWidget {
+  const _ScrollingBars({
+    required this.bars,
+    required this.dates,
+    required this.dailyGoalMinutes,
+    required this.selection,
+    required this.tipSpans,
+    required this.goalLabel,
+  });
+
+  final List<ActivityBar> bars;
+  final List<DateTime> dates;
+  final double dailyGoalMinutes;
+  final PeriodChartSelection selection;
+  final List<InlineSpan> Function(int i) tipSpans;
+  final String goalLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    const double chartHeight = 150;
+    final double peak = <double>[
+      dailyGoalMinutes,
+      for (final ActivityBar b in bars) b.total,
+    ].fold<double>(1, (double a, double b) => math.max(a, b));
+    final double max = peak * 1.15;
+    final int labelStep = (bars.length / 12).ceil().clamp(1, 7);
+
+    return ListenableBuilder(
+      listenable: selection,
+      builder: (BuildContext context, Widget? _) => PeriodScrollChart(
+        count: bars.length,
+        height: chartHeight,
+        selectedIndex: selection.selected,
+        onSelected: selection.select,
+        onVisibleRangeChanged: selection.setVisible,
+        goalOverlay: GoalLineOverlay(
+          visible: dailyGoalMinutes > 0,
+          bottom: chartHeight * (dailyGoalMinutes / max).clamp(0.0, 1.0),
+          label: goalLabel,
+        ),
+        labelBuilder: (int i) => i < dates.length && i % labelStep == 0
+            ? '${dates[i].day}'
+            : '',
+        calloutBuilder: (BuildContext context, int i) =>
+            const SizedBox.shrink(),
+        barBuilder: (BuildContext context, int i) => Tooltip(
+          key: Key('client-exercise-bar-$i'),
+          richMessage: TextSpan(
+            style: const TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              color: AppColors.foreground,
+              height: 1.35,
+            ),
+            children: tipSpans(i),
+          ),
+          child: _ActivityBarColumn(
+            bar: bars[i],
+            max: max,
+            height: chartHeight,
+            dimmed: selection.selected != null && selection.selected != i,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// 한 칸 — 유연성(연) → 근력(진) → 유산소(브랜드) 순으로 아래에서 쌓는다.
+class _ActivityBarColumn extends StatelessWidget {
+  const _ActivityBarColumn({
+    required this.bar,
+    required this.max,
+    required this.height,
+    required this.dimmed,
+  });
+
+  final ActivityBar bar;
+  final double max;
+  final double height;
+  final bool dimmed;
+
+  double _h(double minutes) =>
+      max <= 0 ? 0 : (minutes / max).clamp(0.0, 1.0) * height;
+
+  @override
+  Widget build(BuildContext context) {
+    final double opacity = dimmed ? 0.35 : 1;
+    const Radius cap = Radius.circular(4);
+    Widget seg(double h, Color color, {bool top = false}) => Container(
+      height: h,
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: opacity),
+        borderRadius: top
+            ? const BorderRadius.vertical(top: cap)
+            : BorderRadius.zero,
+      ),
+    );
+
+    final bool cardioTop = bar.cardio > 0;
+    final bool strengthTop = !cardioTop && bar.strength > 0;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 1.5),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: <Widget>[
+          if (bar.cardio > 0)
+            seg(_h(bar.cardio), AppColors.chartCardio, top: true),
+          if (bar.strength > 0)
+            seg(_h(bar.strength), AppColors.chartStrength, top: strengthTop),
+          if (bar.stretch > 0)
+            seg(
+              _h(bar.stretch),
+              AppColors.chartStretching,
+              top: !cardioTop && !strengthTop,
+            ),
+          if (bar.total <= 0)
+            Container(
+              height: 2,
+              decoration: const BoxDecoration(
+                color: AppColors.borderStrong,
+                borderRadius: BorderRadius.vertical(top: cap),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
 }
 
 class _StackedBarPainter extends CustomPainter {

--- a/frontend/flutter_trainer/lib/shared/widgets/period_scroll_chart.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/period_scroll_chart.dart
@@ -1,0 +1,279 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import 'package:oncare_trainer/design_system/tokens/colors.dart';
+
+/// `전체` 그래프의 선택·보이는 구간 상태. (#1018)
+///
+/// 회원 앱 `design_system/charts/period_scroll_chart.dart` 와 같은 내용이다. 두
+/// 앱은 서로 다른 패키지라 위젯을 공유할 수 없어, 같은 그림을 두 곳에 둔다.
+///
+/// 머리의 숫자(평균 또는 고른 날의 값)와 막대는 서로 다른 위젯이 그리는데 같은
+/// 상태를 봐야 한다. 부모가 들고 있다가 둘에게 건넨다.
+class PeriodChartSelection extends ChangeNotifier {
+  int? _selected;
+  (int, int)? _visible;
+
+  /// 고른 칸. null 이면 머리 숫자가 평균이다.
+  int? get selected => _selected;
+
+  /// 화면에 보이는 구간(첫 칸, 끝 칸). null 이면 아직 재지 않았다 = 전 구간.
+  (int, int)? get visible => _visible;
+
+  void select(int? index) {
+    if (_selected == index) return;
+    _selected = index;
+    notifyListeners();
+  }
+
+  void setVisible(int first, int last) {
+    if (_visible != null && _visible!.$1 == first && _visible!.$2 == last) {
+      return;
+    }
+    _visible = (first, last);
+    notifyListeners();
+  }
+
+  /// 지표나 기간을 바꾸면 고른 날은 뜻을 잃는다 — 같이 푼다.
+  void reset() {
+    if (_selected == null) return;
+    _selected = null;
+    notifyListeners();
+  }
+
+  /// 보이는 구간의 평균. 기록이 없는 날(0)은 빼고 낸다 — 넣으면 "적게 먹었다"
+  /// 와 "기록을 안 했다" 가 같은 숫자가 된다.
+  double averageOf(List<double> values) {
+    if (values.isEmpty) return 0;
+    final (int first, int last) = _visible ?? (0, values.length - 1);
+    double sum = 0;
+    int count = 0;
+    for (int i = first; i <= last && i < values.length; i++) {
+      if (values[i] > 0) {
+        sum += values[i];
+        count += 1;
+      }
+    }
+    return count == 0 ? 0 : sum / count;
+  }
+}
+
+/// `전체` 기간 그래프의 뼈대 — 가로 스크롤 + 날짜 선택. (#1018)
+///
+/// 예전에는 한 달치를 한 화면에 욱여넣어 막대가 실처럼 얇았고, 그 앞의 기록은
+/// 볼 방법이 아예 없었다. 아이폰 건강 앱의 1개월 그래프처럼 **한 화면에 30일**을
+/// 두고 옆으로 밀어 과거를 본다.
+///
+/// 막대를 그리는 일은 하지 않는다. 식단은 탄단지를, 운동은 유산소·근력·유연성을
+/// 쌓아 그리는데 그 색이 각 화면이 말하려는 내용이라, 뼈대가 단색으로 통일해
+/// 버리면 그림이 뜻을 잃는다. 그래서 칸 하나를 [barBuilder] 가 그리고 여기서는
+/// 자리와 선택만 맡는다.
+class PeriodScrollChart extends StatefulWidget {
+  const PeriodScrollChart({
+    super.key,
+    required this.count,
+    required this.height,
+    required this.barBuilder,
+    required this.labelBuilder,
+    required this.onVisibleRangeChanged,
+    required this.calloutBuilder,
+    this.selectedIndex,
+    this.onSelected,
+    this.goalOverlay,
+    this.daysPerScreen = 30,
+  });
+
+  /// 칸 개수(= 날짜 수). 0 이면 아무것도 그리지 않는다.
+  final int count;
+
+  /// 막대가 그려지는 높이(라벨 줄 제외).
+  final double height;
+
+  /// [i] 번째 날의 막대. 칸 폭에 맞춰 그려진다.
+  final Widget Function(BuildContext context, int i) barBuilder;
+
+  /// [i] 번째 날의 축 라벨. 빈 문자열이면 적지 않는다 — 30칸에 날짜를 모두
+  /// 적으면 서로 겹친다.
+  final String Function(int i) labelBuilder;
+
+  /// 화면에 보이는 구간이 바뀔 때마다 부른다. 머리의 평균이 이 구간을 따른다 —
+  /// 보이지 않는 날까지 섞은 평균은 지금 보고 있는 그림을 설명하지 못한다.
+  final void Function(int first, int last) onVisibleRangeChanged;
+
+  /// 고른 날 위에 뜨는 회색 상자의 내용.
+  final Widget Function(BuildContext context, int i) calloutBuilder;
+
+  final int? selectedIndex;
+  final void Function(int? i)? onSelected;
+
+  /// 목표선. 칸 전체 폭에 걸쳐 그려지도록 스크롤 안쪽에 얹는다.
+  final Widget? goalOverlay;
+
+  /// 한 화면에 보일 날 수.
+  final int daysPerScreen;
+
+  @override
+  State<PeriodScrollChart> createState() => _PeriodScrollChartState();
+}
+
+class _PeriodScrollChartState extends State<PeriodScrollChart> {
+  final ScrollController _controller = ScrollController();
+  double _slot = 0;
+  double _viewport = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(_reportVisible);
+  }
+
+  @override
+  void dispose() {
+    _controller.removeListener(_reportVisible);
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _reportVisible() {
+    if (_slot <= 0 || _viewport <= 0) return;
+    final double offset = _controller.hasClients ? _controller.offset : 0;
+    final int first = (offset / _slot).floor().clamp(0, widget.count - 1);
+    final int last = ((offset + _viewport) / _slot).ceil() - 1;
+    widget.onVisibleRangeChanged(first, last.clamp(first, widget.count - 1));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.count == 0) return SizedBox(height: widget.height);
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final double viewport = constraints.maxWidth;
+        final double slot = viewport / widget.daysPerScreen;
+        final bool changed = slot != _slot || viewport != _viewport;
+        _slot = slot;
+        _viewport = viewport;
+        if (changed) {
+          // 처음 열면 최근(오른쪽 끝)이다 — 사람이 먼저 궁금해하는 것은 어제와
+          // 오늘이지 석 달 전이 아니다.
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!mounted || !_controller.hasClients) return;
+            _controller.jumpTo(_controller.position.maxScrollExtent);
+            _reportVisible();
+          });
+        }
+        return SingleChildScrollView(
+          controller: _controller,
+          scrollDirection: Axis.horizontal,
+          // 칸이 화면보다 적으면 스크롤할 것이 없다.
+          physics: widget.count <= widget.daysPerScreen
+              ? const NeverScrollableScrollPhysics()
+              : const BouncingScrollPhysics(),
+          child: SizedBox(
+            width: math.max(slot * widget.count, viewport),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                SizedBox(
+                  height: widget.height,
+                  child: Stack(
+                    children: <Widget>[
+                      if (widget.goalOverlay != null) widget.goalOverlay!,
+                      if (widget.selectedIndex != null)
+                        _SelectionLine(
+                          left: slot * widget.selectedIndex! + slot / 2,
+                          height: widget.height,
+                        ),
+                      Row(
+                        crossAxisAlignment: CrossAxisAlignment.end,
+                        children: <Widget>[
+                          for (int i = 0; i < widget.count; i++)
+                            SizedBox(
+                              width: slot,
+                              child: GestureDetector(
+                                behavior: HitTestBehavior.opaque,
+                                onTap: () => widget.onSelected?.call(
+                                  widget.selectedIndex == i ? null : i,
+                                ),
+                                child: widget.barBuilder(context, i),
+                              ),
+                            ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 6),
+                SizedBox(
+                  height: 14,
+                  child: Row(
+                    children: <Widget>[
+                      for (int i = 0; i < widget.count; i++)
+                        SizedBox(
+                          width: slot,
+                          child: Center(
+                            child: Text(
+                              widget.labelBuilder(i),
+                              maxLines: 1,
+                              style: const TextStyle(
+                                fontSize: 10,
+                                fontWeight: FontWeight.w600,
+                                color: AppColors.mutedForeground,
+                              ),
+                            ),
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// 고른 날에 서는 회색 세로선.
+class _SelectionLine extends StatelessWidget {
+  const _SelectionLine({required this.left, required this.height});
+
+  final double left;
+  final double height;
+
+  @override
+  Widget build(BuildContext context) => Positioned(
+    left: left - 0.5,
+    top: 0,
+    child: Container(height: height, width: 1, color: AppColors.chartGoalLine),
+  );
+}
+
+/// 머리에 뜨는 값 — 평소에는 보이는 구간의 평균, 날을 고르면 그날의 값.
+///
+/// 회색 상자는 **고른 날에만** 씌운다. 평균일 때도 상자를 두면 화면에 늘 회색
+/// 덩어리가 있어, 무언가를 고른 상태인지 아닌지가 구분되지 않는다.
+class PeriodChartHeadline extends StatelessWidget {
+  const PeriodChartHeadline({
+    super.key,
+    required this.selected,
+    required this.child,
+  });
+
+  final bool selected;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!selected) return child;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: AppColors.inputBackground,
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: child,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

`이번 달` 그래프가 한 달치를 한 화면에 욱여넣어 막대가 실처럼 얇았고, 그 앞의 기록은 볼 방법이 없었다. 이름도 `이번 달` 이라 달이 바뀌면 앞의 이야기가 사라지는 것처럼 읽혔다.

이름을 `전체` 로 바꾸고 **12주를 옆으로 밀어** 보게 한다. 아이폰 건강 앱의 걸음 수 1개월 그래프가 레퍼런스다.

Closes #1018

## Changes

**보기**

- 기간 토글 `이번 달` → `전체`. 범위도 달력 달에서 **오늘로 끝나는 12주**로 바뀐다.
- 한 화면에 30일이 보이고, 왼쪽으로 밀면 그 이전 기록이 이어진다. 처음 열면 최근(오른쪽 끝)이다 — 사람이 먼저 궁금해하는 것은 어제와 오늘이지 석 달 전이 아니다.
- 쌓은 색은 그대로다. 레퍼런스는 단색이지만 우리 막대의 탄단지와 유산소·근력·유연성은 이 서비스가 말하려는 내용이라, 단색으로 통일하면 그림이 뜻을 잃는다.

**머리의 숫자가 화면을 따라간다**

- 평균은 **지금 보이는 구간만** 센다. 밀면 따라 바뀐다.
- 막대 하나를 고르면 평균 자리에 그날의 값이 회색 상자로 들어서고, 고른 칸에는 회색 세로선이 선다. 다시 누르면 평균으로 돌아온다.
- 트레이너 운동 카드는 평균이 아니라 합계(일수·시간·칼로리)를 머리에 두는데, 같은 규칙으로 보이는 구간의 합계를 보여 준다.

**사용자앱 운동 `전체` 는 실제 기록이 아니었다**

하드코딩된 31칸 배열이 그려지고 있었다. 12주치를 주 단위로 읽어 잇는 provider 를 두고 실제 기록을 그린다 — 트레이너 화면이 고객 기록을 읽는 방식과 같다.

**적용 범위**

사용자앱 식단 `전체`·운동 `전체`, 트레이너웹 고객 식단 `전체`·고객 운동 `전체` — 네 곳 모두.

## Notes

- 전체 그래프에서는 막대가 자라는 애니메이션을 뺐다. 스크롤하는 그래프에서 민 자리마다 다시 자라 오르면 읽기 어렵다.
- 달력 달이 아니라 오늘로 끝나는 구간이 되면서 `아직 오지 않은 날`(#950)이 없어졌다. 그 구분을 검사하던 테스트는 "전체 구간에는 미래 칸이 없다"로 바꿨다.
- **레퍼런스와 다른 점 하나**: 아이폰은 회색 상자가 세로선을 따라 가로로 움직인다. 여기서는 카드 머리(평균이 있던 자리)에 고정해 두었다 — 우리 카드는 그 줄에 목표·상태 배지가 함께 있어서, 상자가 움직이면 그 둘과 겹친다. 상자가 선을 따라가야 하면 알려주세요.
- 스크롤·선택·보이는 구간 평균을 검사하는 테스트를 새로 뒀다. 두 앱 `flutter analyze` 무경고·전체 테스트 통과.
