### PR TITLE
fix(diet): 식단 요약·기간 카드의 중복 문구 삭제

### DIFF
--- a/frontend/flutter/lib/features/diet/presentation/widgets/diet_period_view.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/diet_period_view.dart
@@ -437,17 +437,10 @@ class _PeriodBody extends StatelessWidget {
             ],
           ),
           const SizedBox(height: 10),
+          // 기록한 날 수는 막대 개수가 곧 말해 준다 — 같은 것을 글자로 한 번 더
+          // 적으면 카드 위쪽이 숫자로 붐빈다. (#1054)
           Row(
             children: <Widget>[
-              Text(
-                l.dietPeriodLoggedDays(period.loggedDays),
-                style: const TextStyle(
-                  fontSize: 12.5,
-                  fontWeight: FontWeight.w600,
-                  color: AppColors.foreground,
-                ),
-              ),
-              const SizedBox(width: 10),
               Expanded(
                 child: Text(
                   '${l.dietPeriodTotal} ${format(total)} $unit',

--- a/frontend/flutter/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations.dart
@@ -335,13 +335,13 @@ abstract class AppLocalizations {
   /// No description provided for @dietAmountOver.
   ///
   /// In en, this message translates to:
-  /// **'{amount} over the goal'**
+  /// **'{amount} over'**
   String dietAmountOver(String amount);
 
   /// No description provided for @dietAmountRemaining.
   ///
   /// In en, this message translates to:
-  /// **'{amount} remaining to the goal'**
+  /// **'{amount} to go'**
   String dietAmountRemaining(String amount);
 
   /// No description provided for @homeExerciseActiveTime.
@@ -649,12 +649,6 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Period total'**
   String get dietPeriodTotal;
-
-  /// No description provided for @dietPeriodLoggedDays.
-  ///
-  /// In en, this message translates to:
-  /// **'{days, plural, =1{1 day logged} other{{days} days logged}}'**
-  String dietPeriodLoggedDays(int days);
 
   /// No description provided for @dietPeriodEmpty.
   ///

--- a/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
@@ -132,12 +132,12 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String dietAmountOver(String amount) {
-    return '$amount over the goal';
+    return '$amount over';
   }
 
   @override
   String dietAmountRemaining(String amount) {
-    return '$amount remaining to the goal';
+    return '$amount to go';
   }
 
   @override
@@ -310,17 +310,6 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get dietPeriodTotal => 'Period total';
-
-  @override
-  String dietPeriodLoggedDays(int days) {
-    String _temp0 = intl.Intl.pluralLogic(
-      days,
-      locale: localeName,
-      other: '$days days logged',
-      one: '1 day logged',
-    );
-    return '$_temp0';
-  }
 
   @override
   String get dietPeriodEmpty => 'No meals were logged in this period.';

--- a/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
@@ -130,12 +130,12 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String dietAmountOver(String amount) {
-    return '목표보다 $amount 많아요';
+    return '$amount 많아요';
   }
 
   @override
   String dietAmountRemaining(String amount) {
-    return '목표까지 $amount 남았어요';
+    return '$amount 남았어요';
   }
 
   @override
@@ -308,11 +308,6 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get dietPeriodTotal => '기간 합계';
-
-  @override
-  String dietPeriodLoggedDays(int days) {
-    return '$days일 기록';
-  }
 
   @override
   String get dietPeriodEmpty => '이 기간에 기록된 식단이 없어요.';

--- a/frontend/flutter/lib/l10n/app_en.arb
+++ b/frontend/flutter/lib/l10n/app_en.arb
@@ -49,7 +49,7 @@
   "homeExerciseTrendUnavailable": "Couldn't load this week's workout history.",
   "homeMetricOver": "Over",
   "homeMetricNormal": "On track",
-  "dietAmountOver": "{amount} over the goal",
+  "dietAmountOver": "{amount} over",
   "@dietAmountOver": {
     "placeholders": {
       "amount": {
@@ -57,7 +57,7 @@
       }
     }
   },
-  "dietAmountRemaining": "{amount} remaining to the goal",
+  "dietAmountRemaining": "{amount} to go",
   "@dietAmountRemaining": {
     "placeholders": {
       "amount": {
@@ -165,14 +165,6 @@
   "dietLoadError": "Couldn't load your diet.",
   "dietPeriodAverage": "Daily average",
   "dietPeriodTotal": "Period total",
-  "dietPeriodLoggedDays": "{days, plural, =1{1 day logged} other{{days} days logged}}",
-  "@dietPeriodLoggedDays": {
-    "placeholders": {
-      "days": {
-        "type": "int"
-      }
-    }
-  },
   "dietPeriodEmpty": "No meals were logged in this period.",
   "dietPeriodRange": "{start} - {end}",
   "@dietPeriodRange": {

--- a/frontend/flutter/lib/l10n/app_ko.arb
+++ b/frontend/flutter/lib/l10n/app_ko.arb
@@ -39,7 +39,7 @@
   "homeExerciseTrendUnavailable": "주간 운동 기록을 불러오지 못했어요.",
   "homeMetricOver": "초과",
   "homeMetricNormal": "정상",
-  "dietAmountOver": "목표보다 {amount} 많아요",
+  "dietAmountOver": "{amount} 많아요",
   "@dietAmountOver": {
     "placeholders": {
       "amount": {
@@ -47,7 +47,7 @@
       }
     }
   },
-  "dietAmountRemaining": "목표까지 {amount} 남았어요",
+  "dietAmountRemaining": "{amount} 남았어요",
   "@dietAmountRemaining": {
     "placeholders": {
       "amount": {
@@ -116,7 +116,6 @@
   "dietLoadError": "식단 정보를 불러오지 못했어요.",
   "dietPeriodAverage": "하루 평균",
   "dietPeriodTotal": "기간 합계",
-  "dietPeriodLoggedDays": "{days}일 기록",
   "dietPeriodEmpty": "이 기간에 기록된 식단이 없어요.",
   "dietPeriodRange": "{start} ~ {end}",
   "dietPeriodNoRecord": "기록 없음",

--- a/frontend/flutter/test/features/diet/diet_macros_display_test.dart
+++ b/frontend/flutter/test/features/diet/diet_macros_display_test.dart
@@ -195,8 +195,12 @@ void main() {
       expect(find.textContaining('17.8'), findsOneWidget);
       expect(find.text('목표 초과'), findsOneWidget);
       expect(find.text('정상'), findsOneWidget);
-      expect(find.text('목표보다 1,428mg 많아요'), findsOneWidget);
-      expect(find.text('목표까지 32.2g 남았어요'), findsOneWidget);
+      // 목표 수치는 바로 위 줄에 이미 있다 — `목표보다`·`목표까지` 를 덧붙이면
+      // 같은 말을 두 번 한다. (#1054)
+      expect(find.text('1,428mg 많아요'), findsOneWidget);
+      expect(find.text('32.2g 남았어요'), findsOneWidget);
+      expect(find.textContaining('목표보다'), findsNothing);
+      expect(find.textContaining('목표까지'), findsNothing);
       expect(
         find.byKey(const Key('nutrition-status-vertical-progress-나트륨')),
         findsOneWidget,
@@ -481,7 +485,7 @@ void main() {
 
   testWidgets('목표를 넘기면 달성률이 100% 를 넘어 적힌다 (#846)', (WidgetTester tester) async {
     // 기본 목표는 2,000 kcal. 2,500 kcal 은 125% 다 — 여기가 100% 로 적히면
-    // 같은 카드의 "목표보다 500 kcal 많아요" 와 어긋난다.
+    // 같은 카드의 "500 kcal 많아요" 와 어긋난다.
     const DietDay day = DietDay(
       entries: <DietEntry>[
         DietEntry(

--- a/frontend/flutter/test/features/diet/diet_period_copy_test.dart
+++ b/frontend/flutter/test/features/diet/diet_period_copy_test.dart
@@ -1,0 +1,47 @@
+/// 기간 카드에서 덜어낸 문구 (#1054).
+///
+/// `n일 기록` 은 막대 개수가 곧 말해 주는 값이다. 같은 것을 글자로 한 번 더
+/// 적으면 카드 위쪽이 숫자로 붐빈다.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
+import 'package:oncare/features/diet/presentation/pages/diet_record_page.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+import '../../helpers/fake_diet_repository.dart';
+
+void main() {
+  Future<void> openPeriod(WidgetTester tester, String tabKey) async {
+    await tester.binding.setSurfaceSize(const Size(900, 2400));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          dietRepositoryProvider.overrideWithValue(FakeDietRepository()),
+        ],
+        child: const MaterialApp(
+          locale: Locale('ko'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: DietRecordPage(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(Key('diet-period-tab-$tabKey')));
+    await tester.pumpAndSettle();
+  }
+
+  for (final String tab in <String>['week', 'month']) {
+    testWidgets('$tab 기간 카드에 기록한 날 수를 적지 않는다', (WidgetTester tester) async {
+      await openPeriod(tester, tab);
+
+      expect(find.byKey(const Key('diet-period-card')), findsOneWidget);
+      expect(find.textContaining('일 기록'), findsNothing);
+    });
+  }
+}


### PR DESCRIPTION
Closes #1054

## Summary

나트륨·당류 카드가 `목표보다 1,428mg 많아요` 처럼 적었다. 바로 윗줄에 `3,428 / 2,000mg` 가 이미 있어 목표를 두 번 말하는 셈이다. 남는 양만 남긴다.

기간 카드의 `n일 기록` 도 마찬가지다. 기록한 날 수는 막대 개수가 곧 말해 준다.

## Changes

- `목표보다`·`목표까지` 삭제 — `1,428mg 많아요` · `32.2g 남았어요` 로 남긴다. 영어 문구도 함께 줄인다
- 식단 `이번 주`·`전체` 기간 카드에서 `n일 기록` 텍스트 삭제 (쓰이지 않게 된 문구 키도 함께 정리)

## Notes

- 칼로리 카드도 나트륨·당류와 같은 문구를 쓴다. 한쪽만 줄이면 같은 카드 묶음 안에서 말투가 갈려, 셋을 함께 덜어냈다.
- 회귀 방지 테스트 추가: 기간 카드에 `일 기록` 이 남지 않는지, 요약 카드에 `목표보다`·`목표까지` 가 다시 붙지 않는지.
- 검증: `flutter analyze` 클린, 회원 앱 테스트 전체 통과.
