### PR TITLE
feat(exercise): AI 개인 운동 취소

### DIFF
--- a/backend/app/api/v1/member_coach.py
+++ b/backend/app/api/v1/member_coach.py
@@ -116,6 +116,26 @@ def complete_my_routine(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
+@router.delete("/me/coach/routines/{routine_id}", status_code=204)
+def delete_my_routine(
+    routine_id: str,
+    member: RequireMember,
+    db: Annotated[Session, Depends(get_db)],
+) -> None:
+    """내 개인 운동 취소. **담당 트레이너가 없을 때만.** (#1020)
+
+    담당이 있는 회원에게는 취소가 트레이너의 일이다 — 트레이너가 배정한 것을
+    회원이 조용히 없애면 다음 상담에서 둘이 서로 다른 기록을 본다. 그 경우는
+    403 이다(404 가 아니라): 루틴은 분명히 있고 회원 화면에도 보인다.
+    """
+    try:
+        trainer_service.delete_own_routine(db, member.id, routine_id)
+    except trainer_service.RoutineNotCancellable as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+    except trainer_service.RoutineNotFound as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
 @router.get("/me/coach/sessions", response_model=list[ScheduleSessionOut])
 def my_sessions(
     current_user: CurrentUser,

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -1000,6 +1000,37 @@ def delete_routine(
     db.commit()
 
 
+class RoutineNotCancellable(Exception):
+    """담당 트레이너가 배정한 루틴을 회원이 직접 지우려 했다. (#1020)"""
+
+
+def delete_own_routine(db: Session, member_id: str, routine_id: str) -> None:
+    """회원이 자기 개인 운동을 지운다. **담당 트레이너가 없을 때만.** (#1020)
+
+    트레이너가 배정한 것을 회원이 조용히 없애면, 다음 상담에서 둘이 서로 다른
+    기록을 보게 된다. 담당이 있는 회원에게는 취소가 트레이너의 일이다.
+
+    담당 없이 AI 가 직접 추천한 개인운동(#782)은 승인할 사람이 없으므로 회원이
+    스스로 물릴 수 있어야 한다 — 그러지 않으면 한 번 뜬 추천을 지울 방법이 없다.
+
+    이미 수행한 기록은 남는다. 지우는 것은 **배정**이지 한 일이 아니다.
+    """
+    if get_member_trainer_id(db, member_id) is not None:
+        raise RoutineNotCancellable(
+            "담당 트레이너가 배정한 개인운동은 회원이 직접 취소할 수 없습니다."
+        )
+    routine = db.scalar(
+        select(TrainerRoutine).where(
+            TrainerRoutine.id == routine_id,
+            TrainerRoutine.member_id == member_id,
+        )
+    )
+    if routine is None:
+        raise RoutineNotFound("루틴을 찾을 수 없습니다.")
+    db.delete(routine)
+    db.commit()
+
+
 def _routine_out(
     rt: TrainerRoutine,
     completion: ExerciseSession | None = None,

--- a/backend/tests/test_member_coach.py
+++ b/backend/tests/test_member_coach.py
@@ -156,3 +156,41 @@ def test_inactive_link_member_has_no_current_coach(client):
     assert client.post(
         "/v1/me/coach/chat", json={"text": "안녕하세요"}, headers=_h(tok)
     ).status_code == 404
+
+
+def test_member_with_a_trainer_cannot_cancel_an_assigned_routine(client):
+    """담당이 있으면 취소는 트레이너의 일이다 — 404 가 아니라 403. (#1020)
+
+    루틴은 분명히 있고 회원 화면에도 보인다. 없는 척하면 앱이 목록에서 사라진
+    줄 알고 잘못 갱신한다.
+    """
+    member = _h(_member_tok(client))
+    routines = client.get("/v1/me/coach/routines", headers=member).json()
+    assert routines, "시드 회원에게 배정된 루틴이 있어야 한다"
+
+    routine_id = routines[0]["id"]
+    refused = client.delete(f"/v1/me/coach/routines/{routine_id}", headers=member)
+    assert refused.status_code == 403, refused.text
+
+    still_there = client.get("/v1/me/coach/routines", headers=member).json()
+    assert routine_id in [row["id"] for row in still_there]
+
+
+def test_cancelling_an_unknown_routine_is_404(client):
+    """담당이 없는 회원이 없는 루틴을 지우려 하면 404. (#1020)"""
+    solo = client.post(
+        "/v1/auth/register",
+        json={
+            "email": f"solo-{uuid4().hex[:8]}@oncare.com",
+            "password": "oncare123",
+            "name": "혼자",
+        },
+    )
+    assert solo.status_code in (200, 201), solo.text
+    token = client.post(
+        "/v1/auth/login",
+        data={"username": solo.json()["email"], "password": "oncare123"},
+    ).json()["access_token"]
+
+    missing = client.delete("/v1/me/coach/routines/nope", headers=_h(token))
+    assert missing.status_code == 404, missing.text

--- a/frontend/flutter/lib/features/member_coach/data/repositories/dio_member_coach_repository.dart
+++ b/frontend/flutter/lib/features/member_coach/data/repositories/dio_member_coach_repository.dart
@@ -66,6 +66,15 @@ class DioMemberCoachRepository implements MemberCoachRepository {
   }
 
   @override
+  Future<void> deleteRoutine(String routineId) async {
+    try {
+      await _dio.delete<void>('/me/coach/routines/$routineId');
+    } on DioException catch (e) {
+      throw AppError.fromDio(e);
+    }
+  }
+
+  @override
   Future<List<CoachSession>> fetchSessions() =>
       _getList('/me/coach/sessions', coachSessionFromJson);
 

--- a/frontend/flutter/lib/features/member_coach/data/repositories/mock_member_coach_repository.dart
+++ b/frontend/flutter/lib/features/member_coach/data/repositories/mock_member_coach_repository.dart
@@ -208,6 +208,14 @@ class MockMemberCoachRepository implements MemberCoachRepository {
     return completed;
   }
 
+  @override
+  Future<void> deleteRoutine(String routineId) async {
+    // 데모에는 담당 트레이너가 있다 — 실서버라면 403 이다. 목업에서까지 막으면
+    // 데모에서 이 동작을 보여 줄 수 없으므로 목록에서만 지운다. 화면은 담당이
+    // 없을 때만 이 버튼을 그린다. (#1020)
+    _routines.removeWhere((CoachRoutine routine) => routine.id == routineId);
+  }
+
   /// 데모에는 트레이너가 잡은 일정이 없다. (#490)
   ///
   /// 시드로 만들어 넣지 않는 이유: 데모 홈에 없던 카드가 생겨 화면이 지금과

--- a/frontend/flutter/lib/features/member_coach/domain/repositories/member_coach_repository.dart
+++ b/frontend/flutter/lib/features/member_coach/domain/repositories/member_coach_repository.dart
@@ -22,6 +22,13 @@ abstract interface class MemberCoachRepository {
     String memberNote = '',
   });
 
+  /// 개인 운동을 취소한다. **담당 트레이너가 없을 때만** 서버가 받아 준다 —
+  /// 담당이 배정한 것을 회원이 조용히 없애면 다음 상담에서 둘이 서로 다른
+  /// 기록을 본다. (#1020)
+  ///
+  /// 이미 수행한 기록은 남는다. 지우는 것은 배정이지 한 일이 아니다.
+  Future<void> deleteRoutine(String routineId);
+
   /// PT sessions the coach booked. The trainer owns the schedule — the
   /// member reads it only. (#490)
   Future<List<CoachSession>> fetchSessions();

--- a/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_card.dart
+++ b/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_card.dart
@@ -217,6 +217,9 @@ class AiCoachingCard extends ConsumerWidget {
               _RecommendedExerciseRow(
                 routine: routine,
                 sourceLabel: routineSourceLabel(l, routine, coach),
+                // 담당이 배정한 것을 회원이 조용히 없애면 다음 상담에서 둘이
+                // 서로 다른 기록을 본다. 담당이 없을 때만 스스로 물린다. (#1020)
+                cancellable: coach == null,
               ),
               const SizedBox(height: 10),
             ],
@@ -292,12 +295,16 @@ class _RecommendedExerciseRow extends ConsumerStatefulWidget {
   const _RecommendedExerciseRow({
     required this.routine,
     required this.sourceLabel,
+    required this.cancellable,
   });
 
   /// 회원이 읽는 출처 한 줄 — `AI 추천 · 김트레이너 확인` 처럼.
   final String sourceLabel;
 
   final CoachRoutine routine;
+
+  /// 회원이 스스로 물릴 수 있는가 — 담당 트레이너가 없을 때만 참이다. (#1020)
+  final bool cancellable;
 
   @override
   ConsumerState<_RecommendedExerciseRow> createState() =>
@@ -307,6 +314,50 @@ class _RecommendedExerciseRow extends ConsumerStatefulWidget {
 class _RecommendedExerciseRowState
     extends ConsumerState<_RecommendedExerciseRow> {
   bool _saving = false;
+
+  /// 개인 운동 취소. 담당 트레이너가 없을 때만 화면에 나타난다 — 담당이 있으면
+  /// 취소는 트레이너의 일이라 서버도 403 으로 막는다. (#1020)
+  Future<void> _cancel() async {
+    final AppLocalizations l = AppLocalizations.of(context);
+    final CoachRoutine routine = widget.routine;
+    final bool? ok = await showDialog<bool>(
+      context: context,
+      builder: (BuildContext context) => AlertDialog(
+        content: Text(l.coachRoutineCancelConfirm(routine.name)),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text(l.actionCancel),
+          ),
+          FilledButton(
+            key: const Key('confirmRoutineCancel'),
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text(l.coachRoutineCancel),
+          ),
+        ],
+      ),
+    );
+    if (ok != true || !mounted) return;
+
+    setState(() => _saving = true);
+    try {
+      await ref.read(memberCoachRepositoryProvider).deleteRoutine(routine.id);
+      ref.invalidate(coachRoutinesProvider);
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(l.coachRoutineCancelled)));
+      }
+    } on Object {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(l.coachRoutineCancelFailed)));
+      }
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
 
   Future<void> _complete() async {
     final AppLocalizations l = AppLocalizations.of(context);
@@ -457,6 +508,28 @@ class _RecommendedExerciseRowState
                         color: FigmaColors.primary,
                       ),
                     ),
