### PR TITLE
fix(exercise): AI 최근 활동 판단의 고객앱 운동일 기준 통일

### DIFF
--- a/backend/app/db/seed_member_data.py
+++ b/backend/app/db/seed_member_data.py
@@ -38,6 +38,7 @@ from sqlalchemy.orm import Session
 from app.core import clock
 from app.core.config import get_settings
 from app.db.demo_fixture import FixtureExercise, load_fixture
+from app.services import exercise_activity
 from app.db.seed_trainer import TRAINER_ID, _MEMBERS
 from app.db.session import SessionLocal
 from app.models import models
@@ -444,14 +445,9 @@ def _entry_foods(entry: models.DietEntry) -> list[dict]:
 
 
 def _session_date(session: models.ExerciseSession) -> str:
-    """세션의 실제 날짜. 저장은 (주 시작 + 요일 라벨)로 쪼개져 있다."""
-    try:
-        monday = date.fromisoformat(session.week_start)
-        return (
-            monday + timedelta(days=_WEEKDAY_INDEX[session.day_label])
-        ).isoformat()
-    except (ValueError, KeyError):
-        return session.week_start
+    """세션의 논리 운동일. 규칙은 [exercise_activity.activity_date_of] 하나다."""
+    day = exercise_activity.activity_date_of(session)
+    return day.isoformat() if day is not None else session.week_start
 
 
 def _seed_schedule(db: Session, valid: set[str]) -> None:
@@ -704,6 +700,10 @@ def _seed_from_fixture(db: Session, member_id: str) -> None:
                 minutes=minutes,
                 calories=calories,
                 intensity="moderate",
+                # 실제로 운동한 날의 시각을 함께 적는다 (#1264). `created_at` 은
+                # 재시드 시각이라, 이것이 없으면 35주 전 운동도 방금 만든 행으로
+                # 남아 최근 활동 판단이 어긋난다.
+                completed_at=exercise_activity.noon(day.day),
             ))
 
     _safe_commit(db)

--- a/backend/app/services/coach/personal_ingest.py
+++ b/backend/app/services/coach/personal_ingest.py
@@ -301,13 +301,12 @@ def _entry_foods(foods_json: str | None) -> list[dict]:
 
 
 def exercise_session_date(row) -> str:
-    """세션의 실제 날짜. 저장은 (주 시작 + 요일 라벨)로 쪼개져 있다."""
-    from app.services.exercise_service import WEEKDAY_LABELS
+    """세션의 논리 운동일. 규칙은 [exercise_activity.activity_date_of] 하나다.
 
-    try:
-        monday = date.fromisoformat(row.week_start)
-        return (
-            monday + timedelta(days=WEEKDAY_LABELS.index(row.day_label))
-        ).isoformat()
-    except (ValueError, IndexError):
-        return row.week_start
+    적재 문구에 날짜를 넣으려면 되돌려야 한다 — "월요일" 만 적으면 몇 주 전
+    기록도 똑같이 보여 코치가 최근 것과 구분하지 못한다.
+    """
+    from app.services import exercise_activity
+
+    day = exercise_activity.activity_date_of(row)
+    return day.isoformat() if day is not None else str(row.week_start)

