### PR TITLE
fix(trainer): 고객 운동 오늘 기록 토글 제거

### DIFF
--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_day_record_tile.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_day_record_tile.dart
@@ -71,6 +71,7 @@ class ClientDayRecordTile extends StatelessWidget {
     required this.details,
     required this.expanded,
     required this.onToggle,
+    this.toggleable = true,
     this.emptyLabel,
     this.extra,
   });
@@ -94,6 +95,10 @@ class ClientDayRecordTile extends StatelessWidget {
   /// 줄을 눌렀을 때. 기록이 없는 날은 [logged] 가 false 라 눌리지 않는다.
   final VoidCallback onToggle;
 
+  /// false면 화살표와 탭 동작 없이 상세를 항상 보여 준다.
+  /// `오늘` 화면은 기록을 바로 읽는 일반 박스라서 false를 쓴다.
+  final bool toggleable;
+
   /// 기록이 없을 때 요약 자리에 적을 말.
   final String? emptyLabel;
 
@@ -103,15 +108,16 @@ class ClientDayRecordTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations l = AppLocalizations.of(context);
+    final bool showDetails = logged && (expanded || !toggleable);
     return Column(
       key: ValueKey<String>('client-day-tile-${ymd(date)}'),
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: <Widget>[
         Semantics(
-          button: logged,
-          expanded: logged ? expanded : null,
+          button: logged && toggleable,
+          expanded: logged && toggleable ? expanded : null,
           child: InkWell(
-            onTap: logged ? onToggle : null,
+            onTap: logged && toggleable ? onToggle : null,
             child: Padding(
               padding: const EdgeInsets.symmetric(
                 horizontal: AppSpacing.md,
@@ -168,26 +174,27 @@ class ClientDayRecordTile extends StatelessWidget {
                   ),
                   // 펼칠 것이 없는 날에도 자리는 남긴다 — 화살표만 빠지면
                   // 그 줄의 요약이 오른쪽으로 밀려 열이 어긋난다.
-                  SizedBox(
-                    width: 24,
-                    child: logged
-                        ? AnimatedRotation(
-                            turns: expanded ? 0.5 : 0,
-                            duration: const Duration(milliseconds: 160),
-                            child: const Icon(
-                              Icons.expand_more,
-                              size: 20,
-                              color: AppColors.subtleForeground,
-                            ),
-                          )
-                        : null,
-                  ),
+                  if (toggleable)
+                    SizedBox(
+                      width: 24,
+                      child: logged
+                          ? AnimatedRotation(
+                              turns: expanded ? 0.5 : 0,
+                              duration: const Duration(milliseconds: 160),
+                              child: const Icon(
+                                Icons.expand_more,
+                                size: 20,
+                                color: AppColors.subtleForeground,
+                              ),
+                            )
+                          : null,
+                    ),
                 ],
               ),
             ),
           ),
         ),
-        if (logged && expanded)
+        if (showDetails)
           Padding(
             // 펼친 속에 색을 깔지 않는다. 이 판은 이미 흰 카드이고, 안에서
             // 바탕색이 한 번 더 갈리면 카드 안에 카드가 있는 것처럼 읽힌다.

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/workout_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/workout_view.dart
@@ -600,10 +600,12 @@ class _DailyExerciseRecordsState extends ConsumerState<_DailyExerciseRecords> {
                 // 처리하면 이력이 먼저 생기고 하루 집계는 아직 0 이다. 시간만
                 // 보고 접어 두면 방금 남긴 기록이 갈 곳을 잃는다(#1025).
                 final bool logged = day.minutes > 0 || dayEntries.isNotEmpty;
+                final bool today = widget.period == ClientPeriod.today;
                 return ClientDayRecordTile(
                   date: day.date,
                   logged: logged,
-                  expanded: _openDay == ymd(day.date),
+                  expanded: today || _openDay == ymd(day.date),
+                  toggleable: !today,
                   onToggle: () => setState(() {
                     _openDay = _openDay == ymd(day.date) ? null : ymd(day.date);
                   }),
@@ -611,7 +613,7 @@ class _DailyExerciseRecordsState extends ConsumerState<_DailyExerciseRecords> {
                   // 그날의 미션 카드가 펼친 자리로 들어온다 — 이행률·종류·
                   // 피드백·메모까지, 예전 `운동 기록` 카드가 하던 말 그대로다.
                   // 이력이 없는 날에는 지표에 남은 운동 이름만 보여 준다.
-                  extra: _openDay == ymd(day.date) && logged
+                  extra: (today || _openDay == ymd(day.date)) && logged
                       ? _DayDetail(
                           clientId: widget.clientId,
                           date: day.date,

--- a/frontend/flutter_trainer/test/features/clients/client_detail_workout_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_workout_test.dart
@@ -9,6 +9,7 @@ import 'package:oncare_trainer/app/router/routes.dart';
 import 'package:oncare_trainer/core/storage/app_database.dart';
 import 'package:oncare_trainer/core/storage/seed_data.dart';
 import 'package:oncare_trainer/core/utils/clock.dart';
+import 'package:oncare_trainer/core/utils/date_format.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/features/clients/domain/entities/routine_history_entry.dart';
 import 'package:oncare_trainer/features/coaching/data/repositories/trainer_routine_repository.dart';
@@ -382,6 +383,13 @@ void main() {
         const ValueKey<String>('exercise-daily-records'),
       );
       expect(records, findsOneWidget);
+      final Finder todayRow = find.byKey(
+        ValueKey<String>('client-day-tile-${ymd(todayKst())}'),
+      );
+      expect(
+        find.descendant(of: todayRow, matching: find.byIcon(Icons.expand_more)),
+        findsOneWidget,
+      );
       expect(
         find.descendant(
           of: records,
@@ -408,6 +416,13 @@ void main() {
       );
       expect(find.text('AI 전체 분석'), findsOneWidget);
       expect(find.text('AI 기간 분석'), findsNothing);
+      final Finder todayRow = find.byKey(
+        ValueKey<String>('client-day-tile-${ymd(todayKst())}'),
+      );
+      expect(
+        find.descendant(of: todayRow, matching: find.byIcon(Icons.expand_more)),
+        findsOneWidget,
+      );
     });
 
     testWidgets('김민수 운동 기록이 날짜·이행률·메모와 함께 보인다', (tester) async {
@@ -418,8 +433,16 @@ void main() {
       expect(find.text('운동 현황'), findsOneWidget);
       expect(find.text('이번 주 완료율'), findsNothing);
 
-      // 오늘 줄은 처음부터 펼쳐져 있고, 그 안에 그날의 미션 카드가 선다.
+      // 오늘 줄은 토글이 아닌 일반 박스로 항상 펼쳐져 있다.
+      final Finder todayRow = find.byKey(
+        ValueKey<String>('client-day-tile-${ymd(todayKst())}'),
+      );
       expect(find.text(_todayRowLabel()), findsOneWidget);
+      expect(todayRow, findsOneWidget);
+      expect(
+        find.descendant(of: todayRow, matching: find.byIcon(Icons.expand_more)),
+        findsNothing,
+      );
       // 완료 배지 — 원형 게이지가 아니라 아이콘+글자 배지다(#1025).
       expect(find.text('100%'), findsWidgets);
       expect(find.text('트레이너 메모'), findsOneWidget); // 오늘 것만 메모가 있다


### PR DESCRIPTION
## Summary

* 트레이너 웹 고객 탭의 운동 `오늘` 화면에서 기록을 처음부터 펼친 일반 박스로 표시한다.
* 오늘 기록의 펼치기 화살표와 탭 동작을 제거해 기록을 바로 확인할 수 있게 한다.
* `이번 주`와 `전체` 화면의 날짜별 펼치기·접기 동작은 기존대로 유지한다.

---

## Changes

### 🔧 Improvements

* 공용 `ClientDayRecordTile`에 토글 사용 여부를 추가해, 토글이 필요 없는 화면에서는 상세 내용을 항상 노출하도록 개선했다.
* 토글을 사용하지 않을 때 버튼·펼침 상태 시맨틱을 제거해 실제 UI 동작과 접근성 정보가 일치하도록 했다.

### 🎨 UI/UX

* 고객 운동 `오늘` 기록에서 펼치기 화살표를 제거하고 항상 열린 일반 박스로 변경했다.
* 고객 운동 `이번 주`와 `전체` 기록에는 기존 화살표와 아코디언 동작을 유지했다.
* 고객 식단 `오늘` 화면은 기존 일반 끼니 박스를 그대로 유지하고, `이번 주`와 `전체`의 날짜별 토글 동작도 변경하지 않았다.

### 🐛 Fixes

* 기본적으로 펼쳐져 있으면서도 다시 접을 수 있던 오늘 기록의 불필요한 토글 동작을 제거했다.

---

## Commits

1. `974fea12` fix(trainer): 고객 운동 오늘 기록 토글 제거

---

## Notes

* 변경 범위는 트레이너 웹 고객 탭의 날짜별 기록 UI이며 프로그램 탭의 운동 상세 더보기 동작에는 영향을 주지 않는다.
* 최신 `main` 기준으로 재배치해 기존 고객 식단·운동 개편 변경이 PR에 중복 포함되지 않는다.

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인 (위젯 테스트)
* [ ] 웹 빌드 확인
* [x] 관련 테스트 통과

### Manual Test Steps

1. `cd frontend/flutter_trainer && flutter run -d chrome`으로 트레이너 웹을 실행한다.
2. 고객 탭에서 고객을 선택하고 운동 → 오늘로 이동해 기록이 화살표 없이 항상 펼쳐져 있는지 확인한다.
3. 운동 → 이번 주와 전체로 이동해 날짜별 펼치기·접기 토글이 유지되는지 확인한다.
4. 식단 → 오늘의 끼니 박스와 이번 주·전체의 날짜별 토글이 기존대로 동작하는지 확인한다.

### Automated Tests

* `flutter test test/features/clients/client_detail_workout_test.dart test/features/clients/client_detail_diet_test.dart` — 30개 통과
* `dart analyze lib/features/clients/presentation/widgets/client_day_record_tile.dart lib/features/clients/presentation/widgets/workout_view.dart test/features/clients/client_detail_workout_test.dart` — 이슈 없음

---

## Related Issues

* 없음

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인