### PR TITLE
feat(profile): MY 탭 트레이너·헬스장 카드의 상세 연결과 삭제 버튼

### DIFF
--- a/frontend/flutter/lib/features/exercise/presentation/pages/gym_detail_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/gym_detail_page.dart
@@ -8,8 +8,10 @@ import 'package:oncare/design_system/tokens/colors.dart';
 import 'package:oncare/features/exercise/domain/entities/consultation_request.dart';
 import 'package:oncare/features/exercise/domain/entities/gym.dart';
 import 'package:oncare/features/exercise/domain/entities/trainer.dart';
+import 'package:oncare/features/exercise/domain/repositories/gym_repository.dart';
 import 'package:oncare/features/exercise/presentation/controllers/consultation_request_controller.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
+import 'package:oncare/features/exercise/presentation/widgets/connection_disconnect.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 
 class GymDetailPage extends ConsumerWidget {
@@ -80,14 +82,36 @@ class GymDetailPage extends ConsumerWidget {
   }
 }
 
-class _GymDetails extends StatelessWidget {
+class _GymDetails extends ConsumerWidget {
   const _GymDetails({required this.gym, required this.isMyGym});
 
   final Gym gym;
   final bool isMyGym;
 
+  /// 연결을 끊고, 끊었으면 이 화면을 닫는다 — 지운 대상의 상세에 그대로
+  /// 남아 있으면 방금 무엇을 했는지 화면이 말해 주지 못한다. (#1057)
+  Future<void> _disconnect(BuildContext context, WidgetRef ref) async {
+    final AppLocalizations l = AppLocalizations.of(context);
+    // 아직 읽는 중이면 `valueOrNull` 은 null 이다 — 담당이 있는데도 없다고
+    // 보고 "트레이너도 함께 해제됩니다" 를 빠뜨린다.
+    final Trainer? trainer = await ref.read(myTrainerProvider.future);
+    if (!context.mounted) return;
+    final bool removed = await confirmDisconnect(
+      context,
+      ref,
+      // 담당 트레이너가 있으면 함께 사라진다는 것을 알린다.
+      message: trainer == null
+          ? l.myGymDisconnectConfirm(gym.name)
+          : l.myGymDisconnectWithTrainerConfirm(gym.name, trainer.name),
+      disconnect: (GymRepository repo) => repo.disconnectMyGym(),
+    );
+    // go_router 의 pop 을 쓴다 — 상세는 라우터가 쌓은 화면이라, 그 안의
+    // Navigator 로는 돌아갈 곳이 없다고 나온다.
+    if (removed && context.mounted && context.canPop()) context.pop();
+  }
+
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final AppLocalizations l = AppLocalizations.of(context);
     return Center(
       child: ConstrainedBox(
@@ -203,6 +227,15 @@ class _GymDetails extends StatelessWidget {
             ],
             const SizedBox(height: 12),
             _AffiliatedTrainers(gymId: gym.id),
+            if (isMyGym) ...<Widget>[
+              const SizedBox(height: 24),
+              // 목록 카드에서 삭제를 여기로 옮겼다 (#1057). 상세에 지울 자리가
+              // 없으면 연결을 끊을 방법이 화면에서 사라진다.
+              DisconnectButton(
+                label: l.myGymDisconnectTooltip,
+                onTap: () => _disconnect(context, ref),
+              ),
+            ],
             if (!isMyGym) ...<Widget>[
               const SizedBox(height: 24),
               FilledButton(

--- a/frontend/flutter/lib/features/exercise/presentation/pages/trainer_detail_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/trainer_detail_page.dart
@@ -8,8 +8,10 @@ import 'package:oncare/design_system/tokens/colors.dart';
 import 'package:oncare/features/exercise/domain/entities/consultation_request.dart';
 import 'package:oncare/features/exercise/domain/entities/gym.dart';
 import 'package:oncare/features/exercise/domain/entities/trainer.dart';
+import 'package:oncare/features/exercise/domain/repositories/gym_repository.dart';
 import 'package:oncare/features/exercise/presentation/controllers/consultation_request_controller.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
+import 'package:oncare/features/exercise/presentation/widgets/connection_disconnect.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 
 class TrainerDetailPage extends ConsumerWidget {
@@ -79,7 +81,7 @@ class TrainerDetailPage extends ConsumerWidget {
   }
 }
 
-class _TrainerDetails extends StatelessWidget {
+class _TrainerDetails extends ConsumerWidget {
   const _TrainerDetails({
     required this.trainer,
     required this.gym,
@@ -96,8 +98,28 @@ class _TrainerDetails extends StatelessWidget {
   final bool isMyTrainer;
   final bool hasPending;
 
+  /// 담당 트레이너 연결만 끊는다 — 헬스장은 그대로다. 끊었으면 이 화면을
+  /// 닫는다. 지운 대상의 상세에 남아 있으면 방금 무엇을 했는지 화면이 말해
+  /// 주지 못한다. (#1057)
+  Future<void> _disconnect(BuildContext context, WidgetRef ref) async {
+    final AppLocalizations l = AppLocalizations.of(context);
+    // 아직 읽는 중이면 `valueOrNull` 은 null 이라 확인 문구에서 헬스장 이름이
+    // 빠진다.
+    final Gym? myGym = await ref.read(myGymProvider.future);
+    if (!context.mounted) return;
+    final bool removed = await confirmDisconnect(
+      context,
+      ref,
+      message: l.myTrainerDisconnectConfirm(trainer.name, myGym?.name ?? ''),
+      disconnect: (GymRepository repo) => repo.disconnectMyTrainer(),
+    );
+    // go_router 의 pop 을 쓴다 — 상세는 라우터가 쌓은 화면이라, 그 안의
+    // Navigator 로는 돌아갈 곳이 없다고 나온다.
+    if (removed && context.mounted && context.canPop()) context.pop();
+  }
+
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final AppLocalizations l = AppLocalizations.of(context);
     final String intro = trainer.intro?.trim() ?? '';
     final String career = trainer.career?.trim() ?? '';
@@ -314,6 +336,14 @@ class _TrainerDetails extends StatelessWidget {
                     ),
                   ),
                 ),
+              ),
+            ],
+            if (isMyTrainer) ...<Widget>[
+              const SizedBox(height: 24),
+              // 목록 카드에서 삭제를 여기로 옮겼다 (#1057).
+              DisconnectButton(
+                label: l.myTrainerDisconnectTooltip,
+                onTap: () => _disconnect(context, ref),
               ),
             ],
             if (!isMyTrainer) ...<Widget>[

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/connection_disconnect.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/connection_disconnect.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:oncare/design_system/figma/figma_kit.dart';
+import 'package:oncare/design_system/tokens/colors.dart';
+import 'package:oncare/features/exercise/domain/repositories/gym_repository.dart';
+import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+/// 헬스장·트레이너 연결을 끊는 하나의 흐름 — 확인 창을 띄우고, 승인되면
+/// 끊은 뒤 연결 상태를 새로 읽는다.
+///
+/// MY 탭 카드와 상세 화면이 같은 것을 지운다. 두 화면이 각자 확인 창을 만들면
+/// 한쪽만 "트레이너도 함께 사라진다" 를 알리는 식으로 갈린다. (#1057)
+///
+/// 승인 없이 닫혔으면 `false` 를 돌려준다 — 호출부가 화면을 닫을지 정한다.
+Future<bool> confirmDisconnect(
+  BuildContext context,
+  WidgetRef ref, {
+  required String message,
+  required Future<void> Function(GymRepository repo) disconnect,
+}) async {
+  final AppLocalizations l = AppLocalizations.of(context);
+  final bool ok =
+      await showDialog<bool>(
+        context: context,
+        builder: (BuildContext ctx) => AlertDialog(
+          backgroundColor: Colors.white,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(20),
+          ),
+          title: Text(
+            l.myConnectionDeleteTitle,
+            style: const TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w800,
+              color: FigmaColors.ink,
+            ),
+          ),
+          content: Text(
+            message,
+            style: const TextStyle(
+              fontSize: 14.5,
+              color: AppColors.foreground,
+              height: 1.4,
+            ),
+          ),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(false),
+              style: TextButton.styleFrom(
+                foregroundColor: AppColors.mutedForeground,
+              ),
+              child: Text(l.myCancel),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(true),
+              style: TextButton.styleFrom(
+                foregroundColor: const Color(0xFFFF3B30),
+              ),
+              child: Text(l.myDelete),
+            ),
+          ],
+        ),
+      ) ??
+      false;
+  if (!ok) return false;
+  await disconnect(ref.read(gymRepositoryProvider));
+  // 해제를 기다리는 동안 화면을 벗어났다면 ref 가 이미 폐기됐을 수 있다.
+  if (!context.mounted) return true;
+  // 헬스장 해제는 트레이너까지 끊으므로 두 provider 를 함께 새로 읽는다.
+  ref.invalidate(myGymProvider);
+  ref.invalidate(myTrainerProvider);
+  return true;
+}
+
+/// 상세 화면 하단의 연결 삭제 버튼.
+///
+/// 목록 카드에서 삭제를 상세로 옮겼으므로(#1057), 상세에도 지울 자리가 있어야
+/// 한다. 그러지 않으면 연결을 끊을 방법이 화면에서 사라진다.
+class DisconnectButton extends StatelessWidget {
+  const DisconnectButton({super.key, required this.label, required this.onTap});
+
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: OutlinedButton.icon(
+        key: const Key('connection-disconnect-button'),
+        onPressed: onTap,
+        icon: const Icon(Icons.link_off_rounded, size: 18),
+        style: OutlinedButton.styleFrom(
+          foregroundColor: const Color(0xFFFF3B30),
+          side: const BorderSide(color: Color(0x33FF3B30)),
+          minimumSize: const Size.fromHeight(48),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(14),
+          ),
+        ),
+        label: Text(
+          label,
+          style: const TextStyle(fontSize: 14.5, fontWeight: FontWeight.w700),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
+++ b/frontend/flutter/lib/features/my_health/presentation/pages/my_health_page.dart
@@ -8,7 +8,6 @@ import 'package:oncare/design_system/tokens/colors.dart';
 import 'package:oncare/features/auth/presentation/controllers/session_controller.dart';
 import 'package:oncare/features/exercise/domain/entities/gym.dart';
 import 'package:oncare/features/exercise/domain/entities/trainer.dart';
-import 'package:oncare/features/exercise/domain/repositories/gym_repository.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
 import 'package:oncare/features/member_coach/presentation/widgets/trainer_chat_header_button.dart';
 import 'package:oncare/features/my_health/domain/entities/health_history.dart';
@@ -783,101 +782,6 @@ class _TrainerGymSection extends ConsumerWidget {
   /// 연결된 헬스장이 없을 때 "헬스장 찾기"로 보낼 콜백.
   final VoidCallback onFindGym;
 
-  /// 확인 창을 띄우고, 승인되면 [disconnect] 를 실행한 뒤 연결 상태를 새로
-  /// 읽는다. 헬스장·트레이너 두 삭제가 같은 흐름을 쓴다.
-  Future<void> _confirmDisconnect(
-    BuildContext context,
-    WidgetRef ref, {
-    required String message,
-    required Future<void> Function(GymRepository repo) disconnect,
-  }) async {
-    final AppLocalizations l = AppLocalizations.of(context);
-    final bool ok =
-        await showDialog<bool>(
-          context: context,
-          builder: (BuildContext ctx) => AlertDialog(
-            backgroundColor: Colors.white,
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(20),
-            ),
-            title: Text(
-              l.myConnectionDeleteTitle,
-              style: const TextStyle(
-                fontSize: 16,
-                fontWeight: FontWeight.w800,
-                color: FigmaColors.ink,
-              ),
-            ),
-            content: Text(
-              message,
-              style: const TextStyle(
-                fontSize: 14.5,
-                color: AppColors.foreground,
-                height: 1.4,
-              ),
-            ),
-            actions: <Widget>[
-              TextButton(
-                onPressed: () => Navigator.of(ctx).pop(false),
-                style: TextButton.styleFrom(
-                  foregroundColor: AppColors.mutedForeground,
-                ),
-                child: Text(l.myCancel),
-              ),
-              TextButton(
-                onPressed: () => Navigator.of(ctx).pop(true),
-                style: TextButton.styleFrom(
-                  foregroundColor: const Color(0xFFFF3B30),
-                ),
-                child: Text(l.myDelete),
-              ),
-            ],
-          ),
-        ) ??
-        false;
-    if (!ok) return;
-    await disconnect(ref.read(gymRepositoryProvider));
-    // 해제를 기다리는 동안 탭을 벗어났다면 ref 가 이미 폐기됐을 수 있다.
-    if (!context.mounted) return;
-    // 헬스장 해제는 트레이너까지 끊으므로 두 provider 를 함께 새로 읽는다.
-    ref.invalidate(myGymProvider);
-    ref.invalidate(myTrainerProvider);
-  }
-
-  /// 헬스장 연결 삭제. 담당 트레이너가 있으면 함께 사라진다는 것을 알린다.
-  Future<void> _removeGym(
-    BuildContext context,
-    WidgetRef ref,
-    Gym gym,
-    Trainer? trainer,
-  ) {
-    final AppLocalizations l = AppLocalizations.of(context);
-    return _confirmDisconnect(
-      context,
-      ref,
-      message: trainer == null
-          ? l.myGymDisconnectConfirm(gym.name)
-          : l.myGymDisconnectWithTrainerConfirm(gym.name, trainer.name),
-      disconnect: (GymRepository repo) => repo.disconnectMyGym(),
-    );
-  }
-
-  /// 헬스장은 그대로 두고 담당 트레이너 연결만 삭제.
-  Future<void> _removeTrainer(
-    BuildContext context,
-    WidgetRef ref,
-    Gym gym,
-    Trainer trainer,
-  ) {
-    final AppLocalizations l = AppLocalizations.of(context);
-    return _confirmDisconnect(
-      context,
-      ref,
-      message: l.myTrainerDisconnectConfirm(trainer.name, gym.name),
-      disconnect: (GymRepository repo) => repo.disconnectMyTrainer(),
-    );
-  }
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final AppLocalizations l = AppLocalizations.of(context);
@@ -904,10 +808,13 @@ class _TrainerGymSection extends ConsumerWidget {
               : _GymSummaryCard(
                   gym: gym,
                   trainer: trainer,
-                  onRemoveGym: () => _removeGym(context, ref, gym, trainer),
-                  onRemoveTrainer: trainer == null
+                  onOpenGym: () =>
+                      context.push(AppRoutes.gymDetailPath(gym.id)),
+                  onOpenTrainer: trainer == null
                       ? null
-                      : () => _removeTrainer(context, ref, gym, trainer),
+                      : () => context.push(
+                          AppRoutes.trainerDetailPath(trainer.id),
+                        ),
                   // 헬스장은 이미 연결돼 있고 트레이너만 없는 상태다. 헬스장을
                   // 찾는 화면이 아니라 **그 헬스장의 소속 트레이너**로 보낸다 —
                   // 예전에는 라벨이 '트레이너 찾기'인데 헬스장 탭으로 갔다(#793).
@@ -926,8 +833,8 @@ class _GymSummaryCard extends StatelessWidget {
   const _GymSummaryCard({
     required this.gym,
     required this.trainer,
-    required this.onRemoveGym,
-    required this.onRemoveTrainer,
+    required this.onOpenGym,
+    required this.onOpenTrainer,
     required this.onFindTrainer,
   });
 
@@ -935,8 +842,11 @@ class _GymSummaryCard extends StatelessWidget {
 
   /// 담당 트레이너. null 이면 "담당 트레이너 없음" 행으로 대체된다.
   final Trainer? trainer;
-  final VoidCallback onRemoveGym;
-  final VoidCallback? onRemoveTrainer;
+  /// 헬스장 상세로. 삭제는 그 화면 하단에 있다. (#1057)
+  final VoidCallback onOpenGym;
+
+  /// 담당 트레이너 상세로. 담당이 없으면 null 이다.
+  final VoidCallback? onOpenTrainer;
 
   /// 헬스장은 있는데 담당 트레이너가 없을 때 트레이너를 찾으러 보낸다.
   final VoidCallback onFindTrainer;
@@ -1001,9 +911,11 @@ class _GymSummaryCard extends StatelessWidget {
                     ],
                   ),
                 ),
-                _RemoveLinkButton(
-                  tooltip: l.myGymDisconnectTooltip,
-                  onTap: onRemoveGym,
+                // 카드에서 가장 누르기 쉬운 자리가 되돌릴 수 없는 삭제였다.
+                // 그 자리는 상세로 가는 길이고, 삭제는 상세 하단에 둔다. (#1057)
+                _OpenDetailButton(
+                  tooltip: l.myGymDetailTooltip,
+                  onTap: onOpenGym,
                 ),
               ],
             ),
@@ -1031,10 +943,10 @@ class _GymSummaryCard extends StatelessWidget {
                       ),
                     ),
                   ),
-                  if (onRemoveTrainer != null)
-                    _RemoveLinkButton(
-                      tooltip: l.myTrainerDisconnectTooltip,
-                      onTap: onRemoveTrainer!,
+                  if (onOpenTrainer != null)
+                    _OpenDetailButton(
+                      tooltip: l.myTrainerDetailTooltip,
+                      onTap: onOpenTrainer!,
                     ),
                 ],
               )
@@ -1081,10 +993,10 @@ class _GymSummaryCard extends StatelessWidget {
   }
 }
 
-/// 한 줄짜리 연결(헬스장 또는 트레이너)을 끊는 버튼. 시각적 아이콘은 20이지만
-/// 탭 영역은 접근성 최소 44×44 를 지킨다.
-class _RemoveLinkButton extends StatelessWidget {
-  const _RemoveLinkButton({required this.tooltip, required this.onTap});
+/// 한 줄짜리 연결(헬스장 또는 트레이너)의 상세로 가는 버튼. 시각적 아이콘은
+/// 20이지만 탭 영역은 접근성 최소 44×44 를 지킨다.
+class _OpenDetailButton extends StatelessWidget {
+  const _OpenDetailButton({required this.tooltip, required this.onTap});
 
   final String tooltip;
   final VoidCallback onTap;
@@ -1107,7 +1019,7 @@ class _RemoveLinkButton extends StatelessWidget {
               width: 44,
               height: 44,
               child: Icon(
-                Icons.delete_outline_rounded,
+                Icons.chevron_right_rounded,
                 size: 20,
                 color: FigmaColors.textFaint,
               ),

--- a/frontend/flutter/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations.dart
@@ -1892,6 +1892,18 @@ abstract class AppLocalizations {
   /// **'Disconnect trainer {trainer}?\nYour connection to {gym} will remain.'**
   String myTrainerDisconnectConfirm(String trainer, String gym);
 
+  /// No description provided for @myGymDetailTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Gym details'**
+  String get myGymDetailTooltip;
+
+  /// No description provided for @myTrainerDetailTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Trainer details'**
+  String get myTrainerDetailTooltip;
+
   /// No description provided for @myGymDisconnectTooltip.
   ///
   /// In en, this message translates to:

--- a/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
@@ -1029,6 +1029,12 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get myGymDetailTooltip => 'Gym details';
+
+  @override
+  String get myTrainerDetailTooltip => 'Trainer details';
+
+  @override
   String get myGymDisconnectTooltip => 'Disconnect gym';
 
   @override

--- a/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
@@ -998,6 +998,12 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String get myGymDetailTooltip => '헬스장 상세 보기';
+
+  @override
+  String get myTrainerDetailTooltip => '트레이너 상세 보기';
+
+  @override
   String get myGymDisconnectTooltip => '헬스장 연결 삭제';
 
   @override

--- a/frontend/flutter/lib/l10n/app_en.arb
+++ b/frontend/flutter/lib/l10n/app_en.arb
@@ -582,6 +582,8 @@
       }
     }
   },
+  "myGymDetailTooltip": "Gym details",
+  "myTrainerDetailTooltip": "Trainer details",
   "myGymDisconnectTooltip": "Disconnect gym",
   "myTrainerDisconnectTooltip": "Disconnect trainer",
   "myNoTrainer": "No assigned trainer",

--- a/frontend/flutter/lib/l10n/app_ko.arb
+++ b/frontend/flutter/lib/l10n/app_ko.arb
@@ -385,6 +385,8 @@
       }
     }
   },
+  "myGymDetailTooltip": "헬스장 상세 보기",
+  "myTrainerDetailTooltip": "트레이너 상세 보기",
   "myGymDisconnectTooltip": "헬스장 연결 삭제",
   "myTrainerDisconnectTooltip": "트레이너 연결 삭제",
   "myNoTrainer": "담당 트레이너 없음",

--- a/frontend/flutter/test/features/exercise/connection_disconnect_test.dart
+++ b/frontend/flutter/test/features/exercise/connection_disconnect_test.dart
@@ -1,0 +1,203 @@
+/// 연결 삭제가 상세 화면으로 옮겨 간 뒤의 흐름 (#1057).
+///
+/// MY 탭 카드에서 가장 누르기 쉬운 자리가 되돌릴 수 없는 삭제였다. 그 자리는
+/// 상세로 가는 길이 되고, 삭제는 상세 하단으로 내려왔다. 옮기면서 사라지면
+/// 연결을 끊을 방법이 화면에서 없어지므로 여기서 지킨다.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:oncare/app/router/app_router.dart';
+import 'package:oncare/app/router/routes.dart';
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/features/exercise/data/repositories/mock_gym_repository.dart';
+import 'package:oncare/features/exercise/domain/entities/gym.dart';
+import 'package:oncare/features/exercise/domain/entities/trainer.dart';
+import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+const Gym _myGym = Gym(
+  id: 'gym-mine',
+  name: '온케어짐 신촌점',
+  address: '서울시 서대문구',
+  distanceKm: 0.4,
+  rating: 4.9,
+  tags: <String>['PT'],
+);
+
+const Gym _otherGym = Gym(
+  id: 'gym-other',
+  name: '다른 헬스장',
+  address: '서울시 마포구',
+  distanceKm: 2.1,
+  rating: 4.1,
+  tags: <String>[],
+);
+
+const Trainer _myTrainer = Trainer(
+  id: 'trainer-mine',
+  gymId: 'gym-mine',
+  name: '김트레이너',
+  role: '퍼스널 트레이너',
+);
+
+const AppConfig _config = AppConfig(
+  environment: Environment.dev,
+  apiBaseUrl: 'https://dev.api.test',
+  useMockApi: true,
+);
+
+void main() {
+  Future<MockGymRepository> pumpDetail(
+    WidgetTester tester, {
+    required String location,
+    Gym? myGym = _myGym,
+    Trainer? myTrainer = _myTrainer,
+  }) async {
+    await tester.binding.setSurfaceSize(const Size(390, 900));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final MockGymRepository repository = MockGymRepository();
+    final GoRouter router = buildAppRouter(config: _config);
+    addTearDown(router.dispose);
+    router.go(AppRoutes.gyms);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          appConfigProvider.overrideWithValue(_config),
+          gymRepositoryProvider.overrideWithValue(repository),
+          gymFinderResultsProvider.overrideWith(
+            (ref) async => const <Gym>[_myGym, _otherGym],
+          ),
+          nearbyGymsProvider.overrideWith(
+            (ref) async => const <Gym>[_myGym, _otherGym],
+          ),
+          myGymProvider.overrideWith((ref) async => myGym),
+          myTrainerProvider.overrideWith((ref) async => myTrainer),
+          allTrainersProvider.overrideWith(
+            (ref) async => const <Trainer>[_myTrainer],
+          ),
+          recommendedTrainersProvider.overrideWith(
+            (ref) async => const <Trainer>[_myTrainer],
+          ),
+          gymTrainersProvider(
+            _myGym.id,
+          ).overrideWith((ref) async => const <Trainer>[_myTrainer]),
+          gymTrainersProvider(
+            _otherGym.id,
+          ).overrideWith((ref) async => const <Trainer>[]),
+          trainerProvider(
+            _myTrainer.id,
+          ).overrideWith((ref) async => _myTrainer),
+        ],
+        child: MaterialApp.router(
+          routerConfig: router,
+          locale: const Locale('ko'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+        ),
+      ),
+    );
+    // 상세는 카카오 지도 위젯 등 늘 도는 애니메이션을 품을 수 있어
+    // pumpAndSettle 이 멈추지 않는다 — 정해진 만큼만 흘린다.
+    await tester.pump(const Duration(milliseconds: 300));
+
+    // 목록에서 눌러 들어간 것과 같은 상태로 둔다 — 상세만 띄우면 돌아갈 곳이
+    // 없어, 삭제 뒤 화면을 벗어나는지 볼 수 없다.
+    router.push(location);
+    for (int i = 0; i < 3; i++) {
+      await tester.pump(const Duration(milliseconds: 300));
+    }
+    return repository;
+  }
+
+  /// 대역은 실제 지연을 흉내 내는데, 위젯 테스트의 가짜 시계에서는 그 지연이
+  /// 스스로 깨어나지 않는다 — 저장소 상태는 `runAsync` 로 읽는다.
+  Future<void> tapDisconnect(WidgetTester tester) async {
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('connection-disconnect-button')),
+      250,
+      scrollable: find.byType(Scrollable).last,
+    );
+    await tester.tap(find.byKey(const Key('connection-disconnect-button')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+  }
+
+  testWidgets('내 헬스장 상세에만 삭제 버튼이 있다', (WidgetTester tester) async {
+    await pumpDetail(tester, location: AppRoutes.gymDetailPath(_myGym.id));
+    expect(
+      find.byKey(const Key('connection-disconnect-button')),
+      findsOneWidget,
+    );
+
+    await pumpDetail(tester, location: AppRoutes.gymDetailPath(_otherGym.id));
+    // 연결한 적 없는 헬스장에는 끊을 것이 없다.
+    expect(find.byKey(const Key('connection-disconnect-button')), findsNothing);
+  });
+
+  testWidgets('헬스장 삭제는 트레이너도 함께 해제된다고 알린다', (WidgetTester tester) async {
+    await pumpDetail(tester, location: AppRoutes.gymDetailPath(_myGym.id));
+    await tapDisconnect(tester);
+
+    expect(find.byType(AlertDialog), findsOneWidget);
+    expect(find.textContaining('온케어짐 신촌점'), findsWidgets);
+    expect(find.textContaining('김트레이너 연결도 함께 해제됩니다'), findsOneWidget);
+  });
+
+  testWidgets('취소하면 연결이 유지된다', (WidgetTester tester) async {
+    final MockGymRepository repository = await pumpDetail(
+      tester,
+      location: AppRoutes.gymDetailPath(_myGym.id),
+    );
+    await tapDisconnect(tester);
+
+    await tester.tap(find.text('취소'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.byType(AlertDialog), findsNothing);
+    expect(await tester.runAsync(repository.fetchMyGym), isNotNull);
+  });
+
+  testWidgets('삭제하면 연결이 끊기고 상세를 벗어난다', (WidgetTester tester) async {
+    final MockGymRepository repository = await pumpDetail(
+      tester,
+      location: AppRoutes.gymDetailPath(_myGym.id),
+    );
+    await tapDisconnect(tester);
+
+    await tester.tap(find.text('삭제'));
+    // 다이얼로그 닫힘 → 대역의 지연 → 화면 되돌아가기까지 몇 프레임 걸린다.
+    for (int i = 0; i < 4; i++) {
+      await tester.pump(const Duration(milliseconds: 400));
+    }
+
+    // 지운 대상의 상세에 그대로 남아 있으면 방금 무엇을 했는지 알 수 없다.
+    expect(find.text('헬스장 상세'), findsNothing);
+    expect(await tester.runAsync(repository.fetchMyGym), isNull);
+  });
+
+  testWidgets('트레이너 상세에서는 담당 연결만 끊는다', (WidgetTester tester) async {
+    final MockGymRepository repository = await pumpDetail(
+      tester,
+      location: AppRoutes.trainerDetailPath(_myTrainer.id),
+    );
+    await tapDisconnect(tester);
+
+    expect(find.textContaining('김트레이너'), findsWidgets);
+    await tester.tap(find.text('삭제'));
+    // 다이얼로그 닫힘 → 대역의 지연 → 화면 되돌아가기까지 몇 프레임 걸린다.
+    for (int i = 0; i < 4; i++) {
+      await tester.pump(const Duration(milliseconds: 400));
+    }
+
+    expect(await tester.runAsync(repository.fetchMyTrainer), isNull);
+    // 헬스장은 그대로다.
+    expect(await tester.runAsync(repository.fetchMyGym), isNotNull);
+  });
+}

--- a/frontend/flutter/test/features/my_health/my_health_gym_section_test.dart
+++ b/frontend/flutter/test/features/my_health/my_health_gym_section_test.dart
@@ -136,16 +136,6 @@ void main() {
     ).read(myTrainerProvider.future);
   }
 
