### PR TITLE
fix(demo): 메시지 정렬 수정에 맞춰 시드 플래그 버전 상향

### DIFF
--- a/frontend/flutter_trainer/lib/core/storage/seed_data.dart
+++ b/frontend/flutter_trainer/lib/core/storage/seed_data.dart
@@ -14,7 +14,7 @@ part 'seed_clients.dart';
 
 /// Idempotent seeder for the trainer app's local DB. Runs at bootstrap.
 ///
-/// **Flag.** `AppKeyValues['trainer_seeded_v19']` stores the date string
+/// **Flag.** `AppKeyValues['trainer_seeded_v20']` stores the date string
 /// (`YYYY-MM-DD`) the seed last ran with. Bump the version suffix
 /// whenever the seeded *content* changes — otherwise a browser that
 /// already seeded today keeps the old data until the date rolls over.
@@ -84,7 +84,7 @@ Future<void> seedIfEmpty(
   // 주간 계열을 요일 자리에 놓기 위한 오늘의 인덱스(월=0).
   final todayIndex = now.weekday - 1;
 
-  if (await db.readValue('trainer_seeded_v19') == today) return;
+  if (await db.readValue('trainer_seeded_v20') == today) return;
 
   // 김민수의 하루는 픽스처가 정한다 — 이 앱은 날짜에 붙여 저장하기만 한다(#757).
   final _FixtureClient fixtureClient = _FixtureClient(
@@ -347,7 +347,7 @@ Future<void> seedIfEmpty(
     });
 
     // ---- Mark seeded (inside the txn so it commits atomically) ----
-    await db.putValue('trainer_seeded_v19', today);
+    await db.putValue('trainer_seeded_v20', today);
   });
 }
 

--- a/frontend/flutter_trainer/test/core/storage/seed_data_test.dart
+++ b/frontend/flutter_trainer/test/core/storage/seed_data_test.dart
@@ -63,7 +63,7 @@ void main() {
       }
 
       expect(await db.select(db.clientChatMessages).get(), isNotEmpty);
-      expect(await db.readValue('trainer_seeded_v19'), _todayString());
+      expect(await db.readValue('trainer_seeded_v20'), _todayString());
     });
 
     test(
@@ -295,13 +295,13 @@ void main() {
 
     test('stale flag (different date) re-seeds schedule onto today', () async {
       await seedIfEmpty(db);
-      await db.putValue('trainer_seeded_v19', '2020-01-01');
+      await db.putValue('trainer_seeded_v20', '2020-01-01');
 
       await seedIfEmpty(db);
 
       final schedule = await db.select(db.trainerScheduleEntries).get();
       expect(schedule.every((s) => s.date == _todayString()), isTrue);
-      expect(await db.readValue('trainer_seeded_v19'), _todayString());
+      expect(await db.readValue('trainer_seeded_v20'), _todayString());
     });
 
     test(
@@ -424,7 +424,7 @@ void main() {
         expect(week.length, 7);
         expect(week.any((v) => (v as num) > 0), isTrue);
 
-        expect(await db.readValue('trainer_seeded_v19'), today);
+        expect(await db.readValue('trainer_seeded_v20'), today);
       },
     );
 
@@ -533,7 +533,7 @@ void main() {
           );
 
       // Force a re-seed.
-      await db.putValue('trainer_seeded_v19', '2020-01-01');
+      await db.putValue('trainer_seeded_v20', '2020-01-01');
       await seedIfEmpty(db);
 
       final chat = await db.select(db.clientChatMessages).get();


### PR DESCRIPTION
## Summary

* #1074(메시지 탭 최신순 정렬)가 시드의 채팅 시각 계산(`_chatSpreadDays`)도 함께 고쳤는데 `trainer_seeded_v19` 재시딩 캐시 플래그를 올리지 않았다.
* `seedIfEmpty`는 같은 날 두 번 심지 않으므로, 오늘 이미 데모를 연 브라우저는 날짜가 바뀔 때까지 고치기 전의 채팅 시각을 그대로 들고 있었다 — 정렬 코드는 배포에 반영돼 있는데 그 코드가 읽는 시각 값 자체가 옛것이었다.

---

## Changes

### 🐛 Fixes

* `trainer_seeded_v19` → `trainer_seeded_v20`

---

## Commits

1. `9767ddfa` fix(demo): 메시지 정렬 수정에 맞춰 시드 플래그 버전 상향

---

## Test Plan

* [x] 관련 테스트 통과(`seed_data_test.dart` 포함 트레이너 앱 전체 970건)

### Manual Test Steps

1. 배포된 사이트에서 로컬 스토리지/IndexedDB를 지우거나 날짜가 바뀐 뒤 다시 연다.
2. 메시지 탭 `전체` 필터가 최신 대화 순으로 서는지 확인한다.

---

## Related Issues

Closes #1082

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인
