### PR TITLE
fix(calendar): 주간 달력의 월~일 고정과 선택 날짜 표시

### DIFF
--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -14,6 +14,7 @@ import 'package:oncare/features/diet/presentation/controllers/diet_controller.da
 import 'package:oncare/features/diet/presentation/widgets/diet_flows.dart';
 import 'package:oncare/features/diet/presentation/widgets/diet_period_view.dart';
 import 'package:oncare/features/diet/presentation/widgets/meal_photo_view.dart';
+import 'package:oncare/features/diet/presentation/widgets/week_strip_label.dart';
 import 'package:oncare/features/member_coach/presentation/widgets/trainer_chat_header_button.dart';
 import 'package:oncare/features/notification/presentation/controllers/notification_controller.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
@@ -180,11 +181,6 @@ class _DietRecordPageState extends ConsumerState<DietRecordPage> {
     _selected = _today;
   }
 
-  int _weekOfMonth(DateTime d) {
-    final DateTime first = DateTime(d.year, d.month);
-    final int offset = first.weekday - 1; // days from Monday
-    return ((d.day + offset - 1) / 7).floor() + 1;
-  }
 
   DietDateRange _rangeFor(DietPeriodTab tab, DateTime today) =>
       dietRangeForTab(tab, today);
@@ -202,12 +198,16 @@ class _DietRecordPageState extends ConsumerState<DietRecordPage> {
     final AppLocalizations l = AppLocalizations.of(context);
     final DietPeriodTab selectedPeriod = ref.watch(dietPeriodTabProvider);
     final DateTime today = _today;
-    // Window is always centred on today (+ whole-week shifts): 3 days before,
-    // today in the middle, 3 days after.
+    // 스트립은 늘 월요일에서 시작해 일요일로 끝난다 (#1059). 오늘을 가운데
+    // 두면 한 줄에 지난주 끝과 이번 주 앞이 섞여, `이번 주` 그래프가 세는
+    // 주와 달력이 보여 주는 주가 서로 어긋났다.
     final DateTime center = today.add(Duration(days: _weekShift * 7));
+    final DateTime monday = center.subtract(
+      Duration(days: center.weekday - DateTime.monday),
+    );
     final List<DateTime> days = List<DateTime>.generate(
       7,
-      (int i) => center.add(Duration(days: i - 3)),
+      (int i) => monday.add(Duration(days: i)),
     );
     final bool atToday = _weekShift == 0 && _selected == today;
     // 날짜를 옮기면 기간 토글이 사라진다 — 운동 탭이 오늘이 아닌 날에
@@ -248,9 +248,11 @@ class _DietRecordPageState extends ConsumerState<DietRecordPage> {
                   days: days,
                   today: today,
                   selected: _selected,
-                  weekLabel: l.dietWeekLabel(
-                    center.month,
-                    _weekOfMonth(center),
+                  weekLabel: weekStripLabel(
+                    context,
+                    l,
+                    selected: _selected,
+                    today: today,
                   ),
                   showTodayButton: !atToday,
                   onSelect: (DateTime d) => setState(() => _selected = d),

--- a/frontend/flutter/lib/features/diet/presentation/widgets/week_strip_label.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/week_strip_label.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/widgets.dart';
+import 'package:intl/intl.dart' show DateFormat;
+
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+/// 주간 달력 위에 적는 한 줄 — 고른 날이 오늘이면 `오늘`, 아니면 그 날짜.
+///
+/// 예전에는 `n월 n주차` 였다. 주차 번호는 세는 방법에 따라 달라져, 어느 날을
+/// 보고 있는지 오히려 흐렸다. 지금 고른 날을 그대로 적는다. (#1059)
+String weekStripLabel(
+  BuildContext context,
+  AppLocalizations l, {
+  required DateTime selected,
+  required DateTime today,
+}) {
+  if (selected.year == today.year &&
+      selected.month == today.month &&
+      selected.day == today.day) {
+    return l.exToday;
+  }
+  return DateFormat.yMMMMd(
+    Localizations.localeOf(context).toString(),
+  ).format(selected);
+}

--- a/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
@@ -14,6 +14,7 @@ import 'package:oncare/design_system/charts/period_scroll_chart.dart';
 import 'package:oncare/design_system/figma/figma_kit.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
 import 'package:oncare/design_system/tokens/motion.dart';
+import 'package:oncare/features/diet/presentation/widgets/week_strip_label.dart';
 import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
 import 'package:oncare/features/exercise/presentation/widgets/exercise_flows.dart';
@@ -365,11 +366,6 @@ class _ExerciseWeekStrip extends StatelessWidget {
   final VoidCallback onPrev;
   final VoidCallback? onNext;
 
-  int _weekOfMonth(DateTime d) {
-    final DateTime first = DateTime(d.year, d.month);
-    final int offset = first.weekday - 1;
-    return ((d.day + offset - 1) / 7).floor() + 1;
-  }
 
   String _weekday(AppLocalizations l, int weekday) => switch (weekday) {
     1 => l.dietWeekdayMon,
@@ -384,9 +380,13 @@ class _ExerciseWeekStrip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations l = AppLocalizations.of(context);
+    // 월요일에서 시작해 일요일로 끝난다 — 식단 탭과 같은 규칙이다. (#1059)
+    final DateTime monday = center.subtract(
+      Duration(days: center.weekday - DateTime.monday),
+    );
     final List<DateTime> days = List<DateTime>.generate(
       7,
-      (int i) => center.add(Duration(days: i - 3)),
+      (int i) => monday.add(Duration(days: i)),
     );
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16),
@@ -402,7 +402,12 @@ class _ExerciseWeekStrip extends StatelessWidget {
                 // 좁은 화면에서 오늘 버튼을 밀어내며 넘친다(#766).
                 Flexible(
                   child: Text(
-                    l.dietWeekLabel(center.month, _weekOfMonth(center)),
+                    weekStripLabel(
+                      context,
+                      l,
+                      selected: selected,
+                      today: today,
+                    ),
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     style: const TextStyle(
@@ -1302,6 +1307,9 @@ class _PeriodToggle extends StatelessWidget {
                 button: true,
                 selected: active == i,
                 child: GestureDetector(
+                  // 스트립 라벨도 `오늘` 이 될 수 있어(#1059) 글자로는 두
+                  // 자리가 갈리지 않는다 — 탭마다 이름을 준다.
+                  key: Key('exercise-period-tab-$i'),
                   onTap: () => onChanged(i),
                   behavior: HitTestBehavior.opaque,
                   child: AnimatedContainer(

--- a/frontend/flutter/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations.dart
@@ -530,12 +530,6 @@ abstract class AppLocalizations {
   /// **'Today'**
   String get dietToday;
 
-  /// No description provided for @dietWeekLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'Month {month}, Week {week}'**
-  String dietWeekLabel(int month, int week);
-
   /// No description provided for @dietWeekdayMon.
   ///
   /// In en, this message translates to:

--- a/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
@@ -250,11 +250,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get dietToday => 'Today';
 
   @override
-  String dietWeekLabel(int month, int week) {
-    return 'Month $month, Week $week';
-  }
-
-  @override
   String get dietWeekdayMon => 'Mon';
 
   @override

--- a/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
@@ -248,11 +248,6 @@ class AppLocalizationsKo extends AppLocalizations {
   String get dietToday => '오늘로';
 
   @override
-  String dietWeekLabel(int month, int week) {
-    return '$month월 $week주차';
-  }
-
-  @override
   String get dietWeekdayMon => '월';
 
   @override

--- a/frontend/flutter/lib/l10n/app_en.arb
+++ b/frontend/flutter/lib/l10n/app_en.arb
@@ -135,17 +135,6 @@
   },
   "dietTitle": "Diet",
   "dietToday": "Today",
-  "dietWeekLabel": "Month {month}, Week {week}",
-  "@dietWeekLabel": {
-    "placeholders": {
-      "month": {
-        "type": "int"
-      },
-      "week": {
-        "type": "int"
-      }
-    }
-  },
   "dietWeekdayMon": "Mon",
   "dietWeekdayTue": "Tue",
   "dietWeekdayWed": "Wed",

--- a/frontend/flutter/lib/l10n/app_ko.arb
+++ b/frontend/flutter/lib/l10n/app_ko.arb
@@ -96,7 +96,6 @@
   "unitMinutesValue": "{count}분",
   "dietTitle": "식단",
   "dietToday": "오늘로",
-  "dietWeekLabel": "{month}월 {week}주차",
   "dietWeekdayMon": "월",
   "dietWeekdayTue": "화",
   "dietWeekdayWed": "수",

--- a/frontend/flutter/test/features/diet/week_strip_test.dart
+++ b/frontend/flutter/test/features/diet/week_strip_test.dart
@@ -1,0 +1,94 @@
+/// 주간 달력은 월요일에서 시작해 일요일로 끝난다 (#1059).
+///
+/// 오늘을 가운데 두면 한 줄에 지난주 끝과 이번 주 앞이 섞여, `이번 주` 그래프가
+/// 세는 주와 달력이 보여 주는 주가 서로 어긋났다.
+///
+/// 줄 위의 라벨도 바뀐다. `n월 n주차` 의 주차 번호는 세는 방법에 따라 달라져
+/// 어느 날을 보고 있는지 오히려 흐렸다 — 고른 날을 그대로 적는다.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oncare/core/utils/clock.dart';
+import 'package:oncare/features/account/data/repositories/mock_account_repository.dart';
+import 'package:oncare/features/account/presentation/controllers/account_controller.dart';
+import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
+import 'package:oncare/features/diet/presentation/pages/diet_record_page.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+import '../../helpers/fake_diet_repository.dart';
+
+void main() {
+  Future<void> pumpDiet(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(800, 3000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          dietRepositoryProvider.overrideWithValue(FakeDietRepository()),
+          accountRepositoryProvider.overrideWithValue(MockAccountRepository()),
+        ],
+        child: const MaterialApp(
+          locale: Locale('ko'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: DietRecordPage(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  /// 스트립에 그려진 날짜 칸의 일(日) 숫자들.
+  List<int> stripDays(WidgetTester tester) {
+    final DateTime today = DateUtils.dateOnly(nowKst());
+    final DateTime monday = today.subtract(
+      Duration(days: today.weekday - DateTime.monday),
+    );
+    return <int>[
+      for (int i = 0; i < 7; i++) monday.add(Duration(days: i)).day,
+    ];
+  }
+
+  testWidgets('스트립은 월요일에서 시작해 일요일로 끝난다', (WidgetTester tester) async {
+    await pumpDiet(tester);
+
+    for (final int day in stripDays(tester)) {
+      expect(find.text('$day'), findsWidgets, reason: '$day 일');
+    }
+
+    // 이번 주 월요일의 앞날(지난주 일요일)은 줄에 없다.
+    final DateTime today = DateUtils.dateOnly(nowKst());
+    final DateTime monday = today.subtract(
+      Duration(days: today.weekday - DateTime.monday),
+    );
+    final DateTime beforeMonday = monday.subtract(const Duration(days: 1));
+    if (beforeMonday.month != monday.month || beforeMonday.day > 7) {
+      expect(find.text('${beforeMonday.day}'), findsNothing);
+    }
+  });
+
+  testWidgets('주차 번호 대신 고른 날을 적는다', (WidgetTester tester) async {
+    await pumpDiet(tester);
+
+    // 처음에는 오늘이 골라져 있다.
+    expect(find.textContaining('주차'), findsNothing);
+    expect(find.text('오늘'), findsWidgets);
+
+    // 다른 날을 고르면 그 날짜가 적힌다.
+    final DateTime today = DateUtils.dateOnly(nowKst());
+    final DateTime monday = today.subtract(
+      Duration(days: today.weekday - DateTime.monday),
+    );
+    final DateTime other = monday == today
+        ? monday.add(const Duration(days: 1))
+        : monday;
+    await tester.tap(find.text('${other.day}').first);
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('${other.month}월 ${other.day}일'), findsWidgets);
+  });
+}

--- a/frontend/flutter/test/features/exercise/exercise_chart_animation_test.dart
+++ b/frontend/flutter/test/features/exercise/exercise_chart_animation_test.dart
@@ -96,7 +96,7 @@ void main() {
 
   testWidgets('오늘 도넛은 원을 따라 점점 그려진다', (WidgetTester tester) async {
     await pumpExercise(tester);
-    await tester.tap(find.text('오늘'));
+    await tester.tap(find.byKey(const Key('exercise-period-tab-0')));
     await tester.pump();
 
     const Size size = Size.square(116);

--- a/frontend/flutter/test/features/exercise/exercise_default_period_test.dart
+++ b/frontend/flutter/test/features/exercise/exercise_default_period_test.dart
@@ -92,7 +92,7 @@ void main() {
     expect(find.text('오늘 총 운동 시간'), findsNothing);
 
     // 오늘 ↔ 이번 주 왕복이 상태를 망가뜨리지 않는다.
-    await tester.tap(find.text('오늘'));
+    await tester.tap(find.byKey(const Key('exercise-period-tab-0')));
     await tester.pumpAndSettle();
     expect(find.text('오늘 총 운동 시간'), findsOneWidget);
   });


### PR DESCRIPTION
Closes #1059

## Summary

주간 달력이 오늘을 가운데 두고 앞뒤 사흘씩 채웠다. 그래서 한 줄에 보이는 이레가 지난주 끝과 이번 주 앞이 섞인 구간이 되어, `이번 주` 그래프가 세는 주와 달력이 보여 주는 주가 서로 어긋났다.

`n월 n주차` 도 마찬가지다. 주차 번호는 세는 방법에 따라 달라져 어느 날을 보고 있는지 오히려 흐렸다.

## Changes

- 주간 달력을 항상 월요일에서 시작해 일요일로 끝내기 — 오늘 가운데 고정 해제 (식단·운동 탭 모두)
- `n월 n주차` 삭제, 그 자리에 고른 날을 표시 — 오늘이면 `오늘`, 아니면 그 날짜(예: `2026년 8월 8일`)
- 쓰이지 않게 된 주차 문구 키 정리

## Notes

- 라벨이 `오늘` 이 될 수 있어 기간 토글의 `오늘` 탭과 글자로는 갈리지 않는다. 운동 탭 기간 토글의 각 탭에 이름을 주고, 그 이름으로 누르도록 테스트를 바꿨다.
- 회귀 방지 테스트 추가: 줄이 이번 주 월~일로 채워지는지, 주차 번호 대신 고른 날이 적히는지.
- 검증: `flutter analyze` 클린, 회원 앱 테스트 전체 통과.
