### PR TITLE
fix(chat): 감지 배너 메모 저장 뒤 색 처리 정리

### DIFF
--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
@@ -433,7 +433,16 @@ class _ChatInsightBanner extends StatelessWidget {
         vertical: AppSpacing.sm,
       ),
       decoration: BoxDecoration(
-        color: AppColors.warning.withValues(alpha: 0.10),
+        // 메모로 남기고 나면 **바탕만** 하얗게 비운다. 붉은 바탕은 "여기
+        // 아직 볼 것이 있다" 는 신호인데, 옮겨 적은 뒤에도 그대로 두면
+        // 스레드를 다시 열 때마다 처리한 것과 안 한 것이 똑같이 붉다.
+        //
+        // 윤곽선과 버튼의 붉은색은 남긴다 — 무슨 일이 있었는지(부정적
+        // 피드백)는 바뀌지 않았고, 그 사실까지 회색으로 지우면 나중에
+        // 훑을 때 이 자리가 무엇이었는지 알아볼 수 없다.
+        color: saved
+            ? AppColors.card
+            : AppColors.warning.withValues(alpha: 0.10),
         borderRadius: const BorderRadius.all(AppRadius.card),
         border: Border.all(color: AppColors.warning.withValues(alpha: 0.28)),
       ),
@@ -466,10 +475,12 @@ class _ChatInsightBanner extends StatelessWidget {
             ),
           ),
           const SizedBox(width: AppSpacing.sm),
+          // 버튼은 저장 뒤에도 붉은색이다. 초록으로 뒤집었더니 빨간 배너
+          // 한가운데서 가장 밝은 것이 "메모 추가됨" 이 되어, 정작 읽어야 할
+          // 감지 내용보다 눈에 먼저 들어왔다. 상태 차이는 색이 아니라
+          // 아이콘(＋ → ✓)과 문구가 말한다.
           Material(
-            color: saved
-                ? AppColors.success.withValues(alpha: 0.10)
-                : AppColors.warning.withValues(alpha: 0.13),
+            color: AppColors.warning.withValues(alpha: 0.13),
             borderRadius: const BorderRadius.all(AppRadius.pill),
             child: InkWell(
               key: ValueKey<String>('chat-insight-add-${insight.id}'),
@@ -486,13 +497,13 @@ class _ChatInsightBanner extends StatelessWidget {
                     Icon(
                       saved ? Icons.check_rounded : Icons.add_rounded,
                       size: 15,
-                      color: saved ? AppColors.success : AppColors.warning,
+                      color: AppColors.warning,
                     ),
                     const SizedBox(width: 4),
                     Text(
                       saved ? l.chatInsightMemoAdded : l.chatInsightAddMemo,
-                      style: TextStyle(
-                        color: saved ? AppColors.success : AppColors.warning,
+                      style: const TextStyle(
+                        color: AppColors.warning,
                         fontSize: 11.5,
                         fontWeight: FontWeight.w800,
                       ),

--- a/frontend/flutter_trainer/test/features/messages/messages_page_test.dart
+++ b/frontend/flutter_trainer/test/features/messages/messages_page_test.dart
@@ -319,6 +319,24 @@ void main() {
       await settle(tester);
 
       expect(find.text('메모 추가됨'), findsOneWidget);
+      // 옮겨 적은 뒤에는 바탕만 비운다 — 붉은 바탕은 "아직 볼 것이 있다"
+      // 는 신호라, 처리한 배너와 안 한 배너가 똑같이 붉으면 안 된다.
+      // 윤곽선과 버튼의 붉은색은 무슨 일이 있었는지를 남긴다.
+      final banner = tester.widget<Container>(
+        find.byKey(
+          const ValueKey<String>('chat-insight-banner-seed-chat-1-16'),
+        ),
+      );
+      final decoration = banner.decoration! as BoxDecoration;
+      expect(decoration.color, AppColors.card);
+      expect(
+        (decoration.border! as Border).top.color,
+        AppColors.warning.withValues(alpha: 0.28),
+      );
+      expect(
+        tester.widget<Text>(find.text('메모 추가됨')).style?.color,
+        AppColors.warning,
+      );
       // 채팅에서 저장한 메모는 회원 상세가 읽는 것과 **같은** 메모 목록에 들어간다.
       final memos = await container
           .read(trainerMemoRepositoryProvider)


### PR DESCRIPTION
## Summary

* 감지 배너에서 `+ 메모에 추가` 를 누른 뒤 **바탕만 하얗게** 비웁니다 — 처리한 배너와 안 한 배너가 한눈에 갈립니다.
* **윤곽선은 붉은색 유지** — 무슨 일이 있었는지는 바뀌지 않았습니다.
* **버튼도 붉은색 유지** — 초록으로 뒤집히던 것을 되돌렸습니다. 상태 차이는 아이콘(`＋` → `✓`)과 문구가 말합니다.

---

## Changes

### ✨ Features

* 없음

### 🔧 Improvements

* 없음

### 🎨 UI/UX

* `_ChatInsightBanner` 저장 상태: 바탕 `warning 10%` → `AppColors.card`.
* 버튼 바탕·아이콘·글자에서 `AppColors.success` 제거, `AppColors.warning` 로 통일.

### 📝 Docs

* 없음

### 🐛 Fixes

* 빨간 경고 상자 안에서 초록 버튼이 가장 밝아 감지 내용보다 먼저 읽히던 문제 수정.
* 저장 뒤에도 바탕이 붉어 처리 여부를 구분할 수 없던 문제 수정.

---

## Commits

1. `a29e9ac8` fix(chat): 감지 배너 메모 저장 뒤 색 처리 정리

---

## Notes

* 남색(`AppColors.primary`)은 후보에서 뺐습니다 — `alert_badge.dart` 가 **남색 = 처리 필요, 빨강 = 주의** 로 색의 뜻을 못 박아 두었고(#690), 저장 완료에 남색을 쓰면 그 규칙이 깨집니다.
* 회색(`mutedForeground`)도 검토했지만 "비활성/실패" 로 읽힐 여지가 있어, 붉은색을 유지하고 **바탕**으로만 처리 여부를 말하는 쪽을 골랐습니다.
* 저장된 버튼이 다시 눌리지 않는 동작(`onTap: null`)은 그대로입니다.

---

## Screenshots (Optional)

| Before | After |
| ------ | ----- |
| 붉은 바탕 · 붉은 윤곽선 · **초록** `✓ 메모 추가됨` | **하얀 바탕** · 붉은 윤곽선 · 붉은 `✓ 메모 추가됨` |

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. `cd frontend/flutter_trainer && flutter run -d chrome` 후 데모로 진입.
2. **메시지** 탭 → 김민수 → 대화를 내려 `무릎 불편 표현 감지` 배너를 찾습니다.
3. `+ 메모에 추가` 를 누르면 바탕이 하얘지고, 윤곽선과 버튼은 붉은색으로 남는지 확인.
4. 초록색이 어디에도 나타나지 않는지 확인.
5. `flutter test test/features/messages/messages_page_test.dart`

---

## Related Issues

Closes #1032

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인
