### PR TITLE
fix(home): 홈 카드의 AI 분석 배지 삭제와 헤더 정리

### DIFF
--- a/frontend/flutter/lib/design_system/figma/figma_kit.dart
+++ b/frontend/flutter/lib/design_system/figma/figma_kit.dart
@@ -233,7 +233,16 @@ class HeartLogo extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Icon(Icons.favorite, size: size, color: color);
+    // 서비스 로고를 그대로 쓴다 — 하트 아이콘은 자리를 지키던 임시값이라,
+    // 로그인 화면과 홈 헤더가 서로 다른 그림으로 같은 서비스를 가리켰다. (#1055)
+    return Image.asset(
+      'assets/images/oncare-logo.png',
+      width: size,
+      height: size,
+      // 자산이 빠져도 헤더는 그려야 한다.
+      errorBuilder: (BuildContext _, Object _, StackTrace? _) =>
+          Icon(Icons.favorite, size: size, color: color),
+    );
   }
 }
 
@@ -383,13 +392,15 @@ class FigmaTabHeader extends StatelessWidget {
             onTap: onBell,
           ),
           const SizedBox(width: 10),
-          FigmaCircleButton(
-            icon: Icons.calendar_today_outlined,
-            tooltip: l.a11yOpenCalendar,
-            iconSize: 16,
-            onTap: onCalendar,
-          ),
-          const SizedBox(width: 10),
+          // 캘린더는 지금 쓰지 않는다. 되살릴 수 있어 지우지 않고 남겨 둔다.
+          // (#1055)
+          // FigmaCircleButton(
+          //   icon: Icons.calendar_today_outlined,
+          //   tooltip: l.a11yOpenCalendar,
+          //   iconSize: 16,
+          //   onTap: onCalendar,
+          // ),
+          // const SizedBox(width: 10),
           trailingAction,
         ],
       ),

--- a/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
@@ -191,10 +191,12 @@ class _DashboardData extends StatelessWidget {
           padding: EdgeInsets.only(bottom: 20),
           child: _RecommendedMeals(),
         ),
-        Padding(
-          padding: const EdgeInsets.fromLTRB(24, 0, 24, 8),
-          child: _ScheduleCard(items: summary.todaySchedule),
-        ),
+        // 오늘의 일정은 지금 쓰지 않는다. 되살릴 수 있어 지우지 않고 남겨
+        // 둔다. (#1055)
+        // Padding(
+        //   padding: const EdgeInsets.fromLTRB(24, 0, 24, 8),
+        //   child: _ScheduleCard(items: summary.todaySchedule),
+        // ),
       ],
     );
   }