-  /// 헬스장 행 / 트레이너 행의 삭제 버튼은 툴팁으로 구분한다.
-  Future<void> tapRemove(WidgetTester tester, String tooltip) async {
-    await tester.scrollUntilVisible(
-      gymCard(),
-      250,
-      scrollable: find.byType(Scrollable).first,
-    );
-    await tester.tap(find.byTooltip(tooltip));
-    await tester.pumpAndSettle();
-  }
 
   testWidgets('연결된 헬스장과 담당 트레이너가 트레이너 앱 시드와 같다', (WidgetTester tester) async {
     await pumpMyTab(tester);
@@ -168,8 +158,9 @@ void main() {
     );
 
     expect(find.text('My Trainer & Gym'), findsOneWidget);
-    expect(find.byTooltip('Disconnect gym'), findsOneWidget);
-    expect(find.byTooltip('Disconnect trainer'), findsOneWidget);
+    // 카드의 동작은 상세로 가는 길이다 — 삭제는 그 화면 하단에 있다. (#1057)
+    expect(find.byTooltip('Gym details'), findsOneWidget);
+    expect(find.byTooltip('Trainer details'), findsOneWidget);
     expect(find.text('내 트레이너 · 헬스장'), findsNothing);
   });
 
@@ -181,67 +172,25 @@ void main() {
     expect(find.text('아직 등록된 헬스장이 없어요'), findsNothing);
   });
 
