### PR TITLE
fix(messages): 메시지 탭 목록을 마지막 말이 새로운 순으로

### DIFF
--- a/frontend/flutter_trainer/lib/core/storage/seed_data.dart
+++ b/frontend/flutter_trainer/lib/core/storage/seed_data.dart
@@ -269,8 +269,22 @@ Future<void> seedIfEmpty(
               // reply from a previous day — always sorts after the seed.
               // dayIndex 는 여러 날에 걸친 스레드를 실제로 날짜가 다른
               // 시각으로 만든다 — 라벨만 갈라 두면 화면이 하루로 묶는다.
+              //
+              // 스레드**끼리의** 차례는 `daysAgo` 가 정한다. 예전에는
+              // 이 값이 빠져 있어, 목록을 최신순으로 세우면 화면에 뜬
+              // 시각(`오늘 18:18` · `2026-07-30`)과 순서가 어긋났다 —
+              // 3주 전 대화가 오늘 대화보다 위에 설 수 있었다.
+              // 실제 날짜로 옮기지 않고 epoch 안에서 미는 이유는, 런타임
+              // 답장(지금 시각)이 시드 뒤에 온다는 보장을 깨지 않기
+              // 위해서다.
               createdAt: chatEpoch.add(
-                Duration(days: client.chat[i].dayIndex, minutes: i),
+                Duration(
+                  days:
+                      _chatSpreadDays -
+                      client.daysAgo +
+                      client.chat[i].dayIndex,
+                  minutes: i,
+                ),
               ),
             ),
         ]);
