### PR TITLE
fix(messages): 트레이너가 답장한 스레드의 안읽음 배지 제거

### DIFF
--- a/frontend/flutter_trainer/lib/core/storage/seed_clients.dart
+++ b/frontend/flutter_trainer/lib/core/storage/seed_clients.dart
@@ -25,7 +25,7 @@ part of 'seed_data.dart';
 ///    걸리면 벌크업이 아니라 식습관 문제로 읽힌다. 나트륨 ÷ 칼로리는 1.5mg/kcal
 ///    을 넘지 않는다 — 그 위는 국물만 먹어야 나오는 값이다. 아래로는 제한이
 ///    없다(현미·닭가슴살 위주의 3,000kcal 는 0.6 근처가 정상이다).
-///  * `threadHandled: false` → 답장 대기.
+///  * **답장 대기는 스레드가 정한다** — 마지막 말이 회원 것이면 안읽음이다.
 ///
 /// Coverage this is meant to guarantee, by client:
 ///  1  김민수    나트륨 초과, 톱니형 이행률
@@ -57,7 +57,6 @@ const List<_Client> _clients = <_Client>[
     // 중간 토막을 잘라 써서 목록과 대화의 첫 마디가 서로 달랐다. 길이는 카드가
     // 알아서 줄임표로 자른다 — 여기서 미리 자르면 안 된다.
     lastTime: '18:18',
-    threadHandled: true,
     active: true,
     // 김민수의 수치는 **여기에 없다.** 그는 사용자 앱의 데모 계정(`user-demo`)과
     // 같은 사람이라 두 앱을 나란히 놓고 시연하는데, 각자 만들면 같은 날짜의 숫자가
@@ -339,7 +338,6 @@ const List<_Client> _clients = <_Client>[
     avatar: '정',
     goal: '산후 체력 회복',
     lastTime: '2시간 전',
-    threadHandled: true,
     active: true,
     calories: 1520,
     sodiumMg: 1650,
@@ -409,7 +407,6 @@ const List<_Client> _clients = <_Client>[
     avatar: '최',
     goal: '마라톤 완주 준비',
     lastTime: '어제',
-    threadHandled: true,
     active: true,
     calories: 2600,
     sodiumMg: 1450,
@@ -488,7 +485,6 @@ const List<_Client> _clients = <_Client>[
     avatar: '강',
     goal: '체지방 감량',
     lastTime: '5시간 전',
-    threadHandled: true,
     active: true,
     calories: 2260,
     sodiumMg: 2750,
@@ -564,7 +560,6 @@ const List<_Client> _clients = <_Client>[
     avatar: '임',
     goal: '목표 설정 전',
     lastTime: '-',
-    threadHandled: true,
     active: true,
     calories: 0,
     sodiumMg: 0,
@@ -715,7 +710,6 @@ const List<_Client> _clients = <_Client>[
     avatar: '신',
     goal: '재활 후 복귀',
     lastTime: '3시간 전',
-    threadHandled: true,
     active: true,
     calories: 1590,
     sodiumMg: 1720,
@@ -786,7 +780,6 @@ const List<_Client> _clients = <_Client>[
     avatar: '한',
     goal: '현 체중 유지',
     lastTime: '어제',
-    threadHandled: true,
     active: true,
     calories: 1880,
     sodiumMg: 2010,
@@ -954,7 +947,6 @@ const List<_Client> _clients = <_Client>[
     avatar: '백',
     goal: '식습관 개선',
     lastTime: '어제',
-    threadHandled: true,
     active: true,
     calories: 1920,
     sodiumMg: 2680,
@@ -1009,7 +1001,6 @@ const List<_Client> _clients = <_Client>[
     avatar: '노',
     goal: '운동 습관 만들기',
     lastTime: '어제',
-    threadHandled: true,
     active: true,
     calories: 1280,
     sodiumMg: 1450,

--- a/frontend/flutter_trainer/lib/core/storage/seed_data.dart
+++ b/frontend/flutter_trainer/lib/core/storage/seed_data.dart
@@ -277,7 +277,19 @@ Future<void> seedIfEmpty(
     // The marker is the newest client message's rowid, exactly what
     // `markThreadRead` writes — so opening the thread later is a no-op
     // rather than a second, different value.
-    for (final client in _clients.where((c) => c.threadHandled)) {
+    //
+    // **어느 스레드가 답장된 상태인가는 스레드가 정한다.** 예전에는
+    // `threadHandled: true` 를 고객마다 손으로 적어 뒀는데, 대화를 손볼 때
+    // 한쪽만 바뀌어 이지수·박성호는 트레이너가 마지막으로 답장해 놓고도
+    // 안읽음 배지를 달고 있었다 — 아무것도 기다리는 게 없는데 목록이
+    // "답장하세요" 라고 말했다.
+    //
+    // 실 API 도 같은 뜻이다: 트레이너는 채팅을 **열어야** 답장할 수 있고,
+    // 여는 순간 `read_at` 이 찍힌다. 다만 실 API 에는 코칭·리포트 탭에서
+    // 채팅을 열지 않고 루틴·PDF 를 보내는 길이 있어 "마지막이 트레이너" 가
+    // 곧 "읽었다" 는 아니다. 시드에는 그런 경로가 없으므로 여기서는 스레드의
+    // 마지막 발신자로 판정한다.
+    for (final client in _clients.where(_threadAnswered)) {
       final id = 'seed-client-${client.id}';
       final row = await db
           .customSelect(
@@ -740,7 +752,6 @@ class _Client {
     required this.aiRoutine,
     required this.history,
     required this.chat,
-    this.threadHandled = false,
   });
   final int id;
   final String name;
@@ -769,14 +780,6 @@ class _Client {
   final List<_Routine> aiRoutine;
   final List<_History> history;
   final List<_Chat> chat;
-
-  /// Whether the demo starts with this thread already answered and read.
-  ///
-  /// Unread is "client messages with no read marker", so a thread that
-  /// merely ends with a trainer message still counts every reply the
-  /// member sent. Without this flag the demo opens with all three members
-  /// waiting, which is not the state we want to show.
-  final bool threadHandled;
 }
 
 /// 스레드의 **마지막** 메시지 본문. 대화가 없으면 빈 문자열이다 —
@@ -791,6 +794,18 @@ String _lastChatText(List<_Chat> chat) {
     if (chat[i].dayIndex >= chat[last].dayIndex) last = i;
   }
   return chat[last].text;
+}
+
+/// 시드 스레드가 **답장된 상태로** 시작하는가 — 마지막 말이 트레이너 것이면.
+///
+/// 순서 규칙은 [_lastChatText] 와 같다.
+bool _threadAnswered(_Client client) {
+  if (client.chat.isEmpty) return false;
+  int last = 0;
+  for (var i = 1; i < client.chat.length; i++) {
+    if (client.chat[i].dayIndex >= client.chat[last].dayIndex) last = i;
+  }
+  return client.chat[last].sender == 'trainer';
 }
 
 class _Slot {

--- a/frontend/flutter_trainer/test/core/storage/seed_data_test.dart
+++ b/frontend/flutter_trainer/test/core/storage/seed_data_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:oncare_trainer/core/storage/app_database.dart';
 import 'package:oncare_trainer/core/storage/seed_data.dart';
 import 'package:oncare_trainer/core/utils/clock.dart';
+import 'package:oncare_trainer/shared/services/chat_repository.dart';
 
 /// 시드가 읽는 것과 같은 픽스처. 사용자 앱 테스트도 같은 파일을 본다 — 두 앱의
 /// 단정이 같은 원본을 가리켜야 "같은 날짜, 같은 숫자"가 실제로 지켜진다(#757).
@@ -447,6 +448,36 @@ void main() {
           client.lastMessage,
           thread.isEmpty ? '' : thread.last.body,
           reason: '${client.name}(${client.id})의 미리보기가 스레드와 어긋난다',
+        );
+      }
+    });
+
+    test('트레이너가 마지막으로 말한 스레드는 안읽음이 없다', () async {
+      // 예전에는 `threadHandled: true` 를 고객마다 손으로 적어 뒀다. 대화를
+      // 손볼 때 한쪽만 바뀌어 이지수·박성호는 트레이너가 마지막으로 답장해
+      // 놓고도 안읽음 배지를 달고 있었다 — 아무것도 기다리는 게 없는데
+      // 목록이 "답장하세요" 라고 말했다.
+      await seedIfEmpty(db);
+
+      final unread = await DriftChatRepository(db).watchUnreadCounts().first;
+      final clients = await db.select(db.trainerClients).get();
+      expect(clients, isNotEmpty);
+
+      for (final client in clients) {
+        final thread =
+            await (db.select(db.clientChatMessages)
+                  ..where((t) => t.clientId.equals(client.id))
+                  ..orderBy(<OrderingTerm Function($ClientChatMessagesTable)>[
+                    (t) => OrderingTerm(expression: t.createdAt),
+                  ]))
+                .get();
+        final answered = thread.isEmpty || thread.last.sender == 'trainer';
+        expect(
+          (unread[client.id] ?? 0) == 0,
+          answered,
+          reason:
+              '${client.name}(${client.id}): 마지막 발신자 '
+              '${thread.isEmpty ? '(없음)' : thread.last.sender}',
         );
       }
     });

--- a/frontend/flutter_trainer/test/features/clients/client_detail_chat_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_chat_test.dart
@@ -194,23 +194,27 @@ void main() {
       () async {
         final repo = DriftChatRepository(db);
 
-        // 이지수 · 박성호 are waiting on a reply; 김민수's thread is
-        // seeded already answered and read, so he has no badge.
+        // 오세라 · 배준혁 are waiting on a reply — their threads end with
+        // a member message (오세라's with two in a row). 김민수 · 이지수 ·
+        // 박성호 end with the trainer's reply, so the seed marks them read
+        // and they have no badge.
         var counts = await repo.watchUnreadCounts().first;
         expect(counts.containsKey('seed-client-1'), isFalse);
-        expect(counts['seed-client-2'], 1);
-        expect(counts['seed-client-3'], 1);
-
-        // Opening 이지수's thread clears her badge only.
-        await repo.markThreadRead('seed-client-2');
-        counts = await repo.watchUnreadCounts().first;
         expect(counts.containsKey('seed-client-2'), isFalse);
-        expect(counts['seed-client-3'], 1);
+        expect(counts.containsKey('seed-client-3'), isFalse);
+        expect(counts['seed-client-8'], 2);
+        expect(counts['seed-client-9'], 1);
+
+        // Opening 오세라's thread clears her badge only.
+        await repo.markThreadRead('seed-client-8');
+        counts = await repo.watchUnreadCounts().first;
+        expect(counts.containsKey('seed-client-8'), isFalse);
+        expect(counts['seed-client-9'], 1);
 
         // A trainer message never counts as unread.
-        await repo.sendTrainerMessage(clientId: 'seed-client-2', text: '확인!');
+        await repo.sendTrainerMessage(clientId: 'seed-client-8', text: '확인!');
         counts = await repo.watchUnreadCounts().first;
-        expect(counts.containsKey('seed-client-2'), isFalse);
+        expect(counts.containsKey('seed-client-8'), isFalse);
 
         // A NEW client reply after the marker counts again.
         await db
@@ -218,7 +222,7 @@ void main() {
             .insert(
               ClientChatMessagesCompanion.insert(
                 id: 'chat-reply-1',
-                clientId: 'seed-client-2',
+                clientId: 'seed-client-8',
                 sender: 'client',
                 body: '네 감사합니다!',
                 timeLabel: '09:00',
@@ -226,7 +230,7 @@ void main() {
               ),
             );
         counts = await repo.watchUnreadCounts().first;
-        expect(counts['seed-client-2'], 1);
+        expect(counts['seed-client-8'], 1);
       },
     );
 

--- a/frontend/flutter_trainer/test/features/clients/client_detail_states_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_states_test.dart
@@ -55,7 +55,10 @@ void main() {
       at: AppRoutes.clientDetail('seed-client-3', section: 'diet'),
     );
 
-    expect(find.text('답장 대기'), findsOneWidget);
+    // 박성호의 스레드는 트레이너가 마지막으로 답장해 두어 `답장 대기`가
+    // 아니다. 이 테스트가 재는 것은 "배지가 탭 위에 남는가" 이므로 그가
+    // 실제로 달고 있는 건강 신호로 확인한다.
+    expect(find.text('나트륨 초과'), findsOneWidget);
     final scroll = find
         .descendant(
           of: find.byKey(const ValueKey<String>('diet-seed-client-3')),
@@ -64,7 +67,7 @@ void main() {
         .first;
     await tester.drag(scroll, const Offset(0, -500));
     await tester.pump();
-    expect(find.text('답장 대기'), findsOneWidget);
+    expect(find.text('나트륨 초과'), findsOneWidget);
   });
 
   testWidgets('diet and workout are separated into tabs', (tester) async {

--- a/frontend/flutter_trainer/test/features/dashboard/dashboard_page_test.dart
+++ b/frontend/flutter_trainer/test/features/dashboard/dashboard_page_test.dart
@@ -134,9 +134,10 @@ void main() {
     expect(find.text('주의 고객'), findsOneWidget);
 
     // 13 of the 15 seeded clients are active; 박성호 and 문가영 are the
-    // two 휴면 fixtures. Six threads are waiting on a reply.
+    // two 휴면 fixtures. 답장 대기는 **회원이 마지막으로 말한** 스레드다 —
+    // 시드에서는 넷(오세라 · 배준혁 · 문가영 · 노태강)이 그렇다.
     expect(find.text('휴면 2명'), findsOneWidget);
-    expect(find.text('고객 6명 대기 중'), findsOneWidget);
+    expect(find.text('고객 4명 대기 중'), findsOneWidget);
   });
 
   testWidgets('주의 고객 counts health signals, not the reply backlog', (

--- a/frontend/flutter_trainer/test/features/messages/messages_page_test.dart
+++ b/frontend/flutter_trainer/test/features/messages/messages_page_test.dart
@@ -106,8 +106,15 @@ void main() {
         ),
         findsOneWidget,
       );
+      // 박성호는 트레이너가 마지막으로 답장해 두었다 — 기다리는 것이
+      // 없으므로 안읽음 배지도 없다. 배지는 회원이 마지막으로 말한
+      // 스레드에만 붙는다.
       expect(
         find.byKey(const ValueKey<String>('messages-unread-seed-client-3')),
+        findsNothing,
+      );
+      expect(
+        find.byKey(const ValueKey<String>('messages-unread-seed-client-8')),
         findsOneWidget,
       );
       // 목록은 어느 대화를 열까를 정하는 자리다 — 상태의 자세한 내막은


### PR DESCRIPTION
## Summary

* 트레이너가 마지막으로 답장해 둔 스레드에 **안읽음 배지가 뜨지 않습니다.** 이지수·박성호가 아무것도 기다리는 게 없는데 배지를 달고 있었습니다.
* 데모 시드의 `threadHandled` 를 **지우고 스레드에서 유도**합니다 — 마지막 말이 트레이너 것이면 답장된 상태입니다.
* 실 API 는 손대지 않았습니다(이미 `read_at` 으로 같은 뜻을 지킵니다 — Notes 참고).

---

## Changes

### ✨ Features

* 없음

### 🔧 Improvements

* `_Client.threadHandled` 필드 제거(`seed_clients.dart` 9곳). 시드가 `_threadAnswered(client)` 로 판정합니다.
* 정렬 규칙은 `_lastChatText` 와 동일(`dayIndex` 먼저, 같은 날 안에서는 목록 순서).

### 🎨 UI/UX

* 목록·사이드바·대시보드의 `답장 필요` 가 실제로 기다리는 스레드만 셉니다(6명 → 4명).

### 📝 Docs

* `seed_clients.dart` 머리 주석의 `threadHandled: false → 답장 대기` 를 "답장 대기는 스레드가 정한다" 로 갱신.

### 🐛 Fixes

* 트레이너가 답장한 스레드에 안읽음 배지가 남던 문제 수정.

---

## Commits

1. `ef765fe5` fix(messages): 트레이너가 답장한 스레드의 안읽음 배지 제거

---

## Notes

* **실 API 를 함께 고치지 않은 이유가 핵심입니다.** 실 API 의 안읽음은 `ChatMessage.read_at IS NULL` 이고, 트레이너는 채팅을 **열어야** 답장할 수 있으며 여는 순간 `read_at` 이 찍힙니다. "답장했다" 는 이미 "읽었다" 를 함의합니다.
* 그런데 **"마지막이 트레이너면 무조건 안읽음 0" 은 실 API 에서 틀립니다.** 코칭 탭의 루틴 전송과 리포트 탭의 PDF 전송은 채팅을 열지 않고 트레이너 메시지를 스레드에 쌓습니다 — 그때 회원 메시지는 진짜로 안 읽은 것이므로 배지가 떠야 맞습니다. 규칙은 "답장했다 = 읽었다" 가 아니라 **"채팅을 열었다 = 읽었다"** 이고, 그건 이미 지켜지고 있습니다. 시드에는 그런 경로가 없어 마지막 발신자로 판정해도 같은 뜻이 됩니다.
* `markThreadRead` 의 마커 계산(가장 최근 회원 메시지의 `rowid`)과 멱등성은 그대로입니다. 바뀐 것은 **어느 스레드에 마커를 찍을지** 뿐입니다.
* 회귀 테스트를 `seed_data_test.dart` 에 추가했습니다 — 시드된 전 고객에 대해 `안읽음 0 ⟺ 마지막 발신자가 트레이너` 를 검사합니다.
* 이 PR 은 `test/features/messages/messages_page_test.dart` 를 만집니다. **#1036 과 같은 파일이라 나중에 머지되는 쪽에서 충돌이 날 수 있습니다** — 둘 다 서로 다른 `expect` 블록이라 해소는 간단합니다.

---

## Screenshots (Optional)

| Before | After |
| ------ | ----- |
| `읽지 않음 6` · 박성호 타일에 `1` 배지(마지막 말은 트레이너 답장) | `읽지 않음 4` · 박성호 타일에 배지 없음 |

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. `cd frontend/flutter_trainer && flutter run -d chrome` 후 데모로 진입.
2. **메시지** 탭 → 박성호·이지수 타일에 안읽음 배지가 없는지 확인(대화 맨 아래가 트레이너 답장).
3. 오세라·배준혁에는 그대로 배지가 있는지 확인.
4. 필터 칩이 `읽지 않음 4` 인지, 대시보드 `답장 필요` 가 `고객 4명 대기 중` 인지 확인.
5. 오세라 대화를 열었다 나오면 배지가 사라지는지 확인.
6. `flutter test test/core/storage/seed_data_test.dart test/features/clients/client_detail_chat_test.dart`

---

## Related Issues

Closes #1039

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인
