### PR TITLE
feat(charts): 섹션 아이콘·기간 버튼 폭·전체 그래프 등장 모션

### DIFF
--- a/frontend/flutter/lib/design_system/charts/period_scroll_chart.dart
+++ b/frontend/flutter/lib/design_system/charts/period_scroll_chart.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 
+import 'package:oncare/design_system/charts/chart_reveal.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
 
 /// `전체` 그래프의 선택·보이는 구간 상태. (#1018)
@@ -181,21 +182,42 @@ class _PeriodScrollChartState extends State<PeriodScrollChart> {
                           left: slot * widget.selectedIndex! + slot / 2,
                           height: widget.height,
                         ),
-                      Row(
-                        crossAxisAlignment: CrossAxisAlignment.end,
-                        children: <Widget>[
-                          for (int i = 0; i < widget.count; i++)
-                            SizedBox(
-                              width: slot,
-                              child: GestureDetector(
-                                behavior: HitTestBehavior.opaque,
-                                onTap: () => widget.onSelected?.call(
-                                  widget.selectedIndex == i ? null : i,
+                      // 막대는 바닥에서 자라 오른다 (#1058). 기간을 바꿔 들어온
+                      // 그림이 그냥 나타나면, 다른 기간에서 넘어왔는지 처음부터
+                      // 그랬는지 구분되지 않는다.
+                      //
+                      // 되감기는 칸 수가 바뀔 때만 한다 — 막대를 고를 때마다
+                      // 다시 자라면 눌러 읽는 동작을 방해한다.
+                      ChartReveal(
+                        replayKey: widget.count,
+                        builder: (BuildContext context, double t) => Row(
+                          crossAxisAlignment: CrossAxisAlignment.end,
+                          children: <Widget>[
+                            for (int i = 0; i < widget.count; i++)
+                              SizedBox(
+                                width: slot,
+                                child: GestureDetector(
+                                  behavior: HitTestBehavior.opaque,
+                                  onTap: () => widget.onSelected?.call(
+                                    widget.selectedIndex == i ? null : i,
+                                  ),
+                                  // 자라는 동안 위쪽이 잘려 보이도록 감싼다 —
+                                  // 자르지 않으면 막대가 줄어든 상자 밖으로
+                                  // 삐져나와 그대로 다 보인다.
+                                  child: ClipRect(
+                                    key: ValueKey<String>(
+                                      'period-bar-reveal-$i',
+                                    ),
+                                    child: Align(
+                                      alignment: Alignment.bottomCenter,
+                                      heightFactor: t,
+                                      child: widget.barBuilder(context, i),
+                                    ),
+                                  ),
                                 ),
-                                child: widget.barBuilder(context, i),
                               ),
-                            ),
-                        ],
+                          ],
+                        ),
                       ),
                     ],
                   ),

--- a/frontend/flutter/lib/design_system/figma/section_title.dart
+++ b/frontend/flutter/lib/design_system/figma/section_title.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+import 'package:oncare/design_system/figma/figma_kit.dart';
+
+/// `[아이콘] 제목` 한 줄 — 식단 `영양 요약` · 운동 `운동 현황` 의 제목이다.
+///
+/// 트레이너웹 고객 탭의 같은 두 섹션이 이미 아이콘을 달고 있다. 회원 앱만
+/// 글자만 있으면, 두 화면이 같은 것을 말하는지 한눈에 붙지 않는다. 아이콘은
+/// 같은 모양을 쓰되 색은 이 앱의 메인 색이다. (#1058)
+class SectionTitle extends StatelessWidget {
+  /// Creates the title row.
+  const SectionTitle({super.key, required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        Icon(icon, size: 16, color: FigmaColors.primary),
+        const SizedBox(width: 6),
+        // 좁은 화면·큰 글자 배율에서 제목이 기간 토글을 밀어내면 안 된다.
+        Flexible(
+          child: Text(
+            label,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: const TextStyle(
+              fontSize: 15,
+              fontWeight: FontWeight.w700,
+              color: FigmaColors.ink,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -5,6 +5,7 @@ import 'package:oncare/app/router/routes.dart';
 import 'package:oncare/core/utils/clock.dart';
 import 'package:oncare/design_system/charts/chart_reveal.dart';
 import 'package:oncare/design_system/figma/figma_kit.dart';
+import 'package:oncare/design_system/figma/section_title.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
 import 'package:oncare/design_system/tokens/motion.dart';
 import 'package:oncare/features/account/domain/entities/user_profile.dart';
@@ -150,7 +151,11 @@ DietDateRange dietRangeForTab(DietPeriodTab tab, DateTime today) {
     // `이번 달` 이 아니라 `전체` 다 — 달이 바뀌었다고 앞의 기록이 사라지면
     // 추세를 볼 수 없다.
     return (
-      from: DateTime(today.year, today.month, today.day - kDietAllPeriodDays + 1),
+      from: DateTime(
+        today.year,
+        today.month,
+        today.day - kDietAllPeriodDays + 1,
+      ),
       to: DateTime(today.year, today.month, today.day),
     );
   }
@@ -385,9 +390,16 @@ class _PeriodToggle extends StatelessWidget {
                   behavior: HitTestBehavior.opaque,
                   child: AnimatedContainer(
                     duration: const Duration(milliseconds: 160),
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 12,
-                      vertical: 5,
+                    // 누를 자리가 글자에 딱 붙어 빠듯했다 — 좌우를 넓힌다.
+                    // 다만 글자를 키운 화면에서는 세 탭의 최소 폭 합이 남는
+                    // 폭을 넘겨 줄이 터지므로, 그때는 예전 값으로 돌아간다.
+                    // (#1058)
+                    padding: EdgeInsets.symmetric(
+                      horizontal:
+                          MediaQuery.textScalerOf(context).scale(1) > 1.3
+                          ? 12
+                          : 18,
+                      vertical: 6,
                     ),
                     decoration: BoxDecoration(
                       color: active == tab
@@ -462,15 +474,9 @@ class _NutritionSectionHeader extends StatelessWidget {
           Flexible(
             child: Padding(
               padding: const EdgeInsets.only(right: 8),
-              child: Text(
-                l.dietNutritionSummary,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: const TextStyle(
-                  fontSize: 15,
-                  fontWeight: FontWeight.w700,
-                  color: FigmaColors.ink,
-                ),
+              child: SectionTitle(
+                icon: Icons.restaurant_outlined,
+                label: l.dietNutritionSummary,
               ),
             ),
           ),
@@ -820,13 +826,9 @@ class NutritionSummary extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
           if (showHeader) ...<Widget>[
-            Text(
-              l.dietNutritionSummary,
-              style: const TextStyle(
-                fontSize: 15,
-                fontWeight: FontWeight.w700,
-                color: FigmaColors.ink,
-              ),
+            SectionTitle(
+              icon: Icons.restaurant_outlined,
+              label: l.dietNutritionSummary,
             ),
             const SizedBox(height: 10),
           ],

--- a/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
@@ -12,6 +12,7 @@ import 'package:oncare/design_system/charts/chart_reveal.dart';
 import 'package:oncare/design_system/charts/goal_line.dart';
 import 'package:oncare/design_system/charts/period_scroll_chart.dart';
 import 'package:oncare/design_system/figma/figma_kit.dart';
+import 'package:oncare/design_system/figma/section_title.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
 import 'package:oncare/design_system/tokens/motion.dart';
 import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
@@ -931,20 +932,18 @@ class _ActivityStatusState extends ConsumerState<_ActivityStatus> {
         // 제목과 토글 **사이**로 가고, 둘 다 좁아지면 접힌다. `Spacer` 로 밀면
         // 정렬은 맞지만 접힐 자리가 없어 320px 에서 줄이 넘쳤다(#766).
         Row(
+          // 제목 줄의 오른쪽 끝을 테스트가 잴 수 있어야 한다 — 제목 안에도
+          // Row 가 생겨 바깥 줄을 이름으로 집는다. (#1058)
+          key: const ValueKey<String>('exercise-section-header'),
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: <Widget>[
             Flexible(
               child: Padding(
                 padding: const EdgeInsets.only(right: 8),
-                child: Text(
-                  l.exActivityTitle,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(
-                    fontSize: 15,
-                    fontWeight: FontWeight.w700,
-                    color: FigmaColors.ink,
-                  ),
+                child: SectionTitle(
+                  // 트레이너웹 고객 탭 `운동 현황` 과 같은 아이콘이다. (#1058)
+                  icon: Icons.monitor_heart_outlined,
+                  label: l.exActivityTitle,
                 ),
               ),
             ),
@@ -1306,9 +1305,16 @@ class _PeriodToggle extends StatelessWidget {
                   behavior: HitTestBehavior.opaque,
                   child: AnimatedContainer(
                     duration: const Duration(milliseconds: 160),
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 12,
-                      vertical: 5,
+                    // 누를 자리가 글자에 딱 붙어 빠듯했다 — 좌우를 넓힌다.
+                    // 다만 글자를 키운 화면에서는 세 탭의 최소 폭 합이 남는
+                    // 폭을 넘겨 줄이 터지므로, 그때는 예전 값으로 돌아간다.
+                    // (#1058)
+                    padding: EdgeInsets.symmetric(
+                      horizontal:
+                          MediaQuery.textScalerOf(context).scale(1) > 1.3
+                          ? 12
+                          : 18,
+                      vertical: 6,
                     ),
                     decoration: BoxDecoration(
                       color: active == i
@@ -1459,21 +1465,20 @@ class _ActivityChart extends StatelessWidget {
                         duration: AppMotion.chartGrow,
                         // 막대별 stagger 는 painter 안에서 곡선을 적용한다.
                         curve: Curves.linear,
-                        builder: (BuildContext context, double t) =>
-                            CustomPaint(
-                              painter: _StackedBarPainter(
-                                bars: bars,
-                                dayLabels: dayLabels,
-                                todayIndex: todayIndex,
-                                todayLabel: l.exToday,
-                                goal: dailyGoalMinutes,
-                                goalLabel:
-                                    '${l.homeGoal} '
-                                    '${l.unitMinutesValue(dailyGoalMinutes.round())}',
-                                textDirection: Directionality.of(context),
-                                progress: t,
-                              ),
-                            ),
+                        builder: (BuildContext context, double t) => CustomPaint(
+                          painter: _StackedBarPainter(
+                            bars: bars,
+                            dayLabels: dayLabels,
+                            todayIndex: todayIndex,
+                            todayLabel: l.exToday,
+                            goal: dailyGoalMinutes,
+                            goalLabel:
+                                '${l.homeGoal} '
+                                '${l.unitMinutesValue(dailyGoalMinutes.round())}',
+                            textDirection: Directionality.of(context),
+                            progress: t,
+                          ),
+                        ),
                       ),
                     ),
                     // Transparent per-bar hover regions aligned to the painter's
@@ -1626,13 +1631,12 @@ class _AllPeriodChart extends ConsumerWidget {
               ),
             ),
           ),
-          data: (List<ExerciseDayBar> days) =>
-              _AllPeriodBody(
-                key: const Key('exerciseAllPeriodChart'),
-                days: days,
-                dailyGoalMinutes: dailyGoalMinutes,
-                selection: selection,
-              ),
+          data: (List<ExerciseDayBar> days) => _AllPeriodBody(
+            key: const Key('exerciseAllPeriodChart'),
+            days: days,
+            dailyGoalMinutes: dailyGoalMinutes,
+            selection: selection,
+          ),
         );
   }
 }
@@ -1721,8 +1725,7 @@ class _AllPeriodBody extends StatelessWidget {
             onVisibleRangeChanged: selection.setVisible,
             goalOverlay: GoalLineOverlay(
               visible: dailyGoalMinutes > 0,
-              bottom:
-                  chartHeight * (dailyGoalMinutes / max).clamp(0.0, 1.0),
+              bottom: chartHeight * (dailyGoalMinutes / max).clamp(0.0, 1.0),
               label:
                   '${l.homeGoal} '
                   '${l.unitMinutesValue(dailyGoalMinutes.round())}',
@@ -1732,15 +1735,10 @@ class _AllPeriodBody extends StatelessWidget {
             calloutBuilder: (BuildContext context, int i) =>
                 const SizedBox.shrink(),
             barBuilder: (BuildContext context, int i) => _StackedBarColumn(
-              bar: _Bar(
-                days[i].cardio,
-                days[i].strength,
-                days[i].stretching,
-              ),
+              bar: _Bar(days[i].cardio, days[i].strength, days[i].stretching),
               max: max,
               height: chartHeight,
-              dimmed:
-                  selection.selected != null && selection.selected != i,
+              dimmed: selection.selected != null && selection.selected != i,
             ),
           ),
         ),

--- a/frontend/flutter/test/features/diet/diet_header_alignment_test.dart
+++ b/frontend/flutter/test/features/diet/diet_header_alignment_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:oncare/design_system/figma/section_title.dart';
 import 'package:oncare/features/account/data/repositories/mock_account_repository.dart';
 import 'package:oncare/features/account/presentation/controllers/account_controller.dart';
 import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
@@ -67,16 +68,9 @@ void main() {
         moreOrLessEquals(tester.getRect(header).right, epsilon: 0.5),
       );
       // 제목은 여전히 줄 왼쪽에 있다 — 둘이 가운데로 몰리지 않는다.
+      // 제목 왼쪽에는 이제 아이콘이 붙으므로 제목 묶음 전체로 잰다. (#1058)
       expect(
-        tester
-            .getRect(
-              find.text(
-                AppLocalizations.of(
-                  tester.element(header),
-                ).dietNutritionSummary,
-              ),
-            )
-            .left,
+        tester.getRect(find.byType(SectionTitle).first).left,
         moreOrLessEquals(tester.getRect(header).left, epsilon: 0.5),
       );
     });

--- a/frontend/flutter/test/features/diet/section_chart_polish_test.dart
+++ b/frontend/flutter/test/features/diet/section_chart_polish_test.dart
@@ -1,0 +1,94 @@
+/// 섹션 아이콘 · 기간 버튼 폭 · 전체 그래프 등장 모션 (#1058).
+///
+/// 트레이너웹 고객 탭의 `영양 요약`·`운동 현황` 은 이미 아이콘을 달고 있다.
+/// 회원 앱만 글자만 있으면 두 화면이 같은 것을 말하는지 한눈에 붙지 않는다.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oncare/core/utils/clock.dart';
+import 'package:oncare/design_system/figma/section_title.dart';
+import 'package:oncare/features/account/data/repositories/mock_account_repository.dart';
+import 'package:oncare/features/account/presentation/controllers/account_controller.dart';
+import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
+import 'package:oncare/features/diet/presentation/pages/diet_record_page.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+import '../../helpers/fake_diet_repository.dart';
+
+void main() {
+  Future<void> pumpDiet(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(800, 3000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          dietRepositoryProvider.overrideWithValue(FakeDietRepository()),
+          accountRepositoryProvider.overrideWithValue(MockAccountRepository()),
+        ],
+        child: const MaterialApp(
+          locale: Locale('ko'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: DietRecordPage(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('영양 요약 제목에 아이콘이 붙는다', (WidgetTester tester) async {
+    await pumpDiet(tester);
+
+    final SectionTitle title = tester.widget<SectionTitle>(
+      find.byType(SectionTitle).first,
+    );
+    // 트레이너웹 고객 식단이 쓰는 아이콘과 같은 모양이다.
+    expect(title.icon, Icons.restaurant_outlined);
+    expect(find.text(title.label), findsWidgets);
+  });
+
+  testWidgets('기간 버튼은 글자보다 넉넉하다', (WidgetTester tester) async {
+    await pumpDiet(tester);
+
+    final Rect button = tester.getRect(
+      find.byKey(const Key('diet-period-tab-day')),
+    );
+    final Rect label = tester.getRect(
+      find.descendant(
+        of: find.byKey(const Key('diet-period-tab-day')),
+        matching: find.byType(Text),
+      ),
+    );
+    // 누를 자리가 글자에 딱 붙어 빠듯했다 — 좌우로 여유를 둔다.
+    expect(button.width - label.width, greaterThanOrEqualTo(32));
+  });
+
+  testWidgets('전체 그래프의 막대는 바닥에서 자라 오른다', (WidgetTester tester) async {
+    await pumpDiet(tester);
+    await tester.tap(find.byKey(const Key('diet-period-tab-month')));
+
+    // 전체는 오늘로 끝나는 구간이고 그래프는 끝으로 스크롤돼 열린다 —
+    // 화면에 실제로 있는 마지막 칸을 본다.
+    final Key today = ValueKey<String>(
+      'period-bar-reveal-'
+      '${dietRangeDates(dietRangeForTab(DietPeriodTab.month, nowKst())).length - 1}',
+    );
+
+    // 기간을 바꾸면 값을 다시 읽어 오므로, 막대가 나타날 때까지 프레임을
+    // 흘린 뒤 첫 모습을 잰다.
+    for (int i = 0; i < 20 && find.byKey(today).evaluate().isEmpty; i++) {
+      await tester.pump(const Duration(milliseconds: 16));
+    }
+    final double early = tester.getRect(find.byKey(today)).height;
+
+    await tester.pumpAndSettle();
+    final double settled = tester.getRect(find.byKey(today)).height;
+
+    expect(settled, greaterThan(0));
+    expect(early, lessThan(settled));
+  });
+}

--- a/frontend/flutter/test/features/exercise/exercise_narrow_layout_test.dart
+++ b/frontend/flutter/test/features/exercise/exercise_narrow_layout_test.dart
@@ -18,6 +18,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/design_system/figma/section_title.dart';
 import 'package:oncare/features/account/data/repositories/mock_account_repository.dart';
 import 'package:oncare/features/account/domain/entities/user_profile.dart';
 import 'package:oncare/features/account/presentation/controllers/account_controller.dart';
@@ -118,15 +119,9 @@ void main() {
       // 식단 탭에서 같은 자리가 가운데로 밀렸던 적이 있다(#761).
       await pumpExercise(tester, lang: 'ko', size: const Size(800, 3000));
 
-      final AppLocalizations l = AppLocalizations.of(
-        tester.element(find.byType(ExercisePage)),
+      final Finder row = find.byKey(
+        const ValueKey<String>('exercise-section-header'),
       );
-      final Finder row = find
-          .ancestor(
-            of: find.text(l.exActivityTitle),
-            matching: find.byType(Row),
-          )
-          .first;
       final Finder toggle = find.byKey(
         const ValueKey<String>('exercise-period-toggle'),
       );
@@ -136,9 +131,10 @@ void main() {
         tester.getRect(toggle).right,
         moreOrLessEquals(tester.getRect(row).right, epsilon: 0.5),
       );
-      // 제목은 여전히 줄 왼쪽에 있다 — 둘이 가운데로 몰리지 않는다.
+      // 제목은 여전히 줄 왼쪽에 있다 — 둘이 가운데로 몰리지 않는다. 제목
+      // 왼쪽에는 이제 아이콘이 붙으므로 제목 묶음 전체로 잰다. (#1058)
       expect(
-        tester.getRect(find.text(l.exActivityTitle)).left,
+        tester.getRect(find.byType(SectionTitle).first).left,
         moreOrLessEquals(tester.getRect(row).left, epsilon: 0.5),
       );
     });


### PR DESCRIPTION
Closes #1058

## Summary

식단 `영양 요약` · 운동 `운동 현황` 제목 옆이 비어 있었다. 트레이너웹은 같은 두 섹션에 아이콘을 달아 두었는데 회원 앱만 글자만 있어, 두 화면이 같은 것을 말하는지 한눈에 붙지 않았다.

기간 버튼은 글자에 딱 붙어 누를 자리가 빠듯했고, `전체` 그래프는 화면에 들어올 때 그냥 나타나 다른 기간에서 넘어왔는지 처음부터 그랬는지 구분되지 않았다.

## Changes

- 식단 `영양 요약` · 운동 `운동 현황` 제목 왼쪽에 아이콘 추가 — 트레이너웹 고객 탭의 같은 섹션과 같은 모양, 색만 사용자 앱 메인 색상
- 기간 토글(`오늘 / 이번 주 / 전체`) 버튼 좌우 여백 확대
- 식단·운동 `전체` 그래프의 막대가 바닥에서 자라 오르는 등장 모션 추가

## Notes

- 글자를 키운 화면(배율 1.3 초과)에서는 세 탭의 최소 폭 합이 남는 폭을 넘겨 줄이 터진다. 그 경우에는 예전 여백으로 돌아가 좁은 화면 회귀 테스트를 그대로 지킨다.
- 등장 모션의 되감기는 **칸 수가 바뀔 때만** 한다. 막대를 고를 때마다 다시 자라면 눌러 읽는 동작을 방해한다.
- 자라는 동안 위쪽을 잘라 낸다. 자르지 않으면 막대가 줄어든 상자 밖으로 삐져나와 그대로 다 보인다.
- 제목에 아이콘이 붙으면서 제목 줄 정렬을 재던 기존 테스트가 제목 묶음 전체를 재도록 바뀌었다(#761, #766 회귀 검사는 그대로 유지).
- 검증: `flutter analyze` 클린, 회원 앱 테스트 전체 통과.