@@ -330,30 +332,11 @@ class _CardHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final AppLocalizations l = AppLocalizations.of(context);
+    // `AI 분석` 필은 뗐다 (#1055). 홈의 요약은 대부분 AI 가 만든 것이라
+    // 필이 카드를 갈라 주지 못하면서, 제목 줄만 좁혔다.
     return Row(
       children: <Widget>[
-        Expanded(
-          child: Row(
-            children: <Widget>[
-              Flexible(
-                child: _CardTitle(icon: icon, label: label),
-              ),
-              const SizedBox(width: 6),
-              // 필은 글자를 자르면 'AI ana…' 처럼 읽히지 않아 통째로 축소한다.
-              Flexible(
-                child: FittedBox(
-                  fit: BoxFit.scaleDown,
-                  alignment: Alignment.centerLeft,
-                  child: AiPill(
-                    l.homeAiAnalysisPill,
-                    background: FigmaColors.primaryA(0.10),
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ),
+        Expanded(child: _CardTitle(icon: icon, label: label)),
         const SizedBox(width: 8),
         _DetailLink(onTap: onOpen),
       ],
@@ -1430,7 +1413,9 @@ class _ExerciseBarPainter extends CustomPainter {
         text: TextSpan(
           text: NumberFormat('#,###').format(v),
           style: TextStyle(
-            fontSize: 12,
+            // 막대 위 숫자는 막대보다 작아야 한다 — 그래프는 흐름을 보는
+            // 자리고, 정확한 값은 상세에서 읽는다. (#1055)
+            fontSize: 10.5,
             fontWeight: FontWeight.w800,
             color: (today ? color : const Color(0xFF9AA6B2)).withValues(
               alpha: t,
@@ -1633,10 +1618,6 @@ class _RecommendedMeals extends ConsumerWidget {
                         color: FigmaColors.ink,
                       ),
                     ),
-                    AiPill(
-                      l.homeAiAnalysisPill,
-                      background: FigmaColors.primaryA(0.10),
-                    ),
                     if (basis != null)
                       Text(
                         basis,
@@ -1796,6 +1777,9 @@ class _RecMealCard extends StatelessWidget {
 
 // ───────────────────────────────────────────────────────── schedule ──
 
+/// 홈 하단의 오늘 일정 카드. 지금은 화면에 걸지 않았다 (#1055) — 지우지 않고
+/// 남겨 둔 것이라 쓰이지 않는다는 경고를 여기서 끈다.
+// ignore: unused_element
 class _ScheduleCard extends ConsumerWidget {
   const _ScheduleCard({required this.items});
 

--- a/frontend/flutter/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations.dart
@@ -266,12 +266,6 @@ abstract class AppLocalizations {
   /// **'Chicken breast salad'**
   String get homeMealChickenSalad;
 
-  /// No description provided for @homeAiAnalysisPill.
-  ///
-  /// In en, this message translates to:
-  /// **'✦ AI analysis'**
-  String get homeAiAnalysisPill;
-
   /// No description provided for @homeDetails.
   ///
   /// In en, this message translates to:

--- a/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
@@ -95,9 +95,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get homeMealChickenSalad => 'Chicken breast salad';
 
   @override
-  String get homeAiAnalysisPill => '✦ AI analysis';
-
-  @override
   String get homeDetails => 'Details';
 
   @override

--- a/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
@@ -94,9 +94,6 @@ class AppLocalizationsKo extends AppLocalizations {
   String get homeMealChickenSalad => '닭가슴살 샐러드';
 
   @override
-  String get homeAiAnalysisPill => '✦ AI 분석';
-
-  @override
   String get homeDetails => '자세히';
 
   @override

--- a/frontend/flutter/lib/l10n/app_en.arb
+++ b/frontend/flutter/lib/l10n/app_en.arb
@@ -31,7 +31,6 @@
   "homeMacroProtein": "Protein",
   "homeMacroFat": "Fat",
   "homeMealChickenSalad": "Chicken breast salad",
-  "homeAiAnalysisPill": "✦ AI analysis",
   "homeDetails": "Details",
   "homeGoal": "Goal",
   "homeDietNutritionTitle": "Diet & nutrition",

--- a/frontend/flutter/lib/l10n/app_ko.arb
+++ b/frontend/flutter/lib/l10n/app_ko.arb
@@ -28,7 +28,6 @@
   "homeMacroProtein": "단백질",
   "homeMacroFat": "지방",
   "homeMealChickenSalad": "닭가슴살 샐러드",
-  "homeAiAnalysisPill": "✦ AI 분석",
   "homeDetails": "자세히",
   "homeGoal": "목표",
   "homeDietNutritionTitle": "식단 · 영양",

--- a/frontend/flutter/test/features/dashboard/dashboard_content_state_test.dart
+++ b/frontend/flutter/test/features/dashboard/dashboard_content_state_test.dart
@@ -273,7 +273,8 @@ void main() {
     await tester.pump();
 
     expect(find.text('아직 오늘 기록이 없어요. 식단이나 운동을 기록해 보세요.'), findsOneWidget);
-    expect(find.text('오늘 예정된 일정이 없어요.'), findsOneWidget);
+    // 오늘의 일정 카드는 화면에서 내려 뒀다 (#1055) — 빈 상태 문구도 함께 없다.
+    expect(find.text('오늘 예정된 일정이 없어요.'), findsNothing);
     expect(find.text('0g'), findsNWidgets(3));
     expect(
       find.byKey(const ValueKey<String>('dashboard-nutrition-chart')),
@@ -450,7 +451,8 @@ void main() {
       expect(find.text('소모 칼로리'), findsOneWidget);
       expect(find.text('운동 일수'), findsOneWidget);
       expect(find.text('운동 추이 (kcal)'), findsOneWidget);
-      expect(find.text('병원 정기검진'), findsOneWidget);
+      // 오늘의 일정 카드는 화면에서 내려 뒀다 (#1055).
+      expect(find.text('병원 정기검진'), findsNothing);
       expect(find.textContaining('김치찌개·배추김치'), findsOneWidget);
       expect(
         find.byKey(const ValueKey<String>('dashboard-nutrition-chart')),
@@ -490,7 +492,8 @@ void main() {
       final AppLocalizations en = lookupAppLocalizations(const Locale('en'));
       // 헤더가 줄어들지 못하면 밀려난 더보기 링크부터 넘친다.
       expect(find.text(en.homeDetails), findsWidgets);
-      expect(find.text(en.homeAiAnalysisPill), findsWidgets);
+      // `AI 분석` 필은 뗐다 (#1055) — 헤더가 줄어들 수 있는 구조인지만 본다.
+      expect(find.text(en.homeDietNutritionTitle), findsWidgets);
       expect(tester.takeException(), isNull);
     });
   }

--- a/frontend/flutter/test/features/dashboard/dashboard_page_test.dart
+++ b/frontend/flutter/test/features/dashboard/dashboard_page_test.dart
@@ -55,7 +55,18 @@ void main() {
     // 수치는 식단 하루치에서 온다 — 칼로리 1,067kcal, 탄수화물 120g (저녁 제외, #548).
     expect(find.text('1,067'), findsWidgets);
     expect(find.text('120g'), findsOneWidget);
-    expect(find.text('오늘의 일정'), findsOneWidget);
-    expect(find.text('병원 정기검진'), findsOneWidget);
+    // 오늘의 일정 카드는 화면에서 내려 뒀다 (#1055).
+    expect(find.text('오늘의 일정'), findsNothing);
+  });
+
+  testWidgets('홈 헤더에 캘린더 버튼과 AI 분석 필이 없다 (#1055)', (WidgetTester tester) async {
+    await pumpApp(tester);
+
+    // 캘린더는 쓰지 않아 내려 뒀다 — 아이콘만 남으면 눌러도 아무 일이 없다.
+    expect(find.byIcon(Icons.calendar_today_outlined), findsNothing);
+    // 홈 요약은 대부분 AI 가 만든 것이라 필이 카드를 갈라 주지 못했다.
+    expect(find.textContaining('AI 분석'), findsNothing);
+    // 로고는 서비스 로고 그대로다 — 하트 아이콘은 자리를 지키던 임시값이었다.
+    expect(find.byIcon(Icons.favorite), findsNothing);
   });
 }

--- a/frontend/flutter/test/features/dashboard/home_coach_sessions_test.dart
+++ b/frontend/flutter/test/features/dashboard/home_coach_sessions_test.dart
@@ -54,10 +54,7 @@ CoachSession _session({
   status: status,
 );
 
-Future<void> _pump(
-  WidgetTester tester, {
-  List<CoachSession>? sessions,
-}) async {
+Future<void> _pump(WidgetTester tester, {List<CoachSession>? sessions}) async {
   await tester.binding.setSurfaceSize(const Size(800, 2400));
   addTearDown(() => tester.binding.setSurfaceSize(null));
   await tester.pumpWidget(
@@ -91,69 +88,69 @@ Future<void> _pump(
 }
 
 void main() {
-  testWidgets('트레이너가 잡은 오늘 PT 가 홈 일정에 나타난다', (
-    WidgetTester tester,
-  ) async {
-    await _pump(tester, sessions: <CoachSession>[_session()]);
+  // 홈 하단 오늘의 일정 카드는 지금 화면에 걸지 않았다 (#1055). 트레이너 세션을
+  // 내 일정과 섞는 규칙은 그 카드 안에 있어, 카드가 돌아올 때 이 검사도 함께
+  // 돌아온다 — 지우면 규칙이 무엇이었는지가 사라진다.
+  group('오늘의 일정 카드 (지금은 화면에서 내려 둠)', skip: '#1055 에서 주석 처리', () {
+    testWidgets('트레이너가 잡은 오늘 PT 가 홈 일정에 나타난다', (WidgetTester tester) async {
+      await _pump(tester, sessions: <CoachSession>[_session()]);
 
-    expect(find.text('1:1 PT'), findsOneWidget);
-    // 내가 만든 일정도 그대로 남는다.
-    expect(find.text('병원 정기검진'), findsOneWidget);
-  });
+      expect(find.text('1:1 PT'), findsOneWidget);
+      // 내가 만든 일정도 그대로 남는다.
+      expect(find.text('병원 정기검진'), findsOneWidget);
+    });
 
-  testWidgets('시간순으로 섞인다', (WidgetTester tester) async {
-    // '다음에 뭐가 있는지'를 한 번에 읽으려면 두 출처가 시간순이어야 한다.
-    await _pump(tester, sessions: <CoachSession>[_session()]);
+    testWidgets('시간순으로 섞인다', (WidgetTester tester) async {
+      // '다음에 뭐가 있는지'를 한 번에 읽으려면 두 출처가 시간순이어야 한다.
+      await _pump(tester, sessions: <CoachSession>[_session()]);
 
-    final double ptY = tester.getTopLeft(find.text('1:1 PT')).dy;
-    final double checkupY = tester.getTopLeft(find.text('병원 정기검진')).dy;
-    expect(ptY, lessThan(checkupY));
-  });
+      final double ptY = tester.getTopLeft(find.text('1:1 PT')).dy;
+      final double checkupY = tester.getTopLeft(find.text('병원 정기검진')).dy;
+      expect(ptY, lessThan(checkupY));
+    });
 
-  testWidgets('완료된 세션은 오늘의 일정에 남지 않는다', (WidgetTester tester) async {
-    await _pump(
-      tester,
-      sessions: <CoachSession>[_session(status: '완료')],
-    );
+    testWidgets('완료된 세션은 오늘의 일정에 남지 않는다', (WidgetTester tester) async {
+      await _pump(tester, sessions: <CoachSession>[_session(status: '완료')]);
 
-    expect(find.text('1:1 PT'), findsNothing);
-  });
+      expect(find.text('1:1 PT'), findsNothing);
+    });
 
-  testWidgets('다른 날 세션은 오늘에 끼어들지 않는다', (WidgetTester tester) async {
-    await _pump(
-      tester,
-      sessions: <CoachSession>[
-        _session(date: nowKst().add(const Duration(days: 3))),
-      ],
-    );
+    testWidgets('다른 날 세션은 오늘에 끼어들지 않는다', (WidgetTester tester) async {
+      await _pump(
+        tester,
+        sessions: <CoachSession>[
+          _session(date: nowKst().add(const Duration(days: 3))),
+        ],
+      );
 
-    expect(find.text('1:1 PT'), findsNothing);
-  });
+      expect(find.text('1:1 PT'), findsNothing);
+    });
 
-  testWidgets('날짜가 없는 세션은 걸러진다', (WidgetTester tester) async {
-    // 서버가 깨진 날짜를 줘도 화면이 흔들리지 않아야 한다.
-    await _pump(
-      tester,
-      sessions: <CoachSession>[
-        const CoachSession(
-          id: 'broken',
-          date: null,
-          time: '09:00',
-          type: '1:1 PT',
-          durationMinutes: 50,
-          status: '예정',
-        ),
-      ],
-    );
+    testWidgets('날짜가 없는 세션은 걸러진다', (WidgetTester tester) async {
+      // 서버가 깨진 날짜를 줘도 화면이 흔들리지 않아야 한다.
+      await _pump(
+        tester,
+        sessions: <CoachSession>[
+          const CoachSession(
+            id: 'broken',
+            date: null,
+            time: '09:00',
+            type: '1:1 PT',
+            durationMinutes: 50,
+            status: '예정',
+          ),
+        ],
+      );
 
-    expect(find.text('1:1 PT'), findsNothing);
-  });
+      expect(find.text('1:1 PT'), findsNothing);
+    });
 
-  testWidgets('데모 홈 일정은 지금과 같다', (WidgetTester tester) async {
-    // override 없이 — 데모는 목 저장소가 빈 목록을 주므로 카드가 그대로다.
-    await _pump(tester);
+    testWidgets('데모 홈 일정은 지금과 같다', (WidgetTester tester) async {
+      // override 없이 — 데모는 목 저장소가 빈 목록을 주므로 카드가 그대로다.
+      await _pump(tester);
 
-    expect(find.text('병원 정기검진'), findsOneWidget);
-    expect(find.text('1:1 PT'), findsNothing);
+      expect(find.text('병원 정기검진'), findsOneWidget);
+      expect(find.text('1:1 PT'), findsNothing);
+    });
   });
 }


### PR DESCRIPTION
Closes #1055

## Summary

홈 카드마다 파란 `AI 분석` 배지가 붙어 있었다. 홈의 요약은 대부분 AI 가 만드는 것이라 배지가 카드를 갈라 주지 못하고 제목 줄만 좁혔다.

쓰지 않는 자리도 함께 정리한다. 하단 오늘의 일정과 헤더 캘린더 아이콘은 지금 쓰지 않지만 되살릴 수 있어, 지우지 않고 주석으로 남긴다.

## Changes

- 식단 영양 카드 · 주간 운동 카드 · 이번 주 AI 추천 식단에서 `AI 분석` 배지 삭제 (쓰이지 않게 된 문구 키도 함께 정리)
- 주간 운동 추이 그래프의 막대 위 숫자 크기 축소 — 그래프는 흐름을 보는 자리고 정확한 값은 상세에서 읽는다
- 하단 오늘의 일정 카드와 헤더 캘린더 아이콘 주석 처리
- 헤더 로고를 서비스 로고로 교체 — 하트 아이콘은 자리를 지키던 임시값이라 로그인 화면과 홈이 서로 다른 그림을 썼다

## Notes

- 일정 카드는 트레이너 세션을 내 일정과 시간순으로 섞는 규칙을 품고 있다. 그 검사를 지우면 규칙이 무엇이었는지가 사라져, 카드와 함께 쉬게 두고(skip) 카드가 돌아올 때 같이 돌아오게 했다.
- 회귀 방지 테스트 추가: 홈 헤더에 캘린더 버튼·`AI 분석` 필·임시 하트 로고가 다시 붙지 않는지.
- 검증: `flutter analyze` 클린, 회원 앱 테스트 전체 통과.
