### PR TITLE
fix(messages): 메시지 탭 전체·읽지 않음 필터 최신순 정렬 반영

### DIFF
--- a/frontend/flutter_trainer/lib/features/clients/data/dtos/client_dtos.dart
+++ b/frontend/flutter_trainer/lib/features/clients/data/dtos/client_dtos.dart
@@ -97,6 +97,30 @@ List<TrainerClient> prioritizeClients(
   return <TrainerClient>[for (final d in decorated) d.$1];
 }
 
+/// Orders the roster by recency alone: who spoke most recently first,
+/// regardless of date — a chat from this morning still outranks one from
+/// three days ago. Clients with no chat signal keep the server order at
+/// the bottom. Used by the 대화 목록 for the `전체`/`읽지 않음` filters,
+/// where "무슨 말이 방금 오갔는가" is the only ordering signal — unlike
+/// [prioritizeClients], which the `관리 필요` filter and 고객 탭 use.
+List<TrainerClient> sortByLatestMessage(
+  List<TrainerClient> clients, {
+  Map<String, DateTime> lastChatAt = const <String, DateTime>{},
+}) {
+  final decorated = <(TrainerClient client, int index)>[
+    for (var i = 0; i < clients.length; i++) (clients[i], i),
+  ];
+  final epoch = DateTime.utc(1970);
+  decorated.sort((a, b) {
+    final chat = (lastChatAt[b.$1.id] ?? epoch).compareTo(
+      lastChatAt[a.$1.id] ?? epoch,
+    );
+    if (chat != 0) return chat;
+    return a.$2.compareTo(b.$2);
+  });
+  return <TrainerClient>[for (final d in decorated) d.$1];
+}
+
 String _str(Object? v) => v is String ? v : '';
 
 String? _nullableStr(Object? v) => v is String && v.isNotEmpty ? v : null;

--- a/frontend/flutter_trainer/lib/features/messages/presentation/pages/messages_page.dart
+++ b/frontend/flutter_trainer/lib/features/messages/presentation/pages/messages_page.dart
@@ -59,10 +59,14 @@ class _MessagesPageState extends ConsumerState<MessagesPage> {
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
-    final clientsAsync = ref.watch(prioritizedClientsProvider);
+    final filter = _ConversationFilter.parse(widget.filter);
+    // `관리 필요`는 지금처럼 나트륨 초과 등 주의 신호를 우선한다. 나머지
+    // 필터는 대화 목록이니 "누가 방금 말했는가"만으로 줄을 세운다(#1074).
+    final clientsAsync = filter == _ConversationFilter.attention
+        ? ref.watch(prioritizedClientsProvider)
+        : ref.watch(latestMessageClientsProvider);
     final unread =
         ref.watch(unreadCountsProvider).valueOrNull ?? const <String, int>{};
-    final filter = _ConversationFilter.parse(widget.filter);
 
     return PageScaffold(
       title: l.navMessages,

--- a/frontend/flutter_trainer/lib/shared/services/client_repository.dart
+++ b/frontend/flutter_trainer/lib/shared/services/client_repository.dart
@@ -8,7 +8,7 @@ import 'package:oncare_trainer/core/storage/app_database.dart';
 import 'package:oncare_trainer/core/utils/clock.dart';
 import 'package:oncare_trainer/core/utils/date_format.dart';
 import 'package:oncare_trainer/features/clients/data/dtos/client_dtos.dart'
-    show prioritizeClients;
+    show prioritizeClients, sortByLatestMessage;
 import 'package:oncare_trainer/features/clients/data/repositories/dio_client_repository.dart';
 import 'package:oncare_trainer/features/clients/domain/entities/client_diet_entry.dart';
 import 'package:oncare_trainer/features/clients/domain/entities/client_exercise_week.dart';
@@ -637,6 +637,21 @@ final prioritizedClientsProvider = Provider<AsyncValue<List<TrainerClient>>>((
   return ref
       .watch(clientsProvider)
       .whenData((clients) => prioritizeClients(clients, lastChatAt: lastChat));
+});
+
+/// Streams the roster ordered by recency alone — who spoke most recently
+/// first. For 메시지 탭's `전체`/`읽지 않음` filters, where the ordering
+/// question is "누가 방금 말했는가", not coaching priority(#1074).
+final latestMessageClientsProvider = Provider<AsyncValue<List<TrainerClient>>>((
+  ref,
+) {
+  final lastChat =
+      ref.watch(lastChatAtProvider).valueOrNull ?? const <String, DateTime>{};
+  return ref
+      .watch(clientsProvider)
+      .whenData(
+        (clients) => sortByLatestMessage(clients, lastChatAt: lastChat),
+      );
 });
 
 /// Streams the last chat time per client (priority tiebreak).

--- a/frontend/flutter_trainer/test/features/clients/client_dtos_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_dtos_test.dart
@@ -213,6 +213,62 @@ void main() {
     });
   });
 
