### PR TITLE
fix(chart): 사용자·트레이너 앱 전 그래프의 목표선 라벨 위치와 형식 통일

### DIFF
--- a/frontend/flutter/lib/design_system/charts/goal_line.dart
+++ b/frontend/flutter/lib/design_system/charts/goal_line.dart
@@ -42,46 +42,20 @@ class ChartGoalLine {
       );
     }
   }
-
-  /// 선 위에 붙는 `목표 N` 라벨을 그린다. 오른쪽 끝에 붙이고, 선 위로 띄운다 —
-  /// 아래에 두면 목표에 가까운 막대의 꼭대기와 겹친다.
-  static void paintLabel(
-    Canvas canvas, {
-    required double y,
-    required double right,
-    required String text,
-    required TextDirection textDirection,
-  }) {
-    final TextPainter tp = TextPainter(
-      text: TextSpan(
-        text: text,
-        style: const TextStyle(
-          fontSize: labelFontSize,
-          height: 1.2,
-          fontWeight: FontWeight.w600,
-          color: color,
-        ),
-      ),
-      textDirection: textDirection,
-    )..layout();
-    tp.paint(canvas, Offset(right - tp.width, y - tp.height - 2));
-  }
 }
 
 /// Stack 위에 얹는 목표선. 막대를 위젯으로 그리는 그래프(식단 기간 뷰)가 쓴다.
 ///
 /// [bottom] 은 그래프 바닥에서 목표선까지의 거리다 — 호출부가 자기 축 계산으로
 /// 넘긴다. 목표가 축 밖이면(0 이하거나 최댓값을 넘으면) 아무것도 그리지 않는다.
