### PR TITLE
feat(chat): 트레이너 채팅의 PT 일정 감지와 다음 일정 반영

### DIFF
--- a/backend/app/services/schedule_parse.py
+++ b/backend/app/services/schedule_parse.py
@@ -1,0 +1,148 @@
+"""트레이너 채팅에서 다음 PT 약속을 읽어 낸다. (#1061)
+
+약속은 대화에서 잡힌다 — "다음 PT는 다음 주 수요일 오후 8시로 할게요!" 처럼.
+그런데 그 말은 채팅 안에만 남아, 운동 탭의 `다음 PT 일정` 은 여전히 비어 있거나
+지난 일정을 들고 있었다. 회원은 방금 잡은 약속을 확인하려고 대화를 거슬러
+올라가야 했다.
+
+**해석은 서버가 한다.** 앱과 트레이너웹이 각자 문장을 풀면 같은 대화에서 서로
+다른 약속이 만들어진다.
+
+**모르면 만들지 않는다.** 없는 약속을 지어내는 쪽이, 약속을 놓치는 쪽보다
+나쁘다 — 회원이 엉뚱한 날에 헬스장에 간다. 그래서 세 가지가 **모두** 있어야
+약속으로 본다: PT 를 가리키는 말, 풀 수 있는 날짜, 그리고 시각. 시각이 없으면
+"수요일에 봐요" 같은 인사말과 구분되지 않는다.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import date as date_type
+from datetime import timedelta
+
+#: PT 를 가리키는 말. 이 말이 없으면 날짜·시각이 있어도 약속으로 보지 않는다 —
+#: "내일 오전 10시에 약 드세요" 를 PT 로 만들면 안 된다.
+_PT_WORDS = ("pt", "피티", "수업", "세션", "레슨")
+
+#: 약속이 아니라 **묻는 말**이라는 신호. "수요일 어때요?" 는 아직 정해진 것이
+#: 없다 — 한쪽이 제안했을 뿐이라 일정으로 굳히면 안 된다.
+_ASKING = ("어때", "어떠", "괜찮", "가능하", "될까", "될까요", "?")
+
+#: 취소·변경을 말하는 문장은 새 약속으로 읽지 않는다. 무엇을 지울지까지는 이
+#: 단계에서 알 수 없어, 사람이 일정 화면에서 정리하도록 둔다.
+_NEGATIVE = ("취소", "미루", "연기", "쉬어", "쉬는", "못 가", "못가", "어렵")
+
+_WEEKDAYS = {"월": 0, "화": 1, "수": 2, "목": 3, "금": 4, "토": 5, "일": 6}
+
+
+@dataclass(frozen=True)
+class ParsedSchedule:
+    """읽어 낸 약속 — 날짜(`YYYY-MM-DD`)와 시각(`HH:MM`)."""
+
+    date: str
+    time: str
+
+
+def _weekday_of(text: str) -> int | None:
+    m = re.search(r"([월화수목금토일])\s*요일", text)
+    return _WEEKDAYS[m.group(1)] if m else None
+
+
+def _resolve_date(text: str, sent_on: date_type) -> date_type | None:
+    """상대 표현은 **보낸 날**을 기준으로 푼다.
+
+    "다음 주 수요일" 은 읽는 시점이 아니라 말한 시점에서 센 날이다. 나중에
+    다시 계산하면 같은 문장이 매번 다른 날을 가리킨다.
+    """
+    # 1) 절대 날짜 — "8월 25일". 이미 지난 날짜면 내년으로 본다.
+    m = re.search(r"(\d{1,2})\s*월\s*(\d{1,2})\s*일", text)
+    if m:
+        month, day = int(m.group(1)), int(m.group(2))
+        try:
+            found = date_type(sent_on.year, month, day)
+        except ValueError:
+            return None
+        if found < sent_on:
+            try:
+                found = date_type(sent_on.year + 1, month, day)
+            except ValueError:
+                return None
+        return found
+
+    # 2) 오늘/내일/모레
+    if "모레" in text:
+        return sent_on + timedelta(days=2)
+    if "내일" in text:
+        return sent_on + timedelta(days=1)
+
+    weekday = _weekday_of(text)
+    if weekday is None:
+        # 요일도 날짜도 없이 "오늘 8시" 만 남은 경우.
+        return sent_on if "오늘" in text else None
+
+    # 3) 요일 — 이번 주는 월요일 기준, 다음 주는 그 다음 월요일 기준이다.
+    monday = sent_on - timedelta(days=sent_on.weekday())
+    if "다음 주" in text or "다음주" in text or "담주" in text:
+        return monday + timedelta(days=7 + weekday)
+    if "이번 주" in text or "이번주" in text:
+        return monday + timedelta(days=weekday)
+    # 4) 그냥 "수요일" — 보낸 날 이후 가장 가까운 그 요일이다. 오늘이 그 요일
+    #    이면 오늘로 본다(시각이 뒤에 붙으므로 지난 시간인지는 여기서 따지지
+    #    않는다).
+    ahead = (weekday - sent_on.weekday()) % 7
+    return sent_on + timedelta(days=ahead)
+
+
+def _resolve_time(text: str) -> str | None:
+    """오전/오후가 붙은 시각, 또는 24시간으로 적은 시각만 받는다.
+
+    "7시" 처럼 오전·오후가 없는 한 자리 시각은 짐작하지 않는다. 저녁일 것
+    같다는 이유로 19시로 굳히면, 아침 7시 수업이 12시간 밀린다.
+    """
+    m = re.search(r"(오전|오후|저녁|아침|낮)?\s*(\d{1,2})\s*시(?:\s*(\d{1,2})\s*분)?", text)
+    if m:
+        marker, hour_s, minute_s = m.group(1), m.group(2), m.group(3)
+        hour = int(hour_s)
+        minute = int(minute_s or 0)
+        if marker in ("오후", "저녁") and hour < 12:
+            hour += 12
+        elif marker in ("오전", "아침") and hour == 12:
+            hour = 0
+        elif marker is None and hour < 13:
+            # 오전·오후 없이 12시 이하면 어느 쪽인지 알 수 없다.
+            return None
+        if hour > 23 or minute > 59:
+            return None
+        return f"{hour:02d}:{minute:02d}"
+
+    m = re.search(r"\b(\d{1,2}):(\d{2})\b", text)
+    if m:
+        hour, minute = int(m.group(1)), int(m.group(2))
+        if hour > 23 or minute > 59:
+            return None
+        return f"{hour:02d}:{minute:02d}"
+    return None
+
+
+def parse_schedule(text: str, *, sent_on: date_type) -> ParsedSchedule | None:
+    """[text] 에서 다음 PT 약속을 읽는다. 확실하지 않으면 None.
+
+    [sent_on] 은 그 메시지를 보낸 날(KST)이다.
+    """
+    if not text:
+        return None
+    lowered = text.lower()
+    if not any(word in lowered for word in _PT_WORDS):
+        return None
+    if any(word in text for word in _NEGATIVE):
+        return None
+    if any(word in text for word in _ASKING):
+        return None
+
+    when = _resolve_date(text, sent_on)
+    if when is None:
+        return None
+    at = _resolve_time(text)
+    if at is None:
+        return None
+    return ParsedSchedule(date=when.isoformat(), time=at)

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -45,6 +45,7 @@ from app.services import (
     exercise_types,
     notification_service,
     routine_suggestion_service,
+    schedule_parse,
 )
 from app.services.coach import personal_ingest
 
@@ -644,6 +645,65 @@ def _existing_message_out(
     return chat_message_out(message, viewer)
 
 
+#: 대화에서 읽어 낸 PT 의 종류·길이·표시. 길이는 트레이너 앱의 기본 한 시간을
+#: 따른다 — 문장에 "몇 분" 까지 적히는 일은 드물어 짐작하지 않는다.
+PT_SESSION_TYPE = "1:1 PT"
+_CHAT_SCHEDULE_MINUTES = 60
+_CHAT_SCHEDULE_NOTE = "대화에서 잡은 일정"
+
+
+def _schedule_from_chat(
+    db: Session, trainer_id: str, member_id: str, text: str, sent_at: datetime
+) -> None:
+    """트레이너가 대화에서 잡은 다음 PT 를 일정으로 남긴다. (#1061)
+
+    약속은 대화에서 잡히는데 그 말이 채팅 안에만 남아, 회원 앱의 `다음 PT
+    일정` 은 비어 있거나 지난 일정을 들고 있었다.
+
+    **트레이너가 보낸 말만** 본다. 회원이 제안한 시간은 아직 약속이 아니다 —
+    트레이너가 받아 주기 전에 일정으로 굳히면 오지 않을 시간을 잡아 둔다.
+
+    같은 날 같은 시각의 일정이 이미 있으면 아무것도 하지 않는다. 트레이너가
+    같은 약속을 두 번 말하는 것은 흔한 일이라, 그때마다 칸이 늘면 일정 화면이
+    중복으로 찬다.
+    """
+    parsed = schedule_parse.parse_schedule(
+        text, sent_on=clock.to_seoul(sent_at).date()
+    )
+    if parsed is None:
+        return
+    existing = db.scalar(
+        select(TrainerSchedule).where(
+            TrainerSchedule.trainer_id == trainer_id,
+            TrainerSchedule.member_id == member_id,
+            TrainerSchedule.date == parsed.date,
+            TrainerSchedule.time == parsed.time,
+        )
+    )
+    if existing is not None:
+        return
+    member_name = db.scalar(select(User.name).where(User.id == member_id))
+    db.add(
+        TrainerSchedule(
+            id=f"sched-{uuid.uuid4().hex[:12]}",
+            trainer_id=trainer_id,
+            member_id=member_id,
+            date=parsed.date,
+            time=parsed.time,
+            client_name=member_name or "",
+            type=PT_SESSION_TYPE,
+            duration_minutes=_CHAT_SCHEDULE_MINUTES,
+            status="예정",
+            # 어디서 온 일정인지 남긴다 — 사람이 만든 일정과 섞이면, 잘못
+            # 읽은 약속을 나중에 가려낼 수 없다.
+            note=_CHAT_SCHEDULE_NOTE,
+            program_json="[]",
+            sort_order=0,
+        )
+    )
+    db.flush()
+
+
 def send_message(
     db: Session, trainer_id: str, member_id: str, sender: str, text: str,
     viewer: str = "trainer", notify: str | None = None,
@@ -701,6 +761,9 @@ def send_message(
             if existing is not None:
                 return _existing_message_out(existing, text=text, viewer=viewer)
         raise
+
+    if sender == "trainer":
+        _schedule_from_chat(db, trainer_id, member_id, text, msg.created_at)
 
     if sender == "member":
         member_name = db.scalar(select(User.name).where(User.id == member_id))

--- a/backend/tests/test_chat_schedule.py
+++ b/backend/tests/test_chat_schedule.py
@@ -1,0 +1,113 @@
+"""트레이너 채팅에서 다음 PT 를 읽어 내는 규칙. (#1061)
+
+약속은 대화에서 잡히는데, 그 말이 채팅 안에만 남으면 회원 앱의 `다음 PT 일정`
+은 비어 있거나 지난 일정을 들고 있다.
+
+없는 약속을 지어내는 쪽이 약속을 놓치는 쪽보다 나쁘다 — 회원이 엉뚱한 날에
+헬스장에 간다. 그래서 애매한 문장은 전부 흘려보내는지가 이 파일의 관심사다.
+"""
+from __future__ import annotations
+
+from datetime import date
+from uuid import uuid4
+
+import pytest
+
+from app.services.schedule_parse import parse_schedule
+
+#: 2026-08-21 은 금요일이다.
+FRIDAY = date(2026, 8, 21)
+
+
+def _h(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("다음 PT는 다음 주 수요일 오후 8시로 할게요!", ("2026-08-26", "20:00")),
+        ("내일 오전 10시에 PT 봬요", ("2026-08-22", "10:00")),
+        ("8월 25일 오후 3시 수업 잡아둘게요", ("2026-08-25", "15:00")),
+        ("이번 주 일요일 저녁 7시 세션이요", ("2026-08-23", "19:00")),
+        ("모레 14시 PT 로 하죠", ("2026-08-23", "14:00")),
+    ],
+)
+def test_reads_the_appointment_a_trainer_states(text, expected):
+    parsed = parse_schedule(text, sent_on=FRIDAY)
+    assert parsed is not None, text
+    assert (parsed.date, parsed.time) == expected
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        # 아직 묻는 말이다 — 한쪽이 제안했을 뿐 정해진 것이 없다.
+        "다음 PT 수요일 오후 8시 어때요?",
+        # 취소·변경은 새 약속이 아니다.
+        "다음 주 수요일 오후 8시 PT 는 취소할게요",
+        # 시각이 없으면 인사말과 구분되지 않는다.
+        "다음 주 수요일에 PT 봬요",
+        # 날짜가 없다.
+        "PT 오후 8시로 할게요",
+        # PT 이야기가 아니다.
+        "내일 오전 10시에 약 꼭 드세요",
+        # 오전·오후가 없는 한 자리 시각은 짐작하지 않는다.
+        "내일 7시 PT 예요",
+    ],
+)
+def test_says_nothing_when_it_is_not_sure(text):
+    assert parse_schedule(text, sent_on=FRIDAY) is None
+
+
+def test_trainer_message_puts_the_next_pt_on_the_member_schedule(client):
+    """트레이너가 대화에서 잡은 약속이 회원의 세션 목록에 나타난다."""
+    trainer = client.post(
+        "/v1/auth/login",
+        data={"username": "trainer@oncare.com", "password": "oncare123"},
+    ).json()["access_token"]
+
+    # 문장에 절대 날짜를 적어, 언제 돌려도 같은 날을 가리키게 한다.
+    said = client.post(
+        "/v1/trainer/clients/user-jisu/chat",
+        json={"text": "다음 PT는 12월 24일 오후 8시로 할게요!"},
+        headers=_h(trainer),
+    )
+    assert said.status_code in (200, 201), said.text
+
+    member = client.post(
+        "/v1/auth/login",
+        data={"username": "jisu@oncare.com", "password": "oncare123"},
+    ).json()["access_token"]
+    sessions = client.get("/v1/me/coach/sessions", headers=_h(member)).json()
+    booked = [s for s in sessions if s["time"] == "20:00"]
+    assert booked, sessions
+    assert booked[0]["status"] == "예정"
+
+    # 같은 약속을 두 번 말해도 칸이 늘지 않는다.
+    client.post(
+        "/v1/trainer/clients/user-jisu/chat",
+        json={"text": "다음 PT는 12월 24일 오후 8시예요"},
+        headers=_h(trainer),
+    )
+    again = client.get("/v1/me/coach/sessions", headers=_h(member)).json()
+    assert len([s for s in again if s["time"] == "20:00"]) == len(booked)
+
+
+def test_member_message_does_not_book_anything(client):
+    """회원이 제안한 시간은 아직 약속이 아니다."""
+    member = client.post(
+        "/v1/auth/login",
+        data={"username": "jisu@oncare.com", "password": "oncare123"},
+    ).json()["access_token"]
+
+    before = client.get("/v1/me/coach/sessions", headers=_h(member)).json()
+    asked = client.post(
+        "/v1/me/coach/chat",
+        json={"text": f"다음 PT는 11월 3일 오후 6시로 할게요 {uuid4().hex[:6]}"},
+        headers=_h(member),
+    )
+    assert asked.status_code == 201, asked.text
+
+    after = client.get("/v1/me/coach/sessions", headers=_h(member)).json()
+    assert len(after) == len(before)


### PR DESCRIPTION
Closes #1061

## Summary

약속은 대화에서 잡힌다 — "다음 PT는 다음 주 수요일 오후 8시로 할게요!" 처럼. 그런데 그 말이 채팅 안에만 남아, 운동 탭의 `다음 PT 일정` 은 여전히 비어 있거나 지난 일정을 들고 있었다. 회원은 방금 잡은 약속을 확인하려고 대화를 거슬러 올라가야 했다.

## Changes

- 트레이너 채팅 문장에서 다음 PT 를 읽어 내는 규칙을 서버에 추가 — `다음 주 수요일 오후 8시` · `내일 오전 10시` · `8월 25일 오후 3시` · `모레 14시`
- 트레이너가 보낸 메시지에서 약속을 읽으면 그 회원의 PT 일정으로 남긴다. 회원 앱 `다음 PT 일정` 은 이미 그 데이터를 읽고 있어, 운동 탭을 열면 바로 보인다
- 같은 날 같은 시각의 일정이 이미 있으면 아무것도 하지 않는다 — 같은 약속을 두 번 말해도 칸이 늘지 않는다

## Notes

- **해석은 서버가 한다.** 앱과 트레이너웹이 각자 문장을 풀면 같은 대화에서 서로 다른 약속이 만들어진다.
- 상대 표현은 읽는 시점이 아니라 **말한 시점** 에서 센다. 나중에 다시 계산하면 같은 문장이 매번 다른 날을 가리킨다.
- **모르면 만들지 않는다.** PT 를 가리키는 말·풀 수 있는 날짜·시각이 모두 있어야 약속으로 본다. 묻는 말(`수요일 어때요?`), 취소·연기, 오전/오후 없는 한 자리 시각(`7시`)은 전부 흘려보낸다 — 저녁일 것 같다는 이유로 굳히면 아침 수업이 열두 시간 밀린다.
- 감지 대상은 **트레이너가 보낸 말**뿐이다. 회원이 제안한 시간은 아직 약속이 아니다.
- 대화에서 온 일정은 메모로 표시해 둔다. 사람이 만든 일정과 섞이면 잘못 읽은 약속을 나중에 가려낼 수 없다.
- 검증: 백엔드 pytest 전체 통과(파서 단위 검사 + 트레이너 발신→회원 세션 반영 + 회원 발신은 아무것도 잡지 않음).