+                    // 아직 하지 않은 것만 물릴 수 있다 — 이미 한 운동을 목록에서
+                    // 지우면 기록과 화면이 갈린다.
+                    if (widget.cancellable && !routine.completed)
+                      TextButton(
+                        key: Key('cancelRoutine-${routine.id}'),
+                        onPressed: _saving ? null : _cancel,
+                        style: TextButton.styleFrom(
+                          padding: EdgeInsets.zero,
+                          minimumSize: const Size(0, 28),
+                          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                          foregroundColor: AppColors.mutedForeground,
+                        ),
+                        child: Text(
+                          l.coachRoutineCancel,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: const TextStyle(
+                            fontSize: 11.5,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ),
 
                   ],
                 ),

--- a/frontend/flutter/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations.dart
@@ -3422,6 +3422,30 @@ abstract class AppLocalizations {
   /// **'Done'**
   String get coachRoutineDone;
 
+  /// No description provided for @coachRoutineCancel.
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel this workout'**
+  String get coachRoutineCancel;
+
+  /// No description provided for @coachRoutineCancelConfirm.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove \'{name}\' from the list? Anything you already logged stays.'**
+  String coachRoutineCancelConfirm(String name);
+
+  /// No description provided for @coachRoutineCancelled.
+  ///
+  /// In en, this message translates to:
+  /// **'Workout cancelled'**
+  String get coachRoutineCancelled;
+
+  /// No description provided for @coachRoutineCancelFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t cancel the workout'**
+  String get coachRoutineCancelFailed;
+
   /// The member's own note on a completed routine.
   ///
   /// In en, this message translates to:

--- a/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
@@ -1851,6 +1851,20 @@ class AppLocalizationsEn extends AppLocalizations {
   String get coachRoutineDone => 'Done';
 
   @override
+  String get coachRoutineCancel => 'Cancel this workout';
+
+  @override
+  String coachRoutineCancelConfirm(String name) {
+    return 'Remove \'$name\' from the list? Anything you already logged stays.';
+  }
+
+  @override
+  String get coachRoutineCancelled => 'Workout cancelled';
+
+  @override
+  String get coachRoutineCancelFailed => 'Couldn\'t cancel the workout';
+
+  @override
   String coachRoutineMyNote(String note) {
     return 'My note: $note';
   }

--- a/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
@@ -1791,6 +1791,20 @@ class AppLocalizationsKo extends AppLocalizations {
   String get coachRoutineDone => '수행 완료';
 
   @override
+  String get coachRoutineCancel => '이 개인 운동 취소';
+
+  @override
+  String coachRoutineCancelConfirm(String name) {
+    return '\'$name\'을(를) 목록에서 지울까요? 이미 수행한 기록은 그대로 남아요.';
+  }
+
+  @override
+  String get coachRoutineCancelled => '개인 운동을 취소했어요';
+
+  @override
+  String get coachRoutineCancelFailed => '개인 운동을 취소하지 못했어요';
+
+  @override
   String coachRoutineMyNote(String note) {
     return '내 메모: $note';
   }

--- a/frontend/flutter/lib/l10n/app_en.arb
+++ b/frontend/flutter/lib/l10n/app_en.arb
@@ -1097,6 +1097,13 @@
     "description": "Shown when marking a routine done fails for an unexpected reason."
   },
   "coachRoutineDone": "Done",
+  "coachRoutineCancel": "Cancel this workout",
+  "coachRoutineCancelConfirm": "Remove '{name}' from the list? Anything you already logged stays.",
+  "@coachRoutineCancelConfirm": {
+    "placeholders": { "name": { "type": "String" } }
+  },
+  "coachRoutineCancelled": "Workout cancelled",
+  "coachRoutineCancelFailed": "Couldn't cancel the workout",
   "@coachRoutineDone": {
     "description": "Marks a routine as completed."
   },

--- a/frontend/flutter/lib/l10n/app_ko.arb
+++ b/frontend/flutter/lib/l10n/app_ko.arb
@@ -643,6 +643,13 @@
   "coachRoutineNetworkError": "네트워크 연결을 확인하고 다시 시도해 주세요",
   "coachRoutineLogFailed": "완료 기록에 실패했어요.",
   "coachRoutineDone": "수행 완료",
+  "coachRoutineCancel": "이 개인 운동 취소",
+  "coachRoutineCancelConfirm": "'{name}'을(를) 목록에서 지울까요? 이미 수행한 기록은 그대로 남아요.",
+  "@coachRoutineCancelConfirm": {
+    "placeholders": { "name": { "type": "String" } }
+  },
+  "coachRoutineCancelled": "개인 운동을 취소했어요",
+  "coachRoutineCancelFailed": "개인 운동을 취소하지 못했어요",
   "coachRoutineMyNote": "내 메모: {note}",
   "coachRoutineTrainerFeedback": "트레이너 피드백: {feedback}",
   "coachRoutineCompleteTitle": "루틴 수행 완료",

--- a/frontend/flutter/test/features/exercise/exercise_health_goals_test.dart
+++ b/frontend/flutter/test/features/exercise/exercise_health_goals_test.dart
@@ -81,6 +81,9 @@ class _SessionMemberCoachRepository implements MemberCoachRepository {
     String intensity = 'moderate',
     String memberNote = '',
   }) async => throw UnsupportedError('not used');
+
+  @override
+  Future<void> deleteRoutine(String routineId) async {}
   @override
   Future<List<CoachSession>> fetchSessions() async => sessions;
   @override

--- a/frontend/flutter/test/features/member_coach/coach_invite_test.dart
+++ b/frontend/flutter/test/features/member_coach/coach_invite_test.dart
@@ -80,6 +80,9 @@ class _FakeCoachRepository implements MemberCoachRepository {
     String intensity = 'moderate',
     String memberNote = '',
   }) async => throw UnimplementedError();
