### PR TITLE
style(consultation): 상담 요청 거절 UI와 사유 예시 정리

### DIFF
--- a/frontend/flutter_trainer/lib/features/consultations/presentation/pages/consultations_page.dart
+++ b/frontend/flutter_trainer/lib/features/consultations/presentation/pages/consultations_page.dart
@@ -365,6 +365,7 @@ class _RejectDialogState extends State<_RejectDialog> {
         ),
         TextButton(
           key: const ValueKey<String>('consultation-reject-confirm'),
+          style: TextButton.styleFrom(foregroundColor: AppColors.destructive),
           // Returns '' rather than null when left blank: null is the
           // cancel signal, and an empty note is a valid "no reason given".
           onPressed: () => Navigator.of(context).pop(_controller.text.trim()),

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
@@ -1949,7 +1949,7 @@ abstract class AppLocalizations {
   /// No description provided for @consultRejectHint.
   ///
   /// In en, this message translates to:
-  /// **'e.g. We\'re fully booked this month'**
+  /// **'e.g. I have another appointment at your requested time.'**
   String get consultRejectHint;
 
   /// No description provided for @consultRejectAction.

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
@@ -1,6 +1,5 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
-
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -1054,7 +1053,8 @@ class AppLocalizationsEn extends AppLocalizations {
       'The reason you write is sent to the member as a notification.';
 
   @override
-  String get consultRejectHint => 'e.g. We\'re fully booked this month';
+  String get consultRejectHint =>
+      'e.g. I have another appointment at your requested time.';
 
   @override
   String get consultRejectAction => 'Decline';

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
@@ -1014,7 +1014,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get consultRejectNotice => '입력한 사유는 고객에게 알림으로 전달돼요.';
 
   @override
-  String get consultRejectHint => '예) 이번 달은 정원이 찼어요';
+  String get consultRejectHint => '예) 요청하신 시간에 다른 일정이 있어요.';
 
   @override
   String get consultRejectAction => '거절하기';

--- a/frontend/flutter_trainer/lib/l10n/app_en.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_en.arb
@@ -488,7 +488,7 @@
   "consultApprove": "Approve",
   "consultRejectTitle": "Decline request",
   "consultRejectNotice": "The reason you write is sent to the member as a notification.",
-  "consultRejectHint": "e.g. We're fully booked this month",
+  "consultRejectHint": "e.g. I have another appointment at your requested time.",
   "consultRejectAction": "Decline",
   "consultStatusApproved": "Added as a client",
   "workoutRecords": "Workout log",

--- a/frontend/flutter_trainer/lib/l10n/app_ko.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_ko.arb
@@ -316,7 +316,7 @@
   "consultApprove": "승인",
   "consultRejectTitle": "상담 요청 거절",
   "consultRejectNotice": "입력한 사유는 고객에게 알림으로 전달돼요.",
-  "consultRejectHint": "예) 이번 달은 정원이 찼어요",
+  "consultRejectHint": "예) 요청하신 시간에 다른 일정이 있어요.",
   "consultRejectAction": "거절하기",
   "consultStatusApproved": "담당 고객으로 등록됨",
   "workoutRecords": "운동 기록",

--- a/frontend/flutter_trainer/test/features/consultations/consultations_page_test.dart
+++ b/frontend/flutter_trainer/test/features/consultations/consultations_page_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -6,6 +6,7 @@ import 'package:oncare_trainer/app/router/routes.dart';
 import 'package:oncare_trainer/app/shell/app_shell.dart';
 import 'package:oncare_trainer/app/shell/nav_destinations.dart';
 import 'package:oncare_trainer/core/errors/app_error.dart';
+import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/features/consultations/data/repositories/consultation_repository.dart';
 import 'package:oncare_trainer/features/consultations/domain/entities/consultation_request.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations_ko.dart';
@@ -215,6 +216,47 @@ void main() {
 
     expect(repo.accepted, <String>['consult-1']);
   });
+
+  for (final entry in <(String, String)>[
+    ('스케줄', AppRoutes.consultations),
+    ('대시보드', AppRoutes.consultationsFromDashboard()),
+  ]) {
+    testWidgets('${entry.$1} 상담 거절은 위험 색상과 일정 충돌 예시를 쓴다', (tester) async {
+      await _pumpInbox(
+        tester,
+        _FakeConsultationRepository(
+          requests: <ConsultationRequest>[_request()],
+        ),
+        at: entry.$2,
+      );
+
+      await tester.tap(
+        find.byKey(const ValueKey<String>('consultation-reject-consult-1')),
+      );
+      await settle(tester);
+
+      final confirm = tester.widget<TextButton>(
+        find.byKey(const ValueKey<String>('consultation-reject-confirm')),
+      );
+      final cancel = tester.widget<TextButton>(
+        find.widgetWithText(TextButton, _ko.actionCancel),
+      );
+      expect(
+        confirm.style?.foregroundColor?.resolve(const <WidgetState>{}),
+        AppColors.destructive,
+      );
+      expect(
+        cancel.style?.foregroundColor?.resolve(const <WidgetState>{}),
+        isNot(AppColors.destructive),
+      );
+
+      final reason = tester.widget<TextField>(
+        find.byKey(const ValueKey<String>('consultation-reject-reason')),
+      );
+      expect(reason.decoration?.hintText, '예) 요청하신 시간에 다른 일정이 있어요.');
+      expect(find.textContaining('이번 달은 정원이 찼어요'), findsNothing);
+    });
+  }
 
   testWidgets('a decided request shows its outcome, not the actions', (
     tester,


### PR DESCRIPTION
## Summary

* 대시보드와 스케줄이 공유하는 상담 요청 거절 다이얼로그의 최종 버튼을 붉은 위험 색상으로 변경했습니다.
* 거절 사유 예시를 `요청하신 시간에 다른 일정이 있어요.`로 변경했습니다.
* 두 진입 경로에서 버튼 색상과 문구를 검증하는 위젯 테스트를 추가했습니다.

---

## Changes

### ✨ Features

* 해당 없음

### 🔧 Improvements

* 상담 요청 거절 사유 예시를 요청 시간의 일정 충돌 상황으로 구체화
* 한국어·영어 현지화 생성 코드 동기화

### 🎨 UI/UX

* `거절하기` 버튼에 `AppColors.destructive` 적용
* `취소` 버튼은 기존 중립/브랜드 색상 유지

### 📝 Docs

* 해당 없음

### 🐛 Fixes

* 카드의 붉은 `거절` 버튼과 다이얼로그의 파란 `거절하기` 버튼이 서로 다른 의미를 전달하던 불일치 수정

---

## Commits

1. `d0fb32a5` style(consultation): 거절 동작을 위험 색상으로 통일

---

## Notes

* 대시보드와 스케줄은 같은 상담 요청 페이지와 거절 다이얼로그를 사용합니다.
* 사유 입력, 500자 제한, 저장소 거절 요청 로직은 변경하지 않았습니다.

---

## Screenshots (Optional)

| Before | After |
| ------ | ----- |
| `거절하기` 파란색 | `거절하기` 붉은 위험 색상 |

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [ ] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 트레이너 대시보드에서 상담 요청으로 진입해 `거절`을 누릅니다.
2. `거절하기` 버튼이 붉은색이고 입력 예시가 `요청하신 시간에 다른 일정이 있어요.`인지 확인합니다.
3. 스케줄의 상담 요청 진입에서도 같은 UI가 표시되는지 확인합니다.

자동 검증:

* `flutter test --no-pub test/features/consultations/consultations_page_test.dart` (14 tests)
* 수정 파일 `flutter analyze --no-pub` 통과

---

## Related Issues

Closes #1252

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인