+///
+/// **선만 긋는다.** 목표치는 그래프 왼쪽 [ChartGoalAxis] 칸이 적는다 — 선 위
+/// 오른쪽 끝에 얹던 시절에는 그래프마다 라벨이 다른 자리에 앉았고, 목표 근처의
+/// 막대 꼭대기와 겹쳤다. (#1071)
 class GoalLineOverlay extends StatelessWidget {
-  const GoalLineOverlay({
-    super.key,
-    required this.bottom,
-    required this.label,
-    this.visible = true,
-  });
+  const GoalLineOverlay({super.key, required this.bottom, this.visible = true});
 
   final double bottom;
-  final String label;
   final bool visible;
 
   @override
@@ -91,50 +65,111 @@ class GoalLineOverlay extends StatelessWidget {
       left: 0,
       right: 0,
       bottom: bottom,
-      child: CustomPaint(
-        painter: _GoalLinePainter(
-          label: label,
-          textDirection: Directionality.of(context),
-          textScaler: MediaQuery.textScalerOf(context),
+      child: const IgnorePointer(
+        child: CustomPaint(
+          painter: _GoalLinePainter(),
+          // 선 자체는 높이가 없다. 칸만 잡아 둔다.
+          child: SizedBox(height: 0, width: double.infinity),
         ),
-        // 선 자체는 높이가 없다. 라벨이 선 위로 올라가야 해서 칸만 잡아 둔다.
-        child: const SizedBox(height: 0, width: double.infinity),
       ),
     );
   }
 }
 
 class _GoalLinePainter extends CustomPainter {
-  const _GoalLinePainter({
-    required this.label,
-    required this.textDirection,
-    required this.textScaler,
-  });
-
-  final String label;
-  final TextDirection textDirection;
-  final TextScaler textScaler;
+  const _GoalLinePainter();
 
   @override
   void paint(Canvas canvas, Size size) {
     ChartGoalLine.paint(canvas, y: 0, left: 0, right: size.width);
-    final TextPainter tp = TextPainter(
-      text: TextSpan(
-        text: label,
-        style: const TextStyle(
-          fontSize: ChartGoalLine.labelFontSize,
-          height: 1.2,
-          fontWeight: FontWeight.w600,
-          color: ChartGoalLine.color,
-        ),
-      ),
-      textDirection: textDirection,
-      textScaler: textScaler,
-    )..layout();
-    tp.paint(canvas, Offset(size.width - tp.width, -tp.height - 2));
   }
 
   @override
-  bool shouldRepaint(_GoalLinePainter old) =>
-      old.label != label || old.textScaler != textScaler;
+  bool shouldRepaint(_GoalLinePainter old) => false;
 }
+
+/// 그래프 왼쪽의 목표치 칸. **모든 그래프가 이 칸 하나로 목표치를 적는다.**
+///
+/// 홈 탭 식단 영양 그래프가 쓰던 배치를 그대로 옮겼다 — 폭은 눈금 라벨이 쓰던
+/// 38(글씨 배율을 따라간다), 라벨은 목표선 높이에 맞춰 오른쪽 정렬 두 줄
+/// (`목표` / 목표치)로 앉는다. 한 줄로 두면 칸이 넓어져야 하는데, 그러면 360px
+/// 영어 로케일에서 축 라벨 줄이 넘친다. (#1004, #1071)
+///
+/// 목표가 없어도 칸은 자리를 지킨다 — 지표를 바꿀 때 그래프 폭이 흔들리지
+/// 않게 하려는 것이다.
+class ChartGoalAxis extends StatelessWidget {
+  const ChartGoalAxis({
+    super.key,
+    required this.height,
+    this.label,
+    this.lineBottom,
+    this.style = defaultStyle,
+  });
+
+  /// 그래프(막대·꺾은선)가 그려지는 높이. 축 라벨 줄은 뺀 값이다.
+  final double height;
+
+  /// 두 줄 라벨 — 첫 줄 `목표`, 둘째 줄 목표치. null 이면 칸만 지킨다.
+  final String? label;
+
+  /// 그래프 바닥에서 목표선까지의 거리. null 이면 라벨을 앉히지 않는다.
+  final double? lineBottom;
+
+  /// 글씨 모양. 자리와 두 줄 구성은 모든 그래프가 같지만, 색·굵기는 각 화면이
+  /// 쓰던 값을 그대로 둔다. (#1071)
+  final TextStyle style;
+
+  static const TextStyle defaultStyle = TextStyle(
+    fontSize: ChartGoalLine.labelFontSize,
+    height: 1.35,
+    fontWeight: FontWeight.w600,
+    color: ChartGoalLine.color,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    // 칸도 글씨 배율을 따라간다 (#1004). 상수로 박아 두면 배율이 올라간 순간
+    // `목표` 아래 줄이 상자에 눌려 반만 보인다.
+    final TextScaler ts = MediaQuery.textScalerOf(context);
+    final double width = chartGoalAxisWidth * ts.scale(1);
+    final double labelHeight = ts.scale(style.fontSize ?? 10) * 1.35 * 2;
+    final double? bottom = lineBottom;
+    return SizedBox(
+      width: width,
+      height: height,
+      child: Stack(
+        children: <Widget>[
+          if (label != null && bottom != null)
+            Positioned(
+              right: 0,
+              top: (height - bottom - labelHeight / 2).clamp(
+                0.0,
+                math.max(0, height - labelHeight),
+              ),
+              child: SizedBox(
+                key: chartGoalLabelKey,
+                height: labelHeight,
+                child: Center(
+                  child: Text(
+                    label!,
+                    textAlign: TextAlign.right,
+                    maxLines: 2,
+                    style: style,
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 목표치 칸의 폭(글씨 배율 1 기준).
+const double chartGoalAxisWidth = 38;
+
+/// 목표치 라벨을 집는 키. 화면마다 그래프가 여러 개면 여러 번 나온다.
+const Key chartGoalLabelKey = ValueKey<String>('chart-goal-label');
+
+/// 그래프와 목표치 칸 사이 간격.
+const double chartGoalAxisGap = 6;

--- a/frontend/flutter/lib/design_system/charts/period_scroll_chart.dart
+++ b/frontend/flutter/lib/design_system/charts/period_scroll_chart.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 
 import 'package:oncare/design_system/charts/chart_reveal.dart';
+import 'package:oncare/design_system/charts/goal_line.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
 
 /// `전체` 그래프의 선택·보이는 구간 상태. (#1018)
@@ -78,7 +79,9 @@ class PeriodScrollChart extends StatefulWidget {
     required this.calloutBuilder,
     this.selectedIndex,
     this.onSelected,
-    this.goalOverlay,
+    this.goalBottom,
+    this.goalLabel,
+    this.goalLabelStyle = ChartGoalAxis.defaultStyle,
     this.daysPerScreen = 30,
   });
 
@@ -105,8 +108,16 @@ class PeriodScrollChart extends StatefulWidget {
   final int? selectedIndex;
   final void Function(int? i)? onSelected;
 
-  /// 목표선. 칸 전체 폭에 걸쳐 그려지도록 스크롤 안쪽에 얹는다.
-  final Widget? goalOverlay;
+  /// 그래프 바닥에서 목표선까지의 거리. null 이면 목표선을 긋지 않는다.
+  /// 선은 칸 전체 폭에 걸쳐야 하므로 스크롤 **안쪽**에 얹고, 목표치 라벨은
+  /// 밀려도 늘 보이도록 스크롤 **바깥** 왼쪽 칸에 앉힌다. (#1071)
+  final double? goalBottom;
+
+  /// 왼쪽 칸에 앉는 두 줄 라벨(`목표` / 목표치).
+  final String? goalLabel;
+
+  /// 목표치 글씨 모양. 자리는 모든 그래프가 같고 색·굵기만 화면을 따른다.
+  final TextStyle goalLabelStyle;
 
   /// 한 화면에 보일 날 수.
   final int daysPerScreen;
@@ -144,6 +155,24 @@ class _PeriodScrollChartState extends State<PeriodScrollChart> {
   @override
   Widget build(BuildContext context) {
     if (widget.count == 0) return SizedBox(height: widget.height);
+    // 목표치 칸은 스크롤 바깥에 둔다 — 안에 두면 옆으로 밀 때 같이 흘러가
+    // 화면에서 사라진다.
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        ChartGoalAxis(
+          height: widget.height,
+          label: widget.goalLabel,
+          lineBottom: widget.goalBottom,
+          style: widget.goalLabelStyle,
+        ),
+        const SizedBox(width: chartGoalAxisGap),
+        Expanded(child: _scroller(context)),
+      ],
+    );
+  }
+
+  Widget _scroller(BuildContext context) {
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
         final double viewport = constraints.maxWidth;
@@ -176,7 +205,8 @@ class _PeriodScrollChartState extends State<PeriodScrollChart> {
                   height: widget.height,
                   child: Stack(
                     children: <Widget>[
-                      if (widget.goalOverlay != null) widget.goalOverlay!,
+                      if (widget.goalBottom != null)
+                        GoalLineOverlay(bottom: widget.goalBottom!),
                       if (widget.selectedIndex != null)
                         _SelectionLine(
                           left: slot * widget.selectedIndex! + slot / 2,

--- a/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
+++ b/frontend/flutter/lib/features/dashboard/presentation/widgets/dashboard_content.dart
@@ -936,72 +936,89 @@ class _ExerciseTrend extends StatelessWidget {
         ),
       ),
       child: ExcludeSemantics(
-        child: Column(
+        // 목표치는 왼쪽 칸에 두 줄로 적는다 — 홈 탭 식단 영양 그래프와 같은
+        // 자리다 (#1071). 요일 라벨도 같은 만큼 밀려야 막대와 줄이 맞는다.
+        child: Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            SizedBox(
-              key: const ValueKey<String>('dashboard-exercise-chart'),
+            ChartGoalAxis(
               height: _chartHeight,
-              child: ChartReveal(
-                duration: AppMotion.chartGrow,
-                // 막대마다 시작 시점을 어긋나게 하므로(chartStagger)
-                // 마스터 진행도는 선형으로 받는다.
-                curve: Curves.linear,
-                builder: (BuildContext context, double t) => CustomPaint(
-                  size: Size.infinite,
-                  painter: _ExerciseBarPainter(
-                    data: week,
-                    lo: lo,
-                    hi: hi,
-                    todayIndex: todayIndex,
-                    color: FigmaColors.primary,
-                    goal: dailyGoalCalories,
-                    goalLabel:
-                        '${l.homeGoal} '
-                        '${NumberFormat('#,###').format(dailyGoalCalories.round())}',
-                    textDirection: Directionality.of(context),
-                    progress: t,
-                  ),
-                ),
-              ),
+              label:
+                  '${l.homeGoal}\n'
+                  '${NumberFormat('#,###').format(dailyGoalCalories.round())}',
+              lineBottom: dailyGoalCalories > lo && dailyGoalCalories < hi
+                  ? ((dailyGoalCalories - lo) /
+                            ((hi - lo) <= 0 ? 1 : (hi - lo))) *
+                        (_chartHeight - kExerciseBarLabelGap)
+                  : null,
             ),
-            const SizedBox(height: 6),
-            Row(
-              children: <Widget>[
-                for (int i = 0; i < days.length; i++)
-                  Expanded(
-                    child: Center(
-                      // 식단 영양 카드와 동일하게, 오늘은 #3EAFDF
-                      // 원형 안에 흰색 요일 글씨로 표기한다.
-                      child: i == todayIndex
-                          ? Container(
-                              width: 18,
-                              height: 18,
-                              alignment: Alignment.center,
-                              decoration: const BoxDecoration(
-                                color: FigmaColors.primary,
-                                shape: BoxShape.circle,
-                              ),
-                              child: Text(
-                                days[i],
-                                style: const TextStyle(
-                                  fontSize: 11.5,
-                                  fontWeight: FontWeight.w700,
-                                  color: Colors.white,
-                                ),
-                              ),
-                            )
-                          : Text(
-                              days[i],
-                              style: const TextStyle(
-                                fontSize: 11.5,
-                                fontWeight: FontWeight.w600,
-                                color: AppColors.mutedForeground,
-                              ),
-                            ),
+            const SizedBox(width: chartGoalAxisGap),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  SizedBox(
+                    key: const ValueKey<String>('dashboard-exercise-chart'),
+                    height: _chartHeight,
+                    child: ChartReveal(
+                      duration: AppMotion.chartGrow,
+                      // 막대마다 시작 시점을 어긋나게 하므로(chartStagger)
+                      // 마스터 진행도는 선형으로 받는다.
+                      curve: Curves.linear,
+                      builder: (BuildContext context, double t) => CustomPaint(
+                        size: Size.infinite,
+                        painter: _ExerciseBarPainter(
+                          data: week,
+                          lo: lo,
+                          hi: hi,
+                          todayIndex: todayIndex,
+                          color: FigmaColors.primary,
+                          goal: dailyGoalCalories,
+                          progress: t,
+                        ),
+                      ),
                     ),
                   ),
-              ],
+                  const SizedBox(height: 6),
+                  Row(
+                    children: <Widget>[
+                      for (int i = 0; i < days.length; i++)
+                        Expanded(
+                          child: Center(
+                            // 식단 영양 카드와 동일하게, 오늘은 #3EAFDF
+                            // 원형 안에 흰색 요일 글씨로 표기한다.
+                            child: i == todayIndex
+                                ? Container(
+                                    width: 18,
+                                    height: 18,
+                                    alignment: Alignment.center,
+                                    decoration: const BoxDecoration(
+                                      color: FigmaColors.primary,
+                                      shape: BoxShape.circle,
+                                    ),
+                                    child: Text(
+                                      days[i],
+                                      style: const TextStyle(
+                                        fontSize: 11.5,
+                                        fontWeight: FontWeight.w700,
+                                        color: Colors.white,
+                                      ),
+                                    ),
+                                  )
+                                : Text(
+                                    days[i],
+                                    style: const TextStyle(
+                                      fontSize: 11.5,
+                                      fontWeight: FontWeight.w600,
+                                      color: AppColors.mutedForeground,
+                                    ),
+                                  ),
+                          ),
+                        ),
+                    ],
+                  ),
+                ],
+              ),
             ),
           ],
         ),
@@ -1318,6 +1335,10 @@ HealthIndicator _indicatorFor(DashboardSummary s, _NutTabKind key) =>
 /// The weekly exercise bar chart. Bars sit on a [lo]/[hi] scale whose baseline
 /// is pushed below the smallest value so day-to-day variation is pronounced;
 /// each bar carries its kcal value label, and today's bar is highlighted.
+/// 막대 꼭대기의 값 라벨이 차지하는 위쪽 여백. 목표선 높이 계산도 이 값을
+/// 빼야 왼쪽 칸의 목표치가 선과 같은 높이에 앉는다.
+const double kExerciseBarLabelGap = 20;
+
 class _ExerciseBarPainter extends CustomPainter {
   _ExerciseBarPainter({
     required this.data,
@@ -1326,8 +1347,6 @@ class _ExerciseBarPainter extends CustomPainter {
     required this.todayIndex,
     required this.color,
     required this.goal,
-    required this.goalLabel,
-    required this.textDirection,
     this.progress = 1,
   });
 
@@ -1339,10 +1358,8 @@ class _ExerciseBarPainter extends CustomPainter {
   final int todayIndex;
   final Color color;
 
-  /// 하루 목표 소모 칼로리와 라벨. 가로선은 이 목표선 하나뿐이다 (#1015).
+  /// 하루 목표 소모 칼로리. 가로선은 이 목표선 하나뿐이다 (#1015).
   final double goal;
-  final String goalLabel;
-  final ui.TextDirection textDirection;
 
   /// 0 → 1 진입 애니메이션 진행도(선형). 막대는 월요일부터 차례로 바닥에서
   /// 자라 오르고, 값 라벨은 해당 막대와 함께 페이드인한다.
@@ -1356,21 +1373,16 @@ class _ExerciseBarPainter extends CustomPainter {
     final int n = data.length;
     final double slot = w / n;
     final double barW = math.min(slot * 0.5, 22);
-    const double labelGap = 20;
+    const double labelGap = kExerciseBarLabelGap;
 
     // 가로선은 목표선 하나다 (#1015). 바닥에 긋던 축선은 지운다 — 막대가
     // 이미 바닥을 그리고, 두 선이 같은 굵기라 어느 쪽이 목표인지 헷갈렸다.
     final double span2 = span;
     final double goalY = h - ((goal - lo) / span2) * (h - labelGap);
+    // 목표치는 그래프 왼쪽 칸(`ChartGoalAxis`)이 적는다 — 선 위 오른쪽 끝에
+    // 얹던 시절에는 목표에 가까운 막대의 꼭대기와 겹쳤다. (#1071)
     if (goal > lo && goal < hi) {
       ChartGoalLine.paint(canvas, y: goalY, left: 0, right: w);
-      ChartGoalLine.paintLabel(
-        canvas,
-        y: goalY,
-        right: w,
-        text: goalLabel,
-        textDirection: textDirection,
-      );
     }
 
     for (int i = 0; i < n; i++) {

--- a/frontend/flutter/lib/features/diet/presentation/widgets/diet_period_view.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/diet_period_view.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart' show DateFormat, NumberFormat;
 import 'package:oncare/core/utils/clock.dart';
-import 'package:oncare/design_system/charts/goal_line.dart';
 import 'package:oncare/design_system/charts/period_scroll_chart.dart';
 import 'package:oncare/design_system/figma/figma_kit.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
@@ -711,13 +710,12 @@ class _PeriodBars extends StatelessWidget {
             selectedIndex: selection.selected,
             onSelected: selection.select,
             onVisibleRangeChanged: selection.setVisible,
-            // 목표선은 스크롤 안쪽에 얹는다 — 밀어도 막대와 같은 자리에서
-            // 같은 높이로 따라간다. (#1015)
-            goalOverlay: GoalLineOverlay(
-              visible: hasGoal,
-              bottom: chartHeight * (goal / maxValue).clamp(0.0, 1.0),
-              label: '${l.homeGoal} ${format(goal)}',
-            ),
+            // 목표선은 스크롤 안쪽에 얹혀 밀어도 막대와 같은 높이를 따라가고
+            // (#1015), 목표치는 왼쪽 칸에 두 줄로 적힌다 (#1071).
+            goalBottom: hasGoal
+                ? chartHeight * (goal / maxValue).clamp(0.0, 1.0)
+                : null,
+            goalLabel: '${l.homeGoal}\n${format(goal)}',
             labelBuilder: (int i) =>
                 i % labelStep == 0 ? '${dates[i].day}' : '',
             calloutBuilder: (BuildContext context, int i) =>

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/exercise_activity_status.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/exercise_activity_status.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart' show DateFormat, NumberFormat;
 import 'package:oncare/core/utils/clock.dart';
 import 'package:oncare/design_system/charts/chart_reveal.dart';
+import 'package:oncare/design_system/charts/goal_line.dart';
 import 'package:oncare/design_system/figma/figma_kit.dart';
 import 'package:oncare/design_system/figma/section_title.dart';
 import 'package:oncare/design_system/tokens/colors.dart';
@@ -1271,15 +1272,35 @@ class _WeeklyBurnChart extends StatelessWidget {
             ),
           ),
         );
-        return Stack(
-          key: const Key('exerciseAllPeriodChart'),
+        // 목표치는 그래프 왼쪽 칸에 두 줄로 적는다 — 홈 탭 식단 영양 그래프와
+        // 같은 자리다. 예전에는 점선 오른쪽 끝에 알약 라벨로 얹혀 있어, 그래프
+        // 마다 목표치가 다른 자리에 있었다. (#1071)
+        return Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            Positioned.fill(child: scroller),
-            Positioned(
-              left: 0,
-              right: 0,
-              top: (chartH * (1 - (goal / max).clamp(0.0, 1.0))) - 6,
-              child: IgnorePointer(child: _GoalLine(goal: goal.round())),
+            ChartGoalAxis(
+              height: chartH,
+              label:
+                  '${AppLocalizations.of(context).homeGoal}\n${goal.round()}',
+              lineBottom: chartH * (goal / max).clamp(0.0, 1.0),
+            ),
+            const SizedBox(width: chartGoalAxisGap),
+            Expanded(
+              child: SizedBox(
+                height: c.maxHeight,
+                child: Stack(
+                  key: const Key('exerciseAllPeriodChart'),
+                  children: <Widget>[
+                    Positioned.fill(child: scroller),
+                    Positioned(
+                      left: 0,
+                      right: 0,
+                      top: (chartH * (1 - (goal / max).clamp(0.0, 1.0))) - 6,
+                      child: const IgnorePointer(child: _GoalLine()),
+                    ),
+                  ],
+                ),
+              ),
             ),
           ],
         );
@@ -1288,42 +1309,15 @@ class _WeeklyBurnChart extends StatelessWidget {
   }
 }
 
-/// 주간 목표선 — 점선 위에 알약 라벨.
+/// 주간 목표선 — 점선만 긋는다. 목표치는 왼쪽 [ChartGoalAxis] 칸이 적는다.
 class _GoalLine extends StatelessWidget {
-  const _GoalLine({required this.goal});
-
-  final int goal;
+  const _GoalLine();
 
   @override
-  Widget build(BuildContext context) {
-    final AppLocalizations l = AppLocalizations.of(context);
-    return Row(
-      children: <Widget>[
-        Expanded(
-          child: CustomPaint(
-            size: const Size(double.infinity, 1),
-            painter: _DashPainter(),
-          ),
-        ),
-        const SizedBox(width: 6),
-        Container(
-          padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
-          decoration: BoxDecoration(
-            color: Colors.white.withValues(alpha: 0.92),
-            borderRadius: BorderRadius.circular(999),
-          ),
-          child: Text(
-            '${l.homeGoal} $goal',
-            style: const TextStyle(
-              fontSize: 10,
-              fontWeight: FontWeight.w700,
-              color: FigmaColors.textMuted,
-            ),
-          ),
-        ),
-      ],
-    );
-  }
+  Widget build(BuildContext context) => CustomPaint(
+    size: const Size(double.infinity, 1),
+    painter: _DashPainter(),
+  );
 }
 
 class _DashPainter extends CustomPainter {

--- a/frontend/flutter/lib/shared/widgets/metric_trend_chart.dart
+++ b/frontend/flutter/lib/shared/widgets/metric_trend_chart.dart
@@ -134,49 +134,23 @@ class MetricTrendChart extends StatelessWidget {
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            // 목표선의 실제 높이에 맞춰 라벨 하나. 칸은 목표가 없어도 자리를
-            // 지킨다 — 지표를 바꿀 때 그래프 폭이 흔들리지 않는다.
-            //
-            // 폭은 눈금 라벨이 쓰던 38 그대로다. `목표 2,000` 을 한 줄로 두면 이
-            // 칸이 넓어져야 하는데, 그러면 360px 영어 로케일에서 요일 라벨 줄이
-            // 넘친다. 두 줄로 접어 폭을 지킨다.
-            Builder(
-              builder: (BuildContext context) {
-                // 칸도 글씨 배율을 따라간다 (#1004). 38·26 으로 박아 두면 배율이
-                // 올라간 순간 `목표` 아래 줄(`2,000`)이 상자에 눌려 반만 보인다.
-                final TextScaler ts = MediaQuery.textScalerOf(context);
-                final double labelWidth = 38 * ts.scale(1);
-                // 두 줄(`목표` / 값)이 들어갈 높이를 글씨에서 잰다. 상수로 두면
-                // 배율이 오른 순간 아랫줄이 잘린다. (#1004)
-                final double labelHeight = ts.scale(_axisLabelSize) * 1.35 * 2;
-                return SizedBox(
-                  width: labelWidth,
-                  height: height,
-                  child: Stack(
-                    children: <Widget>[
-                      if (goalLabel != null &&
-                          goal > 0 &&
-                          goal >= lo &&
-                          goal <= hi)
-                        Positioned(
-                          right: 0,
-                          top:
-                              (height -
-                                      ((goal - lo) / (hi - lo)) * height -
-                                      labelHeight / 2)
-                                  .clamp(0.0, height - labelHeight),
-                          child: SizedBox(
-                            key: chartGoalLabelKey,
-                            height: labelHeight,
-                            child: Center(child: _AxisLabel(goalLabel!)),
-                          ),
-                        ),
-                    ],
-                  ),
-                );
-              },
+            // 목표치 칸 — 이 그래프가 쓰던 배치를 [ChartGoalAxis] 로 옮겼고,
+            // 이제 두 앱의 모든 그래프가 같은 칸을 쓴다. (#1071)
+            ChartGoalAxis(
+              height: height,
+              label: goalLabel,
+              lineBottom:
+                  goalLabel != null && goal > 0 && goal >= lo && goal <= hi
+                  ? ((goal - lo) / ((hi - lo) <= 0 ? 1 : (hi - lo))) * height
+                  : null,
+              style: const TextStyle(
+                fontSize: _axisLabelSize,
+                height: 1.35,
+                fontWeight: FontWeight.w600,
+                color: AppColors.mutedForeground,
+              ),
             ),
-            const SizedBox(width: 6),
+            const SizedBox(width: chartGoalAxisGap),
             Expanded(
               child: Column(
                 children: <Widget>[
@@ -243,30 +217,8 @@ class MetricTrendChart extends StatelessWidget {
   }
 }
 
-/// 목표선 라벨 칸. 높이가 글씨 배율을 따라 달라져서, 크기로 찾을 수 없다.
-const Key chartGoalLabelKey = ValueKey<String>('chart-goal-label');
-
 /// 축 라벨 글씨 크기. 라벨 칸 높이를 이 값에서 재므로 한 곳에 둔다. (#1004)
 const double _axisLabelSize = 10;
-
-class _AxisLabel extends StatelessWidget {
-  const _AxisLabel(this.text);
-
-  final String text;
-
-  @override
-  Widget build(BuildContext context) => Text(
-    text,
-    textAlign: TextAlign.right,
-    maxLines: 2,
-    style: const TextStyle(
-      fontSize: _axisLabelSize,
-      height: 1.35,
-      fontWeight: FontWeight.w600,
-      color: AppColors.mutedForeground,
-    ),
-  );
-}
 
 /// 꺾은선 본체. 홈 탭에 있던 `_TrendChartPainter` 를 그대로 옮긴 것이다.
 class MetricTrendPainter extends CustomPainter {

--- a/frontend/flutter/test/design_system/chart_goal_axis_test.dart
+++ b/frontend/flutter/test/design_system/chart_goal_axis_test.dart
@@ -1,0 +1,110 @@
+/// 그래프 목표치는 어디에 어떻게 적히는가 (#1071).
+///
+/// 목표선은 모든 그래프에 들어갔지만 목표치 라벨은 그래프마다 다른 자리에
+/// 있었다 — 어떤 곳은 점선 오른쪽 끝, 어떤 곳은 알약 배지, 어떤 곳은 왼쪽 축
+/// 칸. 홈 탭 식단 영양 그래프가 쓰던 **왼쪽 칸 · 두 줄**로 통일했고, 이 파일이
+/// 그 자리를 지킨다.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oncare/design_system/charts/goal_line.dart';
+import 'package:oncare/design_system/charts/period_scroll_chart.dart';
+
+Widget _app(Widget child) => MaterialApp(
+  home: Scaffold(body: Center(child: SizedBox(width: 360, child: child))),
+);
+
+void main() {
+  testWidgets('목표치는 첫 줄 `목표`, 둘째 줄 목표치로 적힌다', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      _app(
+        const ChartGoalAxis(height: 100, label: '목표\n2,000', lineBottom: 50),
+      ),
+    );
+
+    final Text label = tester.widget<Text>(
+      find.descendant(
+        of: find.byKey(chartGoalLabelKey),
+        matching: find.byType(Text),
+      ),
+    );
+    expect(label.data, '목표\n2,000');
+    expect(label.maxLines, 2, reason: '두 줄 구성이 무너지면 칸 폭이 넓어진다');
+    expect(label.textAlign, TextAlign.right);
+  });
+
+  testWidgets('목표치 칸은 목표가 없어도 폭을 지킨다', (WidgetTester tester) async {
+    // 실제로는 Row 안에 놓인다 — 폭을 꽉 채우는 부모에 바로 넣으면 칸이
+    // 부모 폭으로 늘어나 무엇을 재는지 알 수 없다.
+    await tester.pumpWidget(
+      _app(
+        const Row(children: <Widget>[ChartGoalAxis(height: 100), Spacer()]),
+      ),
+    );
+
+    expect(find.byKey(chartGoalLabelKey), findsNothing);
+    expect(
+      tester.getSize(find.byType(ChartGoalAxis)).width,
+      chartGoalAxisWidth,
+      reason: '목표가 없다고 칸이 사라지면 지표를 바꿀 때 그래프 폭이 흔들린다',
+    );
+  });
+
+  testWidgets('라벨은 목표선 높이를 따라간다', (WidgetTester tester) async {
+    Future<double> topOf(double lineBottom) async {
+      await tester.pumpWidget(
+        _app(
+          ChartGoalAxis(
+            height: 200,
+            label: '목표\n2,000',
+            lineBottom: lineBottom,
+          ),
+        ),
+      );
+      return tester.getRect(find.byKey(chartGoalLabelKey)).center.dy;
+    }
+
+    final double low = await topOf(20);
+    final double high = await topOf(180);
+    expect(
+      high,
+      lessThan(low),
+      reason: '목표가 높을수록 라벨도 위에 앉아야 선과 같은 높이가 된다',
+    );
+  });
+
+  testWidgets('기간 그래프의 막대는 목표치 칸 오른쪽에서 시작한다', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      _app(
+        SizedBox(
+          height: 140,
+          child: PeriodScrollChart(
+            count: 7,
+            height: 100,
+            goalBottom: 50,
+            goalLabel: '목표\n2,000',
+            labelBuilder: (int i) => '$i',
+            onVisibleRangeChanged: (_, _) {},
+            calloutBuilder: (BuildContext context, int i) =>
+                const SizedBox.shrink(),
+            barBuilder: (BuildContext context, int i) =>
+                const ColoredBox(color: Colors.blue),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final Rect axis = tester.getRect(find.byType(ChartGoalAxis));
+    final Rect scroller = tester.getRect(
+      find.byType(SingleChildScrollView).first,
+    );
+    expect(
+      scroller.left,
+      greaterThanOrEqualTo(axis.right),
+      reason: '목표치가 왼쪽에 들어갔으니 그래프는 그만큼 오른쪽으로 밀려야 한다',
+    );
+    expect(axis.left, lessThan(scroller.left));
+  });
+}

--- a/frontend/flutter/test/features/dashboard/home_nutrition_axis_test.dart
+++ b/frontend/flutter/test/features/dashboard/home_nutrition_axis_test.dart
@@ -14,6 +14,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:oncare/design_system/charts/goal_line.dart';
 import 'package:oncare/features/account/data/repositories/mock_account_repository.dart';
 import 'package:oncare/features/account/domain/entities/user_profile.dart';
 import 'package:oncare/features/account/presentation/controllers/account_controller.dart';

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_diet_period_card.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_diet_period_card.dart
@@ -17,7 +17,6 @@ import 'package:oncare_trainer/shared/services/client_repository.dart';
 import 'package:oncare_trainer/shared/widgets/action_button.dart';
 import 'package:oncare_trainer/shared/widgets/activity_charts.dart';
 import 'package:oncare_trainer/shared/widgets/chart_semantics.dart';
-import 'package:oncare_trainer/shared/widgets/goal_line.dart';
 import 'package:oncare_trainer/shared/widgets/metric_trend_chart.dart';
 import 'package:oncare_trainer/shared/widgets/period_scroll_chart.dart';
 import 'package:oncare_trainer/shared/widgets/section_card.dart';
@@ -520,11 +519,11 @@ class _PeriodBars extends StatelessWidget {
             selectedIndex: selection.selected,
             onSelected: selection.select,
             onVisibleRangeChanged: selection.setVisible,
-            goalOverlay: GoalLineOverlay(
-              visible: hasGoal,
-              bottom: chartHeight * (goal / maxValue).clamp(0.0, 1.0),
-              label: '${l.clientPeriodGoal} ${format(goal)}',
-            ),
+            // 목표치는 왼쪽 칸에 두 줄로 적는다 (#1071).
+            goalBottom: hasGoal
+                ? chartHeight * (goal / maxValue).clamp(0.0, 1.0)
+                : null,
+            goalLabel: '${l.clientPeriodGoal}\n${format(goal)}',
             labelBuilder: (int i) =>
                 i % labelStep == 0 ? '${dates[i].day}' : '',
             calloutBuilder: (BuildContext context, int i) =>

--- a/frontend/flutter_trainer/lib/shared/widgets/activity_charts.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/activity_charts.dart
@@ -31,7 +31,6 @@ import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 import 'package:oncare_trainer/shared/exercise_burn_goals.dart';
 import 'package:oncare_trainer/shared/widgets/chart_semantics.dart';
-import 'package:oncare_trainer/shared/widgets/goal_line.dart';
 import 'package:oncare_trainer/shared/widgets/period_scroll_chart.dart';
 
 /// 소모 칼로리 색. 콘솔의 브랜드 색을 그대로 쓴다.
@@ -522,13 +521,12 @@ class BurnBarChart extends StatelessWidget {
             onSelected: selection.select,
             onVisibleRangeChanged: selection.setVisible,
             daysPerScreen: _slotsPerScreen,
-            goalOverlay: GoalLineOverlay(
-              visible: goalKcal > 0,
-              bottom: chartHeight * (goalKcal / max).clamp(0.0, 1.0),
-              label:
-                  '${l.clientPeriodGoal} '
-                  '${goalKcal.round()}${l.unitKcal}',
-            ),
+            // 목표치는 왼쪽 칸에 두 줄로 적는다 (#1071).
+            goalBottom: goalKcal > 0
+                ? chartHeight * (goalKcal / max).clamp(0.0, 1.0)
+                : null,
+            goalLabel:
+                '${l.clientPeriodGoal}\n${goalKcal.round()}${l.unitKcal}',
             // 달이 바뀌는 칸에만 적는다 — 모든 칸에 적으면 글자가 서로 겹쳐
             // 아무것도 읽히지 않는다. 회원 앱 `전체` 그래프와 같은 규칙이다.
             labelBuilder: (int i) =>

--- a/frontend/flutter_trainer/lib/shared/widgets/goal_line.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/goal_line.dart
@@ -45,46 +45,20 @@ class ChartGoalLine {
       );
     }
   }
-
-  /// 선 위에 붙는 `목표 N` 라벨을 그린다. 오른쪽 끝에 붙이고, 선 위로 띄운다 —
-  /// 아래에 두면 목표에 가까운 막대의 꼭대기와 겹친다.
-  static void paintLabel(
-    Canvas canvas, {
-    required double y,
-    required double right,
-    required String text,
-    required TextDirection textDirection,
-  }) {
-    final TextPainter tp = TextPainter(
-      text: TextSpan(
-        text: text,
-        style: const TextStyle(
-          fontSize: labelFontSize,
-          height: 1.2,
-          fontWeight: FontWeight.w600,
-          color: color,
-        ),
-      ),
-      textDirection: textDirection,
-    )..layout();
-    tp.paint(canvas, Offset(right - tp.width, y - tp.height - 2));
-  }
 }
 
 /// Stack 위에 얹는 목표선. 막대를 위젯으로 그리는 그래프(식단 기간 뷰)가 쓴다.
 ///
 /// [bottom] 은 그래프 바닥에서 목표선까지의 거리다 — 호출부가 자기 축 계산으로
 /// 넘긴다. 목표가 축 밖이면(0 이하거나 최댓값을 넘으면) 아무것도 그리지 않는다.
+///
+/// **선만 긋는다.** 목표치는 그래프 왼쪽 [ChartGoalAxis] 칸이 적는다 — 선 위
+/// 오른쪽 끝에 얹던 시절에는 그래프마다 라벨이 다른 자리에 앉았고, 목표 근처의
+/// 막대 꼭대기와 겹쳤다. (#1071)
 class GoalLineOverlay extends StatelessWidget {
-  const GoalLineOverlay({
-    super.key,
-    required this.bottom,
-    required this.label,
-    this.visible = true,
-  });
+  const GoalLineOverlay({super.key, required this.bottom, this.visible = true});
 
   final double bottom;
-  final String label;
   final bool visible;
 
   @override
@@ -94,61 +68,111 @@ class GoalLineOverlay extends StatelessWidget {
       left: 0,
       right: 0,
       bottom: bottom,
-      child: CustomPaint(
-        painter: _GoalLinePainter(
-          label: label,
-          textDirection: Directionality.of(context),
-          textScaler: MediaQuery.textScalerOf(context),
+      child: const IgnorePointer(
+        child: CustomPaint(
+          painter: _GoalLinePainter(),
+          // 선 자체는 높이가 없다. 칸만 잡아 둔다.
+          child: SizedBox(height: 0, width: double.infinity),
         ),
-        // 선 자체는 높이가 없다. 라벨이 선 위로 올라가야 해서 칸만 잡아 둔다.
-        child: const SizedBox(height: 0, width: double.infinity),
       ),
     );
   }
 }
 
 class _GoalLinePainter extends CustomPainter {
-  const _GoalLinePainter({
-    required this.label,
-    required this.textDirection,
-    required this.textScaler,
-  });
-
-  final String label;
-  final TextDirection textDirection;
-  final TextScaler textScaler;
+  const _GoalLinePainter();
 
   @override
   void paint(Canvas canvas, Size size) {
     ChartGoalLine.paint(canvas, y: 0, left: 0, right: size.width);
-    final TextPainter tp = TextPainter(
-      text: TextSpan(
-        text: label,
-        style: const TextStyle(
-          fontSize: ChartGoalLine.labelFontSize,
-          height: 1.2,
-          fontWeight: FontWeight.w600,
-          color: ChartGoalLine.color,
-        ),
-      ),
-      textDirection: textDirection,
-      textScaler: textScaler,
-    )..layout();
-    final Offset at = Offset(size.width - tp.width, -tp.height - 2);
-    // 글자 뒤에 카드 색 판을 깔아 준다 — 막대 꼭대기와 겹치는 자리에서도
-    // 숫자가 읽혀야 한다.
-    final RRect plate = RRect.fromRectAndRadius(
-      Rect.fromLTWH(at.dx - 4, at.dy - 1, tp.width + 8, tp.height + 2),
-      const Radius.circular(4),
-    );
-    canvas.drawRRect(
-      plate,
-      Paint()..color = AppColors.card.withValues(alpha: 0.9),
-    );
-    tp.paint(canvas, at);
   }
 
   @override
-  bool shouldRepaint(_GoalLinePainter old) =>
-      old.label != label || old.textScaler != textScaler;
+  bool shouldRepaint(_GoalLinePainter old) => false;
 }
+
+/// 그래프 왼쪽의 목표치 칸. **모든 그래프가 이 칸 하나로 목표치를 적는다.**
+///
+/// 홈 탭 식단 영양 그래프가 쓰던 배치를 그대로 옮겼다 — 폭은 눈금 라벨이 쓰던
+/// 38(글씨 배율을 따라간다), 라벨은 목표선 높이에 맞춰 오른쪽 정렬 두 줄
+/// (`목표` / 목표치)로 앉는다. 한 줄로 두면 칸이 넓어져야 하는데, 그러면 360px
+/// 영어 로케일에서 축 라벨 줄이 넘친다. (#1004, #1071)
+///
+/// 목표가 없어도 칸은 자리를 지킨다 — 지표를 바꿀 때 그래프 폭이 흔들리지
+/// 않게 하려는 것이다.
+class ChartGoalAxis extends StatelessWidget {
+  const ChartGoalAxis({
+    super.key,
+    required this.height,
+    this.label,
+    this.lineBottom,
+    this.style = defaultStyle,
+  });
+
+  /// 그래프(막대·꺾은선)가 그려지는 높이. 축 라벨 줄은 뺀 값이다.
+  final double height;
+
+  /// 두 줄 라벨 — 첫 줄 `목표`, 둘째 줄 목표치. null 이면 칸만 지킨다.
+  final String? label;
+
+  /// 그래프 바닥에서 목표선까지의 거리. null 이면 라벨을 앉히지 않는다.
+  final double? lineBottom;
+
+  /// 글씨 모양. 자리와 두 줄 구성은 모든 그래프가 같지만, 색·굵기는 각 화면이
+  /// 쓰던 값을 그대로 둔다. (#1071)
+  final TextStyle style;
+
+  static const TextStyle defaultStyle = TextStyle(
+    fontSize: ChartGoalLine.labelFontSize,
+    height: 1.35,
+    fontWeight: FontWeight.w600,
+    color: ChartGoalLine.color,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    // 칸도 글씨 배율을 따라간다 (#1004). 상수로 박아 두면 배율이 올라간 순간
+    // `목표` 아래 줄이 상자에 눌려 반만 보인다.
+    final TextScaler ts = MediaQuery.textScalerOf(context);
+    final double width = chartGoalAxisWidth * ts.scale(1);
+    final double labelHeight = ts.scale(style.fontSize ?? 10) * 1.35 * 2;
+    final double? bottom = lineBottom;
+    return SizedBox(
+      width: width,
+      height: height,
+      child: Stack(
+        children: <Widget>[
+          if (label != null && bottom != null)
+            Positioned(
+              right: 0,
+              top: (height - bottom - labelHeight / 2).clamp(
+                0.0,
+                math.max(0, height - labelHeight),
+              ),
+              child: SizedBox(
+                key: chartGoalLabelKey,
+                height: labelHeight,
+                child: Center(
+                  child: Text(
+                    label!,
+                    textAlign: TextAlign.right,
+                    maxLines: 2,
+                    style: style,
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 목표치 칸의 폭(글씨 배율 1 기준).
+const double chartGoalAxisWidth = 38;
+
+/// 목표치 라벨을 집는 키. 화면마다 그래프가 여러 개면 여러 번 나온다.
+const Key chartGoalLabelKey = ValueKey<String>('chart-goal-label');
+
+/// 그래프와 목표치 칸 사이 간격.
+const double chartGoalAxisGap = 6;

--- a/frontend/flutter_trainer/lib/shared/widgets/metric_trend_chart.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/metric_trend_chart.dart
@@ -126,44 +126,22 @@ class MetricTrendChart extends StatelessWidget {
           children: <Widget>[
             // 목표선의 실제 높이에 맞춰 라벨 하나. 칸은 목표가 없어도 자리를
             // 지킨다 — 지표를 바꿀 때 그래프 폭이 흔들리지 않는다.
-            //
-            // 폭은 눈금 라벨이 쓰던 38 그대로다. `목표 2,000` 을 한 줄로 두면 이
-            // 칸이 넓어져야 하는데, 그러면 360px 영어 로케일에서 요일 라벨 줄이
-            // 넘친다. 두 줄로 접어 폭을 지킨다.
-            Builder(
-              builder: (BuildContext context) {
-                // 칸도 글씨 배율을 따라간다 (#1004). 38·26 으로 박아 두면 배율이
-                // 올라간 순간 `목표` 아래 줄(`2,000`)이 상자에 눌려 반만 보인다.
-                final TextScaler ts = MediaQuery.textScalerOf(context);
-                final double labelWidth = 38 * ts.scale(1);
-                final double labelHeight = ts.scale(_axisLabelSize) * 1.35 * 2;
-                return SizedBox(
-                  width: labelWidth,
-                  height: height,
-                  child: Stack(
-                    children: <Widget>[
-                      if (goalLabel != null &&
-                          goal > 0 &&
-                          goal >= lo &&
-                          goal <= hi)
-                        Positioned(
-                          right: 0,
-                          top:
-                              (height -
-                                      ((goal - lo) / (hi - lo)) * height -
-                                      labelHeight / 2)
-                                  .clamp(0.0, height - labelHeight),
-                          child: SizedBox(
-                            height: labelHeight,
-                            child: Center(child: _AxisLabel(goalLabel!)),
-                          ),
-                        ),
-                    ],
-                  ),
-                );
-              },
+            // 목표치 칸 — 두 앱의 모든 그래프가 같은 칸을 쓴다. (#1071)
+            ChartGoalAxis(
+              height: height,
+              label: goalLabel,
+              lineBottom:
+                  goalLabel != null && goal > 0 && goal >= lo && goal <= hi
+                  ? ((goal - lo) / ((hi - lo) <= 0 ? 1 : (hi - lo))) * height
+                  : null,
+              style: const TextStyle(
+                fontSize: _axisLabelSize,
+                height: 1.35,
+                fontWeight: FontWeight.w600,
+                color: AppColors.mutedForeground,
+              ),
             ),
-            const SizedBox(width: 6),
+            const SizedBox(width: chartGoalAxisGap),
             Expanded(
               child: Column(
                 children: <Widget>[
@@ -240,25 +218,6 @@ class MetricTrendChart extends StatelessWidget {
 
 /// 축 라벨 글씨 크기. 라벨 칸 높이를 이 값에서 재므로 한 곳에 둔다. (#1004)
 const double _axisLabelSize = 10;
-
-class _AxisLabel extends StatelessWidget {
-  const _AxisLabel(this.text);
-
-  final String text;
-
-  @override
-  Widget build(BuildContext context) => Text(
-    text,
-    textAlign: TextAlign.right,
-    maxLines: 2,
-    style: const TextStyle(
-      fontSize: _axisLabelSize,
-      height: 1.35,
-      fontWeight: FontWeight.w600,
-      color: AppColors.mutedForeground,
-    ),
-  );
-}
 
 /// 꺾은선 본체.
 class MetricTrendPainter extends CustomPainter {

--- a/frontend/flutter_trainer/lib/shared/widgets/period_scroll_chart.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/period_scroll_chart.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
+import 'package:oncare_trainer/shared/widgets/goal_line.dart';
 
 /// `전체` 그래프의 선택·보이는 구간 상태. (#1018)
 ///
@@ -80,7 +81,9 @@ class PeriodScrollChart extends StatefulWidget {
     required this.calloutBuilder,
     this.selectedIndex,
     this.onSelected,
-    this.goalOverlay,
+    this.goalBottom,
+    this.goalLabel,
+    this.goalLabelStyle = ChartGoalAxis.defaultStyle,
     this.daysPerScreen = 30,
   });
 
@@ -108,7 +111,13 @@ class PeriodScrollChart extends StatefulWidget {
   final void Function(int? i)? onSelected;
 
   /// 목표선. 칸 전체 폭에 걸쳐 그려지도록 스크롤 안쪽에 얹는다.
-  final Widget? goalOverlay;
+  final double? goalBottom;
+
+  /// 왼쪽 칸에 앉는 두 줄 라벨(`목표` / 목표치).
+  final String? goalLabel;
+
+  /// 목표치 글씨 모양. 자리는 모든 그래프가 같고 색·굵기만 화면을 따른다.
+  final TextStyle goalLabelStyle;
 
   /// 한 화면에 보일 날 수.
   final int daysPerScreen;
@@ -146,6 +155,24 @@ class _PeriodScrollChartState extends State<PeriodScrollChart> {
   @override
   Widget build(BuildContext context) {
     if (widget.count == 0) return SizedBox(height: widget.height);
+    // 목표치 칸은 스크롤 바깥에 둔다 — 안에 두면 옆으로 밀 때 같이 흘러가
+    // 화면에서 사라진다. (#1071)
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        ChartGoalAxis(
+          height: widget.height,
+          label: widget.goalLabel,
+          lineBottom: widget.goalBottom,
+          style: widget.goalLabelStyle,
+        ),
+        const SizedBox(width: chartGoalAxisGap),
+        Expanded(child: _scroller(context)),
+      ],
+    );
+  }
+
+  Widget _scroller(BuildContext context) {
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
         final double viewport = constraints.maxWidth;
@@ -202,7 +229,8 @@ class _PeriodScrollChartState extends State<PeriodScrollChart> {
                       // 목표선은 막대 **위**에 얹는다. 뒤에 깔면 목표에 가까운
                       // 막대가 `목표 N` 라벨을 덮어, 정작 견줄 기준이 안 보인다.
                       // 점선이라 데이터와 경쟁하지도 않는다.
-                      if (widget.goalOverlay != null) widget.goalOverlay!,
+                      if (widget.goalBottom != null)
+                        GoalLineOverlay(bottom: widget.goalBottom!),
                     ],
                   ),
                 ),


### PR DESCRIPTION
Closes #1071

## Summary
목표선(가로선)은 모든 그래프에 들어갔지만 목표치가 적히는 자리는 제각각이었다 — 어떤 곳은 점선 오른쪽 끝, 어떤 곳은 알약 배지, 어떤 곳은 왼쪽 축 칸. `사용자 앱 - 홈 탭 - 식단 영양 그래프`가 쓰던 배치를 공통 위젯으로 꺼내 두 앱의 목표선 그래프를 전부 그리로 맞췄다.

맞춘 것은 **라벨의 자리와 두 줄 구성뿐**이다. 폰트 크기·색·굵기는 각 화면이 쓰던 값을 그대로 둔다.

## Changes

### 공통 위젯
- `ChartGoalAxis` — 그래프 왼쪽 목표치 칸. 폭은 눈금 라벨이 쓰던 38(글씨 배율을 따라간다), 라벨은 목표선 높이에 맞춰 오른쪽 정렬 두 줄(첫 줄 `목표`, 둘째 줄 목표치). 목표가 없어도 칸은 자리를 지켜, 지표를 바꿀 때 그래프 폭이 흔들리지 않는다.
- `GoalLineOverlay` 는 이제 선만 긋는다. 라벨을 선 위 오른쪽 끝에 얹던 시절에는 목표에 가까운 막대 꼭대기와 겹쳤다.
- `PeriodScrollChart` 가 목표선과 목표치 칸을 함께 그린다. 선은 스크롤 안쪽이라 밀어도 막대와 같은 높이를 따라가고, 목표치는 스크롤 바깥이라 밀어도 자리를 지킨다.

### 옮긴 그래프
목표치가 왼쪽에 들어가므로 그래프와 축 라벨이 그만큼 오른쪽으로 밀린다.

| 앱 | 그래프 | 이전 |
|---|---|---|
| 사용자 | 홈 탭 주간 운동 막대 | 점선 오른쪽 끝, 한 줄 |
| 사용자 | 식단 탭 기간 그래프 | 점선 오른쪽 끝, 한 줄 |
| 사용자 | 운동 탭 전체 기간 그래프 | 점선 오른쪽 끝 알약 배지 |
| 트레이너 | 고객 식단 기간 카드 | 점선 오른쪽 끝, 한 줄 |
| 트레이너 | 고객 운동 소모 그래프 | 점선 오른쪽 끝, 한 줄 |

두 앱의 지표 추이 그래프는 이미 왼쪽 두 줄이었지만, 각자 갖고 있던 축 칸 코드를 공통 위젯으로 바꿔 이후에 다시 어긋나지 않게 했다.

## Notes
- 트레이너 리포트의 `최근 4주` 그래프(`FourWeekMetricTrend` · `WeekTrendBar`)는 손대지 않았다. 가로 막대가 세로로 쌓인 형태라 목표선이 **세로선**이고, 왼쪽 두 줄 규칙이 성립하지 않는다. 목표치는 지금도 카드 머리의 `│ 목표 2,000` 이 말한다. 이 형태까지 맞추려면 별도 판단이 필요해 남겨 뒀다.
- 두 앱이 같은 규칙을 쓰되 서로 다른 패키지라 위젯은 각각 둔다(기존 구조 그대로).

## Verification
- `flutter analyze` — 두 앱 모두 무결
- `flutter test` — 사용자 앱 858개, 트레이너 앱 970개 통과
- `test/design_system/chart_goal_axis_test.dart` 를 새로 두어 두 줄 구성 · 오른쪽 정렬 · 목표선 높이 추종 · 그래프가 칸 오른쪽에서 시작하는 것을 고정
- 기준 그래프와 옮긴 그래프를 나란히 렌더해 목표치 칸의 x 범위와 그래프 시작점이 일치하는 것을 눈으로 확인