--- a/backend/app/services/exercise_activity.py
+++ b/backend/app/services/exercise_activity.py
@@ -1,0 +1,114 @@
+"""운동 기록의 **논리 운동일** — 고객 앱이 보는 날짜 하나로 통일한다. (#1264)
+
+회원 앱의 운동 화면과 트레이너 웹의 주간 운동 화면은 둘 다
+`ExerciseSession.week_start + day_label` 을 그 기록의 날짜로 읽는다. 두 화면이
+같은 집계(`exercise_service.build_current_week`)를 공유하므로 그것이 곧 제품의
+날짜 계약이다.
+
+반면 `created_at` 은 **DB 에 적재된 시각**이다. 과거 기록을 다시 시드하거나
+늦게 입력하면 몇 주 전 운동도 방금 만들어진 행이 되어, 고객이 보는 날짜와
+서버가 해석하는 날짜가 갈린다 — 김민수 데모는 35주치(245일)를 재시드할 때마다
+모든 행의 `created_at` 이 재시드 시각이라, AI 가 35주 전 운동을 최근 운동으로
+읽었다.
+
+그래서 날짜의 기준을 하나로 둔다:
+
+1. `week_start + day_label` 이 유효하면 그것이 논리 운동일이다.
+2. 두 값이 깨진 옛 행은 `completed_at` 의 KST 날짜로 떨어뜨린다.
+3. 그것도 없을 때만 마지막 호환 수단으로 `created_at` 의 KST 날짜를 쓴다.
+
+`created_at` 은 감사·적재 시각일 뿐, 최근 활동 판단에 직접 쓰지 않는다.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta
+
+from app.core import clock
+
+#: 요일 라벨(월=0 … 일=6). `exercise_service.WEEKDAY_LABELS` 와 같은 순서다 —
+#: 이 모듈은 모델·서비스 어느 쪽도 import 하지 않아야 순환이 생기지 않는다.
+WEEKDAY_LABELS = ("월", "화", "수", "목", "금", "토", "일")
+
+
+def activity_date_of(row) -> date | None:
+    """[row] 의 논리 운동일. 셋 중 어느 것으로도 알 수 없으면 None.
+
+    None 은 "날짜를 모른다" 이지 "오늘" 이 아니다 — 모르는 행을 오늘로 떨어뜨리면
+    기간 집계가 조용히 부풀어, 아무 운동도 하지 않은 회원에게 최근 기록이 있는
+    것처럼 보인다.
+    """
+    from_labels = _date_from_week_labels(
+        getattr(row, "week_start", None), getattr(row, "day_label", None)
+    )
+    if from_labels is not None:
+        return from_labels
+    completed_at = getattr(row, "completed_at", None)
+    if isinstance(completed_at, datetime):
+        return clock.to_seoul(completed_at).date()
+    created_at = getattr(row, "created_at", None)
+    if isinstance(created_at, datetime):
+        return clock.to_seoul(created_at).date()
+    return None
+
+
+def _date_from_week_labels(week_start, day_label) -> date | None:
+    """`주 시작 + 요일 라벨` → 날짜. 둘 중 하나라도 깨졌으면 None."""
+    if not isinstance(week_start, str) or not isinstance(day_label, str):
+        return None
+    try:
+        monday = date.fromisoformat(week_start)
+        offset = WEEKDAY_LABELS.index(day_label)
+    except (ValueError, IndexError):
+        return None
+    return monday + timedelta(days=offset)
+
+
+def recent_window(days: int, *, today: date | None = None) -> tuple[date, date]:
+    """최근 [days] 일의 (시작, 끝). **오늘을 포함해 [days] 개 날짜**다.
+
+    `오늘 - (days - 1)` 부터라는 뜻이다. 예전에는 `오늘 - days` 부터 세어 14일이
+    실제로는 15개 날짜였다 — 경계가 하루 헐거우면 "최근 2주" 가 화면·서버마다
+    다른 구간을 가리킨다.
+    """
+    end = today if today is not None else clock.today()
+    return end - timedelta(days=max(days, 1) - 1), end
+
+
+def in_window(day: date | None, window: tuple[date, date]) -> bool:
+    """[day] 가 구간 안(양 끝 포함)인가. 날짜를 모르는 행은 밖으로 둔다."""
+    if day is None:
+        return False
+    start, end = window
+    return start <= day <= end
+
+
+def week_starts_covering(start: date, end: date) -> list[str]:
+    """[start, end] 에 걸치는 주의 월요일들(`YYYY-MM-DD`).
+
+    조회를 좁히는 데 쓴다 — 전체 테이블을 읽으면 35주치 데모에서 245일이 매번
+    끌려온다. 다만 이 목록만으로 거르지는 않는다: `week_start` 가 깨진 옛 행은
+    여기에 걸리지 않으므로, 호출부가 `completed_at`·`created_at` 조건을 함께
+    걸어 넓게 가져온 뒤 [activity_date_of] 로 최종 판정한다.
+    """
+    first = start - timedelta(days=start.weekday())
+    last = end - timedelta(days=end.weekday())
+    out: list[str] = []
+    cursor = first
+    while cursor <= last:
+        out.append(cursor.isoformat())
+        cursor += timedelta(days=7)
+    return out
+
+
+def start_of_day(day: date) -> datetime:
+    """KST 자정(tz-aware). `completed_at`·`created_at` 비교의 하한이다."""
+    return datetime.combine(day, time.min, tzinfo=clock.SEOUL)
+
+
+def noon(day: date) -> datetime:
+    """그날 KST 정오. 날짜만 아는 기록에 시각을 채울 때 쓴다.
+
+    자정이 아니라 정오인 이유는 타임존이 어긋난 채 읽혀도 날짜가 넘어가지 않기
+    때문이다 — UTC 로 읽으면 자정은 전날이 된다.
+    """
+    return datetime.combine(day, time(12, 0), tzinfo=clock.SEOUL)

--- a/backend/app/services/routine_suggestion_service.py
+++ b/backend/app/services/routine_suggestion_service.py
@@ -31,9 +31,9 @@ from __future__ import annotations
 import json
 import uuid
 from dataclasses import dataclass, field
-from datetime import date, datetime, time, timedelta
+from datetime import date, timedelta
 
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -44,7 +44,7 @@ from app.models.models import (
     TrainerRoutine,
     TrainerSchedule,
 )
-from app.services import exercise_types
+from app.services import exercise_activity, exercise_types
 
 #: 검토 대기 상태. 상수의 출처는 [app.services.trainer_service] 지만 그 모듈이 이
 #: 모듈을 불러오므로 값을 여기서 다시 적는다(순환 import 회피) —
@@ -234,7 +234,10 @@ def _collect_signals(
 ) -> _Signals:
     """회원의 최근 기록에서 후보의 근거가 될 신호를 모은다."""
     today = clock.today()
-    since = today - timedelta(days=LOOKBACK_DAYS)
+    # 최근 구간은 **오늘을 포함한 [LOOKBACK_DAYS] 개 날짜**다. PT·운동·피드백이
+    # 모두 같은 구간을 보아야 "최근" 이 신호마다 다른 뜻이 되지 않는다.
+    since, _ = exercise_activity.recent_window(LOOKBACK_DAYS, today=today)
+    window = (since, today)
 
     # 완료된 PT 는 날짜(문자열 YYYY-MM-DD)로 비교한다 — 컬럼이 그 표기라
     # 사전순 비교가 곧 날짜 비교다(다른 조회들도 같은 방식이다).
@@ -251,34 +254,28 @@ def _collect_signals(
     pt_just_finished = any(row.date >= recent_cutoff for row in pt_rows)
     pt_note = any((row.note or "").strip() for row in pt_rows)
 
-    routine_feedback = (
-        db.scalar(
-            select(ExerciseSession.id)
-            .where(
-                ExerciseSession.user_id == member_id,
-                ExerciseSession.assigned_trainer_id == trainer_id,
-                ExerciseSession.trainer_feedback != "",
-                ExerciseSession.created_at >= _since_ts(since),
-            )
-            .limit(1)
+    # 운동 기록은 **논리 운동일**(고객 앱이 보는 날짜)로 거른다 (#1264).
+    # `created_at` 은 적재 시각이라, 재시드한 35주 전 운동도 방금 만든 행이
+    # 되어 최근 운동으로 오인된다.
+    recent_sessions = [
+        row
+        for row in db.scalars(_recent_sessions_query(member_id, window)).all()
+        if exercise_activity.in_window(
+            exercise_activity.activity_date_of(row), window
         )
-        is not None
+    ]
+
+    routine_feedback = any(
+        row.assigned_trainer_id == trainer_id
+        and (row.trainer_feedback or "").strip()
+        for row in recent_sessions
     )
 
-    minutes_by_type = {
-        row.type: int(row.total or 0)
-        for row in db.execute(
-            select(
-                ExerciseSession.type,
-                func.sum(ExerciseSession.minutes).label("total"),
-            )
-            .where(
-                ExerciseSession.user_id == member_id,
-                ExerciseSession.created_at >= _since_ts(since),
-            )
-            .group_by(ExerciseSession.type)
-        ).all()
-    }
+    minutes_by_type: dict[str, int] = {}
+    for row in recent_sessions:
+        minutes_by_type[row.type] = minutes_by_type.get(row.type, 0) + int(
+            row.minutes or 0
+        )
     total_minutes = sum(minutes_by_type.values())
     strength_minutes = sum(
         minutes
@@ -313,9 +310,25 @@ def _collect_signals(
     )
 
 
-def _since_ts(since: date) -> datetime:
-    """`created_at` 비교용 시각. 날짜 경계면 충분해 KST 자정으로 맞춘다."""
-    return datetime.combine(since, time.min, tzinfo=clock.SEOUL)
+def _recent_sessions_query(member_id: str, window: tuple[date, date]):
+    """구간에 닿을 수 있는 운동 기록만 가져오는 조회.
+
+    세 갈래로 넓게 긁고 최종 판정은 파이썬이 [exercise_activity.activity_date_of]
+    로 한다 — 주차만 걸면 `week_start` 가 깨진 옛 행을 놓치고, 반대로 전체를
+    읽으면 35주치 데모에서 245일이 매번 끌려온다.
+    """
+    start, _ = window
+    since_ts = exercise_activity.start_of_day(start)
+    return select(ExerciseSession).where(
+        ExerciseSession.user_id == member_id,
+        or_(
+            ExerciseSession.week_start.in_(
+                exercise_activity.week_starts_covering(*window)
+            ),
+            ExerciseSession.completed_at >= since_ts,
+            ExerciseSession.created_at >= since_ts,
+        ),
+    )
 
 
 def _candidates_for(signals: _Signals) -> list[_Candidate]:

--- a/backend/tests/test_exercise_activity_date.py
+++ b/backend/tests/test_exercise_activity_date.py
@@ -1,0 +1,104 @@
+"""운동 기록의 논리 운동일. (#1264)
+
+고객 앱이 보는 날짜(`week_start + day_label`)가 기준이다. `created_at` 은 DB
+적재 시각이라, 과거 기록을 다시 시드하면 몇 주 전 운동도 방금 만든 행이 된다.
+
+DB 없이 도는 순수 규칙 테스트다.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+
+from app.core import clock
+from app.services import exercise_activity as activity
+
+
+class _Row:
+    """필요한 필드만 든 가짜 행 — 모델을 만들지 않고 규칙만 본다."""
+
+    def __init__(self, **fields):
+        self.week_start = fields.get("week_start")
+        self.day_label = fields.get("day_label")
+        self.completed_at = fields.get("completed_at")
+        self.created_at = fields.get("created_at")
+
+
+def test_week_start_and_day_label_win():
+    row = _Row(
+        week_start="2026-08-17",  # 월요일
+        day_label="목",
+        # 적재는 3주 뒤에 됐다 — 그래도 운동한 날은 8/20 이다.
+        completed_at=datetime(2026, 9, 10, 3, 0, tzinfo=timezone.utc),
+        created_at=datetime(2026, 9, 10, 3, 0, tzinfo=timezone.utc),
+    )
+    assert activity.activity_date_of(row) == date(2026, 8, 20)
+
+
+def test_falls_back_to_completed_at_then_created_at():
+    completed = _Row(
+        week_start="깨진값",
+        day_label="목",
+        completed_at=datetime(2026, 8, 20, 9, 0, tzinfo=timezone.utc),
+        created_at=datetime(2026, 9, 1, 9, 0, tzinfo=timezone.utc),
+    )
+    assert activity.activity_date_of(completed) == date(2026, 8, 20)
+
+    created_only = _Row(
+        week_start=None,
+        day_label=None,
+        created_at=datetime(2026, 8, 20, 9, 0, tzinfo=timezone.utc),
+    )
+    assert activity.activity_date_of(created_only) == date(2026, 8, 20)
+
+
+def test_unknown_date_is_none_not_today():
+    # 모르는 행을 오늘로 떨어뜨리면 기간 집계가 조용히 부푼다.
+    assert activity.activity_date_of(_Row()) is None
+    assert activity.activity_date_of(_Row(week_start="2026-08-17")) is None
+    assert (
+        activity.activity_date_of(_Row(week_start="2026-08-17", day_label="X"))
+        is None
+    )
+
+
+def test_fallback_reads_the_timestamp_in_kst():
+    # UTC 로 8/20 15:30 은 KST 로 8/21 00:30 이다. 서버 타임존을 따라가면
+    # 하루가 밀린다(#557 과 같은 함정).
+    row = _Row(completed_at=datetime(2026, 8, 20, 15, 30, tzinfo=timezone.utc))
+    assert activity.activity_date_of(row) == date(2026, 8, 21)
+    assert activity.noon(date(2026, 8, 21)).tzinfo is clock.SEOUL
+
+
+def test_recent_window_counts_today_in():
+    start, end = activity.recent_window(14, today=date(2026, 8, 20))
+    assert end == date(2026, 8, 20)
+    assert start == date(2026, 8, 7)
+    # 오늘 포함 정확히 14개 날짜다.
+    assert (end - start).days + 1 == 14
+
+    window = (start, end)
+    assert activity.in_window(date(2026, 8, 7), window)
+    assert activity.in_window(date(2026, 8, 20), window)
+    assert not activity.in_window(date(2026, 8, 6), window)
+    assert not activity.in_window(date(2026, 8, 21), window)
+    assert not activity.in_window(None, window)
+
+
+def test_week_starts_cover_month_year_and_leap_boundaries():
+    # 해가 바뀌는 구간.
+    assert activity.week_starts_covering(
+        date(2026, 12, 28), date(2027, 1, 4)
+    ) == ["2026-12-28", "2027-01-04"]
+
+    # 윤년 2월 29일이 있는 주.
+    assert "2028-02-28" in activity.week_starts_covering(
+        date(2028, 2, 29), date(2028, 2, 29)
+    )
+
+    # 14일 구간은 언제 시작해도 세 주를 넘지 않는다.
+    for offset in range(370):
+        end = date(2026, 1, 1) + timedelta(days=offset)
+        start = end - timedelta(days=13)
+        weeks = activity.week_starts_covering(start, end)
+        assert 2 <= len(weeks) <= 3
+        assert weeks == sorted(weeks)

--- a/backend/tests/test_member_seed.py
+++ b/backend/tests/test_member_seed.py
@@ -81,6 +81,31 @@ def test_exercise_seed_is_idempotent(client, db_session):
     assert _count() == before
 
 
+def test_fixture_sessions_record_the_day_they_happened(client, db_session):
+    """시드한 운동에 그날의 `completed_at` 이 함께 적힌다. (#1264)
+
+    없으면 재시드마다 모든 행의 `created_at` 이 지금이 되어, 35주 전 운동도
+    최근 활동으로 읽힌다. 논리 운동일과 어긋나지 않는지도 함께 본다.
+    """
+    from app.models.models import ExerciseSession
+    from app.services import exercise_activity
+
+    rows = db_session.scalars(
+        select(ExerciseSession).where(
+            ExerciseSession.user_id == _MEMBER_ID,
+            ExerciseSession.id.like("seed-fix-ex-%"),
+        )
+    ).all()
+    assert rows, "픽스처 운동 시드가 없다"
+
+    for row in rows:
+        assert row.completed_at is not None, row.id
+        day = exercise_activity.activity_date_of(row)
+        assert day is not None
+        # 적힌 시각의 KST 날짜가 곧 그 기록의 운동일이다.
+        assert clock.to_seoul(row.completed_at).date() == day, row.id
+
+
 def test_no_personal_doc_points_at_a_deleted_seed_row(client, db_session):
     """지워진 시드 행을 가리키는 개인 RAG 문서가 남지 않는다.
 

--- a/backend/tests/test_routine_suggestion_activity_date.py
+++ b/backend/tests/test_routine_suggestion_activity_date.py
@@ -1,0 +1,156 @@
+"""AI 개인운동 신호는 **고객 앱이 보는 날짜**로 최근을 판단한다. (#1264)
+
+예전에는 `created_at`(적재 시각)으로 걸렀다. 김민수 데모는 35주치를 재시드할
+때마다 모든 행의 `created_at` 이 재시드 시각이라, 35주 전 운동이 최근 운동으로
+잡혔다. 반대로 과거 기록을 늦게 입력하면 최근 운동이 최근이 아니게 된다.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import delete
+
+from app.core import clock
+from app.models.models import ExerciseSession, User
+from app.services import exercise_activity as activity
+from app.services import routine_suggestion_service as suggestions
+
+TRAINER = "trainer-demo"
+
+#: 적재만 오래된/방금 된 시각. 논리 운동일과 어긋나게 두어 규칙을 드러낸다.
+_LONG_AGO = datetime(2020, 1, 1, tzinfo=timezone.utc)
+
+
+def _labels_for(day: date) -> tuple[str, str]:
+    """그날의 (주 시작, 요일 라벨) — 고객 앱이 저장하는 형태 그대로."""
+    monday = day - timedelta(days=day.weekday())
+    return monday.isoformat(), activity.WEEKDAY_LABELS[day.weekday()]
+
+
+@pytest.fixture()
+def member(db_session):
+    """운동 기록이 하나도 없는 회원. 시드 회원은 일정·기록이 섞여 있어 쓰지 않는다."""
+    member_id = f"user-activity-{clock.now().timestamp():.0f}"
+    db_session.add(
+        User(
+            id=member_id,
+            email=f"{member_id}@example.com",
+            name="활동일 테스트",
+            hashed_password="",
+        )
+    )
+    db_session.commit()
+    yield member_id
+    db_session.execute(
+        delete(ExerciseSession).where(ExerciseSession.user_id == member_id)
+    )
+    db_session.execute(delete(User).where(User.id == member_id))
+    db_session.commit()
+
+
+def _add_session(
+    db,
+    member_id: str,
+    *,
+    day: date | None,
+    minutes: int = 30,
+    type_: str = "strength",
+    created_at: datetime = _LONG_AGO,
+    completed_at: datetime | None = None,
+    feedback: str = "",
+) -> None:
+    week_start, day_label = _labels_for(day) if day else ("", "")
+    row = ExerciseSession(
+        id=f"ex-test-{member_id}-{day}-{type_}-{minutes}",
+        user_id=member_id,
+        week_start=week_start,
+        day_label=day_label,
+        type=type_,
+        minutes=minutes,
+        calories=minutes * 6,
+        completed_at=completed_at,
+        assigned_trainer_id=TRAINER if feedback else None,
+        trainer_feedback=feedback,
+    )
+    db.add(row)
+    db.flush()
+    # `created_at` 은 server_default 라 넣은 뒤에 덮어써야 한다.
+    row.created_at = created_at
+    db.commit()
+
+
+def _signals(db, member_id: str):
+    return suggestions._collect_signals(db, TRAINER, member_id)
+
+
+def test_reseeded_old_workout_is_not_recent(db_session, member):
+    """35주 전 운동을 **오늘 적재**해도 최근 운동이 아니다."""
+    long_ago = clock.today() - timedelta(weeks=35)
+    _add_session(
+        db_session, member, day=long_ago, created_at=clock.now(), minutes=600
+    )
+
+    signals = _signals(db_session, member)
+    assert signals.has_records is False
+    assert signals.strength_heavy is False
+
+
+def test_recent_workout_counts_even_when_loaded_long_ago(db_session, member):
+    """논리 운동일이 최근이면 `created_at` 이 오래돼도 최근 운동이다."""
+    _add_session(db_session, member, day=clock.today() - timedelta(days=1))
+
+    signals = _signals(db_session, member)
+    assert signals.has_records is True
+    # 근력만 있으니 근력 편중이고 유산소가 없다.
+    assert signals.strength_heavy is True
+    assert signals.low_cardio is True
+
+
+@pytest.mark.parametrize(
+    ("days_ago", "counts"),
+    [(0, True), (13, True), (14, False), (20, False)],
+)
+def test_window_is_today_plus_thirteen_days(db_session, member, days_ago, counts):
+    """최근 구간은 **오늘을 포함한 14개 날짜**다."""
+    _add_session(db_session, member, day=clock.today() - timedelta(days=days_ago))
+
+    assert _signals(db_session, member).has_records is counts
+
+
+def test_feedback_uses_the_same_date_rule_as_minutes(db_session, member):
+    """피드백 신호와 분 집계가 같은 날짜 규칙을 쓴다."""
+    old = clock.today() - timedelta(days=30)
+    _add_session(
+        db_session,
+        member,
+        day=old,
+        created_at=clock.now(),
+        feedback="자세를 조금 낮춰 보세요",
+    )
+    # 구간 밖의 피드백은 신호가 아니다 — 분 집계가 세지 않는 날의 피드백만
+    # 신호가 되면 두 신호가 서로 다른 '최근' 을 말하게 된다.
+    assert _signals(db_session, member).trainer_feedback is False
+
+    _add_session(
+        db_session,
+        member,
+        day=clock.today() - timedelta(days=2),
+        feedback="어깨는 무리하지 마세요",
+    )
+    signals = _signals(db_session, member)
+    assert signals.trainer_feedback is True
+    assert signals.has_records is True
+
+
+def test_broken_week_start_falls_back_to_completed_at(db_session, member):
+    """옛 행(주차·요일이 깨짐)은 `completed_at` 의 KST 날짜로 읽는다."""
+    _add_session(
+        db_session,
+        member,
+        day=None,
+        created_at=_LONG_AGO,
+        completed_at=activity.noon(clock.today() - timedelta(days=3)),
+    )
+
+    assert _signals(db_session, member).has_records is True


### PR DESCRIPTION
Refs #1264 (이슈의 앞 절반. 남은 범위는 아래 **Notes** 참고 — 이 PR 로 닫지 않는다.)

## Summary
AI 개인운동 후보의 신호가 `created_at`(DB 적재 시각)으로 "최근" 을 판단했다. 김민수 데모는 35주치(245일)를 재시드할 때마다 모든 행의 적재 시각이 지금이 되어, **35주 전 운동이 최근 운동으로** 잡혔다. 반대로 과거 기록을 늦게 입력하면 고객이 최근으로 보는 운동을 AI 는 오래된 것으로 읽는다.

## Changes
- `app/services/exercise_activity.py` — 논리 운동일 규칙 한 곳. `week_start + day_label` 이 유효하면 그것이 운동일이고, 깨진 옛 행만 `completed_at` → `created_at` 의 KST 날짜로 떨어뜨린다. 어느 것으로도 알 수 없으면 `None` 이다 — 모르는 행을 오늘로 떨어뜨리면 기간 집계가 조용히 부푼다.
- `_collect_signals()` 의 피드백·유형별 분·기록 유무·근력 편중이 모두 이 규칙을 쓴다.
- **최근 구간의 정의**: 오늘을 포함한 14개 날짜(`오늘-13` ~ 오늘). 예전에는 `오늘 - 14` 부터 세어 15개였다. PT 조회도 같은 구간을 쓴다 — 신호마다 "최근" 이 다른 뜻이면 근거가 서로 어긋난다.
- 조회는 구간에 걸치는 주차 + `completed_at`/`created_at` 하한으로 좁힌 뒤 파이썬에서 최종 판정한다. 주차만 걸면 `week_start` 가 깨진 옛 행을 놓치고, 전체를 읽으면 35주치가 매번 끌려온다.
- 픽스처 시드가 각 운동에 그날의 `completed_at` 을 적는다. 기존 DB 는 날짜가 바뀌어 시드가 다시 깔릴 때 채워진다(`seed-` 행만 지웠다 넣는 기존 규칙 그대로).
- 중복이던 날짜 계산 세 벌 중 둘(`seed_member_data._session_date`, `personal_ingest.exercise_session_date`)을 새 규칙에 위임했다.

## Verification
- backend `pytest` 전체 통과.
- 새 테스트 15건: 논리 운동일 규칙 6건(우선순위·폴백·모르는 날짜·KST 경계·구간 정의·월말/연말/윤년 주차), 신호 회귀 8건(재시드한 35주 전 운동은 최근이 아님, 논리 운동일이 최근이면 적재가 오래돼도 최근, 14일 경계 4케이스, 피드백과 분 집계가 같은 규칙, 깨진 주차의 `completed_at` 폴백), 시드 1건(모든 픽스처 운동의 `completed_at` 이 그날과 일치).
- 신호 회귀 8건 중 6건이 수정 전 코드에서 실패하는 것을 확인했다(나머지 2건은 구간 밖 케이스라 예전에도 통과).

## Notes
이슈의 나머지 절반(**회원 수동 기록·PT 파생 기록의 날짜 필드 정렬**, `exercise_service` 로의 날짜 함수 통합)은 이 PR 에 넣지 않았다. 같은 파일들(`app/services/exercise_service.py`, `app/api/v1/exercise.py`, `app/services/trainer_service.py`, `tests/test_exercise.py`)을 #1276 이 지금 고쳐 쓰는 중이라, 함께 건드리면 양쪽이 크게 충돌한다. #1276 이 병합된 뒤 후속 PR 로 이어서 올리고 그때 #1264 를 닫는다.