### PR TITLE
feat(consent): 트레이너 연결 시 식단·운동 공유 동의

### DIFF
--- a/backend/app/api/v1/member_coach.py
+++ b/backend/app/api/v1/member_coach.py
@@ -20,7 +20,8 @@ from app.api.deps import CurrentUser, RequireMember
 from app.db.session import get_db
 from app.schemas.exercise_api import AssignedRoutineCompleteRequest
 from app.schemas.trainer_api import (
-    ChatMessageOut, ChatSendRequest, MemberClientInviteOut, MemberCoachOut, RoutineOut,
+    ChatMessageOut, ChatSendRequest, MemberClientInviteOut,
+    MemberCoachOut, MemberInviteAcceptRequest, RoutineOut,
     ScheduleSessionOut,
 )
 from app.services import trainer_client_invite_service, trainer_service
@@ -236,12 +237,24 @@ def my_coach_invites(
 )
 def accept_coach_invite(
     invite_id: str,
+    payload: MemberInviteAcceptRequest,
     member: RequireMember,
     db: Annotated[Session, Depends(get_db)],
 ) -> MemberClientInviteOut:
-    """수락한다 — 담당 링크가 여기서 생긴다."""
+    """수락한다 — 담당 링크가 여기서 생긴다.
+
+    데이터 공유 동의를 함께 받는다. 수락하는 순간 트레이너가 회원의 식단·운동·
+    신체 정보를 읽으므로, 그 문을 여는 동작과 동의가 같은 요청이어야 한다. (#1022)
+    """
     try:
-        return trainer_client_invite_service.accept(db, member.id, invite_id)
+        return trainer_client_invite_service.accept(
+            db,
+            member.id,
+            invite_id,
+            data_sharing_consent=payload.data_sharing_consent,
+        )
+    except trainer_client_invite_service.DataSharingConsentRequired as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     except trainer_client_invite_service.InviteNotFound as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except (

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -510,6 +510,12 @@ class ConsultationRequest(Base):
     health_purpose_detail: Mapped[str | None] = mapped_column(Text, nullable=True)
     preferred_date: Mapped[str] = mapped_column(String(10))
     preferred_time_slot: Mapped[str] = mapped_column(String(20))
+    #: 회원이 데이터 공유에 동의한 시각. 트레이너가 수락해 담당이 생기면 이
+    #: 값이 담당 링크로 옮겨 간다 — 회원은 신청할 때 동의하고, 연결은 나중에
+    #: 트레이너가 만든다. (#1022)
+    data_consent_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     message: Mapped[str | None] = mapped_column(Text, nullable=True)
     status: Mapped[str] = mapped_column(
         String(20), default="pending", server_default="pending"
@@ -692,6 +698,14 @@ class TrainerClient(Base):
     goal: Mapped[str] = mapped_column(String(200), default="")
     #: 담당 관계가 살아 있는가(해제 여부). 트레이너 화면의 배지가 아니다.
     active: Mapped[bool] = mapped_column(Boolean, default=True)
+    #: 회원이 식단·운동·신체 정보 공유에 동의한 시각. (#1022)
+    #:
+    #: 트레이너는 담당이 되는 순간 회원의 건강 기록을 읽는다. 그 동의를 언제
+    #: 받았는지 답할 수 있어야 하므로 링크에 함께 남긴다. 비어 있는 링크는 이
+    #: 기능 이전에 만들어진 것이다.
+    data_consent_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     #: 트레이너의 관리 상태 — True 면 화면에 '휴면'으로 보인다.
     dormant: Mapped[bool] = mapped_column(Boolean, default=False)
     sort_order: Mapped[int] = mapped_column(Integer, default=0)

--- a/backend/app/schemas/consultation_api.py
+++ b/backend/app/schemas/consultation_api.py
@@ -36,6 +36,11 @@ class ConsultationCreate(BaseModel):
     preferred_date: Date
     preferred_time_slot: PreferredTimeSlot
     message: str | None = Field(default=None, max_length=2000)
+    #: 식단·운동·신체 정보를 트레이너에게 보여 주는 데 동의했는가. (#1022)
+    #:
+    #: 기본값을 두지 않는다 — 빠뜨리면 422 다. 동의는 "안 보냈으니 승낙"이 될 수
+    #: 없고, 화면이 체크를 지우고 보내도 서버가 통과시키면 안 된다.
+    data_sharing_consent: bool
 
     @model_validator(mode="before")
     @classmethod

--- a/backend/app/schemas/trainer_api.py
+++ b/backend/app/schemas/trainer_api.py
@@ -1198,6 +1198,16 @@ class TrainerClientInviteOut(BaseModel):
     decided_at: _datetime | None = None
 
 
+class MemberInviteAcceptRequest(BaseModel):
+    """담당 요청 수락 — 데이터 공유 동의를 함께 받는다. (#1022)
+
+    기본값을 두지 않는다. 빠뜨리면 422 다 — 동의는 "안 보냈으니 승낙" 이 될 수
+    없다.
+    """
+
+    data_sharing_consent: bool
+
+
 class MemberClientInviteOut(BaseModel):
     """회원이 보고 있는 '받은 요청' 카드.
 

--- a/backend/app/services/consultation_service.py
+++ b/backend/app/services/consultation_service.py
@@ -103,6 +103,12 @@ def create_consultation(
 ) -> ConsultationOut:
     if payload.preferred_date < clock.today():
         raise InvalidConsultationRequest("상담 희망일은 오늘 이후여야 합니다.")
+    if not payload.data_sharing_consent:
+        # 동의 없이 신청을 받아 두면, 트레이너가 수락하는 순간 회원이 동의한 적
+        # 없는 기록이 넘어간다. (#1022)
+        raise InvalidConsultationRequest(
+            "식단·운동 기록 공유에 동의해야 상담을 신청할 수 있습니다."
+        )
 
     _validate_target(db, payload)
     if db.scalar(_pending_query(member_id, payload)) is not None:
@@ -122,6 +128,7 @@ def create_consultation(
         preferred_time_slot=payload.preferred_time_slot,
         message=payload.message,
         status="pending",
+        data_consent_at=_now(),
     )
     db.add(consultation)
     _notify_trainer_of_new_request(db, consultation, member_id)
@@ -436,7 +443,12 @@ def link_member_gym(db: Session, member_id: str, gym_id: str | None) -> None:
 
 
 def attach_member_to_trainer(
-    db: Session, trainer_id: str, member_id: str, *, goal: str = ""
+    db: Session,
+    trainer_id: str,
+    member_id: str,
+    *,
+    goal: str = "",
+    consented_at: datetime | None = None,
 ) -> None:
     """담당 링크를 만든다(커밋 없음). 활성 담당이 없는 회원에게만 부른다.
 
@@ -454,6 +466,9 @@ def attach_member_to_trainer(
     )
     if dormant is not None:
         dormant.active = True
+        # 다시 담당이 되는 것도 새 연결이다 — 그때의 동의로 갱신한다. (#1022)
+        if consented_at is not None:
+            dormant.data_consent_at = consented_at
         return
 
     last_order = db.scalar(
@@ -468,6 +483,7 @@ def attach_member_to_trainer(
             member_id=member_id,
             goal=goal,
             active=True,
+            data_consent_at=consented_at,
             sort_order=(last_order or 0) + 1,
         )
     )
@@ -512,6 +528,9 @@ def accept(
             trainer_id,
             row.member_id,
             goal=_GOAL_LABELS.get(row.exercise_goal, ""),
+            # 회원은 신청할 때 동의했고 연결은 지금 만들어진다 — 그 시각을
+            # 옮겨 적는다. (#1022)
+            consented_at=row.data_consent_at,
         )
     # 링크 생성 여부와는 별개 조건이다 — 이미 이 트레이너의 담당인 회원이 상담을
     # 새로 넣고 승인받는 경우에도 헬스장 연결은 이뤄져야 한다(리뷰).

--- a/backend/app/services/trainer_client_invite_service.py
+++ b/backend/app/services/trainer_client_invite_service.py
@@ -197,7 +197,17 @@ def list_for_member(db: Session, member_id: str) -> list[MemberClientInviteOut]:
     return _to_member_out(db, rows)
 
 
-def accept(db: Session, member_id: str, invite_id: str) -> MemberClientInviteOut:
+class DataSharingConsentRequired(Exception):
+    """동의 없이 담당 요청을 수락하려 했다. (#1022)"""
+
+
+def accept(
+    db: Session,
+    member_id: str,
+    invite_id: str,
+    *,
+    data_sharing_consent: bool = False,
+) -> MemberClientInviteOut:
     """회원이 수락한다 — 담당 링크가 **여기서** 생긴다.
 
     상태 전이·링크 생성·헬스장 연결·알림을 한 트랜잭션으로 커밋한다. 나눠 커밋하면
@@ -206,6 +216,13 @@ def accept(db: Session, member_id: str, invite_id: str) -> MemberClientInviteOut
     수락하는 사이에 다른 트레이너의 담당이 생겼으면 [MemberAlreadyCoached] 다.
     회원당 활성 담당 1명이라는 불변식을 IntegrityError 로 만나기 전에 막는다.
     """
+    if not data_sharing_consent:
+        # 수락하는 순간 트레이너가 회원의 식단·운동·신체 정보를 읽는다. 동의를
+        # 받지 않고 그 문을 열 수는 없다. (#1022)
+        raise DataSharingConsentRequired(
+            "식단·운동 기록 공유에 동의해야 담당 요청을 수락할 수 있습니다."
+        )
+
     row = _require_member_row(db, member_id, invite_id)
 
     existing = db.scalar(
@@ -218,7 +235,12 @@ def accept(db: Session, member_id: str, invite_id: str) -> MemberClientInviteOut
         raise MemberAlreadyCoached("이미 다른 트레이너가 담당 중이에요.")
 
     if existing is None:
-        consultation_service.attach_member_to_trainer(db, row.trainer_id, member_id)
+        consultation_service.attach_member_to_trainer(
+            db,
+            row.trainer_id,
+            member_id,
+            consented_at=_now(),
+        )
     consultation_service.link_member_gym(
         db, member_id, consultation_service.trainer_gym_id(db, row.trainer_id)
     )

--- a/backend/migrations/versions/0054_data_sharing_consent.py
+++ b/backend/migrations/versions/0054_data_sharing_consent.py
@@ -1,0 +1,46 @@
+"""회원이 데이터 공유에 동의한 시각을 남긴다.
+
+트레이너는 담당이 되는 순간 회원의 식단·운동·신체 정보를 읽는다. 그런데 연결
+과정 어디에도 "무엇이 넘어가는지 확인하고 동의한다" 는 자리가 없었고, 동의를
+언제 받았는지도 답할 수 없었다(#1022).
+
+동의를 받는 자리가 둘이라 컬럼도 둘이다:
+
+* `trainer_clients.data_consent_at` — 트레이너의 담당 요청을 회원이 수락할 때.
+  회원이 그 자리에서 동의하므로 링크에 바로 적는다.
+* `consultation_requests.data_consent_at` — 회원이 상담을 신청할 때. 연결은
+  나중에 트레이너가 수락하며 만들어지므로, 수락 시점에 이 값을 링크로 옮긴다.
+
+기존 행은 비워 둔다. 이 기능 이전에 만들어진 담당이라는 뜻이고, 소급해서 동의를
+받은 척할 수는 없다.
+
+Revision ID: 0054_data_sharing_consent
+Revises: 0053_exercise_type_four_buckets
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0054_data_sharing_consent"
+down_revision: str | Sequence[str] | None = "0053_exercise_type_four_buckets"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "trainer_clients",
+        sa.Column("data_consent_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "consultation_requests",
+        sa.Column("data_consent_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("consultation_requests", "data_consent_at")
+    op.drop_column("trainer_clients", "data_consent_at")

--- a/backend/tests/test_consultation_decision.py
+++ b/backend/tests/test_consultation_decision.py
@@ -157,6 +157,7 @@ def _request_consultation(client, token: str, *, trainer_id: str) -> str:
         "preferred_date": (clock.today() + timedelta(days=1)).isoformat(),
         "preferred_time_slot": "evening",
         "message": "상담 부탁드립니다.",
+        "data_sharing_consent": True,
     }
     response = client.post("/v1/consultations", headers=_auth(token), json=payload)
     assert response.status_code == 201, response.text

--- a/backend/tests/test_consultations.py
+++ b/backend/tests/test_consultations.py
@@ -122,6 +122,7 @@ def _payload(*, trainer_id: str | None = None) -> dict:
         "preferred_date": (clock.today() + timedelta(days=1)).isoformat(),
         "preferred_time_slot": "afternoon",
         "message": "  상담을 받고 싶습니다.  ",
+        "data_sharing_consent": True,
     }
 
 

--- a/backend/tests/test_member_coach.py
+++ b/backend/tests/test_member_coach.py
@@ -194,3 +194,68 @@ def test_cancelling_an_unknown_routine_is_404(client):
 
     missing = client.delete("/v1/me/coach/routines/nope", headers=_h(token))
     assert missing.status_code == 404, missing.text
+
+
+def test_accepting_a_coach_invite_requires_data_sharing_consent(client, db_session):
+    """동의 없이 수락하면 400 — 수락하는 순간 트레이너가 건강 기록을 읽는다. (#1022)"""
+    from app.models import models
+
+    member = _h(_member_tok(client))
+    # 시드 회원은 이미 담당이 있다. 담당이 없는 회원을 새로 만들어 초대를 건다.
+    email = f"consent-{uuid4().hex[:8]}@oncare.com"
+    created = client.post(
+        "/v1/auth/register",
+        json={"email": email, "password": "oncare123", "name": "동의"},
+    )
+    assert created.status_code in (200, 201), created.text
+    token = client.post(
+        "/v1/auth/login", data={"username": email, "password": "oncare123"}
+    ).json()["access_token"]
+    new_member_id = client.get("/v1/users/me", headers=_h(token)).json()["id"]
+
+    # 시드 트레이너(trainer-demo)를 쓰지 않는다 — 담당이 하나 늘면 시드 로스터
+    # 개수를 검사하는 다른 테스트가 깨진다.
+    trainer_id = f"trainer-{uuid4().hex[:8]}"
+    db_session.add(
+        models.User(
+            id=trainer_id,
+            email=f"{trainer_id}@oncare.com",
+            name="동의 트레이너",
+            hashed_password="x",
+            role="trainer",
+        )
+    )
+    # 트레이너 행이 먼저 커밋돼야 초대의 외래키가 걸린다.
+    db_session.commit()
+
+    invite_id = f"invite-{uuid4().hex[:8]}"
+    db_session.add(
+        models.TrainerClientInvite(
+            id=invite_id,
+            trainer_id=trainer_id,
+            member_id=new_member_id,
+            status="pending",
+        )
+    )
+    db_session.commit()
+
+    refused = client.post(
+        f"/v1/me/coach/invites/{invite_id}/accept",
+        headers=_h(token),
+        json={"data_sharing_consent": False},
+    )
+    assert refused.status_code == 400, refused.text
+
+    # 동의하면 연결되고, 동의 시각이 링크에 남는다.
+    accepted = client.post(
+        f"/v1/me/coach/invites/{invite_id}/accept",
+        headers=_h(token),
+        json={"data_sharing_consent": True},
+    )
+    assert accepted.status_code == 200, accepted.text
+
+    link = db_session.query(models.TrainerClient).filter_by(
+        member_id=new_member_id, active=True
+    ).one()
+    assert link.data_consent_at is not None
+    assert member  # 시드 회원 토큰은 대역 준비용이다.

--- a/backend/tests/test_signup_consultation_seam.py
+++ b/backend/tests/test_signup_consultation_seam.py
@@ -154,6 +154,7 @@ def _request_consultation(client, token: str, trainer_id: str) -> str:
             "preferred_date": (clock.today() + timedelta(days=1)).isoformat(),
             "preferred_time_slot": "morning",
             "message": "상담 부탁드립니다.",
+            "data_sharing_consent": True,
         },
     )
     assert response.status_code == 201, response.text

--- a/backend/tests/test_trainer_client_invite.py
+++ b/backend/tests/test_trainer_client_invite.py
@@ -221,7 +221,8 @@ def test_accepting_creates_the_link_and_the_roster_row(client, db_session):
     invite_id = _invite(client, trainer_token, member_id)
 
     response = client.post(
-        f"/v1/me/coach/invites/{invite_id}/accept", headers=_auth(member_token)
+        f"/v1/me/coach/invites/{invite_id}/accept", headers=_auth(member_token),
+        json={"data_sharing_consent": True},
     )
 
     assert response.status_code == 200, response.text
@@ -240,7 +241,8 @@ def test_accepting_links_the_member_to_the_trainer_gym(client, db_session):
     invite_id = _invite(client, trainer_token, member_id)
 
     client.post(
-        f"/v1/me/coach/invites/{invite_id}/accept", headers=_auth(member_token)
+        f"/v1/me/coach/invites/{invite_id}/accept", headers=_auth(member_token),
+        json={"data_sharing_consent": True},
     )
 
     gym_id = (
@@ -271,7 +273,8 @@ def test_a_decided_invite_cannot_be_decided_again(client, db_session):
     member_id, _, member_token = _member(client)
     invite_id = _invite(client, trainer_token, member_id)
     client.post(
-        f"/v1/me/coach/invites/{invite_id}/accept", headers=_auth(member_token)
+        f"/v1/me/coach/invites/{invite_id}/accept", headers=_auth(member_token),
+        json={"data_sharing_consent": True},
     )
 
     again = client.post(
@@ -301,7 +304,8 @@ def test_a_member_who_already_has_a_trainer_cannot_be_invited(client, db_session
     member_id, _, member_token = _member(client)
     invite_id = _invite(client, first_token, member_id)
     client.post(
-        f"/v1/me/coach/invites/{invite_id}/accept", headers=_auth(member_token)
+        f"/v1/me/coach/invites/{invite_id}/accept", headers=_auth(member_token),
+        json={"data_sharing_consent": True},
     )
 
     response = client.post(
@@ -329,11 +333,13 @@ def test_an_invite_accepted_after_another_trainer_took_the_member_is_refused(
     stale_invite = _invite(client, first_token, member_id)
     other_invite = _invite(client, second_token, member_id)
     client.post(
-        f"/v1/me/coach/invites/{other_invite}/accept", headers=_auth(member_token)
+        f"/v1/me/coach/invites/{other_invite}/accept", headers=_auth(member_token),
+        json={"data_sharing_consent": True},
     )
 
     response = client.post(
-        f"/v1/me/coach/invites/{stale_invite}/accept", headers=_auth(member_token)
+        f"/v1/me/coach/invites/{stale_invite}/accept", headers=_auth(member_token),
+        json={"data_sharing_consent": True},
     )
 
     assert response.status_code == 409
@@ -373,7 +379,8 @@ def test_a_member_cannot_decide_someone_elses_invite(client, db_session):
     invite_id = _invite(client, trainer_token, member_id)
 
     response = client.post(
-        f"/v1/me/coach/invites/{invite_id}/accept", headers=_auth(stranger_token)
+        f"/v1/me/coach/invites/{invite_id}/accept", headers=_auth(stranger_token),
+        json={"data_sharing_consent": True},
     )
 
     assert response.status_code == 404
@@ -397,7 +404,8 @@ def test_the_sent_list_shows_what_happened(client, db_session):
     member_id, _, member_token = _member(client, name="정수락")
     invite_id = _invite(client, trainer_token, member_id)
     client.post(
-        f"/v1/me/coach/invites/{invite_id}/accept", headers=_auth(member_token)
+        f"/v1/me/coach/invites/{invite_id}/accept", headers=_auth(member_token),
+        json={"data_sharing_consent": True},
     )
 
     pending = client.get(

--- a/frontend/flutter/lib/features/exercise/domain/entities/consultation_draft.dart
+++ b/frontend/flutter/lib/features/exercise/domain/entities/consultation_draft.dart
@@ -47,6 +47,7 @@ class ConsultationDraft {
     required this.preferredDate,
     required this.preferredTimeSlot,
     required this.message,
+    this.dataSharingConsent = false,
   });
 
   /// 상담을 받을 트레이너. 헬스장에서 시작해도 소속 트레이너 중 한 명을 고른 뒤에
@@ -61,6 +62,12 @@ class ConsultationDraft {
   final PreferredTimeSlot preferredTimeSlot;
   final String? message;
 
+  /// 식단·운동·신체 정보를 이 트레이너에게 보여 주는 데 동의했는가. (#1022)
+  ///
+  /// 신청은 회원이 하고 연결은 나중에 트레이너가 수락하며 만들어진다. 회원이
+  /// 그 자리에 없으므로 동의는 **신청할 때** 받는다.
+  final bool dataSharingConsent;
+
   Map<String, Object?> toJson() {
     // other 목적에는 상세가 있어야 한다(서버 422). 여기서 막지 않으면 원인을 찾기
     // 어려운 422 로 돌아온다.
@@ -70,6 +77,11 @@ class ConsultationDraft {
     if (healthPurposeType == HealthPurposeType.other &&
         (healthPurposeDetail == null || healthPurposeDetail!.trim().isEmpty)) {
       throw ArgumentError('기타 건강관리 목적에는 상세 내용이 필요합니다.');
+    }
+    if (!dataSharingConsent) {
+      // 서버도 막지만(400) 여기서 먼저 막는다 — 동의 없이 보낸 요청이 트레이너
+      // 인박스에 남았다가 수락되면, 회원이 동의한 적 없는 기록이 넘어간다.
+      throw ArgumentError('식단·운동 기록 공유에 동의해야 상담을 신청할 수 있습니다.');
     }
     return _json();
   }
@@ -87,6 +99,7 @@ class ConsultationDraft {
         '${preferredDate.day.toString().padLeft(2, '0')}',
     'preferred_time_slot': preferredTimeSlotToWire(preferredTimeSlot),
     'message': message,
+    'data_sharing_consent': dataSharingConsent,
   };
 }
 

--- a/frontend/flutter/lib/features/exercise/presentation/pages/consultation_request_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/consultation_request_page.dart
@@ -109,12 +109,18 @@ class _ConsultationRequestPageState
       _healthPurpose == _HealthPurpose.other &&
       _healthPurposeController.text.trim().isEmpty;
 
+  /// 데이터 공유에 동의했는가. 신청은 회원이 하고 연결은 나중에 트레이너가
+  /// 수락하며 만들어진다 — 회원이 그 자리에 없으므로 동의는 여기서 받는다.
+  /// (#1022)
+  bool _dataSharingConsent = false;
+
   bool get _isValid =>
       _exerciseGoal != null &&
       _healthPurpose != null &&
       !_healthPurposeInputMissing &&
       _preferredDate != null &&
-      _preferredTime != null;
+      _preferredTime != null &&
+      _dataSharingConsent;
 
   Future<void> _submit({
     required Gym gym,
@@ -163,6 +169,7 @@ class _ConsultationRequestPageState
       preferredDate: _preferredDate!,
       preferredTimeSlot: _preferredTime!.wire,
       message: message.isEmpty ? null : message,
+      dataSharingConsent: _dataSharingConsent,
     );
 
     final ConsultationRequest? saved;
@@ -298,7 +305,12 @@ class _ConsultationRequestPageState
           children: <Widget>[
             _TargetCard(gym: gym, trainer: trainer),
             const SizedBox(height: 12),
-            const _DataSharingNotice(),
+            _DataSharingNotice(
+              consented: _dataSharingConsent,
+              onChanged: (bool next) =>
+                  setState(() => _dataSharingConsent = next),
+              showRequired: _attempted && !_dataSharingConsent,
+            ),
             const SizedBox(height: 20),
             _ChoiceField<_ExerciseGoal>(
               chipKeyPrefix: 'consult-goal',
@@ -528,7 +540,19 @@ class _TargetCard extends StatelessWidget {
 /// 여기 없는 항목(예: 혈압·혈당)은 애초에 수집하지 않으므로 트레이너도 볼 수
 /// 없다.
 class _DataSharingNotice extends StatelessWidget {
-  const _DataSharingNotice();
+  const _DataSharingNotice({
+    required this.consented,
+    required this.onChanged,
+    required this.showRequired,
+  });
+
+  /// 동의했는가. 이 값은 화면 상태(`_dataSharingConsent`)가 들고 있다 — 제출
+  /// 가능 여부를 함께 판단해야 해서다. (#1022)
+  final bool consented;
+  final ValueChanged<bool> onChanged;
+
+  /// 제출을 눌렀는데 아직 동의하지 않았는가 — 그때만 빨간 안내를 붙인다.
+  final bool showRequired;
 
   @override
   Widget build(BuildContext context) {
@@ -542,25 +566,75 @@ class _DataSharingNotice extends StatelessWidget {
         borderRadius: BorderRadius.circular(12),
         border: Border.all(color: FigmaColors.hairline),
       ),
-      child: Row(
+      child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          const Icon(
-            Icons.info_outline,
-            size: 16,
-            color: FigmaColors.textSub,
-          ),
-          const SizedBox(width: 8),
-          Expanded(
-            child: Text(
-              l.exConsultDataSharingNotice,
-              style: const TextStyle(
-                fontSize: 12.5,
-                height: 1.4,
-                color: FigmaColors.textBody,
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              const Icon(
+                Icons.info_outline,
+                size: 16,
+                color: FigmaColors.textSub,
               ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  l.exConsultDataSharingNotice,
+                  style: const TextStyle(
+                    fontSize: 12.5,
+                    height: 1.4,
+                    color: FigmaColors.textBody,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          // 안내로 지나가지 않고 **동의를 받는다** — 수락되는 순간 넘어가는
+          // 것은 회원의 건강 기록이다. (#1022)
+          const SizedBox(height: 6),
+          InkWell(
+            key: const Key('consultDataSharingConsent'),
+            onTap: () => onChanged(!consented),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Checkbox(
+                  value: consented,
+                  onChanged: (bool? next) => onChanged(next ?? false),
+                  visualDensity: VisualDensity.compact,
+                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  activeColor: FigmaColors.primary,
+                ),
+                const SizedBox(width: 6),
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.only(top: 2),
+                    child: Text(
+                      l.exConsultDataSharingAgree,
+                      style: const TextStyle(
+                        fontSize: 12.5,
+                        height: 1.4,
+                        fontWeight: FontWeight.w600,
+                        color: FigmaColors.ink,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
             ),
           ),
+          if (showRequired) ...<Widget>[
+            const SizedBox(height: 4),
+            Text(
+              l.exConsultDataSharingRequired,
+              style: const TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+                color: FigmaColors.dangerRed,
+              ),
+            ),
+          ],
         ],
       ),
     );

--- a/frontend/flutter/lib/features/member_coach/data/repositories/dio_member_coach_repository.dart
+++ b/frontend/flutter/lib/features/member_coach/data/repositories/dio_member_coach_repository.dart
@@ -152,17 +152,28 @@ class DioMemberCoachRepository implements MemberCoachRepository {
       _getList('/me/coach/invites', coachInviteFromJson);
 
   @override
-  Future<void> acceptInvite(String inviteId) =>
-      _decideInvite(inviteId, 'accept');
+  Future<void> acceptInvite(
+    String inviteId, {
+    required bool dataSharingConsent,
+  }) => _decideInvite(
+    inviteId,
+    'accept',
+    body: <String, Object?>{'data_sharing_consent': dataSharingConsent},
+  );
 
   @override
   Future<void> rejectInvite(String inviteId) =>
       _decideInvite(inviteId, 'reject');
 
-  Future<void> _decideInvite(String inviteId, String action) async {
+  Future<void> _decideInvite(
+    String inviteId,
+    String action, {
+    Map<String, Object?>? body,
+  }) async {
     try {
       await _dio.post<Map<String, Object?>>(
         '/me/coach/invites/${Uri.encodeComponent(inviteId)}/$action',
+        data: body,
       );
     } on DioException catch (e) {
       throw AppError.fromDio(e);

--- a/frontend/flutter/lib/features/member_coach/data/repositories/mock_member_coach_repository.dart
+++ b/frontend/flutter/lib/features/member_coach/data/repositories/mock_member_coach_repository.dart
@@ -271,7 +271,10 @@ class MockMemberCoachRepository implements MemberCoachRepository {
   Future<List<CoachInvite>> fetchInvites() async => const <CoachInvite>[];
 
   @override
-  Future<void> acceptInvite(String inviteId) async {}
+  Future<void> acceptInvite(
+    String inviteId, {
+    required bool dataSharingConsent,
+  }) async {}
 
   @override
   Future<void> rejectInvite(String inviteId) async {}

--- a/frontend/flutter/lib/features/member_coach/domain/repositories/member_coach_repository.dart
+++ b/frontend/flutter/lib/features/member_coach/domain/repositories/member_coach_repository.dart
@@ -53,7 +53,11 @@ abstract interface class MemberCoachRepository {
   Future<List<CoachInvite>> fetchInvites();
 
   /// 요청을 수락한다 — 담당 관계는 이 호출로 생긴다.
-  Future<void> acceptInvite(String inviteId);
+  /// 담당 요청을 수락한다 — 담당 링크가 여기서 생긴다.
+  ///
+  /// [dataSharingConsent] 없이는 서버가 400 으로 막는다. 수락하는 순간
+  /// 트레이너가 회원의 식단·운동·신체 정보를 읽기 때문이다. (#1022)
+  Future<void> acceptInvite(String inviteId, {required bool dataSharingConsent});
 
   /// 요청을 거절한다. 담당은 생기지 않는다.
   Future<void> rejectInvite(String inviteId);

--- a/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_invite_card.dart
+++ b/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_invite_card.dart
@@ -29,15 +29,47 @@ class CoachInviteCard extends ConsumerStatefulWidget {
 class _CoachInviteCardState extends ConsumerState<CoachInviteCard> {
   bool _busy = false;
 
+  /// 담당 연결 전에 무엇이 넘어가는지 알리고 동의를 받는다. (#1022)
+  ///
+  /// 수락하는 순간 트레이너가 회원의 식단·운동·신체 정보를 읽는다. 안내로
+  /// 지나가지 않고 동의를 받아야, 회원이 무엇에 동의했는지 나중에도 말할 수
+  /// 있다. 서버도 동의 없는 수락은 400 으로 막는다.
+  Future<bool> _confirmConsent(CoachInvite invite) async {
+    final AppLocalizations l = AppLocalizations.of(context);
+    final bool? agreed = await showDialog<bool>(
+      context: context,
+      builder: (BuildContext context) => AlertDialog(
+        key: const Key('coachInviteConsentDialog'),
+        title: Text(l.coachInviteConsentTitle),
+        content: Text(l.coachInviteConsentBody(invite.trainerName)),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text(l.actionCancel),
+          ),
+          FilledButton(
+            key: const Key('coachInviteConsentAgree'),
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text(l.coachInviteConsentAgree),
+          ),
+        ],
+      ),
+    );
+    return agreed ?? false;
+  }
+
   Future<void> _decide(CoachInvite invite, {required bool accept}) async {
     if (_busy) return;
     final AppLocalizations l = AppLocalizations.of(context);
+    // 동의는 수락에만 필요하다 — 거절은 아무것도 열지 않는다.
+    if (accept && !await _confirmConsent(invite)) return;
+    if (!mounted) return;
     final messenger = ScaffoldMessenger.of(context);
     setState(() => _busy = true);
     try {
       final repository = ref.read(memberCoachRepositoryProvider);
       if (accept) {
-        await repository.acceptInvite(invite.id);
+        await repository.acceptInvite(invite.id, dataSharingConsent: true);
       } else {
         await repository.rejectInvite(invite.id);
       }

--- a/frontend/flutter/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations.dart
@@ -2390,6 +2390,36 @@ abstract class AppLocalizations {
   /// **'Once this trainer accepts your request, they\'ll be able to see your diet log, exercise log, and body info and health goals.'**
   String get exConsultDataSharingNotice;
 
+  /// No description provided for @exConsultDataSharingAgree.
+  ///
+  /// In en, this message translates to:
+  /// **'I have read this and agree to share my meal and workout records and body information with this trainer'**
+  String get exConsultDataSharingAgree;
+
+  /// No description provided for @exConsultDataSharingRequired.
+  ///
+  /// In en, this message translates to:
+  /// **'Please agree to sharing before requesting a consultation'**
+  String get exConsultDataSharingRequired;
+
+  /// No description provided for @coachInviteConsentTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Before you connect'**
+  String get coachInviteConsentTitle;
+
+  /// No description provided for @coachInviteConsentBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Once {name} becomes your trainer, they can see your meal records, workout records, body information and health goals. Disconnecting also revokes that access.'**
+  String coachInviteConsentBody(String name);
+
+  /// No description provided for @coachInviteConsentAgree.
+  ///
+  /// In en, this message translates to:
+  /// **'Agree and connect'**
+  String get coachInviteConsentAgree;
+
   /// No description provided for @exExerciseGoal.
   ///
   /// In en, this message translates to:

--- a/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
@@ -1294,6 +1294,25 @@ class AppLocalizationsEn extends AppLocalizations {
       'Once this trainer accepts your request, they\'ll be able to see your diet log, exercise log, and body info and health goals.';
 
   @override
+  String get exConsultDataSharingAgree =>
+      'I have read this and agree to share my meal and workout records and body information with this trainer';
+
+  @override
+  String get exConsultDataSharingRequired =>
+      'Please agree to sharing before requesting a consultation';
+
+  @override
+  String get coachInviteConsentTitle => 'Before you connect';
+
+  @override
+  String coachInviteConsentBody(String name) {
+    return 'Once $name becomes your trainer, they can see your meal records, workout records, body information and health goals. Disconnecting also revokes that access.';
+  }
+
+  @override
+  String get coachInviteConsentAgree => 'Agree and connect';
+
+  @override
   String get exExerciseGoal => 'Exercise Goal';
 
   @override

--- a/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
@@ -1261,6 +1261,24 @@ class AppLocalizationsKo extends AppLocalizations {
       '요청이 수락되면 이 트레이너가 회원님의 식단 기록, 운동 기록, 신체 정보와 건강 목표를 확인할 수 있어요.';
 
   @override
+  String get exConsultDataSharingAgree =>
+      '위 내용을 확인했고, 식단·운동 기록과 신체 정보를 이 트레이너에게 공유하는 데 동의해요';
+
+  @override
+  String get exConsultDataSharingRequired => '공유에 동의해야 상담을 신청할 수 있어요';
+
+  @override
+  String get coachInviteConsentTitle => '담당 연결 전에 확인해 주세요';
+
+  @override
+  String coachInviteConsentBody(String name) {
+    return '$name 트레이너와 담당으로 연결되면, 회원님의 식단 기록·운동 기록·신체 정보와 건강 목표를 이 트레이너가 볼 수 있어요. 연결을 해제하면 열람 권한도 함께 사라져요.';
+  }
+
+  @override
+  String get coachInviteConsentAgree => '동의하고 연결';
+
+  @override
   String get exExerciseGoal => '운동 목표';
 
   @override

--- a/frontend/flutter/lib/l10n/app_en.arb
+++ b/frontend/flutter/lib/l10n/app_en.arb
@@ -675,6 +675,14 @@
   "exTrainerConsultType": "Trainer Consultation",
   "exAssignedTrainer": "Assigned Trainer",
   "exConsultDataSharingNotice": "Once this trainer accepts your request, they'll be able to see your diet log, exercise log, and body info and health goals.",
+  "exConsultDataSharingAgree": "I have read this and agree to share my meal and workout records and body information with this trainer",
+  "exConsultDataSharingRequired": "Please agree to sharing before requesting a consultation",
+  "coachInviteConsentTitle": "Before you connect",
+  "coachInviteConsentBody": "Once {name} becomes your trainer, they can see your meal records, workout records, body information and health goals. Disconnecting also revokes that access.",
+  "@coachInviteConsentBody": {
+    "placeholders": { "name": { "type": "String" } }
+  },
+  "coachInviteConsentAgree": "Agree and connect",
   "exExerciseGoal": "Exercise Goal",
   "exGoalWeightLoss": "Weight Loss",
   "exGoalStrength": "Build Strength",

--- a/frontend/flutter/lib/l10n/app_ko.arb
+++ b/frontend/flutter/lib/l10n/app_ko.arb
@@ -471,6 +471,14 @@
   "exTrainerConsultType": "트레이너 상담",
   "exAssignedTrainer": "담당 트레이너",
   "exConsultDataSharingNotice": "요청이 수락되면 이 트레이너가 회원님의 식단 기록, 운동 기록, 신체 정보와 건강 목표를 확인할 수 있어요.",
+  "exConsultDataSharingAgree": "위 내용을 확인했고, 식단·운동 기록과 신체 정보를 이 트레이너에게 공유하는 데 동의해요",
+  "exConsultDataSharingRequired": "공유에 동의해야 상담을 신청할 수 있어요",
+  "coachInviteConsentTitle": "담당 연결 전에 확인해 주세요",
+  "coachInviteConsentBody": "{name} 트레이너와 담당으로 연결되면, 회원님의 식단 기록·운동 기록·신체 정보와 건강 목표를 이 트레이너가 볼 수 있어요. 연결을 해제하면 열람 권한도 함께 사라져요.",
+  "@coachInviteConsentBody": {
+    "placeholders": { "name": { "type": "String" } }
+  },
+  "coachInviteConsentAgree": "동의하고 연결",
   "exExerciseGoal": "운동 목표",
   "exGoalWeightLoss": "체중 감량",
   "exGoalStrength": "근력 향상",

--- a/frontend/flutter/test/features/exercise/consultation_draft_test.dart
+++ b/frontend/flutter/test/features/exercise/consultation_draft_test.dart
@@ -6,6 +6,7 @@ ConsultationDraft _draft({
   String trainerId = 'trainer-1',
   HealthPurposeType purpose = HealthPurposeType.general,
   String? detail,
+  bool consent = true,
 }) => ConsultationDraft(
   trainerId: trainerId,
   exerciseGoal: ExerciseGoal.fitness,
@@ -14,6 +15,8 @@ ConsultationDraft _draft({
   preferredDate: DateTime(2026, 8, 20),
   preferredTimeSlot: PreferredTimeSlot.morning,
   message: null,
+  // 동의 없이는 보낼 수 없다(#1022) — 기본 대역은 동의한 상태로 둔다.
+  dataSharingConsent: consent,
 );
 
 void main() {
@@ -51,5 +54,18 @@ void main() {
           .toJson()['health_purpose_detail'],
       '허리 통증',
     );
+  });
+
+  test('동의하지 않으면 보내지 못한다 (#1022)', () {
+    // 서버도 400 으로 막지만, 동의 없이 만든 요청이 트레이너 인박스에 남았다가
+    // 수락되면 회원이 동의한 적 없는 기록이 넘어간다.
+    expect(
+      () => _draft(consent: false).toJson(),
+      throwsA(isA<ArgumentError>()),
+    );
+  });
+
+  test('동의 여부를 함께 보낸다 (#1022)', () {
+    expect(_draft().toJson()['data_sharing_consent'], isTrue);
   });
 }

--- a/frontend/flutter/test/features/exercise/consultation_request_flow_test.dart
+++ b/frontend/flutter/test/features/exercise/consultation_request_flow_test.dart
@@ -279,6 +279,12 @@ void main() {
     );
     final AppLocalizations l = _localizations(tester);
 
+    // 데이터 공유 동의 없이는 보낼 수 없다 (#1022) — 수락되는 순간 넘어가는
+    // 것이 회원의 건강 기록이라 신청 화면에서 동의를 받는다. 동의 줄은 대상
+    // 카드 바로 아래(=화면 위쪽)에 있다.
+    await tester.tap(find.byKey(const Key('consultDataSharingConsent')));
+    await tester.pumpAndSettle();
+
     await tester.tap(find.text(l.exGoalWeightLoss));
     await _revealInForm(tester, find.text(l.exPurposeNone), 180);
     await tester.tap(find.text(l.exPurposeNone));
@@ -310,6 +316,7 @@ void main() {
     expect(tester.widget<Material>(dateMaterial).color, FigmaColors.softBlue);
     await _revealInForm(tester, find.text(l.exTimeAfternoon), 180);
     await tester.tap(find.text(l.exTimeAfternoon));
+
     await _revealInForm(tester, find.text(l.exSendConsultRequest), 220);
     await tester.tap(find.text(l.exSendConsultRequest));
     await tester.pumpAndSettle();

--- a/frontend/flutter/test/features/exercise/exercise_health_goals_test.dart
+++ b/frontend/flutter/test/features/exercise/exercise_health_goals_test.dart
@@ -102,7 +102,10 @@ class _SessionMemberCoachRepository implements MemberCoachRepository {
   Future<List<CoachInvite>> fetchInvites() async => const <CoachInvite>[];
 
   @override
-  Future<void> acceptInvite(String inviteId) async {}
+  Future<void> acceptInvite(
+    String inviteId, {
+    required bool dataSharingConsent,
+  }) async {}
 
   @override
   Future<void> rejectInvite(String inviteId) async {}

--- a/frontend/flutter/test/features/member_coach/coach_invite_test.dart
+++ b/frontend/flutter/test/features/member_coach/coach_invite_test.dart
@@ -36,7 +36,10 @@ class _FakeCoachRepository implements MemberCoachRepository {
   Future<List<CoachInvite>> fetchInvites() async => invites;
 
   @override
-  Future<void> acceptInvite(String inviteId) async {
+  Future<void> acceptInvite(
+    String inviteId, {
+    required bool dataSharingConsent,
+  }) async {
     if (failure case final AppError error) throw error;
     accepted.add(inviteId);
     invites = <CoachInvite>[];
@@ -163,6 +166,11 @@ void main() {
       );
       await tester.pumpAndSettle();
 
+      // 연결 전에 무엇이 넘어가는지 알리고 동의를 받는다 (#1022).
+      expect(find.byKey(const Key('coachInviteConsentDialog')), findsOneWidget);
+      await tester.tap(find.byKey(const Key('coachInviteConsentAgree')));
+      await tester.pumpAndSettle();
+
       expect(repository.accepted, <String>['tci-1']);
       expect(repository.rejected, isEmpty);
     });
@@ -192,8 +200,30 @@ void main() {
         find.byKey(const ValueKey<String>('coach-invite-accept-tci-1')),
       );
       await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('coachInviteConsentAgree')));
+      await tester.pumpAndSettle();
 
       expect(find.text('처리하지 못했어요. 다시 시도해 주세요'), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey<String>('coach-invite-accept-tci-1')),
+        findsOneWidget,
+      );
+    });
+    testWidgets('동의를 취소하면 연결하지 않는다 (#1022)', (tester) async {
+      final repository = _FakeCoachRepository(
+        invites: const <CoachInvite>[_invite],
+      );
+      await _pumpCard(tester, repository);
+
+      await tester.tap(
+        find.byKey(const ValueKey<String>('coach-invite-accept-tci-1')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('취소'));
+      await tester.pumpAndSettle();
+
+      // 동의하지 않았으면 아무것도 열리지 않는다 — 요청은 그대로 남는다.
+      expect(repository.accepted, isEmpty);
       expect(
         find.byKey(const ValueKey<String>('coach-invite-accept-tci-1')),
         findsOneWidget,
@@ -205,7 +235,10 @@ void main() {
     test('실 API 는 수락 경로를 그대로 부른다', () async {
       final dio = _MockDio();
       when(
-        () => dio.post<Map<String, Object?>>('/me/coach/invites/tci-1/accept'),
+        () => dio.post<Map<String, Object?>>(
+          '/me/coach/invites/tci-1/accept',
+          data: any(named: 'data'),
+        ),
       ).thenAnswer(
         (_) async => _ok<Map<String, Object?>>(
           const <String, Object?>{},
@@ -213,10 +246,16 @@ void main() {
         ),
       );
 
-      await DioMemberCoachRepository(dio).acceptInvite('tci-1');
+      await DioMemberCoachRepository(
+        dio,
+      ).acceptInvite('tci-1', dataSharingConsent: true);
 
+      // 동의 여부를 함께 보낸다 — 서버가 동의 없는 수락을 400 으로 막는다. (#1022)
       verify(
-        () => dio.post<Map<String, Object?>>('/me/coach/invites/tci-1/accept'),
+        () => dio.post<Map<String, Object?>>(
+          '/me/coach/invites/tci-1/accept',
+          data: <String, Object?>{'data_sharing_consent': true},
+        ),
       ).called(1);
     });
 

--- a/frontend/flutter/test/features/notification/alert_navigation_test.dart
+++ b/frontend/flutter/test/features/notification/alert_navigation_test.dart
@@ -86,7 +86,10 @@ class _FakeCoachRepository implements MemberCoachRepository {
   Future<List<CoachInvite>> fetchInvites() async => const <CoachInvite>[];
 
   @override
-  Future<void> acceptInvite(String inviteId) async {}
+  Future<void> acceptInvite(
+    String inviteId, {
+    required bool dataSharingConsent,
+  }) async {}
 
   @override
   Future<void> rejectInvite(String inviteId) async {}

--- a/frontend/flutter/test_e2e/support/e2e_harness.dart
+++ b/frontend/flutter/test_e2e/support/e2e_harness.dart
@@ -757,10 +757,16 @@ Future<void> submitConsultation(
 
   // 데이터 공유 동의 없이는 보낼 수 없다 (#1022) — 수락되는 순간 넘어가는 것이
   // 회원의 건강 기록이라, 신청 화면에서 동의를 받는다.
-  final Finder consent = await _revealInForm(
-    tester,
-    find.byKey(const Key('consultDataSharingConsent')),
+  //
+  // 스크롤로 찾지 않고 체크 박스를 직접 짚는다. 이 줄은 폼 맨 위(대상 카드 바로
+  // 아래)라 이미 트리에 있고, `_revealInForm` 의 스크롤 경로는 폼 안에 스크롤이
+  // 여럿일 때 흔들린다.
+  final Finder consent = find.descendant(
+    of: find.byKey(const Key('consult-data-sharing-notice')),
+    matching: find.byType(Checkbox),
   );
+  await tester.ensureVisible(consent);
+  await tester.pump();
   await tester.tap(consent);
   await tester.pump();
 

--- a/frontend/flutter/test_e2e/support/e2e_harness.dart
+++ b/frontend/flutter/test_e2e/support/e2e_harness.dart
@@ -724,6 +724,19 @@ Future<void> submitConsultation(
     await tester.pump();
   }
 
+  // 데이터 공유 동의 없이는 보낼 수 없다 (#1022) — 수락되는 순간 넘어가는 것이
+  // 회원의 건강 기록이라, 신청 화면에서 동의를 받는다.
+  //
+  // 폼을 스크롤하기 **전에** 짚는다. 폼이 지연 목록이라 아래로 내려가면 맨 위의
+  // 동의 줄은 트리에서 사라진다.
+  final Finder consent = find.descendant(
+    of: find.byKey(const Key('consult-data-sharing-notice')),
+    matching: find.byType(Checkbox),
+  );
+  await pumpUntil(tester, consent, step: '데이터 공유 동의');
+  await tester.tap(consent);
+  await tester.pump();
+
   await tapChip('consult-goal', goalIndex);
   await tapChip('consult-purpose', purposeIndex);
 
@@ -753,21 +766,6 @@ Future<void> submitConsultation(
     find.byKey(const Key('consult-message')),
   );
   await tester.enterText(box, message);
-  await tester.pump();
-
-  // 데이터 공유 동의 없이는 보낼 수 없다 (#1022) — 수락되는 순간 넘어가는 것이
-  // 회원의 건강 기록이라, 신청 화면에서 동의를 받는다.
-  //
-  // 스크롤로 찾지 않고 체크 박스를 직접 짚는다. 이 줄은 폼 맨 위(대상 카드 바로
-  // 아래)라 이미 트리에 있고, `_revealInForm` 의 스크롤 경로는 폼 안에 스크롤이
-  // 여럿일 때 흔들린다.
-  final Finder consent = find.descendant(
-    of: find.byKey(const Key('consult-data-sharing-notice')),
-    matching: find.byType(Checkbox),
-  );
-  await tester.ensureVisible(consent);
-  await tester.pump();
-  await tester.tap(consent);
   await tester.pump();
 
   final Finder submit = await _revealInForm(

--- a/frontend/flutter/test_e2e/support/e2e_harness.dart
+++ b/frontend/flutter/test_e2e/support/e2e_harness.dart
@@ -755,6 +755,15 @@ Future<void> submitConsultation(
   await tester.enterText(box, message);
   await tester.pump();
 
+  // 데이터 공유 동의 없이는 보낼 수 없다 (#1022) — 수락되는 순간 넘어가는 것이
+  // 회원의 건강 기록이라, 신청 화면에서 동의를 받는다.
+  final Finder consent = await _revealInForm(
+    tester,
+    find.byKey(const Key('consultDataSharingConsent')),
+  );
+  await tester.tap(consent);
+  await tester.pump();
+
   final Finder submit = await _revealInForm(
     tester,
     find.byKey(const Key('consult-submit')),

--- a/frontend/flutter/test_e2e/support/e2e_harness.dart
+++ b/frontend/flutter/test_e2e/support/e2e_harness.dart
@@ -196,6 +196,8 @@ class E2eApi {
             .substring(0, 10),
         'preferred_time_slot': 'evening',
         'message': 'E2E 예외 케이스',
+        // 동의 없이는 서버가 422 다 (#1022).
+        'data_sharing_consent': true,
       };
 
   Future<Map<String, dynamic>> createConsultation({


### PR DESCRIPTION
## Summary

트레이너는 담당이 되는 순간 회원의 식단·운동 기록과 신체 정보를 읽는다. 그런데 연결 과정 어디에도 "무엇이 넘어가는지 확인하고 동의한다"는 자리가 없었고, 동의를 언제 받았는지도 답할 수 없었다.

Closes #1022

## Changes

동의를 받는 자리는 **회원이 연결을 승낙하는 그 순간**이다. 담당이 생기는 경로가 둘이라 자리도 둘이다.

**트레이너의 담당 요청을 수락할 때**

회원이 그 자리에 있으므로 수락 직전에 동의 창을 띄운다. 무엇이 넘어가는지(식단 기록·운동 기록·신체 정보·건강 목표)와 연결을 해제하면 열람 권한도 사라진다는 것을 적었다. 취소하면 연결하지 않는다.

**회원이 상담을 신청할 때**

연결은 나중에 트레이너가 수락하며 만들어져 회원이 그 자리에 없다. 그래서 신청 화면에서 동의를 받아 요청에 적어 두고, 수락으로 링크가 생길 때 그 시각을 옮긴다. 기존 안내 문구(#914)는 그대로 두고 그 아래에 동의 체크를 붙였다 — 무엇이 넘어가는지 읽는 것과 동의하는 것은 다른 동작이다.

**서버가 막는다**

두 경로 모두 동의 없는 요청을 거절한다(각각 400). 화면이 체크를 지우고 보내도 통과하면 안 된다 — 수락된 뒤에는 회원이 동의한 적 없는 기록이 이미 넘어가 있다.

**동의 시각을 남긴다**

`trainer_clients.data_consent_at`, `consultation_requests.data_consent_at` (migration 0054). "언제 동의했나"에 답할 수 있어야 한다. 다시 담당이 되는 경우(휴면 링크 되살리기)도 새 연결이므로 그때의 동의로 갱신한다.

## Notes

- 기존 행의 동의 시각은 비워 둔다. 이 기능 이전에 만들어진 담당이라는 뜻이고, 소급해서 동의를 받은 척할 수는 없다.
- 검사: 동의 없는 수락은 400·동의하면 링크에 시각이 남는지(백엔드), 동의 없이는 상담 draft 가 나가지 않는지(단위), 동의 창을 취소하면 연결하지 않는지(위젯).
- 백엔드 전체 테스트, 두 앱 `flutter analyze` 무경고·전체 테스트 통과.
