### PR TITLE
feat(diet): 끼니 카드의 사진 확대와 정상 배지 색 통일

### DIFF
--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -13,7 +13,7 @@ import 'package:oncare/features/diet/domain/entities/diet_day.dart';
 import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
 import 'package:oncare/features/diet/presentation/widgets/diet_flows.dart';
 import 'package:oncare/features/diet/presentation/widgets/diet_period_view.dart';
-import 'package:oncare/features/diet/presentation/widgets/stored_meal_photo.dart';
+import 'package:oncare/features/diet/presentation/widgets/meal_photo_view.dart';
 import 'package:oncare/features/member_coach/presentation/widgets/trainer_chat_header_button.dart';
 import 'package:oncare/features/notification/presentation/controllers/notification_controller.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
@@ -1773,23 +1773,26 @@ class _MealCard extends StatelessWidget {
                   spacing: 6,
                   runSpacing: 6,
                   children: <Widget>[
+                    // 정상은 초록이다 — 같은 탭의 기간 그래프·나트륨 카드가
+                    // 이미 초록으로 정상을 말한다. 여기만 파랑이면 한 탭 안에서
+                    // 같은 뜻이 두 색을 쓰게 된다. (#1053)
                     _TotalPill(
                       label: l.dietCalories,
                       value: '${_formatInt(meal.total)} ${l.unitKcal}',
-                      color: FigmaColors.primary,
+                      color: FigmaColors.statusNormal,
                     ),
                     _TotalPill(
                       label: l.dietSodium,
                       value: '${_formatInt(meal.sodium)} ${l.dietUnitMg}',
-                      // 좋으면 파란계열, 나트륨이 과다하면 빨간계열.
+                      // 정상은 초록, 나트륨이 과다하면 빨강.
                       color: meal.sodium > 1000
                           ? FigmaColors.dangerRed
-                          : FigmaColors.primary,
+                          : FigmaColors.statusNormal,
                     ),
                     _TotalPill(
                       label: l.dietSugar,
                       value: '${_formatG(meal.sugar)} ${l.dietUnitG}',
-                      color: FigmaColors.primary,
+                      color: FigmaColors.statusNormal,
                     ),
                   ],
                 ),
@@ -1809,53 +1812,20 @@ class _MealCard extends StatelessWidget {
 /// Meal thumbnail: the photo the member uploaded, then the bundled demo
 /// asset, then the meal-type emoji chip.
 ///
-/// 실서버에서는 회원이 올린 사진(`photoUrl`)이 온다. 번들 자산은 실서버에 붙으면
-/// 늘 비어 있던 데모 값이라 뒤로 물린다. (#699)
+/// 고르는 순서는 [MealPhotoView] 가 안다 — 수정 화면 상단의 큰 사진과 같은
+/// 규칙을 쓴다. (#1053)
 class _MealThumb extends StatelessWidget {
   const _MealThumb({required this.meal});
   final DietMeal meal;
 
   @override
-  Widget build(BuildContext context) {
-    final String? url = meal.photoUrl;
-    if (url != null && url.isNotEmpty) {
-      return StoredMealPhoto(
-        path: url,
-        size: 52,
-        fallback: _assetOrEmojiThumb(),
-      );
-    }
-    return _assetOrEmojiThumb();
-  }
-
-  Widget _assetOrEmojiThumb() {
-    final String? asset = meal.photoAsset;
-    if (asset != null) {
-      return ClipRRect(
-        borderRadius: BorderRadius.circular(12),
-        child: Image.asset(
-          asset,
-          width: 52,
-          height: 52,
-          fit: BoxFit.cover,
-          // Fall back to the emoji chip if the bundled asset is missing.
-          errorBuilder: (BuildContext _, Object _, StackTrace? _) =>
-              _emojiThumb(),
-        ),
-      );
-    }
-    return _emojiThumb();
-  }
-
-  Widget _emojiThumb() => Container(
+  Widget build(BuildContext context) => MealPhotoView(
+    photoUrl: meal.photoUrl,
+    photoAsset: meal.photoAsset,
+    emoji: meal.emoji,
+    background: meal.thumbBg,
     width: 52,
     height: 52,
-    alignment: Alignment.center,
-    decoration: BoxDecoration(
-      color: meal.thumbBg,
-      borderRadius: BorderRadius.circular(12),
-    ),
-    child: Text(meal.emoji, style: const TextStyle(fontSize: 24)),
   );
 }
 

--- a/frontend/flutter/lib/features/diet/presentation/widgets/diet_flows.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/diet_flows.dart
@@ -15,6 +15,7 @@ import 'package:oncare/features/diet/domain/entities/diet_analysis_failure.dart'
 import 'package:oncare/features/diet/domain/entities/diet_day.dart';
 import 'package:oncare/features/diet/domain/entities/meal_photo.dart';
 import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
+import 'package:oncare/features/diet/presentation/widgets/meal_photo_view.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -1133,6 +1134,18 @@ class _MealEditSheetState extends ConsumerState<_MealEditSheet> {
     }
   }
 
