### PR TITLE
fix(demo): 시드 내용 변경에 맞춰 시드 플래그 버전 상향

### DIFF
--- a/frontend/flutter_trainer/lib/core/storage/app_database.dart
+++ b/frontend/flutter_trainer/lib/core/storage/app_database.dart
@@ -4,8 +4,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 part 'app_database.g.dart';
 
-/// Generic key-value table. Holds tiny app-level state — currently the
-/// seed flag (`trainer_seeded_v1`).
+/// Generic key-value table. Holds tiny app-level state — the seed flag
+/// (`trainer_seeded_v<N>`, bumped whenever the seeded content changes)
+/// and the per-client chat read markers.
 class AppKeyValues extends Table {
   TextColumn get key => text()();
   TextColumn get value => text()();

--- a/frontend/flutter_trainer/lib/core/storage/seed_data.dart
+++ b/frontend/flutter_trainer/lib/core/storage/seed_data.dart
@@ -14,7 +14,7 @@ part 'seed_clients.dart';
 
 /// Idempotent seeder for the trainer app's local DB. Runs at bootstrap.
 ///
-/// **Flag.** `AppKeyValues['trainer_seeded_v18']` stores the date string
+/// **Flag.** `AppKeyValues['trainer_seeded_v19']` stores the date string
 /// (`YYYY-MM-DD`) the seed last ran with. Bump the version suffix
 /// whenever the seeded *content* changes — otherwise a browser that
 /// already seeded today keeps the old data until the date rolls over.
@@ -84,7 +84,7 @@ Future<void> seedIfEmpty(
   // 주간 계열을 요일 자리에 놓기 위한 오늘의 인덱스(월=0).
   final todayIndex = now.weekday - 1;
 
-  if (await db.readValue('trainer_seeded_v18') == today) return;
+  if (await db.readValue('trainer_seeded_v19') == today) return;
 
   // 김민수의 하루는 픽스처가 정한다 — 이 앱은 날짜에 붙여 저장하기만 한다(#757).
   final _FixtureClient fixtureClient = _FixtureClient(
@@ -333,7 +333,7 @@ Future<void> seedIfEmpty(
     });
 
     // ---- Mark seeded (inside the txn so it commits atomically) ----
-    await db.putValue('trainer_seeded_v18', today);
+    await db.putValue('trainer_seeded_v19', today);
   });
 }
 

--- a/frontend/flutter_trainer/test/core/storage/seed_data_test.dart
+++ b/frontend/flutter_trainer/test/core/storage/seed_data_test.dart
@@ -63,7 +63,7 @@ void main() {
       }
 
       expect(await db.select(db.clientChatMessages).get(), isNotEmpty);
-      expect(await db.readValue('trainer_seeded_v18'), _todayString());
+      expect(await db.readValue('trainer_seeded_v19'), _todayString());
     });
 
     test(
@@ -295,13 +295,13 @@ void main() {
 
     test('stale flag (different date) re-seeds schedule onto today', () async {
       await seedIfEmpty(db);
-      await db.putValue('trainer_seeded_v18', '2020-01-01');
+      await db.putValue('trainer_seeded_v19', '2020-01-01');
 
       await seedIfEmpty(db);
 
       final schedule = await db.select(db.trainerScheduleEntries).get();
       expect(schedule.every((s) => s.date == _todayString()), isTrue);
-      expect(await db.readValue('trainer_seeded_v18'), _todayString());
+      expect(await db.readValue('trainer_seeded_v19'), _todayString());
     });
 
     test(
@@ -424,7 +424,7 @@ void main() {
         expect(week.length, 7);
         expect(week.any((v) => (v as num) > 0), isTrue);
 
-        expect(await db.readValue('trainer_seeded_v18'), today);
+        expect(await db.readValue('trainer_seeded_v19'), today);
       },
     );
 
@@ -533,7 +533,7 @@ void main() {
           );
 
       // Force a re-seed.
-      await db.putValue('trainer_seeded_v18', '2020-01-01');
+      await db.putValue('trainer_seeded_v19', '2020-01-01');
       await seedIfEmpty(db);
 
       final chat = await db.select(db.clientChatMessages).get();


### PR DESCRIPTION
## Summary

* 시드 플래그를 `trainer_seeded_v18` → **`v19`** 로 올렸습니다. 오늘 이미 데모를 연 브라우저가 **한 번 다시 심습니다.**
* #989 · #1039 · #1044 가 시드 내용을 바꾸고도 플래그를 올리지 않아, 새 값이 화면에 나타나지 않았습니다.
* `app_database.dart` 주석이 가리키던 **없는 키**(`trainer_seeded_v1`)를 버전 무관 문구로 바꿨습니다.

---

## Changes

### ✨ Features

* 없음

### 🔧 Improvements

* `seed_data.dart` 의 플래그 키와 문서 주석, `seed_data_test.dart` 의 참조 5곳을 `v19` 로 상향.

### 🎨 UI/UX

* 기존 데모 DB 에서도 시각(`18:18` / `어제` / `2026-08-17`) · 미리보기 · 안읽음 배지가 제대로 나옵니다.

### 📝 Docs

* `app_database.dart` — `AppKeyValues` 설명이 실재하지 않는 키 대신 `trainer_seeded_v<N>` 와 채팅 읽음 마커를 가리킵니다.

### 🐛 Fixes

* 오늘 이미 심은 브라우저가 옛 시드 값을 계속 들고 있던 문제 수정.

---

## Commits

1. `b71666e9` fix(demo): 시드 내용 변경에 맞춰 시드 플래그 버전 상향

---

## Notes

* **왜 놓쳤는지**: 위젯 코드는 즉시 반영되고 시드 값만 굳어 있어, "새 레이아웃 + 옛 시각(`3일 전`)" 이라는 **코드가 안 들어간 것처럼 보이는** 화면이 나왔습니다. 규칙 자체는 `seed_data.dart` 문서 주석에 이미 있습니다 — *"Bump the version suffix whenever the seeded content changes"*.
* 다시 심어도 **`seed-` 접두사가 없는 행은 지우지 않습니다** — 런타임에 보낸 답장은 살아남고, 그걸 검증하는 테스트도 그대로입니다.
* `seed_data_test.dart` 의 `trainer_seeded_v12` 는 일부러 낮은 값입니다("옛 플래그로 이미 심은 빌드" 를 흉내 내는 테스트) — 건드리지 않았습니다.
* **앞으로 시드 값을 바꾸는 PR 은 이 플래그를 함께 올려야 합니다.**

---

## Screenshots (Optional)

| Before (오늘 이미 연 브라우저) | After |
| ------ | ----- |
| 새 레이아웃인데 `3일 전` · `5시간 전` · `30분 전` | `2026-08-17` · `18:18` · `어제` |

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 데모를 한 번 연 상태(오늘 이미 시드됨)에서 이 브랜치로 `flutter run -d chrome`.
2. **메시지** 탭 → 시각이 `18:18` / `어제` / `2026-08-17` 로 바뀌었는지 확인.
3. 미리보기가 대화의 마지막 말과 같은지, 트레이너가 답장한 스레드에 안읽음 배지가 없는지 확인.
4. 메시지를 하나 보낸 뒤 새로고침 → 그 답장이 남아 있는지 확인(런타임 행은 안 지워집니다).
5. `flutter test test/core/storage/seed_data_test.dart`

---

## Related Issues

Closes #1049

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인
