### PR TITLE
fix(diet): 오늘 지표 카드의 정상 색을 초록으로 통일

### DIFF
--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -885,8 +885,12 @@ class _NutritionSummaryCard extends StatelessWidget {
     // 카드의 칼로리와 아래의 나트륨·당류는 이미 이렇게 갈린다 — 탄단지 바만
     // 예외였다(#890). 세 항목이 각자 판단하므로 지방만 넘긴 날은 지방 바만
     // 빨개진다.
-    Color macroColor(_NutritionSummaryItem item) =>
-        item.isOverGoal ? FigmaColors.dangerRed : FigmaColors.primaryA(0.65);
+    // 정상은 초록이다 (#1019). 바로 아래 나트륨·당류 카드가 이미 초록으로
+    // 말하는데 여기만 파랑이면, 파랑이 "정상"인지 "다른 종류의 지표"인지 알 수
+    // 없다. 위아래로 붙어 있는 카드가 같은 상태를 다른 색으로 칠할 이유가 없다.
+    Color macroColor(_NutritionSummaryItem item) => item.isOverGoal
+        ? FigmaColors.statusOver
+        : FigmaColors.statusNormal.withValues(alpha: 0.65);
     final List<_MacroProgressData> macros = <_MacroProgressData>[
       _MacroProgressData(item: carbs, color: macroColor(carbs)),
       _MacroProgressData(item: protein, color: macroColor(protein)),
@@ -894,8 +898,8 @@ class _NutritionSummaryCard extends StatelessWidget {
     ];
     final AppLocalizations l = AppLocalizations.of(context);
     final Color calorieColor = calories.isOverGoal
-        ? FigmaColors.dangerRed
-        : FigmaColors.primary;
+        ? FigmaColors.statusOver
+        : FigmaColors.statusNormal;
     final String calorieStatus = calories.isOverGoal
         ? l.dietAmountOver('$calorieDifference ${calories.unit}')
         : l.dietAmountRemaining('$calorieDifference ${calories.unit}');
@@ -1202,16 +1206,16 @@ class _NutritionStatusCards extends StatelessWidget {
       item: sodium,
       difference: sodiumDifference,
       progressColor: sodium.isOverGoal
-          ? FigmaColors.dangerRed
-          : FigmaColors.greenText,
+          ? FigmaColors.statusOver
+          : FigmaColors.statusNormal,
     );
     final Widget sugarCard = _NutritionStatusCard(
       key: const Key('nutrition-sugar-status'),
       item: sugar,
       difference: sugarDifference,
       progressColor: sugar.isOverGoal
-          ? FigmaColors.dangerRed
-          : FigmaColors.greenText,
+          ? FigmaColors.statusOver
+          : FigmaColors.statusNormal,
     );
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
@@ -1253,8 +1257,8 @@ class _NutritionStatusCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final AppLocalizations l = AppLocalizations.of(context);
     final Color statusColor = item.isOverGoal
-        ? FigmaColors.dangerRed
-        : FigmaColors.greenText;
+        ? FigmaColors.statusOver
+        : FigmaColors.statusNormal;
     final String differenceText = item.isOverGoal
         ? l.dietAmountOver('$difference${item.unit}')
         : l.dietAmountRemaining('$difference${item.unit}');
@@ -1265,8 +1269,8 @@ class _NutritionStatusCard extends StatelessWidget {
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
           color: item.isOverGoal
-              ? FigmaColors.dangerRed.withValues(alpha: 0.32)
-              : FigmaColors.primaryA(0.18),
+              ? FigmaColors.statusOver.withValues(alpha: 0.32)
+              : FigmaColors.statusNormal.withValues(alpha: 0.18),
         ),
         boxShadow: kCardShadow,
       ),

--- a/frontend/flutter/test/features/diet/diet_macro_over_color_test.dart
+++ b/frontend/flutter/test/features/diet/diet_macro_over_color_test.dart
@@ -114,19 +114,19 @@ void main() {
     expect(barColor(tester, '지방'), FigmaColors.dangerRed);
     expect(
       barColor(tester, '탄수화물'),
-      FigmaColors.primaryA(0.65),
+      FigmaColors.statusNormal.withValues(alpha: 0.65),
       reason: '탄수화물은 목표 아래인데 빨강이 됐습니다.',
     );
-    expect(barColor(tester, '단백질'), FigmaColors.primaryA(0.65));
+    expect(barColor(tester, '단백질'), FigmaColors.statusNormal.withValues(alpha: 0.65));
   });
 