+
+  @override
+  Future<void> deleteRoutine(String routineId) async {}
 }
 
 const CoachInvite _invite = CoachInvite(

--- a/frontend/flutter/test/features/member_coach/recommended_exercise_cards_test.dart
+++ b/frontend/flutter/test/features/member_coach/recommended_exercise_cards_test.dart
@@ -132,12 +132,13 @@ Widget _chatApp(Widget home) => MaterialApp(
 void main() {
   Future<void> pumpRecommendationCards(
     WidgetTester tester,
-    List<CoachRoutine> routines,
-  ) async {
+    List<CoachRoutine> routines, {
+    MemberCoach? coach = _trainer,
+  }) async {
     await tester.pumpWidget(
       ProviderScope(
         overrides: <Override>[
-          memberCoachProvider.overrideWith((ref) async => _trainer),
+          memberCoachProvider.overrideWith((ref) async => coach),
           coachRoutinesProvider.overrideWith((ref) async => routines),
           coachUnreadProvider.overrideWith((ref) async => 0),
         ],
@@ -712,6 +713,29 @@ void main() {
     expect(repository.paths, <String>['/chat/attachments/pdf-file']);
     expect(find.text('PDF를 열지 못했어요. 다시 시도해 주세요'), findsOneWidget);
   });
+
+  testWidgets('담당 트레이너가 없으면 개인 운동을 스스로 취소할 수 있다 (#1020)', (
+    WidgetTester tester,
+  ) async {
+    await pumpRecommendationCards(
+      tester,
+      <CoachRoutine>[_aiRoutine],
+      coach: null,
+    );
+
+    expect(find.byKey(Key('cancelRoutine-${_aiRoutine.id}')), findsOneWidget);
+  });
+
+  testWidgets('담당 트레이너가 있으면 취소는 트레이너의 일이다 (#1020)', (
+    WidgetTester tester,
+  ) async {
+    await pumpRecommendationCards(tester, <CoachRoutine>[_aiRoutine]);
+
+    // 담당이 배정한 것을 회원이 조용히 없애면 다음 상담에서 둘이 서로 다른
+    // 기록을 본다 — 버튼 자체를 그리지 않는다(서버도 403 으로 막는다).
+    expect(find.byKey(Key('cancelRoutine-${_aiRoutine.id}')), findsNothing);
+  });
+
 }
 
 /// 내려받기가 항상 실패하는 저장소. 요청된 경로를 기록해 둔다.

--- a/frontend/flutter/test/features/notification/alert_navigation_test.dart
+++ b/frontend/flutter/test/features/notification/alert_navigation_test.dart
@@ -100,6 +100,9 @@ class _FakeCoachRepository implements MemberCoachRepository {
   }) async => throw UnimplementedError();
 
   @override
+  Future<void> deleteRoutine(String routineId) async {}
+
+  @override
   Future<void> markRead() async {}
 
   @override

--- a/frontend/flutter_trainer/lib/features/coaching/presentation/pages/coaching_page.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/pages/coaching_page.dart
@@ -1983,6 +1983,13 @@ class _SendHistoryCard extends ConsumerWidget {
                                 color: AppColors.primary,
                               ),
                             ),
+                      // 보낸 뒤 물리는 자리. 여기 목록이 배정된 개인운동을
+                      // 보여 주는 유일한 곳인데 취소가 없어서, 잘못 보냈을 때
+                      // 고객 탭까지 옮겨 가야 지울 수 있었다. (#1020)
+                      _CancelRoutineButton(
+                        clientId: client.id,
+                        routine: routine,
+                      ),
                     ],
                   ),
                 ),