+  group('sortByLatestMessage', () {
+    test('orders by most recent chat regardless of coaching priority', () {
+      final ordered = sortByLatestMessage(
+        <TrainerClient>[
+          _client('a', sodiumMg: 2500), // over target, but spoke earliest
+          _client('b', sodiumMg: 100),
+          _client('c', sodiumMg: 100),
+        ],
+        lastChatAt: <String, DateTime>{
+          'a': DateTime.utc(2026, 8, 20, 9),
+          'b': DateTime.utc(2026, 8, 22, 20, 10),
+          'c': DateTime.utc(2026, 8, 22, 18, 18),
+        },
+      );
+
+      expect(ordered.map((c) => c.id).toList(), <String>['b', 'c', 'a']);
+    });
+
+    test('breaks ties across different dates, not just time-of-day', () {
+      // 'today' 가 어제보다 이르게 읽히면 하루 넘어간 두 대화 사이
+      // 순서가 뒤집힌다 — 전체 타임스탬프로 비교해야 한다.
+      final ordered = sortByLatestMessage(
+        <TrainerClient>[
+          _client('yesterday-late', sodiumMg: 0),
+          _client('today-early', sodiumMg: 0),
+        ],
+        lastChatAt: <String, DateTime>{
+          'yesterday-late': DateTime.utc(2026, 8, 21, 23, 50),
+          'today-early': DateTime.utc(2026, 8, 22, 0, 5),
+        },
+      );
+
+      expect(ordered.map((c) => c.id).toList(), <String>[
+        'today-early',
+        'yesterday-late',
+      ]);
+    });
+
+    test('clients with no chat signal keep server order at the bottom', () {
+      final ordered = sortByLatestMessage(
+        <TrainerClient>[
+          _client('quiet-first', sodiumMg: 0),
+          _client('spoke', sodiumMg: 0),
+          _client('quiet-second', sodiumMg: 0),
+        ],
+        lastChatAt: <String, DateTime>{'spoke': DateTime.utc(2026, 8, 22, 9)},
+      );
+
+      expect(ordered.map((c) => c.id).toList(), <String>[
+        'spoke',
+        'quiet-first',
+        'quiet-second',
+      ]);
+    });
+  });
+
   group('sugar warning threshold', () {
     test('keeps the existing strict greater-than rule for decimal values', () {
       expect(

--- a/frontend/flutter_trainer/test/features/messages/messages_page_test.dart
+++ b/frontend/flutter_trainer/test/features/messages/messages_page_test.dart
@@ -184,6 +184,96 @@ void main() {
     });
   });
 
+  testWidgets('전체 필터는 나트륨 초과가 아니라 최신 대화 순으로 정렬한다 (#1074)', (tester) async {
+    await withWideSurface(tester, () async {
+      // 나트륨 초과인 'over'가 가장 먼저 심어졌지만 가장 늦게 말했고,
+      // 'yesterday'는 그제였지만 'today-early'보다 늦은 시각(어제 밤)에
+      // 말했다 — 날짜가 갈려도 전체 타임스탬프로 비교해야 한다.
+      await pumpTrainerApp(
+        tester,
+        token: 'demo-trainer-token-existing',
+        extraOverrides: <Override>[
+          clientsProvider.overrideWith(
+            (ref) => Stream<List<TrainerClient>>.value(<TrainerClient>[
+              const TrainerClient(
+                id: 'over',
+                name: '나트륨과다',
+                avatar: '나',
+                goal: '',
+                lastMessage: '옛날 메시지',
+                lastTime: '-',
+                active: true,
+                calories: 0,
+                sodiumMg: 2500,
+                sugarG: 0,
+                lastRoutine: '-',
+                weekCompletion: <int>[],
+                sodiumWeek: <int>[],
+              ),
+              const TrainerClient(
+                id: 'today-early',
+                name: '오늘아침',
+                avatar: '오',
+                goal: '',
+                lastMessage: '방금 메시지',
+                lastTime: '-',
+                active: true,
+                calories: 0,
+                sodiumMg: 100,
+                sugarG: 0,
+                lastRoutine: '-',
+                weekCompletion: <int>[],
+                sodiumWeek: <int>[],
+              ),
+              const TrainerClient(
+                id: 'yesterday-late',
+                name: '어제밤',
+                avatar: '어',
+                goal: '',
+                lastMessage: '어제 늦은 메시지',
+                lastTime: '-',
+                active: true,
+                calories: 0,
+                sodiumMg: 100,
+                sugarG: 0,
+                lastRoutine: '-',
+                weekCompletion: <int>[],
+                sodiumWeek: <int>[],
+              ),
+            ]),
+          ),
+          lastChatAtProvider.overrideWith(
+            (ref) => Stream<Map<String, DateTime>>.value(<String, DateTime>{
+              'over': DateTime.utc(2026, 8, 18, 9),
+              'today-early': DateTime.utc(2026, 8, 22, 0, 5),
+              'yesterday-late': DateTime.utc(2026, 8, 21, 23, 50),
+            }),
+          ),
+        ],
+      );
+      await goTo(tester, AppRoutes.messages);
+
+      // 화면에 그려진 실제 순서를 위→아래로 읽는다.
+      const order = <String>['over', 'today-early', 'yesterday-late'];
+      final positions = <String, double>{
+        for (final id in order)
+          id: tester
+              .getTopLeft(
+                find.byKey(ValueKey<String>('messages-conversation-$id')),
+              )
+              .dy,
+      };
+      final sortedByPosition = order.toList()
+        ..sort((a, b) => positions[a]!.compareTo(positions[b]!));
+
+      expect(sortedByPosition, <String>[
+        'today-early',
+        'yesterday-late',
+        'over',
+      ]);
+    });
+  });
+
   testWidgets(
     'narrowest desktop split keeps message and time without overflow',
     (tester) async {


### PR DESCRIPTION
## Summary

* 메시지 탭의 `전체`·`읽지 않음` 필터가 필터와 무관하게 항상 나트륨 초과 우선(`prioritizeClients`)으로 정렬되던 문제 수정
* `전체`·`읽지 않음`은 마지막 대화 시각 기준 최신순, `관리 필요`는 기존 주의 신호 우선 정렬을 유지

---

## Changes

### 🐛 Fixes

* `sortByLatestMessage` 순수 함수 추가 — 전체 타임스탬프 기준 최신순 정렬(날짜가 달라도 올바르게 비교)
* `latestMessageClientsProvider` 추가, `messages_page.dart`가 필터에 따라 `prioritizedClientsProvider`/`latestMessageClientsProvider`를 골라 쓰도록 수정

---

## Commits

1. `92aec4e2` fix(messages): 전체·읽지 않음 필터가 최신 대화순으로 정렬되도록 반영

---

## Notes

* #1074(6b1e1873)가 이 정렬 분기를 의도했다고 커밋 메시지에 적어 두었지만, `sortByLatestMessage` 함수 자체가 코드에 없어 실제로는 반영되지 않은 채 병합되어 있었다. 배포 화면에서 재현 확인함(전체 필터에서 18:18, 20:10, 14:31, 16:48, 13:25, 11:49 순으로 뒤섞여 나타남).

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인 (날짜가 다른 대화끼리도 전체 타임스탬프로 정렬되는지 단위 테스트로 확인)
* [x] UI 확인 (위젯 테스트로 화면에 그려진 순서까지 확인)
* [x] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 트레이너 웹 메시지 탭 → `전체` 필터 → 대화가 마지막 메시지 시각 기준 최신순인지 확인
2. `관리 필요` 필터로 전환 → 나트륨 초과 등 주의 신호가 있는 고객이 우선인지 확인

---

## Related Issues

Closes #1087

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인