-  testWidgets('목표 아래면 기존 색을 유지한다', (WidgetTester tester) async {
+  testWidgets('목표 아래면 정상 초록이다 (#1019)', (WidgetTester tester) async {
     await pumpDiet(tester, carbsG: 120, proteinG: 45, fatG: 45);
 
     for (final String label in <String>['탄수화물', '단백질', '지방']) {
       expect(
         barColor(tester, label),
-        FigmaColors.primaryA(0.65),
+        FigmaColors.statusNormal.withValues(alpha: 0.65),
         reason: label,
       );
     }
@@ -139,7 +139,7 @@ void main() {
     for (final String label in <String>['탄수화물', '단백질', '지방']) {
       expect(
         barColor(tester, label),
-        FigmaColors.primaryA(0.65),
+        FigmaColors.statusNormal.withValues(alpha: 0.65),
         reason: label,
       );
     }

--- a/frontend/flutter/test/features/diet/diet_macros_display_test.dart
+++ b/frontend/flutter/test/features/diet/diet_macros_display_test.dart
@@ -295,7 +295,7 @@ void main() {
       expect(progressColors.last.color, expectedColor);
     }
 
-    final Color macroProgressColor = FigmaColors.primaryA(0.65);
+    final Color macroProgressColor = FigmaColors.statusNormal.withValues(alpha: 0.65);
     expectMacroProgressColor('탄수화물', macroProgressColor);
     expectMacroProgressColor('단백질', macroProgressColor);
     expectMacroProgressColor('지방', macroProgressColor);

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/nutrition_summary_card.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/nutrition_summary_card.dart
@@ -196,9 +196,12 @@ class _CalorieRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations l = AppLocalizations.of(context);
+    // 정상은 초록이다 (#1019). 바로 옆 나트륨·당류 카드가 이미 초록으로
+    // 말하는데 여기만 파랑이면, 파랑이 "정상" 인지 "다른 종류의 지표" 인지 알 수
+    // 없다. 회원 앱 식단 탭도 같은 규칙으로 맞췄다.
     final Color color = calories.isOverGoal
-        ? AppColors.overTarget
-        : AppColors.primary;
+        ? AppColors.statusOver
+        : AppColors.statusNormal;
     return Row(
       children: <Widget>[
         Expanded(
@@ -369,8 +372,8 @@ class _MacroItem extends StatelessWidget {
         _Bar(
           progress: item.ratio,
           color: item.isOverGoal
-              ? AppColors.overTarget
-              : AppColors.primary.withValues(alpha: 0.65),
+              ? AppColors.statusOver
+              : AppColors.statusNormal.withValues(alpha: 0.65),
         ),
       ],
     );
@@ -460,8 +463,8 @@ class _StatusCard extends StatelessWidget {
     final AppLocalizations l = AppLocalizations.of(context);
     // 나트륨·당류는 같은 성격의 지표다. "정상" 을 서로 다른 색으로 말하지 않는다.
     final Color status = item.isOverGoal
-        ? AppColors.overTarget
-        : AppColors.userSugarGreen;
+        ? AppColors.statusOver
+        : AppColors.statusNormal;
     return Container(
       padding: const EdgeInsets.all(AppSpacing.md),
       decoration: BoxDecoration(
@@ -469,8 +472,8 @@ class _StatusCard extends StatelessWidget {
         borderRadius: const BorderRadius.all(AppRadius.card),
         border: Border.all(
           color: item.isOverGoal
-              ? AppColors.overTarget.withValues(alpha: 0.32)
-              : AppColors.primary.withValues(alpha: 0.18),
+              ? AppColors.statusOver.withValues(alpha: 0.32)
+              : AppColors.statusNormal.withValues(alpha: 0.18),
         ),
         boxShadow: kCardShadow,
       ),

--- a/frontend/flutter_trainer/test/features/clients/client_detail_diet_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_diet_test.dart
@@ -236,7 +236,8 @@ void main() {
       final calorieProgress = tester.widget<CircularProgressIndicator>(
         find.byKey(const Key('client-nutrition-calorie-progress')),
       );
-      expect(calorieProgress.valueColor?.value, AppColors.primary);
+      // 정상은 초록이다 (#1019) — 나트륨·당류 카드와 같은 색.
+      expect(calorieProgress.valueColor?.value, AppColors.statusNormal);
       for (final String label in <String>['탄수화물', '단백질', '지방']) {
         expect(
           find.byKey(Key('client-nutrition-macro-$label')),
@@ -252,10 +253,12 @@ void main() {
                 ),
               )
               .any(
-                (box) => box.color == AppColors.primary.withValues(alpha: 0.65),
+                (box) =>
+                    box.color ==
+                    AppColors.statusNormal.withValues(alpha: 0.65),
               ),
           isTrue,
-          reason: '$label 그래프가 기존 트레이너 앱 색상을 써야 합니다.',
+          reason: '$label 그래프가 정상 초록을 써야 합니다.',
         );
       }
       Finder inMacro(String label, String text) => find.descendant(

--- a/frontend/flutter_trainer/test/features/clients/nutrition_macro_over_color_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/nutrition_macro_over_color_test.dart
@@ -59,13 +59,13 @@ void main() {
     expect(barColors(tester, '단백질'), isNot(contains(AppColors.overTarget)));
   });
 
-  testWidgets('목표 아래면 기존 남색을 유지한다', (WidgetTester tester) async {
+  testWidgets('목표 아래면 정상 초록이다 (#1019)', (WidgetTester tester) async {
     await pumpCard(tester, makeClient(carbsG: 120, proteinG: 45, fatG: 45));
 
     for (final String label in <String>['탄수화물', '단백질', '지방']) {
       expect(
         barColors(tester, label),
-        contains(AppColors.primary.withValues(alpha: 0.65)),
+        contains(AppColors.statusNormal.withValues(alpha: 0.65)),
         reason: label,
       );
       expect(barColors(tester, label), isNot(contains(AppColors.overTarget)));


### PR DESCRIPTION
## Summary

식단 `오늘` 화면이 **같은 뜻을 두 색으로** 말했다. 나트륨·당류 카드는 정상이 초록인데, 바로 위 칼로리·탄수화물·단백질·지방은 정상이 파랑이었다. 초과는 양쪽 다 빨강이다.

위아래로 붙어 있는 카드가 같은 상태를 다른 색으로 칠하면, 파랑이 "정상"인지 "다른 종류의 지표"인지 알 수 없다.

Closes #1019

## Changes

- 칼로리 링, 탄단지 바, 카드 테두리의 정상 색을 초록으로 옮겼다. 초과는 그대로 빨강.
- 색은 #995 에서 만든 `statusNormal`·`statusOver` 토큰으로 읽는다. 나트륨·당류가 쓰던 `greenText`·`dangerRed` 도 같은 토큰으로 바꿨다 — 같은 뜻을 두 이름으로 부르면 한쪽만 바뀌는 날이 온다.
- 사용자앱 식단 탭과 트레이너웹 고객 식단(오늘) 모두.

## Notes

- 파랑은 브랜드 색이라 "지금 보고 있는 지표"(선택된 탭·버튼) 같은 자리에는 그대로 남는다. **상태를 말하는 자리에서만** 뺐다.
- 홈 탭의 지표 배지는 이미 초록이었다 — 어긋난 곳은 식단 탭과 트레이너 고객 카드뿐이었다.
- 색을 검사하던 테스트 네 개의 기대값을 새 색으로 옮겼다. 두 앱 `flutter analyze` 무경고·전체 테스트 통과.
