### PR TITLE
fix(schedule): 데모 PT·상담 시간을 운영 규칙에 맞게 배치

### DIFF
--- a/frontend/flutter_trainer/lib/core/storage/seed_data.dart
+++ b/frontend/flutter_trainer/lib/core/storage/seed_data.dart
@@ -1113,7 +1113,7 @@ class _WeekSlot {
 }
 
 /// 트레이너의 한 주 — 10~22시 사이 짝수 정시는 1:1 PT, 그 사이 홀수
-/// 정시는 상담으로 둔다. PT는 60분, 상담은 30분으로 통일한다.
+/// 정시는 상담으로 둔다. 실제 운영 화면처럼 PT와 상담 길이는 다양하게 둔다.
 ///
 /// 오늘 몫은 [_schedule] 이 따로 들고 있어서, 오늘에 해당하는 요일은 시딩이
 /// 건너뛴다. 두 목록이 같은 날에 겹치면 오늘 화면에 없던 수업이 끼어든다.
@@ -1124,7 +1124,7 @@ const List<_WeekSlot> _weekSchedule = <_WeekSlot>[
     time: '10:00',
     clientName: '최우진',
     type: SessionType.personalTraining,
-    durationMinutes: 60,
+    durationMinutes: 30,
     note: '출근 전 수업. 상체 위주로 짧게 끊어 간다.',
     program: <Map<String, Object?>>[
       <String, Object?>{'name': '랫풀다운', 'sets': 4, 'reps': '10회', 'weight': '35kg'},
@@ -1136,7 +1136,7 @@ const List<_WeekSlot> _weekSchedule = <_WeekSlot>[
     time: '13:00',
     clientName: '정하윤',
     type: SessionType.consultation,
-    durationMinutes: 30,
+    durationMinutes: 45,
     note: '식단 기록 습관 점검. 저녁 외식 빈도를 함께 본다.',
   ),
   _WeekSlot(
@@ -1144,7 +1144,7 @@ const List<_WeekSlot> _weekSchedule = <_WeekSlot>[
     time: '18:00',
     clientName: '임도현',
     type: SessionType.personalTraining,
-    durationMinutes: 60,
+    durationMinutes: 90,
     note: '데드리프트 자세 교정 중. 허리 통증 여부를 매 세트 확인한다.',
     program: <Map<String, Object?>>[
       <String, Object?>{'name': '데드리프트', 'sets': 4, 'reps': '8회', 'weight': '60kg'},
@@ -1157,7 +1157,7 @@ const List<_WeekSlot> _weekSchedule = <_WeekSlot>[
     time: '10:00',
     clientName: '신유나',
     type: SessionType.personalTraining,
-    durationMinutes: 60,
+    durationMinutes: 45,
     note: '유산소 비중을 늘리는 주. 심박 130 안쪽으로 유지한다.',
   ),
   _WeekSlot(
@@ -1165,7 +1165,7 @@ const List<_WeekSlot> _weekSchedule = <_WeekSlot>[
     time: '14:00',
     clientName: '오세라',
     type: SessionType.personalTraining,
-    durationMinutes: 60,
+    durationMinutes: 50,
     note: '어깨 가동 범위 회복 단계. 중량보다 자세를 본다.',
     program: <Map<String, Object?>>[
       <String, Object?>{'name': '밴드 외전', 'sets': 3, 'reps': '20회', 'weight': '밴드'},
@@ -1177,7 +1177,7 @@ const List<_WeekSlot> _weekSchedule = <_WeekSlot>[
     time: '20:00',
     clientName: '한지호',
     type: SessionType.personalTraining,
-    durationMinutes: 60,
+    durationMinutes: 90,
     note: '하체 중량 구간. 무릎 각도 확인하며 스쿼트 깊이를 잡는다.',
   ),
   // 수
@@ -1198,7 +1198,7 @@ const List<_WeekSlot> _weekSchedule = <_WeekSlot>[
     time: '15:00',
     clientName: '문가영',
     type: SessionType.consultation,
-    durationMinutes: 30,
+    durationMinutes: 60,
     note: '수업 시간대 변경 상담. 오전 이동 가능 여부를 확인한다.',
   ),
   _WeekSlot(
@@ -1206,7 +1206,7 @@ const List<_WeekSlot> _weekSchedule = <_WeekSlot>[
     time: '20:00',
     clientName: '백서진',
     type: SessionType.personalTraining,
-    durationMinutes: 60,
+    durationMinutes: 30,
     note: '야간 수업. 다음 날 근육통을 고려해 볼륨을 낮게 잡는다.',
   ),
   // 목
@@ -1215,7 +1215,7 @@ const List<_WeekSlot> _weekSchedule = <_WeekSlot>[
     time: '10:00',
     clientName: '강서연',
     type: SessionType.personalTraining,
-    durationMinutes: 60,
+    durationMinutes: 90,
     note: '전신 순환. 세트 사이 휴식을 45초로 줄여 본다.',
     program: <Map<String, Object?>>[
       <String, Object?>{'name': '케틀벨 스윙', 'sets': 4, 'reps': '15회', 'weight': '12kg'},
@@ -1227,7 +1227,7 @@ const List<_WeekSlot> _weekSchedule = <_WeekSlot>[
     time: '16:00',
     clientName: '류태경',
     type: SessionType.personalTraining,
-    durationMinutes: 60,
+    durationMinutes: 45,
     note: '재활 마무리 단계. 통증 없는 범위에서만 중량을 올린다.',
   ),
   // 금
@@ -1236,7 +1236,7 @@ const List<_WeekSlot> _weekSchedule = <_WeekSlot>[
     time: '10:00',
     clientName: '노은채',
     type: SessionType.personalTraining,
-    durationMinutes: 60,
+    durationMinutes: 50,
     note: '주 마지막 근력 수업. 상체 볼륨을 채운다.',
   ),
   _WeekSlot(
@@ -1252,7 +1252,7 @@ const List<_WeekSlot> _weekSchedule = <_WeekSlot>[
     time: '16:00',
     clientName: '최우진',
     type: SessionType.personalTraining,
-    durationMinutes: 60,
+    durationMinutes: 30,
     note: '주 2회 중 두 번째 수업. 월요일에 못 채운 하체를 넣는다.',
     program: <Map<String, Object?>>[
       <String, Object?>{'name': '레그프레스', 'sets': 4, 'reps': '12회', 'weight': '70kg'},
@@ -1264,7 +1264,7 @@ const List<_WeekSlot> _weekSchedule = <_WeekSlot>[
     time: '20:00',
     clientName: '이지수',
     type: SessionType.personalTraining,
-    durationMinutes: 60,
+    durationMinutes: 90,
     note: '컨디션에 따라 유산소로 대체할 수 있다.',
   ),
   // 토
@@ -1273,7 +1273,7 @@ const List<_WeekSlot> _weekSchedule = <_WeekSlot>[
     time: '10:00',
     clientName: '정하윤',
     type: SessionType.personalTraining,
-    durationMinutes: 60,
+    durationMinutes: 45,
     note: '주말 수업. 평일보다 길게 가져가되 마무리 스트레칭을 넉넉히 둔다.',
     program: <Map<String, Object?>>[
       <String, Object?>{'name': '체스트프레스', 'sets': 4, 'reps': '10회', 'weight': '25kg'},
@@ -1295,7 +1295,7 @@ const List<_WeekSlot> _weekSchedule = <_WeekSlot>[
     time: '17:00',
     clientName: '서지훈',
     type: SessionType.consultation,
-    durationMinutes: 30,
+    durationMinutes: 45,
     note: '주말 상담. 헬스장 이용 시간대와 목표를 맞춰 본다.',
   ),
   // 일
@@ -1304,7 +1304,7 @@ const List<_WeekSlot> _weekSchedule = <_WeekSlot>[
     time: '10:00',
     clientName: '임도현',
     type: SessionType.personalTraining,
-    durationMinutes: 60,
+    durationMinutes: 50,
     note: '가벼운 마무리 수업. 다음 주 계획을 함께 정한다.',
   ),
 ];
@@ -1314,7 +1314,7 @@ const List<_Slot> _schedule = <_Slot>[
     time: '10:00',
     clientName: '김민수',
     type: SessionType.personalTraining,
-    durationMinutes: 60,
+    durationMinutes: 30,
     status: ScheduleStatus.done,
     note: '무릎 컨디션 양호. 레그프레스 중량 소폭 증가 가능.',
     program: <Map<String, Object?>>[
@@ -1342,7 +1342,7 @@ const List<_Slot> _schedule = <_Slot>[
     time: '12:00',
     clientName: '이지수',
     type: SessionType.personalTraining,
-    durationMinutes: 60,
+    durationMinutes: 50,
     status: ScheduleStatus.done,
     note: '데드리프트 자세 안정적. 다음 세션 60kg 도전.',
     program: <Map<String, Object?>>[
@@ -1375,7 +1375,7 @@ const List<_Slot> _schedule = <_Slot>[
     time: '16:00',
     clientName: '박성호',
     type: SessionType.personalTraining,
-    durationMinutes: 60,
+    durationMinutes: 45,
     status: ScheduleStatus.upcoming,
     note: '',
     program: <Map<String, Object?>>[
@@ -1400,7 +1400,7 @@ const List<_Slot> _schedule = <_Slot>[
     time: '17:00',
     clientName: '윤가온',
     type: SessionType.consultation,
-    durationMinutes: 30,
+    durationMinutes: 60,
     status: ScheduleStatus.upcoming,
     note: '',
     program: <Map<String, Object?>>[],

--- a/frontend/flutter_trainer/lib/core/storage/seed_data.dart
+++ b/frontend/flutter_trainer/lib/core/storage/seed_data.dart
@@ -1112,7 +1112,8 @@ class _WeekSlot {
   final List<Map<String, Object?>> program;
 }
 
-/// 트레이너의 한 주 — 요일마다 다른 시간대·길이의 1:1 PT 와 상담.
+/// 트레이너의 한 주 — 10~22시 사이 짝수 정시는 1:1 PT, 그 사이 홀수
+/// 정시는 상담으로 둔다. PT는 60분, 상담은 30분으로 통일한다.
 ///
 /// 오늘 몫은 [_schedule] 이 따로 들고 있어서, 오늘에 해당하는 요일은 시딩이
 /// 건너뛴다. 두 목록이 같은 날에 겹치면 오늘 화면에 없던 수업이 끼어든다.
@@ -1120,10 +1121,10 @@ const List<_WeekSlot> _weekSchedule = <_WeekSlot>[
   // 월
   _WeekSlot(
     weekday: 1,
-    time: '07:00',
+    time: '10:00',
     clientName: '최우진',
     type: SessionType.personalTraining,
-    durationMinutes: 50,
+    durationMinutes: 60,
     note: '출근 전 수업. 상체 위주로 짧게 끊어 간다.',
     program: <Map<String, Object?>>[
       <String, Object?>{'name': '랫풀다운', 'sets': 4, 'reps': '10회', 'weight': '35kg'},
@@ -1132,7 +1133,7 @@ const List<_WeekSlot> _weekSchedule = <_WeekSlot>[
   ),
   _WeekSlot(
     weekday: 1,
-    time: '11:00',
+    time: '13:00',
     clientName: '정하윤',
     type: SessionType.consultation,
     durationMinutes: 30,
@@ -1153,18 +1154,18 @@ const List<_WeekSlot> _weekSchedule = <_WeekSlot>[
   // 화
   _WeekSlot(
     weekday: 2,
-    time: '09:00',
+    time: '10:00',
     clientName: '신유나',
     type: SessionType.personalTraining,
-    durationMinutes: 40,
+    durationMinutes: 60,
     note: '유산소 비중을 늘리는 주. 심박 130 안쪽으로 유지한다.',
   ),
   _WeekSlot(
     weekday: 2,
-    time: '13:00',
+    time: '14:00',
     clientName: '오세라',
     type: SessionType.personalTraining,
-    durationMinutes: 50,
+    durationMinutes: 60,
     note: '어깨 가동 범위 회복 단계. 중량보다 자세를 본다.',
     program: <Map<String, Object?>>[
       <String, Object?>{'name': '밴드 외전', 'sets': 3, 'reps': '20회', 'weight': '밴드'},
@@ -1173,7 +1174,7 @@ const List<_WeekSlot> _weekSchedule = <_WeekSlot>[
   ),
   _WeekSlot(
     weekday: 2,
-    time: '19:00',
+    time: '20:00',
     clientName: '한지호',
     type: SessionType.personalTraining,
     durationMinutes: 60,
@@ -1182,7 +1183,7 @@ const List<_WeekSlot> _weekSchedule = <_WeekSlot>[
   // 수
   _WeekSlot(
     weekday: 3,
-    time: '08:00',
+    time: '10:00',
     clientName: '배준혁',
     type: SessionType.personalTraining,
     durationMinutes: 60,
@@ -1194,7 +1195,7 @@ const List<_WeekSlot> _weekSchedule = <_WeekSlot>[
   ),
   _WeekSlot(
     weekday: 3,
-    time: '14:00',
+    time: '15:00',
     clientName: '문가영',
     type: SessionType.consultation,
     durationMinutes: 30,
@@ -1205,7 +1206,7 @@ const List<_WeekSlot> _weekSchedule = <_WeekSlot>[
     time: '20:00',
     clientName: '백서진',
     type: SessionType.personalTraining,
-    durationMinutes: 50,
+    durationMinutes: 60,
     note: '야간 수업. 다음 날 근육통을 고려해 볼륨을 낮게 잡는다.',
   ),
   // 목
@@ -1226,21 +1227,21 @@ const List<_WeekSlot> _weekSchedule = <_WeekSlot>[
     time: '16:00',
     clientName: '류태경',
     type: SessionType.personalTraining,
-    durationMinutes: 40,
+    durationMinutes: 60,
     note: '재활 마무리 단계. 통증 없는 범위에서만 중량을 올린다.',
   ),
   // 금
   _WeekSlot(
     weekday: 5,
-    time: '07:30',
+    time: '10:00',
     clientName: '노은채',
     type: SessionType.personalTraining,
-    durationMinutes: 50,
+    durationMinutes: 60,
     note: '주 마지막 근력 수업. 상체 볼륨을 채운다.',
   ),
   _WeekSlot(
     weekday: 5,
-    time: '12:00',
+    time: '13:00',
     clientName: '조은비',
     type: SessionType.consultation,
     durationMinutes: 30,
@@ -1248,7 +1249,7 @@ const List<_WeekSlot> _weekSchedule = <_WeekSlot>[
   ),
   _WeekSlot(
     weekday: 5,
-    time: '17:00',
+    time: '16:00',
     clientName: '최우진',
     type: SessionType.personalTraining,
     durationMinutes: 60,
@@ -1260,16 +1261,16 @@ const List<_WeekSlot> _weekSchedule = <_WeekSlot>[
   ),
   _WeekSlot(
     weekday: 5,
-    time: '19:30',
+    time: '20:00',
     clientName: '이지수',
     type: SessionType.personalTraining,
-    durationMinutes: 40,
+    durationMinutes: 60,
     note: '컨디션에 따라 유산소로 대체할 수 있다.',
   ),
   // 토
   _WeekSlot(
     weekday: 6,
-    time: '09:00',
+    time: '10:00',
     clientName: '정하윤',
     type: SessionType.personalTraining,
     durationMinutes: 60,
@@ -1283,18 +1284,18 @@ const List<_WeekSlot> _weekSchedule = <_WeekSlot>[
   // 더하면 회원 앱과 트레이너 웹의 같은 날짜가 다른 이야기를 한다.
   _WeekSlot(
     weekday: 6,
-    time: '11:00',
+    time: '14:00',
     clientName: '박성호',
     type: SessionType.personalTraining,
-    durationMinutes: 50,
+    durationMinutes: 60,
     note: '주말 보강 수업. 평일에 빠진 하체를 채운다.',
   ),
   _WeekSlot(
     weekday: 6,
-    time: '15:00',
+    time: '17:00',
     clientName: '서지훈',
     type: SessionType.consultation,
-    durationMinutes: 40,
+    durationMinutes: 30,
     note: '주말 상담. 헬스장 이용 시간대와 목표를 맞춰 본다.',
   ),
   // 일
@@ -1303,7 +1304,7 @@ const List<_WeekSlot> _weekSchedule = <_WeekSlot>[
     time: '10:00',
     clientName: '임도현',
     type: SessionType.personalTraining,
-    durationMinutes: 40,
+    durationMinutes: 60,
     note: '가벼운 마무리 수업. 다음 주 계획을 함께 정한다.',
   ),
 ];
@@ -1341,7 +1342,7 @@ const List<_Slot> _schedule = <_Slot>[
     time: '12:00',
     clientName: '이지수',
     type: SessionType.personalTraining,
-    durationMinutes: 50,
+    durationMinutes: 60,
     status: ScheduleStatus.done,
     note: '데드리프트 자세 안정적. 다음 세션 60kg 도전.',
     program: <Map<String, Object?>>[
@@ -1371,7 +1372,7 @@ const List<_Slot> _schedule = <_Slot>[
     program: <Map<String, Object?>>[],
   ),
   _Slot(
-    time: '15:00',
+    time: '16:00',
     clientName: '박성호',
     type: SessionType.personalTraining,
     durationMinutes: 60,

--- a/frontend/flutter_trainer/test/core/storage/schedule_week_seed_test.dart
+++ b/frontend/flutter_trainer/test/core/storage/schedule_week_seed_test.dart
@@ -88,7 +88,7 @@ void main() {
     expect(today.every((r) => !r.id.startsWith('seed-schedule-w')), isTrue);
   });
 
-  test('PT는 10~22시 짝수 정시 60분, 상담은 홀수 정시 30분이다', () async {
+  test('PT와 상담은 규칙적인 시작 시간에 다양한 길이로 배치된다', () async {
     await seedIfEmpty(db, clock: _dayOfWeek(4));
 
     final rows = await db.select(db.trainerScheduleEntries).get();
@@ -115,21 +115,49 @@ void main() {
 
       if (row.type == SessionType.personalTraining) {
         expect(hour.isEven, isTrue, reason: '${row.date} ${row.time}');
-        expect(row.durationMinutes, 60, reason: '${row.date} ${row.time}');
+        expect(
+          <int>{30, 45, 50, 60, 90},
+          contains(row.durationMinutes),
+          reason: '${row.date} ${row.time}',
+        );
       } else if (row.type == SessionType.consultation) {
         expect(hour.isOdd, isTrue, reason: '${row.date} ${row.time}');
-        expect(row.durationMinutes, 30, reason: '${row.date} ${row.time}');
+        expect(
+          <int>{30, 45, 60},
+          contains(row.durationMinutes),
+          reason: '${row.date} ${row.time}',
+        );
       }
     }
 
-    for (final consultation in consultations) {
-      expect(
-        training.any(
-          (pt) => pt.date == consultation.date && pt.time == consultation.time,
-        ),
-        isFalse,
-        reason: '상담은 같은 날 PT가 없는 빈 시간에 배치한다',
-      );
+    expect(
+      training.map((r) => r.durationMinutes).toSet(),
+      containsAll(<int>{30, 45, 50, 60, 90}),
+    );
+    expect(
+      consultations.map((r) => r.durationMinutes).toSet(),
+      containsAll(<int>{30, 45, 60}),
+    );
+
+    for (final date in rows.map((r) => r.date).toSet()) {
+      final day = scheduled.where((r) => r.date == date).toList()
+        ..sort((a, b) => a.time.compareTo(b.time));
+      for (var index = 1; index < day.length; index++) {
+        final previous = day[index - 1];
+        final current = day[index];
+        final previousParts = previous.time.split(':').map(int.parse).toList();
+        final currentParts = current.time.split(':').map(int.parse).toList();
+        final previousEnd =
+            previousParts[0] * 60 +
+            previousParts[1] +
+            previous.durationMinutes;
+        final currentStart = currentParts[0] * 60 + currentParts[1];
+        expect(
+          previousEnd,
+          lessThanOrEqualTo(currentStart),
+          reason: '$date ${previous.time}와 ${current.time} 일정이 겹친다',
+        );
+      }
     }
   });
 

--- a/frontend/flutter_trainer/test/core/storage/schedule_week_seed_test.dart
+++ b/frontend/flutter_trainer/test/core/storage/schedule_week_seed_test.dart
@@ -88,7 +88,7 @@ void main() {
     expect(today.every((r) => !r.id.startsWith('seed-schedule-w')), isTrue);
   });
 
-  test('한 주에 1:1 PT 와 상담이 여러 요일에 흩어져 있다', () async {
+  test('PT는 10~22시 짝수 정시 60분, 상담은 홀수 정시 30분이다', () async {
     await seedIfEmpty(db, clock: _dayOfWeek(4));
 
     final rows = await db.select(db.trainerScheduleEntries).get();
@@ -105,16 +105,32 @@ void main() {
       reason: '상담이 하루에만 있으면 상담 흐름을 다른 요일에서 시연할 수 없다',
     );
     expect(training.map((r) => r.date).toSet().length, greaterThanOrEqualTo(5));
-    // 시간대와 길이도 섞여 있어야 시간표가 실제 사용 화면처럼 보인다.
-    expect(rows.map((r) => r.time).toSet().length, greaterThanOrEqualTo(8));
-    expect(
-      rows
-          .map((r) => r.durationMinutes)
-          .where((m) => m > 0)
-          .toSet()
-          .length,
-      greaterThanOrEqualTo(3),
-    );
+    final scheduled = rows.where((r) => r.durationMinutes > 0);
+    for (final row in scheduled) {
+      final parts = row.time.split(':');
+      final hour = int.parse(parts.first);
+      final minute = int.parse(parts.last);
+      expect(hour, inInclusiveRange(10, 22), reason: '${row.date} ${row.time}');
+      expect(minute, 0, reason: '${row.date} ${row.time}');
+
+      if (row.type == SessionType.personalTraining) {
+        expect(hour.isEven, isTrue, reason: '${row.date} ${row.time}');
+        expect(row.durationMinutes, 60, reason: '${row.date} ${row.time}');
+      } else if (row.type == SessionType.consultation) {
+        expect(hour.isOdd, isTrue, reason: '${row.date} ${row.time}');
+        expect(row.durationMinutes, 30, reason: '${row.date} ${row.time}');
+      }
+    }
+
+    for (final consultation in consultations) {
+      expect(
+        training.any(
+          (pt) => pt.date == consultation.date && pt.time == consultation.time,
+        ),
+        isFalse,
+        reason: '상담은 같은 날 PT가 없는 빈 시간에 배치한다',
+      );
+    }
   });
 
   test('명단에 있는 이름은 고객 id 로, 미등록 상담자는 이름만 남는다', () async {

--- a/frontend/flutter_trainer/test/features/schedule/schedule_cancel_no_show_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/schedule_cancel_no_show_test.dart
@@ -290,7 +290,7 @@ void main() {
 
       expect(find.textContaining('취소·노쇼로 남기세요'), findsNothing);
       expect(
-        find.text('10:00–11:00 김민수님 PT 일정을 삭제할까요?'),
+        find.text('10:00–10:30 김민수님 PT 일정을 삭제할까요?'),
         findsOneWidget,
       );
     });

--- a/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
@@ -70,7 +70,7 @@ void main() {
         '10:00',
         '12:00',
         '14:00',
-        '15:00',
+        '16:00',
         '17:00',
         '19:00',
       ]);
@@ -548,7 +548,7 @@ void main() {
 
       // 블록은 시간 범위와 종류를 함께 말한다.
       expect(find.text('10:00\u201311:00'), findsWidgets);
-      expect(find.text('17:00\u201317:30'), findsOneWidget);
+      expect(find.text('17:00\u201317:30'), findsWidgets);
       expect(find.text('김민수'), findsWidgets);
       expect(find.textContaining('이지수'), findsWidgets);
       expect(find.textContaining('박성호'), findsWidgets);
@@ -969,7 +969,7 @@ void main() {
       expect(confirm.onPressed, isNull);
     });
 
-    testWidgets('일정 수정 moves 박성호 to a 15-minute step (15:00 → 15:30)', (
+    testWidgets('일정 수정 moves 박성호 to a 15-minute step (16:00 → 16:30)', (
       tester,
     ) async {
       await openSchedule(tester);
@@ -996,7 +996,7 @@ void main() {
         findsNothing,
       );
 
-      await enterTimeRange(tester, start: '15:30', end: '16:30');
+      await enterTimeRange(tester, start: '16:30', end: '17:30');
       await tester.ensureVisible(find.text('저장하기'));
       await tester.pump();
       await tester.tap(find.text('저장하기'));
@@ -1006,11 +1006,17 @@ void main() {
       expect(
         find.descendant(
           of: find.byKey(const Key('week-detail')),
-          matching: find.text('15:30\u201316:30'),
+          matching: find.text('16:30\u201317:30'),
         ),
         findsOneWidget,
       );
-      expect(find.text('15:00\u201316:00'), findsNothing);
+      expect(
+        find.descendant(
+          of: find.byKey(const Key('week-detail')),
+          matching: find.text('16:00\u201317:00'),
+        ),
+        findsNothing,
+      );
     });
 
     testWidgets('프로그램 수정 opens a dialog to edit exercises', (tester) async {
@@ -1065,7 +1071,7 @@ void main() {
         find.byKey(const ValueKey<String>('program-editor-seed-schedule-3')),
         findsNothing,
       );
-      expect(find.textContaining('15:00\u201316:00'), findsWidgets);
+      expect(find.textContaining('16:00\u201317:00'), findsWidgets);
       expect(find.text('덤벨 플라이'), findsOneWidget);
       expect(find.textContaining('4세트'), findsOneWidget);
       // 프로그램만 고쳤으므로 원래 메모는 그대로 남는다.

--- a/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
@@ -336,7 +336,9 @@ void main() {
         type: '1:1 PT',
         durationMinutes: 60,
       );
-      final slot = (await repo.watchDate(ymd(yesterday)).first).single;
+      final slot = (await repo.watchDate(ymd(yesterday)).first).firstWhere(
+        (entry) => entry.clientName == '이지수' && entry.time == '11:00',
+      );
 
       await repo.completeSession(slot.id, note: '어제 세션 뒤늦게 기록');
 

--- a/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
@@ -547,8 +547,8 @@ void main() {
       expect(find.text('22:00'), findsOneWidget);
 
       // 블록은 시간 범위와 종류를 함께 말한다.
-      expect(find.text('10:00\u201311:00'), findsWidgets);
-      expect(find.text('17:00\u201317:30'), findsWidgets);
+      expect(find.text('10:00\u201310:30'), findsWidgets);
+      expect(find.text('17:00\u201318:00'), findsWidgets);
       expect(find.text('김민수'), findsWidgets);
       expect(find.textContaining('이지수'), findsWidgets);
       expect(find.textContaining('박성호'), findsWidgets);
@@ -947,7 +947,7 @@ void main() {
       await tester.tap(find.text('추가하기'));
       await settle(tester);
 
-      expect(find.text('10:00\u201311:30'), findsOneWidget);
+      expect(find.text('10:00\u201311:30'), findsWidgets);
     });
 
     testWidgets('종료 시간이 시작보다 이르면 확인을 막는다 (#1090)', (tester) async {
@@ -1071,7 +1071,7 @@ void main() {
         find.byKey(const ValueKey<String>('program-editor-seed-schedule-3')),
         findsNothing,
       );
-      expect(find.textContaining('16:00\u201317:00'), findsWidgets);
+      expect(find.textContaining('16:00\u201316:45'), findsWidgets);
       expect(find.text('덤벨 플라이'), findsOneWidget);
       expect(find.textContaining('4세트'), findsOneWidget);
       // 프로그램만 고쳤으므로 원래 메모는 그대로 남는다.
@@ -1530,7 +1530,7 @@ void main() {
 
       expect(clientName, '윤가온'); // not reassigned to 김민수
       expect(type, '상담');
-      expect(duration, 30);
+      expect(duration, 60);
     });
 
     testWidgets('unsupported program action does not call chat repository', (

--- a/frontend/flutter_trainer/test/features/schedule/schedule_panel_actions_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/schedule_panel_actions_test.dart
@@ -128,7 +128,7 @@ void main() {
     expect(
       find.descendant(
         of: find.byKey(const Key('week-detail')),
-        matching: find.text('10:00\u201311:00'),
+        matching: find.text('10:00\u201310:30'),
       ),
       findsOneWidget,
       reason: '시각은 자르지 않는다 — 소요 시간은 옆에 다시 적지 않는다',


### PR DESCRIPTION
## Summary

트레이너 데모 스케줄을 10~22시 운영 범위 안에서 규칙적인 PT 시간과 빈 슬롯 상담으로 정리하고, 실제 운영처럼 소요 시간을 다양화합니다.

## Changes

### Fixes

- 오늘 및 주간 1:1 PT를 짝수 정시에 규칙적으로 배치
- 1:1 PT 소요 시간을 30·45·50·60·90분으로 다양화
- 상담을 PT 사이 홀수 정시에 배치하고 30·45·60분으로 다양화
- 07:00, 07:30, 08:00, 09:00 등 운영 범위 밖 데모 일정 제거
- 날짜별 일정의 실제 시작·종료 구간 중복 방지 테스트 추가

## Commits

- `fix(schedule): 데모 PT와 상담 시간을 규칙적으로 배치`
- `test(schedule): 변경된 데모 시간을 반영`
- `fix(schedule): 데모 일정 소요 시간을 다양화`

## Notes

- 공백 슬롯은 기존 상태 표현을 유지합니다.
- 고객, 운동 프로그램, 일정 상태 데이터는 변경하지 않았습니다.

## Test Plan

- [x] `schedule_week_seed_test.dart`
- [x] `schedule_page_test.dart`
- [x] 관련 테스트 64개 통과
- [x] 변경 파일 정적 분석 통과

## Related Issues

Closes #1297

## Checklist

- [x] 기존 코드 스타일을 따랐습니다.
- [x] 관련 테스트를 추가하고 통과했습니다.
- [x] 관계없는 파일 변경을 포함하지 않았습니다.