### PR TITLE
fix(chat): 긴 메시지 말풍선 폭 상한 적용

### DIFF
--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
@@ -612,6 +612,18 @@ class _SentBanner extends StatelessWidget {
 class _Bubble extends ConsumerWidget {
   const _Bubble({required this.message, required this.avatar});
 
+  /// 말풍선이 차지할 수 있는 대화 폭의 최대 비율.
+  ///
+  /// 상한이 없으면 긴 메시지가 대화 창을 가로로 다 채운다. 그러면 말풍선이
+  /// 말풍선으로 읽히지 않는다 — 누가 한 말인지는 색과 **어느 쪽으로 붙어
+  /// 있는가**가 말하는데, 양쪽 끝에 닿아 버리면 그 신호가 사라진다.
+  ///
+  /// 절대값 상한은 두지 않는다. 대화 패널이 가장 넓어지는 경우
+  /// (`wideMaxWidth` 1440 에서 `splitListWidth` 380 을 뺀 ~1000)에도 이
+  /// 비율이면 720 안쪽이라, 읽기 좋은 줄 길이의 기준으로 이미 쓰고 있는
+  /// `contentMaxWidth`(760) 를 넘지 않는다.
+  static const double _maxWidthFraction = 0.72;
+
   final ClientChatMessage message;
   final String avatar;
 
@@ -681,18 +693,30 @@ class _Bubble extends ConsumerWidget {
       ],
     );
 
-    return Row(
-      mainAxisAlignment: fromTrainer
-          ? MainAxisAlignment.end
-          : MainAxisAlignment.start,
-      crossAxisAlignment: CrossAxisAlignment.end,
-      children: <Widget>[
-        if (!fromTrainer) ...<Widget>[
-          ClientAvatar(label: avatar, size: 28),
-          const SizedBox(width: AppSpacing.sm),
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) => Row(
+        mainAxisAlignment: fromTrainer
+            ? MainAxisAlignment.end
+            : MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: <Widget>[
+          if (!fromTrainer) ...<Widget>[
+            ClientAvatar(label: avatar, size: 28),
+            const SizedBox(width: AppSpacing.sm),
+          ],
+          // `Flexible` 도 함께 둔다. 아주 좁은 폭에서는 아바타와 여백이
+          // 먼저 자리를 가져가 비율로 계산한 상한보다도 남는 폭이 적을 수
+          // 있는데, 그때는 상한이 아니라 남은 폭을 따라야 넘치지 않는다.
+          Flexible(
+            child: ConstrainedBox(
+              constraints: BoxConstraints(
+                maxWidth: constraints.maxWidth * _maxWidthFraction,
+              ),
+              child: bubble,
+            ),
+          ),
         ],
-        Flexible(child: bubble),
-      ],
+      ),
     );
   }
 

--- a/frontend/flutter_trainer/test/features/messages/messages_page_test.dart
+++ b/frontend/flutter_trainer/test/features/messages/messages_page_test.dart
@@ -250,6 +250,33 @@ void main() {
     });
   });
 
+  testWidgets('a long message never fills the whole thread width', (
+    tester,
+  ) async {
+    await withWideSurface(tester, () async {
+      await pumpTrainerApp(tester, token: 'demo-trainer-token-existing');
+      await goTo(tester, AppRoutes.messagesFor('seed-client-3'));
+
+      // 상한이 없으면 긴 메시지가 대화 창을 가로로 다 채운다. 그러면 누가
+      // 한 말인지를 말해 주던 "어느 쪽으로 붙어 있는가" 가 사라진다.
+      final thread = find.byKey(
+        const ValueKey<String>('messages-thread-seed-client-3'),
+      );
+      // 같은 문장이 목록 미리보기에도 있다 — 대화 쪽 말풍선만 잰다.
+      final message = find.descendant(
+        of: thread,
+        matching: find.textContaining('이해해요! 대신 AI 식단 분석'),
+      );
+      expect(message, findsOneWidget);
+      final threadWidth = tester.getSize(thread).width;
+      final bubbleWidth = tester.getSize(message).width;
+
+      expect(bubbleWidth, lessThan(threadWidth * 0.75));
+      // 그렇다고 쓸데없이 좁지도 않다 — 넓은 화면에서는 상한까지 쓴다.
+      expect(bubbleWidth, greaterThan(threadWidth * 0.5));
+    });
+  });
+
   testWidgets('client query keeps the selected member in the thread', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary

* 긴 메시지의 말풍선이 대화 창을 가로로 다 채우던 것을 **대화 폭의 72%** 로 제한했습니다.
* 반대쪽에 항상 여백이 남아, 누가 한 말인지(좌/우)가 다시 보입니다.

---

## Changes

### ✨ Features

* 없음

### 🔧 Improvements

* `_Bubble` 에 `_maxWidthFraction = 0.72` 상수와 `LayoutBuilder` + `ConstrainedBox` 추가.

### 🎨 UI/UX

* 말풍선이 양쪽 끝에 닿지 않습니다 — 대화가 공지처럼 보이던 문제 해소.
* 줄 길이가 짧아져 읽기 편해집니다.

### 📝 Docs

* 없음

### 🐛 Fixes

* 없음

---

## Commits

1. `11a021fe` fix(chat): 긴 메시지 말풍선 폭 상한 적용

---

## Notes

* **절대값 상한(예: 560px)은 두지 않았습니다.** 대화 패널이 가장 넓어지는 경우(`wideMaxWidth` 1440 − `splitListWidth` 380 ≈ 1000)에도 72% 는 720 안쪽이라, 읽기 좋은 줄 길이의 기준으로 이 저장소가 이미 쓰고 있는 `contentMaxWidth`(760)를 넘지 않습니다. 상수를 하나 더 두는 대신 기존 기준 안에 들어오게 비율을 골랐습니다.
* **`Flexible` 을 함께 둔 이유**: 아주 좁은 폭에서는 아바타(28)와 여백(8)이 먼저 자리를 가져가 비율로 계산한 상한보다도 남는 폭이 적을 수 있습니다. 그때는 상한이 아니라 남은 폭을 따라야 오버플로가 나지 않습니다.
* 사진 첨부는 `ChatImageAttachment.maxEdge` 가 220 이라 상한에 걸리지 않습니다. PDF 카드는 말풍선 안에서 함께 줄어듭니다.
* 새 테스트는 대화 폭 대비 말풍선 폭의 **비율**을 재므로, 화면 크기가 달라져도 의미가 유지됩니다.

---

## Screenshots (Optional)

| Before | After |
| ------ | ----- |
| 트레이너 답장이 왼쪽 끝~오른쪽 끝을 다 채움 | 오른쪽에 붙되 왼쪽에 여백이 남음(폭 72%) |

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. `cd frontend/flutter_trainer && flutter run -d chrome` 후 데모로 진입.
2. **메시지** 탭 → 박성호 → 마지막 트레이너 답장이 오른쪽에 붙되 왼쪽에 여백이 남는지 확인.
3. 창을 넓혔다 좁혔다 하며 비율이 유지되고 오버플로가 없는지 확인.
4. `flutter test test/features/messages/messages_page_test.dart`

---

## Related Issues

Closes #1051

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인
