### PR TITLE
refactor(messages): 메시지 탭에서 활성 상태와 목표 걷어내기

### DIFF
--- a/frontend/flutter_trainer/lib/features/messages/presentation/pages/messages_page.dart
+++ b/frontend/flutter_trainer/lib/features/messages/presentation/pages/messages_page.dart
@@ -20,7 +20,6 @@ import 'package:oncare_trainer/shared/widgets/client_avatar.dart';
 import 'package:oncare_trainer/shared/widgets/client_identity.dart';
 import 'package:oncare_trainer/shared/widgets/page_scaffold.dart';
 import 'package:oncare_trainer/shared/widgets/section_card.dart';
-import 'package:oncare_trainer/shared/widgets/status_dot_label.dart';
 
 enum _ConversationFilter {
   all('all'),
@@ -320,12 +319,10 @@ class _ConversationTile extends StatelessWidget {
             ),
             child: Row(
               children: <Widget>[
-                ClientAvatar(
-                  label: client.avatar,
-                  size: 36,
-                  showStatus: true,
-                  active: client.active,
-                ),
+                // 활성/휴면 점은 없다. 메시지 탭은 회원을 **관리**하는
+                // 곳이 아니라 이야기하는 곳이고, 활성 여부는 어느 대화를
+                // 열지 정하는 데 쓰이지 않는다 — 그 판단은 고객 탭이 한다.
+                ClientAvatar(label: client.avatar, size: 36),
                 const SizedBox(width: AppSpacing.md),
                 Expanded(
                   child: Column(
@@ -352,31 +349,32 @@ class _ConversationTile extends StatelessWidget {
                           ),
                         ],
                       ),
-                      // 오른쪽 대화 패널 머리에는 목표가 있는데 정작 고객을
-                      // 고르는 목록에는 없었다(#898).
-                      const SizedBox(height: 2),
-                      ClientGoalLabel(client: client),
-                      // 활성/주의 배지는 여기 없다. 목록은 **어느 대화를 열까**
-                      // 를 정하는 자리라 이름 · 목표 · 마지막 말 · 안읽음이면
-                      // 충분하고, 상태의 자세한 내막은 대화를 연 뒤 헤더가
-                      // 말한다(#991). 같은 사실을 두 번 세우면 목록이 길어질
-                      // 뿐 고르는 데 도움이 되지 않는다. 활성/휴면만은 아바타
-                      // 모서리의 점으로 남는다 — 훑는 자리의 표시다.
-                      const SizedBox(height: 3),
+                      // 목표(`혈압 관리 · 체중 감량`)는 여기 없다. #898 이
+                      // 넣었을 때는 대화 패널 머리에만 있어서 목록에서 고를
+                      // 근거가 없었는데, 지금은 헤더가 목표를 말한다. 어느
+                      // 대화를 열지는 **마지막에 무슨 말이 오갔는가**로
+                      // 정하지 목표로 정하지 않는다.
+                      //
+                      // 그 자리를 미리보기에 준다 — 두 줄이면 "이번 주 일이
+                      // 너무 많아서" 뒤에 무엇이 붙는지까지 읽히고, 열어 볼
+                      // 대화인지 목록에서 판단할 수 있다.
+                      const SizedBox(height: 4),
                       Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
                         children: <Widget>[
                           Expanded(
                             child: Text(
                               hasPreview
                                   ? client.lastMessage
                                   : l.messagesNoPreview,
-                              maxLines: 1,
+                              maxLines: 2,
                               overflow: TextOverflow.ellipsis,
                               style: TextStyle(
                                 color: hasPreview
                                     ? AppColors.mutedForeground
                                     : AppColors.subtleForeground,
                                 fontSize: 11.5,
+                                height: 1.35,
                                 fontStyle: hasPreview
                                     ? FontStyle.normal
                                     : FontStyle.italic,
@@ -506,11 +504,7 @@ class _Identity extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final l = AppLocalizations.of(context);
     final alerts = healthAlertsFor(client);
-    final statusColor = client.active
-        ? AppColors.success
-        : AppColors.disabledForeground;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
@@ -534,22 +528,11 @@ class _Identity extends StatelessWidget {
                   ),
                 ),
               ),
-              Container(
-                key: const ValueKey<String>('messages-thread-status'),
-                padding: const EdgeInsets.symmetric(
-                  horizontal: AppSpacing.sm,
-                  vertical: 3,
-                ),
-                decoration: BoxDecoration(
-                  color: statusColor.withValues(alpha: 0.12),
-                  borderRadius: const BorderRadius.all(AppRadius.pill),
-                ),
-                child: StatusDotLabel(
-                  label: client.active ? l.clientActive : l.clientDormant,
-                  filled: client.active,
-                  color: statusColor,
-                ),
-              ),
+              // 활성/휴면 알약도 없다 — 이 사람과 지금 이야기하는 데
+              // 쓰이지 않는 값이고, 바꿀 수 있는 자리도 고객 탭이다.
+              // 주의사항은 다르다: 나트륨이 넘쳤다는 사실은 **지금 이
+              // 대화에서 할 말**을 바꾼다.
+              //
               // 배지는 하나씩 `Wrap` 의 자식이다. 묶어서 넣으면 그 묶음이
               // 통째로 다음 줄로 내려가고, 묶음 안에서는 다시 접히지 않는다.
               //

--- a/frontend/flutter_trainer/test/features/messages/messages_page_test.dart
+++ b/frontend/flutter_trainer/test/features/messages/messages_page_test.dart
@@ -45,7 +45,7 @@ void main() {
       final avatar = tester.widget<ClientAvatar>(
         find.descendant(of: selectedTile, matching: find.byType(ClientAvatar)),
       );
-      expect(avatar.showStatus, isTrue);
+      expect(avatar.showStatus, isFalse);
       expect(avatar.size, 36);
       final surface = tester.widget<Material>(
         find
@@ -110,16 +110,25 @@ void main() {
         find.byKey(const ValueKey<String>('messages-unread-seed-client-3')),
         findsOneWidget,
       );
-      // 목록은 어느 대화를 열까를 정하는 자리다 — 상태의 자세한 내막은
-      // 대화를 연 뒤 헤더가 말한다. 활성/휴면은 아바타 점으로만 남는다.
+      // 목록은 어느 대화를 열까를 정하는 자리다 — 이름 · 시각 · 마지막
+      // 말 · 안읽음뿐이고, 목표도 상태도 없다.
       expect(
-        find.descendant(of: conversation, matching: find.text('휴면')),
+        find.descendant(of: conversation, matching: find.text('근력 향상')),
         findsNothing,
       );
       expect(
         find.descendant(of: conversation, matching: find.text('나트륨 초과')),
         findsNothing,
       );
+      // 목표 자리를 미리보기가 가져갔다 — 두 줄이면 뒤에 무엇이 붙는지까지
+      // 읽히고, 열어 볼 대화인지 목록에서 판단할 수 있다.
+      final preview = tester.widget<Text>(
+        find.descendant(
+          of: conversation,
+          matching: find.textContaining('이해해요! 대신 AI 식단 분석'),
+        ),
+      );
+      expect(preview.maxLines, 2);
     });
   });
 
@@ -210,21 +219,16 @@ void main() {
         const ValueKey<String>('messages-thread-identity'),
       );
       expect(identity, findsOneWidget);
-      // 활성/휴면 알약이 이름 줄에 선다.
+      // 활성/휴면은 메시지 탭 어디에도 없다 — 이 사람과 지금 이야기하는
+      // 데 쓰이지 않는 값이고, 바꿀 수 있는 자리도 고객 탭이다.
       expect(
-        find.descendant(
-          of: identity,
-          matching: find.byKey(
-            const ValueKey<String>('messages-thread-status'),
-          ),
-        ),
-        findsOneWidget,
+        find.byKey(const ValueKey<String>('messages-thread-status')),
+        findsNothing,
       );
-      expect(
-        find.descendant(of: identity, matching: find.text('휴면')),
-        findsOneWidget,
-      );
-      // 목록과 달리 주의 배지는 **전부** 선다 — 자세한 쪽이 여기다.
+      expect(find.text('휴면'), findsNothing);
+      expect(find.text('활성'), findsNothing);
+      // 주의 배지는 **전부** 선다 — 나트륨이 넘쳤다는 사실은 지금 이
+      // 대화에서 할 말을 바꾼다.
       expect(
         find.descendant(of: identity, matching: find.text('나트륨 초과')),
         findsOneWidget,

--- a/frontend/flutter_trainer/test/shared/client_goal_in_lists_test.dart
+++ b/frontend/flutter_trainer/test/shared/client_goal_in_lists_test.dart
@@ -40,19 +40,25 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  testWidgets('메시지 스레드 목록 행에 고객 목표가 보인다', (tester) async {
-    await openTab(tester, AppRoutes.messages);
+  // 메시지 탭 **목록**은 예외다. #898 이 목표를 넣었을 때는 대화 패널
+  // 머리에만 있어서 목록에서 고를 근거가 없었는데, 지금은 헤더가 목표를
+  // 말한다. 어느 대화를 열지는 마지막에 오간 말로 정하지 목표로 정하지
+  // 않으므로, 그 자리를 미리보기 두 줄에 넘겼다.
+  testWidgets('메시지 목록 행에는 목표가 없고 대화 헤더가 대신 말한다', (tester) async {
+    await openTab(tester, AppRoutes.messagesFor('goal-client'));
 
+    // 목록 타일에는 없다.
     expect(
       find.descendant(
         of: find.byKey(
           const ValueKey<String>('messages-conversation-goal-client'),
         ),
-        matching: find.byType(ClientGoalLabel),
+        matching: find.text(goal),
       ),
-      findsOneWidget,
+      findsNothing,
     );
-    expect(find.text(goal), findsWidgets);
+    // 대화를 연 헤더가 대신 말한다.
+    expect(find.text(goal), findsOneWidget);
   });
 
   testWidgets('프로그램 회원 목록 행은 마지막 루틴과 함께 목표를 보여 준다', (tester) async {
@@ -108,7 +114,9 @@ void main() {
     await pumpTrainerApp(
       tester,
       token: 'demo-trainer-token',
-      at: AppRoutes.messages,
+      // 메시지 목록은 더 이상 목표를 그리지 않는다 — 아직 그리는
+      // 목록(프로그램 회원 목록)에서 빈 목표를 확인한다.
+      at: AppRoutes.coaching,
       extraOverrides: <Override>[
         clientsProvider.overrideWith(
           (ref) => Stream<List<TrainerClient>>.value(<TrainerClient>[


### PR DESCRIPTION
## Summary

* 메시지 탭에서 **활성/휴면을 완전히 걷어냈습니다** — 목록 아바타의 점, 헤더의 알약 둘 다.
* 목록 타일에서 **목표를 뺐습니다.** 어느 대화를 열지는 마지막에 오간 말로 정하지 목표로 정하지 않습니다.
* 비워진 자리를 **미리보기 두 줄**에 넘겼습니다.
* **주의 배지와 목표는 헤더에 그대로** 둡니다.

---

## Changes

### ✨ Features

* 없음

### 🔧 Improvements

* `_ConversationTile` 에서 `ClientGoalLabel` 과 `ClientAvatar.showStatus` 제거.
* `_Identity` 에서 `StatusDotLabel` 알약 제거(주의 배지·목표는 유지). `status_dot_label.dart` import 정리.

### 🎨 UI/UX

* 목록 타일: `아바타 · 이름 성별·나이 · 시각 / 마지막 메시지 두 줄 · 안읽음`.
* 미리보기 `maxLines: 1` → `2`, `height: 1.35`.
* 헤더: `아바타 · 이름 성별·나이 · 주의 배지 / 목표 · 고객 상세 ›`.

### 📝 Docs

* 없음

### 🐛 Fixes

* 없음

---

## Commits

1. `81f4a57b` refactor(messages): 메시지 탭에서 활성 상태와 목표 걷어내기

---

## Notes

* **#898 의 결정을 메시지 목록에 한해 뒤집습니다.** 그때는 대화 패널 머리에만 목표가 있어서 목록에서 고를 근거가 없다는 이유였는데, 지금은 헤더가 목표를 말합니다. 다른 목록(프로그램·리포트·스케줄)은 그대로입니다.
* `client_goal_in_lists_test.dart` 의 메시지 케이스를 "목록에는 없고 헤더가 대신 말한다" 로 바꿨고, `목표가 비면 빈 줄을 만들지 않는다` 는 아직 목표를 그리는 **프로그램 회원 목록**으로 옮겼습니다.
* **주의사항을 남긴 이유**: 나트륨이 넘쳤다는 사실은 지금 이 대화에서 할 말을 바꿉니다. 활성/휴면은 그렇지 않고, 이 화면에서는 바꿀 수도 없었습니다(읽기 전용) — 상태를 바꾸는 자리는 고객 탭(`client-status-toggle`)입니다.
* 남은 후속 작업 두 가지는 별도 이슈로 뺐습니다 — **목록 시각 표기**(오늘 `HH:MM` / `어제` / 그 외 날짜)와 **안읽음 배지 규칙**(트레이너가 마지막이면 0). 시각은 실 API 가 `last_time` 을 **문자열로** 내려주고 `DioClientRepository.watchLastChatAt()` 가 빈 맵이라, 백엔드 `relative_time_label` 을 함께 고쳐야 두 모드가 같아집니다.

---

## Screenshots (Optional)

| Before | After |
| ------ | ----- |
| `[김 ●] 김민수 남성·35세  18:18`<br>`혈압 관리 · 체중 감량`<br>`확인했어요. AI가 오늘 식단…  [3]` | `[김] 김민수 남성·35세  18:18`<br>`확인했어요. AI가 오늘 식단 기반으로 유산소`<br>`루틴을 추천했는데, 무릎 상태 감안해서…  [3]` |
| 헤더: `박성호 남성·37세 ●휴면 ⓘ나트륨 초과 ⓘ당류 초과` | 헤더: `박성호 남성·37세 ⓘ나트륨 초과 ⓘ당류 초과` |

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. `cd frontend/flutter_trainer && flutter run -d chrome` 후 데모로 진입.
2. **메시지** 탭 → 목록 타일에 목표가 없고, 아바타에 점이 없는지 확인.
3. 미리보기가 두 줄까지 보이는지 확인(김민수처럼 긴 메시지).
4. 박성호 선택 → 헤더에 `휴면` 이 없고 주의 배지 두 개와 목표만 있는지 확인.
5. 폭 1024·360 에서 오버플로가 없는지 확인.
6. `flutter test test/features/messages/messages_page_test.dart test/shared/client_goal_in_lists_test.dart`

---

## Related Issues

Closes #1035

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인