@@ -2038,6 +2045,93 @@ class _SendHistoryCard extends ConsumerWidget {
           );
         },
       ),
+    );
+  }
+}
+
+/// 배정한 개인운동을 물리는 버튼. (#1020)
+///
+/// 지운다고 회원이 이미 수행한 기록까지 사라지지는 않는다 — 지우는 것은
+/// **배정**이지 한 일이 아니다.
+class _CancelRoutineButton extends ConsumerStatefulWidget {
+  const _CancelRoutineButton({required this.clientId, required this.routine});
+
+  final String clientId;
+  final AssignedRoutine routine;
+
+  @override
+  ConsumerState<_CancelRoutineButton> createState() =>
+      _CancelRoutineButtonState();
+}
+
+class _CancelRoutineButtonState extends ConsumerState<_CancelRoutineButton> {
+  bool _busy = false;
+
+  Future<void> _cancel() async {
+    final AppLocalizations l = AppLocalizations.of(context);
+    final bool? ok = await showDialog<bool>(
+      context: context,
+      builder: (BuildContext ctx) => AlertDialog(
+        title: Text(l.routineDeleteTitle),
+        content: Text(l.routineDeleteBody(widget.routine.name)),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(l.actionCancel),
+          ),
+          TextButton(
+            key: const ValueKey<String>('confirm-cancel-routine'),
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: Text(
+              l.actionDelete,
+              style: const TextStyle(color: AppColors.destructive),
+            ),
+          ),
+        ],
+      ),
+    );
+    if (ok != true || !mounted) return;
+
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    setState(() => _busy = true);
+    try {
+      await ref
+          .read(trainerRoutineRepositoryProvider)
+          .deleteRoutine(widget.clientId, widget.routine.id);
+      messenger.showSnackBar(SnackBar(content: Text(l.routineDeleted)));
+    } on StateError {
+      // 404 — 이미 없는 것을 지우려 했다. 목적은 이뤄진 셈이라 목록만 다시 읽고
+      // 그 줄을 화면에서 걷어낸다.
+      messenger.showSnackBar(SnackBar(content: Text(l.routineAlreadyGone)));
+    } on Object {
+      messenger.showSnackBar(SnackBar(content: Text(l.routineDeleteFailed)));
+    } finally {
+      if (mounted) setState(() => _busy = false);
+      ref.invalidate(assignedRoutinesProvider(widget.clientId));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_busy) {
+      return const Padding(
+        padding: EdgeInsets.only(left: AppSpacing.sm),
+        child: SizedBox(
+          width: 14,
+          height: 14,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+      );
+    }
+    return IconButton(
+      key: ValueKey<String>('history-cancel-routine-${widget.routine.id}'),
+      onPressed: _cancel,
+      icon: const Icon(Icons.close_rounded, size: 15),
+      color: AppColors.mutedForeground,
+      tooltip: AppLocalizations.of(context).routineDelete,
+      visualDensity: VisualDensity.compact,
+      constraints: const BoxConstraints(minWidth: 28, minHeight: 28),
+      padding: EdgeInsets.zero,
     );
   }
 }