-  testWidgets('헬스장 삭제 버튼은 트레이너도 함께 해제된다고 알린다', (WidgetTester tester) async {
+  testWidgets('카드의 동작은 삭제가 아니라 상세로 가는 길이다 (#1057)', (
+    WidgetTester tester,
+  ) async {
     await pumpMyTab(tester);
-    await tapRemove(tester, '헬스장 연결 삭제');
+    await tester.scrollUntilVisible(
+      gymCard(),
+      250,
+      scrollable: find.byType(Scrollable).first,
+    );
 
-    expect(find.byType(AlertDialog), findsOneWidget);
-    expect(find.textContaining('온케어짐 신촌점 연결을 삭제하시겠습니까?'), findsOneWidget);
-    expect(find.textContaining('김트레이너 연결도 함께 해제됩니다'), findsOneWidget);
-  });
-
-  testWidgets('취소하면 연결이 유지된다', (WidgetTester tester) async {
-    await pumpMyTab(tester);
-    await tapRemove(tester, '헬스장 연결 삭제');
-
-    await tester.tap(find.text('취소'));
-    await tester.pumpAndSettle();
-
-    expect(find.byType(AlertDialog), findsNothing);
-    expect(gymCard(), findsOneWidget);
-    expect(await connectedGym(tester), isNotNull);
-  });
-
-  testWidgets('헬스장을 삭제하면 카드가 빈 상태로 바뀐다', (WidgetTester tester) async {
-    await pumpMyTab(tester);
-    await tapRemove(tester, '헬스장 연결 삭제');
-
-    await tester.tap(find.text('삭제'));
-    await tester.pumpAndSettle();
-
-    expect(gymCard(), findsNothing);
-    expect(find.text('아직 등록된 헬스장이 없어요'), findsOneWidget);
-    // 운동 탭도 같은 provider 를 읽으므로 그쪽에서도 연결이 사라진다.
-    expect(await connectedGym(tester), isNull);
-    expect(await connectedTrainer(tester), isNull);
-  });
-
-  testWidgets('트레이너만 삭제하면 헬스장 연결은 남는다', (WidgetTester tester) async {
-    await pumpMyTab(tester);
-    await tapRemove(tester, '트레이너 연결 삭제');
-
-    expect(find.textContaining('김트레이너 연결을 삭제하시겠습니까?'), findsOneWidget);
-    expect(find.textContaining('헬스장 연결은 유지됩니다'), findsOneWidget);
-
-    await tester.tap(find.text('삭제'));
-    await tester.pumpAndSettle();
-
-    expect(gymCard(), findsOneWidget);
-    expect(find.text('온케어짐 신촌점'), findsOneWidget);
-    expect(find.text('담당 트레이너 없음'), findsOneWidget);
-    expect(find.text('트레이너 찾기'), findsOneWidget);
-
-    expect(await connectedGym(tester), isNotNull);
-    expect(await connectedTrainer(tester), isNull);
-  });
-
-  testWidgets('트레이너를 뗀 뒤에는 트레이너 삭제 버튼이 사라진다', (WidgetTester tester) async {
-    await pumpMyTab(tester);
-    await tapRemove(tester, '트레이너 연결 삭제');
-    await tester.tap(find.text('삭제'));
-    await tester.pumpAndSettle();
-
+    // 카드에서 가장 누르기 쉬운 자리가 되돌릴 수 없는 삭제였다.
+    expect(find.byTooltip('헬스장 상세 보기'), findsOneWidget);
+    expect(find.byTooltip('트레이너 상세 보기'), findsOneWidget);
+    expect(find.byTooltip('헬스장 연결 삭제'), findsNothing);
     expect(find.byTooltip('트레이너 연결 삭제'), findsNothing);
-    expect(find.byTooltip('헬스장 연결 삭제'), findsOneWidget);
+    expect(find.byIcon(Icons.delete_outline_rounded), findsNothing);
+
+    // 연결은 그대로다 — 이 화면에서는 아무것도 지우지 않는다.
+    expect(await connectedGym(tester), isNotNull);
+    expect(await connectedTrainer(tester), isNotNull);
   });
 }


### PR DESCRIPTION
Closes #1057

## Summary

MY 탭의 내 트레이너·헬스장 카드에 있는 동작이 휴지통 하나뿐이었다. 연결된 트레이너가 누구인지 다시 보려면 운동 탭까지 돌아가야 했고, 카드에서 가장 누르기 쉬운 자리가 되돌릴 수 없는 삭제였다.

그 자리를 상세로 가는 길로 바꾸고, 삭제는 상세 하단으로 내린다.

## Changes

- 내 트레이너/헬스장 카드의 휴지통 아이콘을 `>` 로 교체 — 누르면 상세로 이동
- 상세는 운동 탭 → 헬스장/트레이너에서 열던 화면을 그대로 쓴다
- 내 헬스장·내 트레이너 상세 하단에 연결 삭제 버튼 추가. 연결한 적 없는 헬스장·트레이너 상세에는 붙지 않는다 — 끊을 것이 없다
- 확인 창과 해제 흐름을 한곳에 모음. 두 화면이 각자 만들면 한쪽만 "트레이너도 함께 해제됩니다" 를 알리는 식으로 갈린다

## Notes

- 삭제는 연결 해제다(트레이너↔회원 링크). 기록은 그대로 남는다.
- 지운 뒤에는 그 상세를 벗어난다. 지운 대상의 화면에 그대로 남아 있으면 방금 무엇을 했는지 화면이 말해 주지 못한다.
- 확인 문구를 만들 때 담당 정보를 `valueOrNull` 로 읽으면, 아직 읽는 중일 때 담당이 없다고 보고 "트레이너도 함께 해제됩니다" 를 빠뜨린다 — 값을 기다린 뒤 문구를 만든다.
- MY 탭에 있던 삭제 흐름 검사는 상세 화면 검사로 옮겼다(취소 시 유지, 삭제 시 해제, 트레이너만 끊으면 헬스장은 남음).
- 검증: `flutter analyze` 클린, 회원 앱 테스트 전체 통과.
