### PR TITLE
fix(schedule): 시간표 현재 시각 선을 세션 블록 앞으로

### DIFF
--- a/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/schedule_week_timetable.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/schedule_week_timetable.dart
@@ -420,13 +420,6 @@ class _DayColumn extends StatelessWidget {
                   right: 0,
                   child: const Divider(height: 1, color: AppColors.border),
                 ),
-              // 오늘 열에만 현재 시각 선을 얹는다. 위치를 정하는 시각은 선
-              // 안에서 읽는다 — 여기서 읽으면 1분마다 이 열이 통째로 다시
-              // 그려지고, 그 안의 세션 블록까지 따라 온다(#1006).
-              if (isToday)
-                Positioned.fill(
-                  child: _NowLine(window: window, hourHeight: hourHeight),
-                ),
               for (final p in placed)
                 Positioned(
                   top:
@@ -459,6 +452,17 @@ class _DayColumn extends StatelessWidget {
                     selected: p.session.id == selectedSessionId,
                     onTap: () => onPickSession(p.session),
                   ),
+                ),
+              // 오늘 열에만 현재 시각 선을 얹는다. 위치를 정하는 시각은 선
+              // 안에서 읽는다 — 여기서 읽으면 1분마다 이 열이 통째로 다시
+              // 그려지고, 그 안의 세션 블록까지 따라 온다(#1006).
+              //
+              // 세션 블록 **뒤에** 둔다 — `Stack` 은 나중에 그려지는 자식이
+              // 위에 앉는다. 블록보다 먼저 그렸을 때는 그 시간대에 일정이
+              // 있으면 선이 블록에 가려 카드 안쪽에서 보이지 않았다(#1081).
+              if (isToday)
+                Positioned.fill(
+                  child: _NowLine(window: window, hourHeight: hourHeight),
                 ),
             ],
           );


### PR DESCRIPTION
## Summary

* 시간표의 현재 시각 선(`_NowLine`, #1006)이 세션 블록보다 뒤에 그려져, 지금 시각이 일정과 겹치는 시간대에 있으면 블록에 가려 보이지 않았다.
* `Stack` 안에서 `_NowLine`을 세션 블록들 뒤로 옮겨 항상 맨 위에 그려지게 한다.

---

## Changes

### 🐛 Fixes

* 현재 시각 선을 세션 블록 뒤(위)로 이동 — z-order만 바뀌고 동작(`IgnorePointer`)은 그대로.

---

## Commits

1. `e1196e05` fix(schedule): 시간표 현재 시각 선을 세션 블록 앞으로

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] UI 확인
* [x] 빌드 성공
* [x] 관련 테스트 통과 (`schedule_now_line_test.dart` 포함 128건)

### Manual Test Steps

1. 오늘 시간표에 지금 시각과 겹치는 일정을 만든다.
2. 빨간 선이 그 블록 카드 위로 온전히 그려지는지 확인한다.
3. 그 시간대를 눌러 여전히 아래 세션이 열리는지 확인한다(탭 가로채기 없음).

---

## Related Issues

Closes #1081

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인