### PR DESCRIPTION
## Summary

배정한 개인운동을 물릴 방법이 없었다. 트레이너 화면의 전송 이력은 보낸 것을 보여 주기만 했고, 잘못 보냈으면 고객 탭까지 옮겨 가야 지울 수 있었다. 회원은 아예 방법이 없었다.

Closes #1020

## Changes

**트레이너**

전송 이력의 각 줄에 취소를 뒀다. 배정된 개인운동을 보여 주는 유일한 자리에 취소가 없어서, 방금 보낸 것을 물리려면 다른 탭으로 옮겨야 했다.

**회원**

담당 트레이너가 **없을 때만** 스스로 물릴 수 있다.

- 담당이 배정한 것을 회원이 조용히 없애면 다음 상담에서 둘이 서로 다른 기록을 본다.
- 반대로 담당 없이 AI 가 직접 추천한 개인운동(#782)은 승인할 사람이 없으므로 회원이 물릴 수 있어야 한다 — 그러지 않으면 한 번 뜬 추천을 지울 방법이 없다.

**서버**

`DELETE /me/coach/routines/{id}` 를 새로 두고 같은 규칙으로 막는다. 담당이 있는 회원의 취소는 **403** 이다 — 404 가 아니다. 루틴은 분명히 있고 회원 화면에도 보이므로, 없는 척하면 앱이 목록에서 사라진 줄 알고 잘못 갱신한다.

트레이너 쪽은 이미 있던 `DELETE /trainer/clients/{member}/routines/{id}`(#504)를 그대로 쓴다.

## Notes

- **이미 수행한 기록은 남는다.** 지우는 것은 배정이지 한 일이 아니다(`delete_routine` 이 원래 그렇게 동작한다). 아직 하지 않은 것만 취소 버튼이 보인다 — 이미 한 운동을 목록에서 지우면 기록과 화면이 갈린다.
- 권한 규칙을 검사하는 백엔드 테스트 두 개(담당 있음 → 403 / 없는 루틴 → 404)와, 버튼이 담당 유무에 따라 나타나고 사라지는지 보는 위젯 테스트 두 개를 뒀다.
- 백엔드 전체 테스트, 두 앱 `flutter analyze` 무경고·전체 테스트 통과.