@@ -810,6 +824,11 @@ _Chat _lastChat(List<_Chat> chat) {
 /// 화면이 그 자리에 "아직 대화가 없어요" 를 대신 그린다.
 String _lastChatText(List<_Chat> chat) =>
     chat.isEmpty ? '' : _lastChat(chat).text;
+
+/// 시드 대화를 epoch 위에 펼칠 폭(일). `daysAgo` 를 여기서 빼서 자리를
+/// 잡으므로 가장 오래된 스레드(`daysAgo` 21)보다 넉넉해야 한다 — 음수가 되면
+/// epoch 앞으로 넘어가 스레드 차례가 뒤집힌다.
+const int _chatSpreadDays = 40;
 
 /// 목록 오른쪽 위에 뜨는 시각 — 카카오톡과 같은 규칙이다.
 ///

--- a/frontend/flutter_trainer/lib/features/clients/data/dtos/client_dtos.dart
+++ b/frontend/flutter_trainer/lib/features/clients/data/dtos/client_dtos.dart
@@ -97,6 +97,34 @@ List<TrainerClient> prioritizeClients(
   return <TrainerClient>[for (final d in decorated) d.$1];
 }
 
+/// 마지막 메시지가 새로운 순. 메시지 탭 목록의 기본 차례다.
+///
+/// 대화 목록에서 먼저 보여야 하는 것은 **방금 무슨 말이 오갔는가** 다 —
+/// 나트륨이 넘쳤는지는 그 대화를 열지 말지를 정하는 기준이 아니고, 그
+/// 판단이 필요한 사람은 `관리 필요` 로 좁혀 본다([prioritizeClients]).
+///
+/// [lastChatAt] 이 없는 고객은 뒤로 간다(대화가 없다는 뜻이다). 값이 같으면
+/// 들어온 차례를 지킨다 — 정렬이 흔들리면 목록이 매번 다시 배열된다.
+/// 실 API 의 로스터 엔드포인트는 아직 채팅 시각을 주지 않아 그 모드에서는
+/// 들어온 차례 그대로다([prioritizeClients] 와 같은 한계다).
+List<TrainerClient> sortByLatestMessage(
+  List<TrainerClient> clients, {
+  Map<String, DateTime> lastChatAt = const <String, DateTime>{},
+}) {
+  final decorated = <(TrainerClient client, int index)>[
+    for (var i = 0; i < clients.length; i++) (clients[i], i),
+  ];
+  final epoch = DateTime.utc(1970);
+  decorated.sort((a, b) {
+    final chat = (lastChatAt[b.$1.id] ?? epoch).compareTo(
+      lastChatAt[a.$1.id] ?? epoch,
+    );
+    if (chat != 0) return chat;
+    return a.$2.compareTo(b.$2);
+  });
+  return <TrainerClient>[for (final d in decorated) d.$1];
+}
+
 String _str(Object? v) => v is String ? v : '';
 
 String? _nullableStr(Object? v) => v is String && v.isNotEmpty ? v : null;

--- a/frontend/flutter_trainer/lib/features/messages/presentation/pages/messages_page.dart
+++ b/frontend/flutter_trainer/lib/features/messages/presentation/pages/messages_page.dart
@@ -59,10 +59,16 @@ class _MessagesPageState extends ConsumerState<MessagesPage> {
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
-    final clientsAsync = ref.watch(prioritizedClientsProvider);
     final unread =
         ref.watch(unreadCountsProvider).valueOrNull ?? const <String, int>{};
     final filter = _ConversationFilter.parse(widget.filter);
+    // 차례는 필터가 정한다. `전체`·`읽지 않음` 은 대화 목록이므로 **마지막
+    // 말이 새로운 순**이고, `관리 필요` 는 챙길 사람을 고르는 자리이므로
+    // 주의 신호를 앞세운다. 예전에는 어느 필터에서든 나트륨 초과가 맨 위로
+    // 올라와, 방금 답장이 온 고객이 목록 아래에 묻혔다.
+    final clientsAsync = filter == _ConversationFilter.attention
+        ? ref.watch(prioritizedClientsProvider)
+        : ref.watch(recentlyMessagedClientsProvider);
 
     return PageScaffold(
       title: l.navMessages,

--- a/frontend/flutter_trainer/lib/shared/services/client_repository.dart
+++ b/frontend/flutter_trainer/lib/shared/services/client_repository.dart
@@ -8,7 +8,7 @@ import 'package:oncare_trainer/core/storage/app_database.dart';
 import 'package:oncare_trainer/core/utils/clock.dart';
 import 'package:oncare_trainer/core/utils/date_format.dart';
 import 'package:oncare_trainer/features/clients/data/dtos/client_dtos.dart'
-    show prioritizeClients;
+    show prioritizeClients, sortByLatestMessage;
 import 'package:oncare_trainer/features/clients/data/repositories/dio_client_repository.dart';
 import 'package:oncare_trainer/features/clients/domain/entities/client_diet_entry.dart';
 import 'package:oncare_trainer/features/clients/domain/entities/client_exercise_week.dart';
@@ -638,6 +638,24 @@ final prioritizedClientsProvider = Provider<AsyncValue<List<TrainerClient>>>((
       .watch(clientsProvider)
       .whenData((clients) => prioritizeClients(clients, lastChatAt: lastChat));
 });
+
+/// 마지막 메시지가 새로운 순으로 정렬된 로스터 — 메시지 탭 목록이 쓴다.
+///
+/// [prioritizedClientsProvider] 와 나뉘어 있는 이유: 두 화면이 서로 다른
+/// 질문에 답한다. 고객 탭은 "누구를 먼저 챙길까"(주의 신호 우선), 메시지
+/// 탭은 "방금 무슨 말이 오갔나"(최신순)다. 한 provider 를 돌려 쓰면 둘 중
+/// 하나는 자기 화면과 맞지 않는 차례를 보게 된다.
+final recentlyMessagedClientsProvider =
+    Provider<AsyncValue<List<TrainerClient>>>((ref) {
+      final lastChat =
+          ref.watch(lastChatAtProvider).valueOrNull ??
+          const <String, DateTime>{};
+      return ref
+          .watch(clientsProvider)
+          .whenData(
+            (clients) => sortByLatestMessage(clients, lastChatAt: lastChat),
+          );
+    });
 
 /// Streams the last chat time per client (priority tiebreak).
 final lastChatAtProvider = StreamProvider<Map<String, DateTime>>((ref) {

--- a/frontend/flutter_trainer/test/features/clients/client_detail_diet_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_diet_test.dart
@@ -175,13 +175,14 @@ void main() {
         )
         .first;
 
-    Future<void> openDiet(WidgetTester tester, String clientName) async {
-      await pumpTrainerApp(
-        tester,
-        token: 'demo-trainer-token',
-        at: AppRoutes.clientDetail(seedClientIds[clientName]!, section: 'diet'),
-      );
-    }
+    Future<ProviderContainer> openDiet(
+      WidgetTester tester,
+      String clientName,
+    ) => pumpTrainerApp(
+      tester,
+      token: 'demo-trainer-token',
+      at: AppRoutes.clientDetail(seedClientIds[clientName]!, section: 'diet'),
+    );
 
     testWidgets('a failed diet retries in place on a narrow viewport', (
       tester,
@@ -254,8 +255,7 @@ void main() {
               )
               .any(
                 (box) =>
-                    box.color ==
-                    AppColors.statusNormal.withValues(alpha: 0.65),
+                    box.color == AppColors.statusNormal.withValues(alpha: 0.65),
               ),
           isTrue,
           reason: '$label 그래프가 정상 초록을 써야 합니다.',
@@ -444,7 +444,7 @@ void main() {
     testWidgets('AI 코멘트가 기간을 따라 바뀐다 (#1017)', (tester) async {
       // 오늘 하루만 보고 쓴 문장을 이번 주 그래프 아래 그대로 두면, 화면과
       // 조언이 서로 다른 기간을 말한다.
-      await openDiet(tester, '김민수');
+      final container = await openDiet(tester, '김민수');
       await tester.scrollUntilVisible(
         find.textContaining('나트륨이 목표치를'),
         150,
@@ -454,12 +454,25 @@ void main() {
       await tester.tap(find.byKey(const Key('client-period-week')));
       await tester.pumpAndSettle();
 
+      // 이번 주 며칠이 넘었는지는 실행한 요일마다 달라진다 — 시드가 오늘까지만
+      // 채우기 때문이다(#826 과 같은 종류). 고정된 "2일" 을 기대하면 코드를
+      // 건드리지 않아도 요일에 따라 깨진다. `sodiumOverDays` 는 위젯이 읽는
+      // 것과 같은 이번 주 계열에서 나온 값이라, 실행한 날과 무관하게 맞는
+      // 문장을 고를 수 있다.
+      final minsu = container
+          .read(clientsProvider)
+          .value!
+          .firstWhere((c) => c.id == 'seed-client-1');
+      final over = minsu.sodiumOverDays;
+      final expectedText = over >= 3
+          ? '이번 주 $over일이나 나트륨 권장량을 넘었어요'
+          : over > 0
+          ? '이번 주 $over일만 권장량을 넘었어요'
+          : '이번 주 내내 나트륨을 권장량 안에서 지켰어요';
+
       // 오늘 문장은 사라지고, 그 자리에 이번 주를 읽은 문장이 온다.
       expect(find.textContaining('나트륨이 목표치를'), findsNothing);
-      expect(
-        find.textContaining('이번 주 2일만 권장량을 넘었어요'),
-        findsOneWidget,
-      );
+      expect(find.textContaining(expectedText), findsOneWidget);
     });
 
     testWidgets('이지수 (sodium under target) shows the balanced AI comment', (

--- a/frontend/flutter_trainer/test/features/clients/clients_page_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/clients_page_test.dart
@@ -40,6 +40,25 @@ class _RecordingRefreshClientRepository extends DriftClientRepository
   }
 }
 
+/// 로스터 목록을 [finder] 가 그려질 때까지 끌어 내린다.
+///
+/// 목록은 지연 생성이라 화면 밖 카드가 트리에 아예 없다. 아래쪽에 선 고객을
+/// 단언하려면 먼저 그려지게 해야 한다 — `.last`·`.first` 를 붙인 finder 를
+/// 그대로 넘기면 아직 한 건도 없는 동안 `Bad state: No element` 로 깨진다.
+Future<void> scrollToClient(
+  WidgetTester tester,
+  Finder finder,
+) => tester.scrollUntilVisible(
+  finder,
+  150,
+  scrollable: find
+      .byWidgetPredicate(
+        (widget) =>
+            widget is Scrollable && widget.axisDirection == AxisDirection.down,
+      )
+      .first,
+);
+
 void main() {
   group('ClientRepository', () {
     late AppDatabase db;
@@ -335,24 +354,17 @@ void main() {
 
       // Priority order: sodium-over clients come first, so a client who
       // is under target is further down a now-long, lazily built list.
+      // 같은 신호를 든 고객끼리는 마지막 대화가 새로운 쪽이 앞이라, 사흘 전
+      // 대화가 마지막인 박성호는 첫 화면 아래에 선다.
       expect(find.text('김민수'), findsOneWidget);
-      expect(find.text('박성호'), findsOneWidget);
       expect(
         find.byKey(const ValueKey<String>('clients-roster-search')),
         findsNothing,
       );
       expect(find.byType(ClientSearchBar), findsOneWidget);
-      await tester.scrollUntilVisible(
-        find.text('이지수'),
-        150,
-        scrollable: find
-            .byWidgetPredicate(
-              (widget) =>
-                  widget is Scrollable &&
-                  widget.axisDirection == AxisDirection.down,
-            )
-            .first,
-      );
+      await scrollToClient(tester, find.text('박성호'));
+      expect(find.text('박성호'), findsOneWidget);
+      await scrollToClient(tester, find.text('이지수'));
       expect(find.text('이지수'), findsWidgets);
     });
 
@@ -378,6 +390,7 @@ void main() {
         at: AppRoutes.clients,
       );
 
+      await scrollToClient(tester, find.text('박성호'));
       final sunghoCard = find.ancestor(
         of: find.text('박성호'),
         matching: find.byType(ClientCard),
@@ -525,17 +538,7 @@ void main() {
       final clientCard = find.byKey(
         const ValueKey<String>('client-seed-client-3'),
       );
-      await tester.scrollUntilVisible(
-        clientCard.last,
-        150,
-        scrollable: find
-            .byWidgetPredicate(
-              (widget) =>
-                  widget is Scrollable &&
-                  widget.axisDirection == AxisDirection.down,
-            )
-            .first,
-      );
+      await scrollToClient(tester, clientCard);
       expect(find.text('신규 고객'), findsNothing);
 
       await tester.tap(clientCard.last);

--- a/frontend/flutter_trainer/test/features/messages/messages_page_test.dart
+++ b/frontend/flutter_trainer/test/features/messages/messages_page_test.dart
@@ -81,7 +81,10 @@ void main() {
   testWidgets('conversation list keeps unread and status information', (
     tester,
   ) async {
-    await withWideSurface(tester, () async {
+    // 목록이 최신순이라 박성호는 아래쪽에 선다. 기본 높이로는 지연 생성
+    // 목록이 그를 만들지 않아, `findsNothing` 단언이 화면 밖이라는 이유로
+    // 통과해 버린다 - 목록 전체가 한 화면에 들어오는 높이로 띄운다.
+    await withWideSurface(tester, size: const Size(1440, 2200), () async {
       // 박성호의 배지는 요일에 따라 뒤집힌다. 시드가 주간 계열을 오늘까지만
       // 채우므로, 화요일에는 그 주에 기록된 날이 33% 하루뿐이라 이행률 저조가
       // 나트륨 초과보다 급한 신호가 된다. 주가 끝난 일요일로 고정해 어느 날

--- a/frontend/flutter_trainer/test/features/messages/messages_page_test.dart
+++ b/frontend/flutter_trainer/test/features/messages/messages_page_test.dart
@@ -277,6 +277,43 @@ void main() {
     });
   });
 
+  testWidgets('전체는 마지막 말이 새로운 순, 관리 필요만 주의 우선', (tester) async {
+    // 두 대화의 세로 자리를 재는 단언이라 둘 다 그려져 있어야 한다 -
+    // 지연 생성 목록이 화면 밖 대화를 만들지 않으므로 목록 전체가 들어오는
+    // 높이로 띄운다.
+    await withWideSurface(tester, size: const Size(1440, 2200), () async {
+      await pumpTrainerApp(
+        tester,
+        token: 'demo-trainer-token-existing',
+        seedClock: DateTime(2026, 8, 16), // 일요일 — 배지 우선순위 고정
+      );
+
+      double topOf(String id) => tester
+          .getTopLeft(find.byKey(ValueKey<String>('messages-conversation-$id')))
+          .dy;
+
+      // `전체` 는 대화 목록이다 — 방금 말이 오간 순서로 선다. 노태강은
+      // 오늘, 박성호는 사흘 전에 마지막 말이 오갔다. 예전에는 어느
+      // 필터에서든 나트륨이 넘친 박성호가 위로 올라와, 방금 답장이 온
+      // 고객이 목록 아래에 묻혔다.
+      await goTo(tester, AppRoutes.messages);
+      expect(topOf('seed-client-13'), lessThan(topOf('seed-client-3')));
+
+      // `관리 필요` 는 챙길 사람을 고르는 자리다 — 주의 신호가 앞선다.
+      // 노태강은 신호가 없어 목록에서 아예 빠진다.
+      await goTo(tester, AppRoutes.messagesFor(null, filter: 'attention'));
+      expect(
+        find.byKey(
+          const ValueKey<String>('messages-conversation-seed-client-13'),
+        ),
+        findsNothing,
+      );
+      // 나트륨이 넘친 박성호는 이행률만 낮은 고객보다 위다 — 사흘 전
+      // 대화인데도. 최신순이었다면 반대로 섰다.
+      expect(topOf('seed-client-3'), lessThan(topOf('seed-client-12')));
+    });
+  });
+
   testWidgets('client query keeps the selected member in the thread', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary

* 메시지 탭 대화 목록을 고객 탭과 같은 `prioritizeClients`(주의 신호 우선) 대신, 마지막 메시지가 새로운 순으로 정렬한다.
* `전체`·`읽지 않음` 필터는 최신순(`sortByLatestMessage`), `관리 필요` 필터만 지금처럼 주의 신호 우선을 유지한다.
* 시드 스레드끼리의 차례를 `daysAgo` 로 잡아, 화면에 뜬 시각과 목록 순서가 어긋나지 않게 한다.

---

## Changes

### 🔧 Improvements

* 대화 목록 정렬 기준을 화면(고객 탭 vs 메시지 탭)이 답해야 하는 질문에 맞춰 분리(`recentlyMessagedClientsProvider` 추가)

### 🐛 Fixes

* 어느 필터에서든 나트륨·당류 초과 고객이 맨 위로 올라와 방금 답장 온 고객이 목록 아래에 묻히던 문제 수정

---

## Commits

1. `6b1e1873` fix(messages): 메시지 탭 목록을 마지막 말이 새로운 순으로
2. `631acb92` test(messages): 최신순 목록에서 화면 밖 카드까지 확인하도록

---

## Notes

* `lastChatAtProvider` 를 그대로 재사용해 마지막 메시지 시각을 얻는다 — 실 API 로스터 엔드포인트가 아직 채팅 시각을 주지 않는 한계는 `prioritizedClientsProvider` 와 같다.
* 최신순으로 목록이 바뀌면서 지연 생성 목록의 아래쪽 카드를 검증하는 테스트 2건이 기본 테스트 표면 높이에서 카드가 그려지지 않아 실패했다 — 목록 전체가 들어오는 높이로 띄우거나 스크롤해 그려지게 고쳤다.

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 빌드 성공
* [x] 관련 테스트 통과 (`flutter test` 945/945 — 무관한 날짜 의존 테스트 1건은 `origin/main` 에서도 재현됨)

### Manual Test Steps

1. 메시지 탭 `전체` 필터에서 오늘 답장한 고객이 목록 맨 위, 사흘 전 대화한 고객이 아래에 서는지 확인
2. `관리 필요` 필터에서 나트륨 초과 고객이 이행률 저조 고객보다 위에 서는지 확인(대화 시각과 무관하게)

---

## Related Issues

Closes #1074

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인
