### PR TITLE
fix(ui): 하단 추가 메뉴 포인트 색 교체와 알림 배지 빨간색

### DIFF
--- a/frontend/flutter/lib/app/router/main_shell.dart
+++ b/frontend/flutter/lib/app/router/main_shell.dart
@@ -430,14 +430,15 @@ class _RecordAddSheet extends StatelessWidget {
                 padding: const EdgeInsets.fromLTRB(20, 12, 20, 0),
                 child: Row(
                   children: <Widget>[
+                    // 식단은 초록, 운동은 파랑이다 (#1060). 앱 안에서 식단
+                    // 그래프가 초록, 운동 그래프가 파랑인데 이 메뉴만 뒤집혀
+                    // 있어, 같은 두 영역이 자리마다 색이 바뀌었다.
                     Expanded(
                       child: _RecordOption(
                         icon: Icons.restaurant,
-                        iconColor: FigmaColors.primary,
-                        iconBg: FigmaColors.softBlue,
-                        borderColor: FigmaColors.primary.withValues(
-                          alpha: 0.35,
-                        ),
+                        iconColor: FigmaColors.green,
+                        iconBg: const Color(0xFFEAF8F2),
+                        borderColor: FigmaColors.green.withValues(alpha: 0.35),
                         title: l.navDiet,
                         subtitle: l.navDietOptionSub,
                         onTap: onDiet,
@@ -447,9 +448,11 @@ class _RecordAddSheet extends StatelessWidget {
                     Expanded(
                       child: _RecordOption(
                         icon: Icons.fitness_center,
-                        iconColor: FigmaColors.green,
-                        iconBg: const Color(0xFFEAF8F2),
-                        borderColor: FigmaColors.green.withValues(alpha: 0.35),
+                        iconColor: FigmaColors.primary,
+                        iconBg: FigmaColors.softBlue,
+                        borderColor: FigmaColors.primary.withValues(
+                          alpha: 0.35,
+                        ),
                         title: l.navExercise,
                         subtitle: l.navExerciseOptionSub,
                         onTap: onExercise,

--- a/frontend/flutter/lib/design_system/figma/figma_kit.dart
+++ b/frontend/flutter/lib/design_system/figma/figma_kit.dart
@@ -254,7 +254,10 @@ class FigmaCircleButton extends StatelessWidget {
     required this.icon,
     this.onTap,
     this.showDot = false,
-    this.dotColor = FigmaColors.orange,
+    // 읽지 않은 알림은 `주의` 가 아니라 새 소식이다 — 같은 화면의 주황(주의)과
+    // 겹치지 않도록 빨강으로 둔다. 옆의 채팅 버튼이 이미 쓰던 그 빨강이라,
+    // 헤더의 두 점이 같은 색으로 같은 뜻을 말한다. (#1060)
+    this.dotColor = FigmaColors.redDot,
     this.size = 36,
     this.iconSize = 18,
     this.enabled = true,

--- a/frontend/flutter/lib/features/member_coach/presentation/widgets/trainer_chat_header_button.dart
+++ b/frontend/flutter/lib/features/member_coach/presentation/widgets/trainer_chat_header_button.dart
@@ -37,7 +37,6 @@ class TrainerChatHeaderButton extends ConsumerWidget {
         key: const Key('trainerChatHeaderButton'),
         icon: Icons.chat_bubble_outline_rounded,
         showDot: unread > 0,
-        dotColor: FigmaColors.redDot,
         enabled: ready,
         onTap: ready
             ? () => openTrainerChatPage(context, trainerName: coach.name)

--- a/frontend/flutter/test/design_system/accent_colors_test.dart
+++ b/frontend/flutter/test/design_system/accent_colors_test.dart
@@ -1,0 +1,33 @@
+/// 같은 뜻은 같은 색으로 (#1060).
+///
+/// 하단 `+` 메뉴만 식단이 파랑, 운동이 초록이었다. 앱 안에서는 식단 그래프가
+/// 초록, 운동 그래프가 파랑이라 같은 두 영역이 자리마다 색이 뒤바뀌었다.
+///
+/// 헤더 알림 점은 주황이라 같은 화면의 `주의` 색과 겹쳤다. 읽지 않은 알림은
+/// 주의가 아니라 새 소식이다.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oncare/design_system/figma/figma_kit.dart';
+
+void main() {
+  testWidgets('알림 점은 주황이 아니라 빨강이다', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: FigmaCircleButton(
+            icon: Icons.notifications_none_rounded,
+            showDot: true,
+          ),
+        ),
+      ),
+    );
+
+    final FigmaCircleButton bell = tester.widget<FigmaCircleButton>(
+      find.byType(FigmaCircleButton),
+    );
+    expect(bell.dotColor, FigmaColors.redDot);
+    expect(bell.dotColor, isNot(FigmaColors.orange));
+  });
+}

--- a/frontend/flutter/test/features/dashboard/dashboard_content_state_test.dart
+++ b/frontend/flutter/test/features/dashboard/dashboard_content_state_test.dart
@@ -212,7 +212,9 @@ void main() {
     // 점은 이제 **서버 미읽음을 따른다.** 예전에는 항상 켜져 있어서 읽을 것이
     // 없어도 남았다(#636).
     expect(notificationButton.showDot, isTrue);
-    expect(notificationButton.dotColor, FigmaColors.orange);
+    // 읽지 않은 알림은 `주의` 가 아니라 새 소식이다 — 주황은 같은 화면의
+    // 주의 색과 겹쳤다. 옆 채팅 버튼이 이미 쓰던 빨강으로 맞춘다. (#1060)
+    expect(notificationButton.dotColor, FigmaColors.redDot);
   });
 
   testWidgets('읽지 않은 알림이 없으면 벨에 점이 없다', (WidgetTester tester) async {

--- a/frontend/flutter/test/widget_test.dart
+++ b/frontend/flutter/test/widget_test.dart
@@ -10,6 +10,7 @@ import 'package:oncare/app/router/routes.dart';
 import 'package:oncare/app/session_feature_reset.dart';
 import 'package:oncare/core/config/app_config.dart';
 import 'package:oncare/core/logging/app_logger.dart';
+import 'package:oncare/design_system/figma/figma_kit.dart';
 import 'package:oncare/features/dashboard/data/repositories/mock_dashboard_repository.dart';
 import 'package:oncare/features/dashboard/domain/repositories/dashboard_repository.dart';
 import 'package:oncare/features/dashboard/presentation/controllers/dashboard_controller.dart';
@@ -144,6 +145,26 @@ void main() {
     await tester.tap(exerciseOption);
     await tester.pumpAndSettle();
   }
+
+  testWidgets('추가 메뉴는 식단이 초록, 운동이 파랑이다 (#1060)', (tester) async {
+    await pumpApp(tester);
+    await tester.tap(find.byKey(const Key('recordAddButton')));
+    await tester.pumpAndSettle();
+
+    Color? iconColorOf(IconData icon) => tester
+        .widget<Icon>(
+          find.descendant(
+            of: find.byKey(const Key('recordOptions')),
+            matching: find.byIcon(icon),
+          ),
+        )
+        .color;
+
+    // 앱 안에서 식단 그래프가 초록, 운동 그래프가 파랑이다. 이 메뉴만 뒤집혀
+    // 있으면 같은 두 영역이 자리마다 색이 바뀐다.
+    expect(iconColorOf(Icons.restaurant), FigmaColors.green);
+    expect(iconColorOf(Icons.fitness_center), FigmaColors.primary);
+  });
 
   testWidgets('Enters the Home tab in English after demo', (tester) async {
     await pumpApp(tester, locale: const Locale('en'));


### PR DESCRIPTION
Closes #1060

## Summary

하단 `+` 메뉴만 식단이 파랑, 운동이 초록이었다. 앱 안에서는 식단 그래프가 초록, 운동 그래프가 파랑이라 같은 두 영역이 자리마다 색이 뒤바뀌어 보였다.

헤더 알림 점은 주황이라 같은 화면의 `주의` 색과 겹쳤다. 읽지 않은 알림은 주의가 아니라 새 소식이다.

## Changes

- 하단 `+` 메뉴의 포인트 색 교체 — 식단은 초록, 운동은 파랑
- 헤더 알림 동그라미를 주황에서 빨강으로 변경

## Notes

- 알림 점 색은 옆의 트레이너 채팅 버튼이 이미 쓰던 빨강으로 맞췄다. 헤더의 두 점이 같은 색으로 같은 뜻(읽지 않음)을 말한다 — 그 버튼이 따로 색을 지정하던 줄은 이제 기본값과 같아 지웠다.
- 회귀 방지 테스트 추가: 추가 메뉴의 두 아이콘 색, 알림 점 색.
- 검증: `flutter analyze` 클린, 회원 앱 테스트 전체 통과.
