### PR TITLE
docs(readme): 근거 표 통계 수치 정정

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,15 +72,17 @@
 
 | 지표 (연령대 · 조사연도) | 수치 |
 | --- | --- |
-| **당뇨병** 유병률 (19–39세 · ~2020) | 10년 새 **2배** (1.02% → 2.02%, 약 37만 명) |
-| **당뇨병 전단계** (19–39세 · ~2020) | **26.5%** (약 303만 명) |
-| **고혈압** 인지율 / 치료율 (20–39세 · 2022) | **36% / 35%** (전체 성인 77% / 74%) |
+| **2형 당뇨병** 유병률 (19–39세 · 2010→2020) | 1.02% → **2.02%** — 10년 새 2배 (2020년 372,726명) |
+| **당뇨병 전단계** (19–39세 · 2019–2022) | **21.8%** (약 303만 명 · 남성 26.5% / 여성 16.7%) |
+| 당뇨병 **인지율 / 치료율** (19–39세 당뇨 환자 · 2019–2022) | **43.3% / 34.6%** (혈당 조절률 29.6%) |
+| **고혈압** 유병 인구 (20–39세 · 2022) | 약 **89만 명** (전체 고혈압 환자 1,300만 명의 6.9%) |
+| 고혈압 **인지율 / 치료율** (20–39세 · 2022) | **36% / 35%** (전체 성인 77% / 74%) |
 | 고혈압 치료 **미순응** (20–39세 · 2022) | **84.9%** (20대는 24%만 꾸준히 치료) |
-| **유산소 신체활동** 실천율 (성인 전체 · 2014→2020) | 58.3% → **45.6%**, 좌식 7.5 → 8.6시간 |
+| **유산소 신체활동** 실천율 (성인 전체 · 2014→2020) | 58.3% → **45.6%**, 좌식 7.5 → **8.6시간** (20대 9.7시간) |
 
-<sub>※ 지표마다 연령대·조사연도가 다릅니다(신체활동은 성인 전체 추세). 동일 표본의 직접 비교가 아니라, 2030 중심의 만성질환 증가와 관리 공백을 함께 보여주는 근거로 제시합니다.</sub>
+<sub>※ 지표마다 연령대·조사연도·자료원이 다릅니다(2형 당뇨 유병률은 건보공단 청구자료, 나머지 질환 지표는 국민건강영양조사 기반 팩트시트, 신체활동은 성인 전체 추세). 동일 표본의 직접 비교가 아니라, 2030 중심의 만성질환 증가와 관리 공백을 함께 보여주는 근거로 제시합니다.</sub>
 
-<sub>Sources — [Diabetes Fact Sheets in Korea 2024](https://www.e-dmj.org/journal/view.php?number=2909) · [Korea Hypertension Fact Sheet 2024](https://pmc.ncbi.nlm.nih.gov/articles/PMC11903208/) · [Physical Activity Trends, KNHANES](https://pmc.ncbi.nlm.nih.gov/articles/PMC9100085/) · [The Korea Herald](https://www.koreaherald.com/article/10478765)</sub>
+<sub>Sources — [Young Adults with T2DM in South Korea 2010–2020, *Diabetes Metab J* 2025](https://www.e-dmj.org/journal/view.php?number=2927) · [Diabetes Fact Sheets in Korea 2024](https://www.e-dmj.org/journal/view.php?number=2909) · [Korea Hypertension Fact Sheet 2024](https://pmc.ncbi.nlm.nih.gov/articles/PMC11903208/) · [Physical Activity Trends, KNHANES](https://pmc.ncbi.nlm.nih.gov/articles/PMC9100085/) · [The Korea Herald](https://www.koreaherald.com/article/10478765)</sub>
 
 ---
 


### PR DESCRIPTION
Closes #1206

## Summary

README `Background` 표의 통계를 원자료로 직접 확인해 잘못된 값과 출처 오귀속을 정정했습니다. 공모전 제출 영상이 같은 표를 근거로 쓰기 때문에, 영상에 넣기 전에 표를 먼저 맞췄습니다.

## Changes

- **당뇨병 전단계 26.5% → 21.8%** — 26.5%는 19–39세 **남성**의 비율입니다. 함께 적혀 있던 인원(약 303만 명)에 대응하는 전체 비율은 21.8%이며, 남녀 값(26.5% / 16.7%)을 괄호로 함께 남겼습니다.
- **당뇨병 유병률 추이의 출처 분리** — "10년 새 2배(1.02% → 2.02%)"는 팩트시트가 아니라 건보공단 맞춤형DB를 분석한 별도 논문이 근거입니다. Sources 에 해당 논문을 추가하고, 2020년 환자 수를 372,726명으로 정확히 적었습니다.
- **조사연도 정정** — 당뇨 전단계·인지율의 `~2020` 을 국민건강영양조사 `2019–2022` 로 바꿨습니다.
- **행 추가** — 고혈압 유병 인구(20–39세 약 89만 명), 당뇨병 인지율 / 치료율(43.3% / 34.6%). 두 질환을 같은 축(유병 규모 · 인지율)으로 나란히 볼 수 있습니다.
- **좌식시간 보강** — 20대 9.7시간을 병기했습니다.
- **각주 보완** — 자료원이 서로 다르다는 점(건보공단 청구자료 / 국민건강영양조사 기반 팩트시트 / 성인 전체 추세)을 명시했습니다.

## Verification

| 항목 | 결과 |
| --- | --- |
| 당뇨 전단계 19–39세 | 21.8% (약 303만 명), 남 26.5% / 여 16.7% — Diabetes Fact Sheets in Korea 2024 |
| 2형 당뇨 유병률 19–39세 | 1.02%(2010) → 2.02%(2020), 372,726명 — Diabetes Metab J 2025, 건보공단 맞춤형DB |
| 고혈압 20–39세 | 약 89만 명, 인지율 36% / 치료율 35%, 미순응 84.9% — Korea Hypertension Fact Sheet 2024 |
| 전체 성인 고혈압 인지율 / 치료율 | 77% / 74% — 기존 값 그대로 확인 |
| 유산소 실천율 · 좌식시간 | 58.3% → 45.6%, 7.5 → 8.6시간(20대 9.7시간) — 국민건강영양조사 |

## Notes

- 이 PR은 루트 `README.md` 한 파일만 건드립니다.
- `docs/elevator_speech.md` 의 "최근 5년간 20~30대 당뇨 38%, 고혈압 28% 증가(국민건강보험공단)" 는 원자료를 찾지 못했습니다. 발표용 문서라 이번 PR 범위에서 제외했고, 확인 후 별도로 다루는 편이 좋겠습니다.