+  /// 수정 화면 상단의 큰 끼니 사진.
+  MealPhotoView get _photo => MealPhotoView(
+    photoUrl: widget.meal.photoUrl,
+    photoAsset: widget.meal.photoAsset,
+    emoji: widget.meal.emoji,
+    background: widget.meal.thumbBg,
+    width: double.infinity,
+    height: 200,
+    borderRadius: 16,
+    emojiSize: 64,
+  );
+
   @override
   Widget build(BuildContext context) {
     final AppLocalizations l = AppLocalizations.of(context);
@@ -1178,6 +1191,13 @@ class _MealEditSheetState extends ConsumerState<_MealEditSheet> {
               shrinkWrap: true,
               padding: const EdgeInsets.fromLTRB(20, 4, 20, 28),
               children: <Widget>[
+                // 무엇을 고치는 끼니인지 사진으로 먼저 알아본다 — 숫자를
+                // 고치기 전에 눈으로 확인하는 순서가 자연스럽다. 사진이 없는
+                // 끼니는 큰 이모지 자리를 만들지 않고 지금까지처럼 연다. (#1053)
+                if (_photo.hasPhoto) ...<Widget>[
+                  _photo,
+                  const SizedBox(height: 12),
+                ],
                 _card(<Widget>[
                   _FieldLabel(l.dietMealInfo),
                   const SizedBox(height: 10),

--- a/frontend/flutter/lib/features/diet/presentation/widgets/meal_photo_view.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/meal_photo_view.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+
+import 'package:oncare/features/diet/presentation/widgets/stored_meal_photo.dart';
+
+/// 끼니 사진 — 회원이 올린 사진, 없으면 번들 자산, 그것도 없으면 끼니 이모지.
+///
+/// 목록의 작은 썸네일과 수정 화면 상단의 큰 사진이 **같은 순서**로 고르도록
+/// 한곳에 둔다. 두 화면이 각자 고르면, 같은 끼니가 목록에서는 사진으로
+/// 보이는데 수정 화면에서는 이모지로 열리는 일이 생긴다. (#699, #1053)
+class MealPhotoView extends StatelessWidget {
+  /// Creates the photo view at [width] × [height].
+  const MealPhotoView({
+    super.key,
+    required this.photoUrl,
+    required this.photoAsset,
+    required this.emoji,
+    required this.background,
+    required this.width,
+    required this.height,
+    this.borderRadius = 12,
+    this.emojiSize = 24,
+  });
+
+  /// API path of the photo the member uploaded (`/diet/photos/<id>`).
+  final String? photoUrl;
+
+  /// Bundled demo asset — 실서버에 붙으면 늘 비어 있어 뒤로 물린다.
+  final String? photoAsset;
+
+  /// 사진이 하나도 없을 때 그리는 끼니 이모지.
+  final String emoji;
+
+  /// 이모지 칩의 배경 — 끼니 종류마다 다르다.
+  final Color background;
+
+  final double width;
+  final double height;
+  final double borderRadius;
+  final double emojiSize;
+
+  /// 실제 사진(회원이 올린 것이든 번들 자산이든)이 있는지.
+  bool get hasPhoto =>
+      (photoUrl != null && photoUrl!.isNotEmpty) || photoAsset != null;
+
+  @override
+  Widget build(BuildContext context) {
+    final String? url = photoUrl;
+    if (url != null && url.isNotEmpty) {
+      return StoredMealPhoto(
+        path: url,
+        width: width,
+        height: height,
+        borderRadius: borderRadius,
+        fallback: _assetOrEmoji(),
+      );
+    }
+    return _assetOrEmoji();
+  }
+
+  Widget _assetOrEmoji() {
+    final String? asset = photoAsset;
+    if (asset != null) {
+      return ClipRRect(
+        borderRadius: BorderRadius.circular(borderRadius),
+        child: Image.asset(
+          asset,
+          width: width,
+          height: height,
+          fit: BoxFit.cover,
+          // 번들 자산이 빠져 있어도 카드는 그려야 한다.
+          errorBuilder: (BuildContext _, Object _, StackTrace? _) => _emoji(),
+        ),
+      );
+    }
+    return _emoji();
+  }
+
+  Widget _emoji() => Container(
+    width: width,
+    height: height,
+    alignment: Alignment.center,
+    decoration: BoxDecoration(
+      color: background,
+      borderRadius: BorderRadius.circular(borderRadius),
+    ),
+    child: Text(emoji, style: TextStyle(fontSize: emojiSize)),
+  );
+}

--- a/frontend/flutter/lib/features/diet/presentation/widgets/stored_meal_photo.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/stored_meal_photo.dart
@@ -37,8 +37,8 @@ final storedMealPhotoProvider = FutureProvider.family<Uint8List?, String>((
   }
 });
 
-/// Square thumbnail of a **stored** meal photo (the one the member already
-/// uploaded), with [fallback] shown while it
+/// A **stored** meal photo (the one the member already uploaded) drawn at
+/// [width] × [height], with [fallback] shown while it
 /// loads and whenever it can't be shown (no photo, network failure, corrupt
 /// bytes). The fallback is the existing emoji/asset chip, so a photo that
 /// isn't there changes nothing about the layout.
@@ -46,14 +46,19 @@ class StoredMealPhoto extends ConsumerWidget {
   const StoredMealPhoto({
     super.key,
     required this.path,
-    required this.size,
+    required this.width,
+    required this.height,
     required this.fallback,
     this.borderRadius = 12,
   });
 
   /// API path relative to the API base (`/diet/photos/<id>`).
   final String path;
-  final double size;
+
+  /// 크기는 호출부가 정한다 — 목록 썸네일은 정사각, 수정 화면 상단은 가로로
+  /// 넓은 사진이다. (#1053)
+  final double width;
+  final double height;
   final Widget fallback;
   final double borderRadius;
 
@@ -69,8 +74,8 @@ class StoredMealPhoto extends ConsumerWidget {
               borderRadius: BorderRadius.circular(borderRadius),
               child: Image.memory(
                 bytes,
-                width: size,
-                height: size,
+                width: width,
+                height: height,
                 fit: BoxFit.cover,
                 errorBuilder: (BuildContext _, Object _, StackTrace? _) =>
                     fallback,

--- a/frontend/flutter/test/features/diet/meal_card_photo_and_badges_test.dart
+++ b/frontend/flutter/test/features/diet/meal_card_photo_and_badges_test.dart
@@ -1,0 +1,134 @@
+/// 끼니 카드의 정상 배지 색과, 수정 화면 상단의 큰 사진 (#1053).
+///
+/// 배지는 같은 탭 안에서 뜻이 하나여야 한다. 기간 그래프와 나트륨·당류 카드가
+/// 이미 초록으로 `정상` 을 말하는데 끼니 카드만 파랑이면, 파랑이 정상인지
+/// 다른 종류의 지표인지 화면만 보고는 알 수 없다.
+///
+/// 수정 화면은 무엇을 고치는 끼니인지부터 보여 준다 — 사진을 먼저 확인하고
+/// 숫자를 고치는 순서다.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oncare/design_system/figma/figma_kit.dart';
+import 'package:oncare/features/diet/domain/entities/diet_day.dart';
+import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
+import 'package:oncare/features/diet/presentation/pages/diet_record_page.dart';
+import 'package:oncare/features/diet/presentation/widgets/diet_flows.dart';
+import 'package:oncare/features/diet/presentation/widgets/meal_photo_view.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+import '../../helpers/fake_diet_repository.dart';
+
+/// 대역의 아침 — 사진 자산이 붙어 있는 끼니다.
+const DietMeal _breakfast = DietMeal(
+  id: 'entry-breakfast',
+  mealType: MealType.breakfast,
+  time: '08:20',
+  total: 217,
+  emoji: '🥣',
+  thumbBg: Color(0xFFFFF3E0),
+  photoAsset: 'assets/images/breakfast-scrambled-egg-strawberry.jpg',
+  items: <DietFood>[DietFood('스크램블 에그', 185), DietFood('딸기', 32)],
+  tags: <DietTag>[],
+  sodium: 221,
+  sugar: 6.3,
+);
+
+void main() {
+  Future<void> pumpDiet(WidgetTester tester) async {
+    await tester.binding.setSurfaceSize(const Size(900, 2400));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          dietRepositoryProvider.overrideWithValue(FakeDietRepository()),
+        ],
+        child: const MaterialApp(
+          locale: Locale('ko'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: DietRecordPage(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  /// 배지 안에서 **값** 에 칠해진 색. 라벨은 같은 색을 옅게 쓰므로 마지막으로
+  /// 색이 지정된 조각이 값이다. `Text.rich` 가 스팬을 한 겹 감싸 두어 곧장
+  /// `children.last` 를 보면 색이 없는 껍데기가 잡힌다.
+  Color? badgeColorOf(WidgetTester tester, String text) {
+    // 끼니마다 같은 배지가 있다 — 첫 끼니 것만 본다.
+    final RichText rich = tester
+        .widgetList<RichText>(
+          find.byWidgetPredicate(
+            (Widget w) =>
+                w is RichText && w.text.toPlainText().startsWith('$text '),
+          ),
+        )
+        .first;
+    Color? color;
+    rich.text.visitChildren((InlineSpan span) {
+      if (span.style?.color != null) color = span.style!.color;
+      return true;
+    });
+    return color;
+  }
+
+  testWidgets('끼니 카드의 정상 배지는 기간 그래프와 같은 초록이다', (WidgetTester tester) async {
+    await pumpDiet(tester);
+
+    final AppLocalizations l = AppLocalizations.of(
+      tester.element(find.byType(DietRecordPage)),
+    );
+    // 대역의 아침은 217kcal · 나트륨 320mg — 세 지표 모두 정상 범위다.
+    expect(badgeColorOf(tester, l.dietCalories), FigmaColors.statusNormal);
+    expect(badgeColorOf(tester, l.dietSugar), FigmaColors.statusNormal);
+    expect(badgeColorOf(tester, l.dietSodium), FigmaColors.statusNormal);
+  });
+
+  testWidgets('목록 썸네일은 정사각 52 다', (WidgetTester tester) async {
+    await pumpDiet(tester);
+
+    final List<MealPhotoView> thumbs = tester
+        .widgetList<MealPhotoView>(find.byType(MealPhotoView))
+        .toList();
+    expect(thumbs, isNotEmpty);
+    expect(thumbs.every((MealPhotoView p) => p.height == 52), isTrue);
+  });
+
+  testWidgets('끼니를 열면 상단에 사진이 크게 뜬다', (WidgetTester tester) async {
+    await tester.binding.setSurfaceSize(const Size(900, 2400));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    // 수정 화면은 탭 껍데기 위에 라우터로 열린다 — 여기서는 그 페이지만 띄운다.
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          dietRepositoryProvider.overrideWithValue(FakeDietRepository()),
+        ],
+        child: MaterialApp(
+          locale: const Locale('ko'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: DietMealDetailPage(
+            entryId: _breakfast.id!,
+            initialMeal: _breakfast,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final MealPhotoView hero = tester.widget<MealPhotoView>(
+      find.byType(MealPhotoView).first,
+    );
+    expect(hero.height, greaterThan(52));
+    expect(hero.width, double.infinity);
+    // 목록과 같은 사진을 고른다 — 두 화면이 각자 고르면 어긋난다.
+    expect(hero.photoAsset, _breakfast.photoAsset);
+  });
+}

--- a/frontend/flutter/test/features/diet/stored_meal_photo_test.dart
+++ b/frontend/flutter/test/features/diet/stored_meal_photo_test.dart
@@ -45,7 +45,8 @@ Future<void> _pump(WidgetTester tester, Dio dio) async {
         home: Scaffold(
           body: StoredMealPhoto(
             path: _path,
-            size: 52,
+            width: 52,
+            height: 52,
             fallback: Text(_fallbackText),
           ),
         ),
@@ -152,7 +153,8 @@ void main() {
             home: Scaffold(
               body: StoredMealPhoto(
                 path: _path,
-                size: 52,
+                width: 52,
+                height: 52,
                 fallback: Text(_fallbackText),
               ),
             ),


### PR DESCRIPTION
Closes #1053

## Summary

끼니를 눌러 여는 수정 화면에 정작 무엇을 먹었는지가 없었다. 사진으로 먼저 알아보고 숫자를 고치는 순서가 자연스러워 상단에 사진을 크게 둔다.

끼니 카드의 `정상` 배지도 옮긴다. 같은 탭의 기간 그래프와 나트륨·당류 카드가 이미 초록으로 정상을 말하는데 끼니 카드만 파랑이라, 파랑이 정상인지 다른 종류의 지표인지 화면만 보고는 알 수 없었다.

## Changes

- 식단 수정 화면 상단에 끼니 사진 배치 — 사진이 없는 끼니는 큰 이모지 자리를 만들지 않고 지금까지처럼 연다
- 목록 썸네일과 상단 사진이 같은 규칙(회원이 올린 사진 → 번들 자산 → 이모지)으로 고르도록 한곳에 모음. 두 화면이 각자 고르면 같은 끼니가 목록에서는 사진, 수정 화면에서는 이모지로 열린다
- 끼니 카드의 칼로리·나트륨·당류 `정상` 배지를 초록으로 변경 (나트륨 과다는 빨강 그대로)

## Notes

- 회귀 방지 테스트 추가: 정상 배지 색, 썸네일 크기, 수정 화면 상단 사진이 목록과 같은 사진인지.
- 검증: `flutter analyze` 클린, 회원 앱 테스트 전체 통과.
