### PR TITLE
refactor(exercise): 사용자 운동 기록 화면 재구성

### DIFF
--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -17,6 +17,7 @@ import 'package:oncare/features/diet/presentation/widgets/stored_meal_photo.dart
 import 'package:oncare/features/member_coach/presentation/widgets/trainer_chat_header_button.dart';
 import 'package:oncare/features/notification/presentation/controllers/notification_controller.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
+import 'package:oncare/shared/widgets/ai_advice_card.dart';
 import 'package:oncare/shared/widgets/modals/schedule_calendar_sheet.dart';
 
 /// 식단 tab, rebuilt to match the On-Care Figma redesign. The weekly date
@@ -1430,53 +1431,14 @@ class _AiFeedback extends StatelessWidget {
   final String message;
 
   @override
-  Widget build(BuildContext context) {
-    if (message.trim().isEmpty) return const SizedBox.shrink();
-    final AppLocalizations l = AppLocalizations.of(context);
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 24),
-      child: Container(
-        padding: const EdgeInsets.all(14),
-        decoration: BoxDecoration(
-          color: FigmaColors.softBlue,
-          borderRadius: BorderRadius.circular(16),
-          border: Border.all(color: FigmaColors.primaryA(0.15)),
-        ),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            const OniAvatar(size: 40),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  Text(
-                    l.dietAiFeedback,
-                    style: const TextStyle(
-                      fontSize: 13.5,
-                      fontWeight: FontWeight.w700,
-                      color: FigmaColors.primary,
-                    ),
-                  ),
-                  const SizedBox(height: 2),
-                  Text(
-                    message,
-                    style: const TextStyle(
-                      fontSize: 13.5,
-                      height: 1.5,
-                      fontWeight: FontWeight.w500,
-                      color: FigmaColors.ink,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.symmetric(horizontal: 24),
+    // 운동 탭도 같은 카드를 쓴다 — 그림은 공용 위젯에 있다. (#1021)
+    child: AiAdviceCard(
+      title: AppLocalizations.of(context).dietAiFeedback,
+      message: message,
+    ),
+  );
 }
 
 // ─────────────────────────────────────────────────────────── meal log ──

--- a/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
@@ -26,6 +26,7 @@ import 'package:oncare/features/member_coach/presentation/widgets/trainer_chat_h
 import 'package:oncare/features/notification/presentation/controllers/notification_controller.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 import 'package:oncare/shared/services/exercise_burn_goal_provider.dart';
+import 'package:oncare/shared/widgets/ai_advice_card.dart';
 import 'package:oncare/shared/widgets/chart_semantics.dart';
 import 'package:oncare/shared/widgets/modals/schedule_calendar_sheet.dart';
 
@@ -233,7 +234,6 @@ class _RecordTabState extends ConsumerState<_RecordTab> {
     final AsyncValue<ExerciseWeek> weekAsync = ref.watch(
       exerciseWeekViewProvider,
     );
-    final ExerciseGoals goals = ref.watch(exerciseGoalsProvider);
     final DateTime today = _today;
     final DateTime center = today.add(Duration(days: _weekShift * 7));
     final bool atToday = _weekShift == 0 && _selected == today;
@@ -294,58 +294,24 @@ class _RecordTabState extends ConsumerState<_RecordTab> {
             // "기록이 없어요"만 그려, 시드가 있는 날조차 비어 보였다(#671).
             _ExerciseSelectedDay(thisWeek: week, date: _selected)
           else ...<Widget>[
-            // 1) 이번 주 운동 요약
-            Padding(
-              padding: const EdgeInsets.fromLTRB(24, 0, 24, 12),
-              child: Text(
-                l.exWeekSummary,
-                style: const TextStyle(
-                  fontSize: 15,
-                  fontWeight: FontWeight.w700,
-                  color: FigmaColors.ink,
-                ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 24),
-              child: Row(
-                children: <Widget>[
-                  Expanded(
-                    child: _StatCard(
-                      label: l.exStatTime,
-                      value: '${week.totalMinutes}',
-                      unit: l.unitMinutes,
-                      goal: '${goals.minutes}',
-                      accent: true,
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: _StatCard(
-                      label: l.exStatCalories,
-                      value: '${week.totalCalories}',
-                      unit: l.unitKcal,
-                      goal: NumberFormat('#,###').format(goals.burnCalories),
-                      accent: true,
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: _StatCard(
-                      label: l.exStatStreak,
-                      value: '${week.streakDays}',
-                      unit: l.exUnitStreakDays,
-                      streak: true,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            const SizedBox(height: 20),
-            // 2) 운동 현황 (오늘 / 이번 주 / 이번 달)
+            // 1) 운동 현황 — 이 화면이 먼저 답해야 하는 것은 "얼마나 했나" 다.
+            //
+            // 예전에는 위에 `이번 주 운동 요약`(시간·칼로리·연속 카드 석 장)이
+            // 있었는데, 시간과 칼로리는 바로 아래 그래프가 이미 말하고 있었다.
+            // 연속 일수만 그래프가 말하지 못하므로 카드 머리로 옮겼다. (#1021)
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 24),
               child: _ActivityStatus(week: week),
+            ),
+            const SizedBox(height: 20),
+            // 2) AI 맞춤 조언 — "얼마나 했나" 다음은 "그래서 오늘 뭘 할까" 다.
+            //    식단 탭과 같은 카드를 쓴다. (#1021)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: AiAdviceCard(
+                title: l.dietAiFeedback,
+                message: week.aiCoachMessage,
+              ),
             ),
             const SizedBox(height: 20),
             // 3) 오늘 완료한 PT 일지 (트레이너 피드백 포함)
@@ -354,22 +320,20 @@ class _RecordTabState extends ConsumerState<_RecordTab> {
               child: _PtLogCard(),
             ),
             const SizedBox(height: 20),
-            // 4) AI 코칭 — 코칭 포인트와 추천 개인운동.
+            // 4) AI 코칭 — 추천 개인운동.
             //
             // PT 피드백 바로 다음에 둔다. `오늘 PT 에서 받은 피드백 → 그래서
-            // 어떤 관리가 필요한지 → 어떤 개인운동을 하면 되는지` 가 한 흐름으로
-            // 읽혀야 한다. 예전에는 조언이 맨 위, 추천 운동이 맨 아래라 그 사이를
-            // 회원이 직접 이어 붙여야 했다(#782).
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 24),
-              child: AiCoachingCard(coachingPoint: week.aiCoachMessage),
+            // 어떤 개인운동을 하면 되는지` 가 한 흐름으로 읽혀야 한다. 코칭
+            // 포인트는 위의 AI 맞춤 조언 카드로 옮겼다 — 같은 말이 한 화면에 두
+            // 번 있으면 안 된다. (#1021)
+            const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 24),
+              child: AiCoachingCard(),
             ),
             const SizedBox(height: 20),
-            // 5) 담당 트레이너 — 관계와 소통만. 추천 운동은 AI 코칭에 모였다.
-            //    받은 담당 요청은 그 바로 위에 둔다 — "내 담당은 누구인가" 와
-            //    "담당이 되겠다는 사람이 있다" 는 같은 질문의 앞뒤다. (#919)
+            // 5) 받은 담당 요청. 담당 트레이너 카드는 뺐다 — 이 화면은 기록을
+            //    보는 자리이고, 트레이너와의 관계는 MY 탭이 말한다. (#1021)
             const CoachInviteCard(),
-            const CoachCard(),
           ],
         ],
       ),
@@ -610,7 +574,6 @@ class _ExerciseDayDetail extends StatelessWidget {
     final double minutes = _at(week.dailyMinutes, i);
     if (minutes <= 0) return const _ExerciseDayEmpty();
 
-    final double calories = _at(week.dailyCalories, i);
     final String dayLabel = i < week.dayLabels.length ? week.dayLabels[i] : '';
     final List<ExerciseSession> sessions = week.sessions
         .where((ExerciseSession s) => s.dayLabel == dayLabel)
@@ -648,29 +611,10 @@ class _ExerciseDayDetail extends StatelessWidget {
               color: FigmaColors.ink,
             ),
           ),
+          // 시간·칼로리 카드는 뺐다 — 아래 도넛과 기록 줄이 같은 값을 이미
+          // 말하고, 지난 날짜에서 제일 궁금한 것은 합계가 아니라 **무슨 운동을
+          // 했나** 다. (#1021)
           const SizedBox(height: 12),
-          Row(
-            children: <Widget>[
-              Expanded(
-                child: _StatCard(
-                  label: l.exStatTime,
-                  value: '${minutes.round()}',
-                  unit: l.unitMinutes,
-                  accent: true,
-                ),
-              ),
-              const SizedBox(width: 8),
-              Expanded(
-                child: _StatCard(
-                  label: l.exStatCalories,
-                  value: NumberFormat('#,###').format(calories.round()),
-                  unit: l.unitKcal,
-                  accent: true,
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 14),
           _TodayDonut(segs: segs),
           if (sessions.isNotEmpty) ...<Widget>[
             const SizedBox(height: 14),
@@ -687,27 +631,83 @@ class _ExerciseDayDetail extends StatelessWidget {
                     color: FigmaColors.softBlue,
                     borderRadius: BorderRadius.circular(14),
                   ),
-                  child: Row(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
-                      Expanded(
-                        child: Text(
-                          _exerciseTypeLabel(l, s.type),
+                      Row(
+                        children: <Widget>[
+                          Expanded(
+                            child: Text(
+                              s.assignedRoutineName.isNotEmpty
+                                  ? s.assignedRoutineName
+                                  : _exerciseTypeLabel(l, s.type),
+                              style: const TextStyle(
+                                fontSize: 13.5,
+                                fontWeight: FontWeight.w700,
+                                color: FigmaColors.ink,
+                              ),
+                            ),
+                          ),
+                          Text(
+                            '${s.minutes}${l.unitMinutes} · '
+                            '${NumberFormat('#,###').format(s.calories)} ${l.unitKcal}',
+                            style: const TextStyle(
+                              fontSize: 12.5,
+                              fontWeight: FontWeight.w600,
+                              color: AppColors.mutedForeground,
+                            ),
+                          ),
+                        ],
+                      ),
+                      // 무슨 운동을 했는지 — 유형만 적으면 `유산소 30분` 이
+                      // 러닝인지 자전거인지 알 수 없다. (#1021)
+                      if (s.items.isNotEmpty) ...<Widget>[
+                        const SizedBox(height: 6),
+                        for (final String item in s.items)
+                          Padding(
+                            padding: const EdgeInsets.only(top: 2),
+                            child: Row(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: <Widget>[
+                                const Padding(
+                                  padding: EdgeInsets.only(top: 5, right: 6),
+                                  child: SizedBox(
+                                    width: 4,
+                                    height: 4,
+                                    child: DecoratedBox(
+                                      decoration: BoxDecoration(
+                                        color: FigmaColors.primary,
+                                        shape: BoxShape.circle,
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                                Expanded(
+                                  child: Text(
+                                    item,
+                                    style: const TextStyle(
+                                      fontSize: 12.5,
+                                      height: 1.35,
+                                      fontWeight: FontWeight.w500,
+                                      color: AppColors.foreground,
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                      ],
+                      if (s.memberNote.isNotEmpty) ...<Widget>[
+                        const SizedBox(height: 6),
+                        Text(
+                          s.memberNote,
                           style: const TextStyle(
-                            fontSize: 13.5,
-                            fontWeight: FontWeight.w700,
-                            color: FigmaColors.ink,
+                            fontSize: 12.5,
+                            height: 1.35,
+                            color: AppColors.mutedForeground,
                           ),
                         ),
-                      ),
-                      Text(
-                        '${s.minutes}${l.unitMinutes} · '
-                        '${NumberFormat('#,###').format(s.calories)} ${l.unitKcal}',
-                        style: const TextStyle(
-                          fontSize: 12.5,
-                          fontWeight: FontWeight.w600,
-                          color: AppColors.mutedForeground,
-                        ),
-                      ),
+                      ],
                     ],
                   ),
                 ),
@@ -828,115 +828,6 @@ class _WeekDay extends StatelessWidget {
   }
 }
 
-class _StatCard extends StatelessWidget {
-  const _StatCard({
-    required this.label,
-    required this.value,
-    required this.unit,
-    this.goal,
-    this.accent = false,
-    this.streak = false,
-  });
-
-  final String label;
-  final String value;
-  final String unit;
-
-  /// Optional small "/목표" suffix shown after the value (e.g. "/150").
-  final String? goal;
-  final bool accent;
-  final bool streak;
-
-  @override
-  Widget build(BuildContext context) {
-    final Color bg = streak
-        ? FigmaColors.heartOrange
-        : accent
-        ? FigmaColors.primaryA(0.07)
-        : FigmaColors.statBg;
-    final Color valueColor = streak
-        ? Colors.white
-        : accent
-        ? FigmaColors.primary
-        : FigmaColors.ink;
-    final Color labelColor = streak
-        ? Colors.white.withValues(alpha: 0.8)
-        : AppColors.mutedForeground;
-    return Container(
-      padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-        color: bg,
-        borderRadius: BorderRadius.circular(16),
-        border: streak
-            ? null
-            : Border.all(
-                color: accent
-                    ? FigmaColors.primaryA(0.15)
-                    : FigmaColors.hairline,
-              ),
-        boxShadow: streak ? kCardShadow : null,
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Row(
-            children: <Widget>[
-              Expanded(
-                child: Text(
-                  label,
-                  style: TextStyle(
-                    fontSize: 12,
-                    fontWeight: FontWeight.w600,
-                    color: labelColor,
-                  ),
-                ),
-              ),
-              if (streak) const Text('🔥', style: TextStyle(fontSize: 12)),
-            ],
-          ),
-          const SizedBox(height: 6),
-          // Value with the unit inline to its right → one line shorter.
-          Text.rich(
-            TextSpan(
-              children: <InlineSpan>[
-                TextSpan(
-                  text: value,
-                  style: TextStyle(
-                    fontSize: accent ? 14 : 16,
-                    fontWeight: FontWeight.w800,
-                    color: valueColor,
-                    height: 1,
-                    letterSpacing: -0.4,
-                  ),
-                ),
-                if (goal != null)
-                  TextSpan(text: ' /$goal$unit', style: kGoalSuffixStyle)
-                else
-                  TextSpan(
-                    text: ' $unit',
-                    style: TextStyle(
-                      fontSize: 12,
-                      fontWeight: FontWeight.w600,
-                      color: streak
-                          ? Colors.white.withValues(alpha: 0.85)
-                          : accent
-                          ? FigmaColors.primary.withValues(alpha: 0.7)
-                          : AppColors.mutedForeground,
-                    ),
-                  ),
-              ],
-            ),
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-/// A period of the "운동 현황" chart: the stacked bars, their x-labels, and
-/// which bar (if any) represents "now" for the highlight/label.
 class _ChartPeriod {
   const _ChartPeriod(this.bars, this.labels, this.todayIndex);
   final List<_Bar> bars;
@@ -1063,6 +954,33 @@ class _ActivityStatusState extends ConsumerState<_ActivityStatus> {
                 labels: <String>[l.exToday, l.exThisWeek, l.exPeriodAll],
                 onChanged: (int i) =>
                     ref.read(exerciseActivityPeriodProvider.notifier).state = i,
+              ),
+            ),
+          ],
+        ),
+        // 며칠 연속인지는 그래프가 말하지 못한다 — 카드 머리에 한 줄로 둔다.
+        // 예전에는 위쪽 `이번 주 운동 요약` 의 주황 카드가 하던 말인데, 그
+        // 요약을 걷어내면서 이 자리로 옮겼다. (#1021)
+        const SizedBox(height: 8),
+        Row(
+          children: <Widget>[
+            const Icon(
+              Icons.local_fire_department_rounded,
+              size: 16,
+              color: FigmaColors.heartOrange,
+            ),
+            const SizedBox(width: 4),
+            Flexible(
+              child: Text(
+                widget.week.streakDays > 0
+                    ? l.exStreakCheer(widget.week.streakDays)
+                    : l.exStreakStart,
+                maxLines: 2,
+                style: const TextStyle(
+                  fontSize: 12.5,
+                  fontWeight: FontWeight.w700,
+                  color: FigmaColors.heartOrange,
+                ),
               ),
             ),
           ],
@@ -2281,6 +2199,9 @@ class _CompletedPtSessionCard extends StatelessWidget {
               ),
             ),
           ],
+          // 오늘 들은 말 다음은 "그럼 다음엔 언제 보나" 다. (#1021)
+          const SizedBox(height: 10),
+          const _NextPtBadge(),
         ],
       ),
     );
@@ -2467,10 +2388,60 @@ class _DemoPtLogCard extends StatelessWidget {
                     color: FigmaColors.ink,
                   ),
                 ),
+                const SizedBox(height: 10),
+                const _NextPtBadge(),
               ],
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+/// 다음 PT 가 언제인지 한 줄로. (#1021)
+///
+/// 오늘 받은 피드백 **바로 아래**에 둔다 — "오늘 이런 얘기를 들었다" 다음에
+/// 회원이 궁금해하는 것은 "그럼 다음엔 언제 보나" 다. 일정 탭까지 가서 찾게
+/// 하지 않는다.
+class _NextPtBadge extends ConsumerWidget {
+  const _NextPtBadge();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AppLocalizations l = AppLocalizations.of(context);
+    final DateTime now = nowKst();
+    final DateTime today = DateTime(now.year, now.month, now.day);
+    final List<CoachSession> upcoming =
+        (ref.watch(coachSessionsProvider).valueOrNull ?? const <CoachSession>[])
+            .where((CoachSession s) {
+              final DateTime? date = s.date;
+              return s.isUpcoming &&
+                  date != null &&
+                  !DateTime(date.year, date.month, date.day).isBefore(today);
+            })
+            .toList(growable: false)
+          ..sort((CoachSession a, CoachSession b) {
+            final int byDate = a.date!.compareTo(b.date!);
+            return byDate != 0 ? byDate : a.time.compareTo(b.time);
+          });
+
+    final String when;
+    if (upcoming.isEmpty) {
+      when = '';
+    } else {
+      final CoachSession next = upcoming.first;
+      final String date = DateFormat.MMMEd(
+        Localizations.localeOf(context).toString(),
+      ).format(next.date!);
+      when = next.time.isEmpty ? date : '$date ${next.time}';
+    }
+    return Align(
+      alignment: AlignmentDirectional.centerStart,
+      child: _MetaChip(
+        icon: Icons.event_available_rounded,
+        text: when.isEmpty ? l.exNextPtNone : l.exNextPtSchedule(when),
+        color: when.isEmpty ? AppColors.mutedForeground : FigmaColors.primary,
       ),
     );
   }

--- a/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_card.dart
+++ b/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_card.dart
@@ -132,10 +132,7 @@ class CoachCard extends ConsumerWidget {
 /// 운동**이다. 그래서 추천할 것이 없는 날은 빈 카드를 만들지 않고 코칭 포인트만
 /// 남긴다 — AI 가 매번 운동을 억지로 만들어 낼 이유가 없다.
 class AiCoachingCard extends ConsumerWidget {
-  const AiCoachingCard({required this.coachingPoint, super.key});
-
-  /// 이번 코칭 포인트. 운동 주간 데이터의 `aiCoachMessage` 가 그대로 들어온다.
-  final String coachingPoint;
+  const AiCoachingCard({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -145,11 +142,14 @@ class AiCoachingCard extends ConsumerWidget {
     final List<CoachRoutine> routines =
         ref.watch(coachRoutinesProvider).valueOrNull ?? const <CoachRoutine>[];
     final MemberCoach? coach = ref.watch(memberCoachProvider).valueOrNull;
-    final String point = coachingPoint.trim();
 
-    // 코칭 포인트도 추천도 없으면 카드 자체를 그리지 않는다. 빈 카드는 자리만
-    // 차지하고 아무것도 알려 주지 않는다.
-    if (point.isEmpty && routines.isEmpty) return const SizedBox.shrink();
+    // 추천이 없으면 카드 자체를 그리지 않는다. 빈 카드는 자리만 차지하고
+    // 아무것도 알려 주지 않는다.
+    //
+    // 예전에는 이 카드가 `이번 코칭 포인트` 도 함께 말했다. 지금은 화면 위쪽의
+    // AI 맞춤 조언 카드가 그 말을 하므로 여기서는 뺐다 — 같은 말이 한 화면에
+    // 두 번 있으면 안 된다. (#1021)
+    if (routines.isEmpty) return const SizedBox.shrink();
 
     return Container(
       key: const Key('aiCoachingCard'),
@@ -185,27 +185,6 @@ class AiCoachingCard extends ConsumerWidget {
               ),
             ],
           ),
-          if (point.isNotEmpty) ...<Widget>[
-            const SizedBox(height: 12),
-            Text(
-              l.coachPointsTitle,
-              style: const TextStyle(
-                fontSize: 13,
-                fontWeight: FontWeight.w700,
-                color: FigmaColors.primary,
-              ),
-            ),
-            const SizedBox(height: 4),
-            Text(
-              point,
-              style: const TextStyle(
-                fontSize: 13.5,
-                height: 1.5,
-                fontWeight: FontWeight.w500,
-                color: FigmaColors.ink,
-              ),
-            ),
-          ],
           if (routines.isNotEmpty) ...<Widget>[
             const SizedBox(height: 14),
             Text(
@@ -243,6 +222,50 @@ class AiCoachingCard extends ConsumerWidget {
             ],
           ],
         ],
+      ),
+    );
+  }
+}
+
+/// 추천 운동을 했는지 표시하는 체크 박스. (#1021)
+///
+/// 한 번 체크하면 풀 수 없다. 수행은 기록으로 남아 주간 시간·칼로리에 더해지고
+/// 트레이너에게도 보인다 — 체크를 무르는 것은 그 기록을 지우는 일이라, 지금
+/// 구조에서 조용히 되돌릴 수 있는 동작이 아니다.
+class _RoutineCheckbox extends StatelessWidget {
+  const _RoutineCheckbox({
+    super.key,
+    required this.done,
+    required this.saving,
+    required this.onCheck,
+  });
+
+  final bool done;
+  final bool saving;
+  final VoidCallback onCheck;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations l = AppLocalizations.of(context);
+    if (saving) {
+      return const Padding(
+        padding: EdgeInsets.all(9),
+        child: SizedBox.square(
+          dimension: 18,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+      );
+    }
+    return Semantics(
+      checked: done,
+      label: l.coachRoutineDone,
+      child: Checkbox(
+        value: done,
+        // 다 한 것은 되돌리지 않는다 — 눌러도 아무 일이 없다는 뜻으로 비활성.
+        onChanged: done ? null : (bool? _) => onCheck(),
+        visualDensity: VisualDensity.compact,
+        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        activeColor: FigmaColors.primary,
       ),
     );
   }
@@ -348,7 +371,19 @@ class _RecommendedExerciseRowState
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
           Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
+              // 했는지 안 했는지는 체크 박스로 말한다 (#1021). 예전에는 오른쪽
+              // 아래에 `수행 완료` 버튼이 있었는데, 시간·유형 아래에 붙어 있어
+              // 무엇에 대한 버튼인지 한눈에 붙지 않았다. 체크 박스를 줄 맨
+              // 앞에 두면 "이 운동을 했다" 가 그 줄에서 바로 읽힌다.
+              _RoutineCheckbox(
+                key: Key('completeRoutine-${routine.id}'),
+                done: routine.completed,
+                saving: _saving,
+                onCheck: _complete,
+              ),
+              const SizedBox(width: 8),
               Expanded(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -422,43 +457,7 @@ class _RecommendedExerciseRowState
                         color: FigmaColors.primary,
                       ),
                     ),
-                    const SizedBox(height: 4),
-                    if (routine.completed)
-                      Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: <Widget>[
-                          const Icon(
-                            Icons.check_circle,
-                            size: 16,
-                            color: Colors.green,
-                          ),
-                          const SizedBox(width: 4),
-                          Flexible(child: Text(l.coachRoutineDone)),
-                        ],
-                      )
-                    else
-                      SizedBox(
-                        height: 30,
-                        child: OutlinedButton(
-                          key: Key('completeRoutine-${routine.id}'),
-                          onPressed: _saving ? null : _complete,
-                          style: OutlinedButton.styleFrom(
-                            padding: const EdgeInsets.symmetric(horizontal: 10),
-                          ),
-                          child: _saving
-                              ? const SizedBox.square(
-                                  dimension: 14,
-                                  child: CircularProgressIndicator(
-                                    strokeWidth: 2,
-                                  ),
-                                )
-                              : Text(
-                                  l.coachRoutineDone,
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
-                                ),
-                        ),
-                      ),
+
                   ],
                 ),
               ),

--- a/frontend/flutter/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations.dart
@@ -1298,6 +1298,18 @@ abstract class AppLocalizations {
   /// **'day streak'**
   String get exUnitStreakDays;
 
+  /// No description provided for @exStreakCheer.
+  ///
+  /// In en, this message translates to:
+  /// **'{days} days in a row!'**
+  String exStreakCheer(int days);
+
+  /// No description provided for @exStreakStart.
+  ///
+  /// In en, this message translates to:
+  /// **'Start a streak with today\'s workout.'**
+  String get exStreakStart;
+
   /// No description provided for @exToday.
   ///
   /// In en, this message translates to:
@@ -3571,6 +3583,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Today\'s feedback'**
   String get exPtFeedbackTitle;
+
+  /// No description provided for @exNextPtSchedule.
+  ///
+  /// In en, this message translates to:
+  /// **'Next PT · {when}'**
+  String exNextPtSchedule(String when);
+
+  /// No description provided for @exNextPtNone.
+  ///
+  /// In en, this message translates to:
+  /// **'No PT scheduled yet'**
+  String get exNextPtNone;
 
   /// Screen title carrying the selected date.
   ///

--- a/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
@@ -675,6 +675,14 @@ class AppLocalizationsEn extends AppLocalizations {
   String get exUnitStreakDays => 'day streak';
 
   @override
+  String exStreakCheer(int days) {
+    return '$days days in a row!';
+  }
+
+  @override
+  String get exStreakStart => 'Start a streak with today\'s workout.';
+
+  @override
   String get exToday => 'Today';
 
   @override
@@ -1929,6 +1937,14 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get exPtFeedbackTitle => 'Today\'s feedback';
+
+  @override
+  String exNextPtSchedule(String when) {
+    return 'Next PT · $when';
+  }
+
+  @override
+  String get exNextPtNone => 'No PT scheduled yet';
 
   @override
   String exDatedTitle(int month, int day, String title) {

--- a/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
@@ -659,6 +659,14 @@ class AppLocalizationsKo extends AppLocalizations {
   String get exUnitStreakDays => '일 연속';
 
   @override
+  String exStreakCheer(int days) {
+    return '$days일 연속 운동 중이에요!';
+  }
+
+  @override
+  String get exStreakStart => '오늘 운동으로 연속 기록을 시작해 봐요.';
+
+  @override
   String get exToday => '오늘';
 
   @override
@@ -1866,6 +1874,14 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get exPtFeedbackTitle => '오늘의 피드백';
+
+  @override
+  String exNextPtSchedule(String when) {
+    return '다음 PT · $when';
+  }
+
+  @override
+  String get exNextPtNone => '다음 PT 일정이 아직 없어요';
 
   @override
   String exDatedTitle(int month, int day, String title) {

--- a/frontend/flutter/lib/l10n/app_en.arb
+++ b/frontend/flutter/lib/l10n/app_en.arb
@@ -329,6 +329,11 @@
   "exStatCalories": "Calories",
   "exStatStreak": "Streak",
   "exUnitStreakDays": "day streak",
+  "exStreakCheer": "{days} days in a row!",
+  "@exStreakCheer": {
+    "placeholders": { "days": { "type": "int" } }
+  },
+  "exStreakStart": "Start a streak with today's workout.",
   "exToday": "Today",
   "exLoadError": "Couldn't load your exercise data.",
   "exCompletedPtTitle": "Today's completed PT",
@@ -1210,6 +1215,11 @@
     "description": "Title of the completed PT session card."
   },
   "exPtFeedbackTitle": "Today's feedback",
+  "exNextPtSchedule": "Next PT · {when}",
+  "@exNextPtSchedule": {
+    "placeholders": { "when": { "type": "String" } }
+  },
+  "exNextPtNone": "No PT scheduled yet",
   "@exPtFeedbackTitle": {
     "description": "Label above the trainer's feedback."
   },

--- a/frontend/flutter/lib/l10n/app_ko.arb
+++ b/frontend/flutter/lib/l10n/app_ko.arb
@@ -232,6 +232,11 @@
   "exStatCalories": "칼로리",
   "exStatStreak": "연속",
   "exUnitStreakDays": "일 연속",
+  "exStreakCheer": "{days}일 연속 운동 중이에요!",
+  "@exStreakCheer": {
+    "placeholders": { "days": { "type": "int" } }
+  },
+  "exStreakStart": "오늘 운동으로 연속 기록을 시작해 봐요.",
   "exToday": "오늘",
   "exLoadError": "운동 정보를 불러오지 못했어요.",
   "exCompletedPtTitle": "오늘 완료한 PT",
@@ -665,6 +670,11 @@
   "alertJustNow": "방금",
   "exPtLogTitle": "오늘 완료한 PT",
   "exPtFeedbackTitle": "오늘의 피드백",
+  "exNextPtSchedule": "다음 PT · {when}",
+  "@exNextPtSchedule": {
+    "placeholders": { "when": { "type": "String" } }
+  },
+  "exNextPtNone": "다음 PT 일정이 아직 없어요",
   "exDatedTitle": "{month}월 {day}일 {title}",
   "a11yChartSummary": "{title}. {detail}",
   "@a11yChartSummary": {"placeholders": {"title": {"type": "String"}, "detail": {"type": "String"}}},

--- a/frontend/flutter/lib/shared/widgets/ai_advice_card.dart
+++ b/frontend/flutter/lib/shared/widgets/ai_advice_card.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+
+import 'package:oncare/design_system/figma/figma_kit.dart';
+
+/// AI 가 건네는 한 문단짜리 조언 카드. (#1021)
+///
+/// 식단 탭이 쓰던 그림을 그대로 꺼내 둔 것이다. 운동 탭도 같은 자리에서 같은
+/// 말을 하게 됐는데, 두 탭이 조금씩 다른 카드를 쓰면 회원은 "이 카드가 그
+/// 카드인가" 를 매번 다시 판단해야 한다.
+///
+/// 문구가 비면 아무것도 그리지 않는다 — 빈 카드는 자리만 차지하고 아무것도
+/// 알려 주지 않는다.
+class AiAdviceCard extends StatelessWidget {
+  const AiAdviceCard({
+    super.key,
+    required this.title,
+    required this.message,
+  });
+
+  /// 카드 머리 — `AI 맞춤 조언` 처럼 무슨 말인지 알려 주는 한 줄.
+  final String title;
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    if (message.trim().isEmpty) return const SizedBox.shrink();
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: FigmaColors.softBlue,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: FigmaColors.primaryA(0.15)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          const OniAvatar(size: 40),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  title,
+                  style: const TextStyle(
+                    fontSize: 13.5,
+                    fontWeight: FontWeight.w700,
+                    color: FigmaColors.primary,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  message,
+                  style: const TextStyle(
+                    fontSize: 13.5,
+                    height: 1.5,
+                    fontWeight: FontWeight.w500,
+                    color: FigmaColors.ink,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/flutter/test/features/exercise/exercise_health_goals_test.dart
+++ b/frontend/flutter/test/features/exercise/exercise_health_goals_test.dart
@@ -23,6 +23,7 @@ import 'package:oncare/features/member_coach/domain/repositories/member_coach_re
 import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
 import 'package:oncare/features/my_health/presentation/widgets/my_flows.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
+import 'package:oncare/shared/widgets/ai_advice_card.dart';
 
 class _GoalSyncHost extends StatefulWidget {
   const _GoalSyncHost();
@@ -164,7 +165,7 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  testWidgets('운동 탭 요약은 일수 카드를 제외한 운동 목표를 표시한다', (
+  testWidgets('운동 탭에는 주간 요약 카드가 없다 — 연속만 응원 문구로 남는다 (#1021)', (
     WidgetTester tester,
   ) async {
     await pumpExercise(
@@ -179,14 +180,47 @@ void main() {
       ),
     );
 
+    // 시간·칼로리는 바로 아래 그래프가 이미 말한다 — 카드로 한 번 더 적지
+    // 않는다. 목표는 그래프의 목표선이 말한다(#1015).
     expect(find.text('일수'), findsNothing);
-    expect(find.text('2 /5일'), findsNothing);
-    expect(find.text('100 /240분'), findsOneWidget);
-    expect(find.text('300 /900kcal'), findsOneWidget);
-    expect(find.text('연속'), findsOneWidget);
+    expect(find.text('100 /240분'), findsNothing);
+    expect(find.text('300 /900kcal'), findsNothing);
+
+    // 며칠 연속인지는 그래프가 말하지 못하므로 카드 머리에 남는다.
+    expect(find.textContaining('연속'), findsWidgets);
   });
 
-  testWidgets('운동 목표가 없으면 필드별 기본값을 표시한다', (WidgetTester tester) async {
+  testWidgets('기록 화면은 현황 → 조언 → PT 순서로 놓인다 (#1021)', (
+    WidgetTester tester,
+  ) async {
+    await pumpExercise(
+      tester,
+      profile: const UserProfile(
+        id: 'member',
+        name: '테스트',
+        email: 'member@example.com',
+      ),
+    );
+
+    // 걷어낸 것: 주간 요약 제목과 화면 맨 아래 담당 트레이너 카드.
+    expect(find.text('이번 주 운동 요약'), findsNothing);
+    expect(find.byKey(const Key('coachCard')), findsNothing);
+
+    // 더한 것: 운동 현황과 PT 카드 사이의 AI 맞춤 조언 카드. 식단 탭과 같은
+    // 위젯이라 카드 머리 문구도 같다.
+    final Finder advice = find.byType(AiAdviceCard);
+    expect(advice, findsOneWidget);
+    expect(find.text('AI 맞춤 조언'), findsOneWidget);
+
+    // 순서: 운동 현황 → 조언. 기간 토글이 현황 카드의 머리에 있다.
+    final double statusY = tester.getTopLeft(find.text('이번 주').first).dy;
+    final double adviceY = tester.getTopLeft(advice).dy;
+    expect(adviceY, greaterThan(statusY));
+  });
+
+  testWidgets('운동 목표는 그래프의 목표선이 말한다 (#1015, #1021)', (
+    WidgetTester tester,
+  ) async {
     await pumpExercise(
       tester,
       profile: const UserProfile(
@@ -198,9 +232,9 @@ void main() {
       ),
     );
 
-    expect(find.text('2 /4일'), findsNothing);
-    expect(find.text('100 /150분'), findsOneWidget);
-    expect(find.text('300 /800kcal'), findsOneWidget);
+    // 요약 카드가 없어졌으니 `100 /150분` 같은 문구도 없다.
+    expect(find.text('100 /150분'), findsNothing);
+    expect(find.text('300 /800kcal'), findsNothing);
   });
 
   testWidgets('트레이너가 완료한 PT 프로그램과 피드백을 표시한다', (WidgetTester tester) async {
@@ -315,9 +349,10 @@ void main() {
 
     await tester.tap(find.byKey(const Key('showExercise')));
     await tester.pumpAndSettle();
-    expect(find.text('2 /5일'), findsNothing);
-    expect(find.text('100 /240분'), findsOneWidget);
-    expect(find.text('300 /900kcal'), findsOneWidget);
+    // 운동 탭의 요약 카드는 없어졌다 — 바뀐 목표는 홈 카드와 그래프의 목표선이
+    // 말한다. (#1021)
+    expect(find.text('100 /240분'), findsNothing);
+    expect(find.text('300 /900kcal'), findsNothing);
 
     await tester.pump(const Duration(seconds: 3));
     await tester.pumpAndSettle();

--- a/frontend/flutter/test/features/member_coach/recommended_exercise_cards_test.dart
+++ b/frontend/flutter/test/features/member_coach/recommended_exercise_cards_test.dart
@@ -20,7 +20,6 @@ import 'package:oncare/features/member_coach/presentation/widgets/coach_chat_she
 import 'package:oncare/gen/l10n/app_localizations.dart';
 
 /// 코칭 포인트 — 운동 주간 데이터의 `aiCoachMessage` 자리에 들어가는 값.
-const String _coachingPoint = '오른쪽 어깨가 들리는 경향이 있어 어깨 안정화에 집중해요.';
 
 const MemberCoach _trainer = MemberCoach(
   trainerId: 'trainer-1',
@@ -152,7 +151,7 @@ void main() {
                 children: <Widget>[
                   Padding(
                     padding: EdgeInsets.all(24),
-                    child: AiCoachingCard(coachingPoint: _coachingPoint),
+                    child: AiCoachingCard(),
                   ),
                   CoachCard(),
                 ],
@@ -177,13 +176,11 @@ void main() {
 
     // 예전에는 조언(맨 위)과 추천 운동(맨 아래)이 멀리 떨어져 있었다.
     expect(find.text('AI 코칭'), findsOneWidget);
+    // 코칭 포인트는 화면 위쪽의 AI 맞춤 조언 카드로 옮겼다 — 같은 말이 한
+    // 화면에 두 번 있으면 안 된다. (#1021)
     expect(
       find.descendant(of: coaching, matching: find.text('이번 코칭 포인트')),
-      findsOneWidget,
-    );
-    expect(
-      find.descendant(of: coaching, matching: find.text(_coachingPoint)),
-      findsOneWidget,
+      findsNothing,
     );
     // 트레이너 추천과 AI 추천이 같은 목록에 있다 — 회원에게는 한 가지 질문이다.
     expect(
@@ -247,7 +244,7 @@ void main() {
           supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
             body: SingleChildScrollView(
-              child: AiCoachingCard(coachingPoint: _coachingPoint),
+              child: AiCoachingCard(),
             ),
           ),
         ),
@@ -259,11 +256,13 @@ void main() {
     expect(find.textContaining('확인'), findsNothing);
   });
 
-  testWidgets('추천 운동이 없으면 코칭 포인트만 보여 준다 (#782)', (WidgetTester tester) async {
+  testWidgets('추천 운동이 없으면 카드를 그리지 않는다 (#782, #1021)', (
+    WidgetTester tester,
+  ) async {
     await pumpRecommendationCards(tester, const <CoachRoutine>[]);
 
-    expect(find.text('이번 코칭 포인트'), findsOneWidget);
-    expect(find.text(_coachingPoint), findsOneWidget);
+    // 코칭 포인트가 이 카드를 떠난 뒤로, 추천이 없으면 카드에 남는 말이 없다.
+    expect(find.text('AI 코칭'), findsNothing);
     // 빈 추천 카드를 만들지 않는다 — AI 가 매번 운동을 지어낼 이유가 없다.
     expect(find.text('추천 개인운동'), findsNothing);
     expect(find.text('현재 추천할 수 있는 AI 맞춤 운동이 없어요'), findsNothing);
@@ -380,7 +379,7 @@ void main() {
           locale: Locale('ko'),
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
-          home: Scaffold(body: AiCoachingCard(coachingPoint: _coachingPoint)),
+          home: Scaffold(body: AiCoachingCard()),
         ),
       ),
     );
@@ -401,7 +400,16 @@ void main() {
         .firstWhere((CoachRoutine routine) => routine.id == 'seed-r2');
     expect(find.text('운동 기록에 반영했어요'), findsOneWidget);
     expect(find.text('내 메모: 허리는 편안했어요'), findsOneWidget);
-    expect(find.byKey(const Key('completeRoutine-seed-r2')), findsNothing);
+    // 체크 박스는 그대로 있고 체크된 채로 잠긴다 — 한 일이 화면에서 사라지면
+    // 무엇을 했는지 다시 확인할 데가 없다. (#1021)
+    final Checkbox box = tester.widget<Checkbox>(
+      find.descendant(
+        of: find.byKey(const Key('completeRoutine-seed-r2')),
+        matching: find.byType(Checkbox),
+      ),
+    );
+    expect(box.value, isTrue);
+    expect(box.onChanged, isNull);
     expect(completed.completedIntensity, 'high');
   });
 

--- a/frontend/flutter/test/l10n/english_locale_test.dart
+++ b/frontend/flutter/test/l10n/english_locale_test.dart
@@ -215,7 +215,7 @@ void main() {
     await pump(
       tester,
       const Scaffold(
-        body: SingleChildScrollView(child: AiCoachingCard(coachingPoint: '')),
+        body: SingleChildScrollView(child: AiCoachingCard()),
       ),
       lang: 'en',
       overrides: <Override>[


### PR DESCRIPTION
## Summary

운동 탭 `운동 기록` 화면에 카드가 너무 많고, 그중 여럿이 그래프가 이미 말한 것을 다시 말했다. 반대로 정작 필요한 것(그날 무슨 운동을 했는지, 다음 PT 가 언제인지)은 없었다.

한 화면이 답해야 하는 질문 순서대로 다시 세운다: **얼마나 했나 → 오늘 뭘 할까 → 무엇을 했나 → 트레이너가 뭐라 했나.**

Closes #1021

## Changes

**덜어낸 것**

- `이번 주 운동 요약`(시간·칼로리·연속 카드 석 장) 통째로. 시간과 칼로리는 바로 아래 그래프가 이미 말하고, 목표는 목표선이 말한다(#1015).
- 며칠 연속인지만 그래프가 말하지 못하므로 **운동 현황 카드 머리에 주황 응원 문구**로 옮겼다.
- 화면 맨 아래 담당 트레이너 카드. 이 화면은 기록을 보는 자리이고, 트레이너와의 관계는 MY 탭이 말한다. 받은 담당 요청 카드는 남긴다.

**고친 것**

- AI 코칭 카드의 `수행 완료` 버튼 → **체크 박스**, 줄 맨 앞으로. 버튼이 시간·유형 아래 오른쪽에 붙어 있어 무엇에 대한 버튼인지 한눈에 붙지 않았다. 한 번 체크하면 잠긴다 — 수행은 기록으로 남아 주간 합계와 트레이너 화면까지 가므로 조용히 무를 수 없다.
- 지난 날짜의 시간·칼로리 카드를 빼고 그 자리에 **무슨 운동을 했는지**를 넣었다. 유형만 적으면 `유산소 30분` 이 러닝인지 자전거인지 알 수 없다.

**보탠 것**

- 운동 현황과 PT 카드 사이에 **AI 맞춤 조언 카드**. 식단 탭이 쓰던 카드를 공용 위젯으로 꺼내 그대로 쓴다 — 두 탭이 조금씩 다른 카드를 쓰면 회원은 "이 카드가 그 카드인가"를 매번 다시 판단해야 한다.
- 문구는 AI 코칭 카드의 `이번 코칭 포인트` 를 **옮겨 온 것**이라 코칭 카드에서는 뺐다. 같은 말이 한 화면에 두 번 있으면 안 된다.
- 트레이너 피드백 아래 **다음 PT 일정 배지**. 오늘 들은 말 다음에 궁금한 것은 "그럼 다음엔 언제 보나"다.

## Notes

- 코칭 포인트가 떠나면서 AI 코칭 카드는 추천 운동이 없으면 아예 그리지 않는다 — 남는 말이 없어서다.
- 화면 구성을 검사하는 테스트를 새로 뒀다(요약 카드 없음 / 조언 카드가 현황 다음 / 트레이너 카드 없음). 요약 카드의 목표 문구를 검사하던 기존 테스트 세 개는 새 화면에 맞게 바꿨다.
- `flutter analyze` 무경고, 전체 테스트 통과.
