### PR TITLE
fix(ui): 사용자 앱 날짜 선택 달력 배경색 통일

### DIFF
--- a/frontend/flutter/lib/core/utils/portrait_date_picker.dart
+++ b/frontend/flutter/lib/core/utils/portrait_date_picker.dart
@@ -30,7 +30,19 @@ Future<DateTime?> showPortraitDatePicker({
     lastDate: lastDate,
     initialEntryMode: initialEntryMode,
     builder: (context, child) {
-      final Widget themed = builder == null ? child! : builder(context, child);
+      final Widget whitePicker = Theme(
+        data: Theme.of(context).copyWith(
+          datePickerTheme: Theme.of(context).datePickerTheme.copyWith(
+            backgroundColor: Colors.white,
+            headerBackgroundColor: Colors.white,
+            surfaceTintColor: Colors.transparent,
+          ),
+        ),
+        child: child!,
+      );
+      final Widget themed = builder == null
+          ? whitePicker
+          : builder(context, whitePicker);
       final MediaQueryData query = MediaQuery.of(context);
       if (query.size.width <= query.size.height) return themed;
       return MediaQuery(

--- a/frontend/flutter/lib/features/exercise/presentation/pages/consultation_request_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/consultation_request_page.dart
@@ -76,18 +76,6 @@ class _ConsultationRequestPageState
       initialDate: _preferredDate ?? today,
       firstDate: today,
       lastDate: DateTime(today.year + 100),
-      builder: (BuildContext context, Widget? child) {
-        return Theme(
-          data: Theme.of(context).copyWith(
-            datePickerTheme: const DatePickerThemeData(
-              backgroundColor: Colors.white,
-              headerBackgroundColor: Colors.white,
-              surfaceTintColor: Colors.transparent,
-            ),
-          ),
-          child: child!,
-        );
-      },
     );
     if (selected != null && mounted) {
       setState(() => _preferredDate = selected);

--- a/frontend/flutter/test/core/utils/portrait_date_picker_test.dart
+++ b/frontend/flutter/test/core/utils/portrait_date_picker_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oncare/core/utils/portrait_date_picker.dart';
+
+void main() {
+  testWidgets('공용 날짜 선택기는 흰 배경과 투명 surface tint를 사용한다', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(
+          colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+        ),
+        home: Builder(
+          builder: (BuildContext context) => TextButton(
+            onPressed: () => showPortraitDatePicker(
+              context: context,
+              initialDate: DateTime(2026, 8, 24),
+              firstDate: DateTime(2026),
+              lastDate: DateTime(2027),
+            ),
+            child: const Text('달력 열기'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('달력 열기'));
+    await tester.pumpAndSettle();
+
+    final BuildContext pickerContext = tester.element(
+      find.byType(DatePickerDialog),
+    );
+    final DatePickerThemeData theme = DatePickerTheme.of(pickerContext);
+    expect(theme.backgroundColor, Colors.white);
+    expect(theme.headerBackgroundColor, Colors.white);
+    expect(theme.surfaceTintColor, Colors.transparent);
+  });
+}


### PR DESCRIPTION
## Summary

* 사용자 앱의 공용 날짜 선택 달력 배경을 흰색으로 통일했습니다.
* 상담 요청 화면의 개별 DatePicker 테마를 공용 유틸로 이동했습니다.
* 기존 portrait 배치와 날짜 선택 동작은 유지했습니다.

---

## Changes

### ✨ Features

* 없음

### 🔧 Improvements

* 날짜 선택기 스타일 책임을 `showPortraitDatePicker` 한 곳으로 통합했습니다.

### 🎨 UI/UX

* 달력 본문과 헤더 배경을 흰색으로 통일했습니다.
* Material surface tint를 투명하게 설정해 파란색 계열 오버레이가 생기지 않도록 했습니다.

### 📝 Docs

* 없음

### 🐛 Fixes

* 호출 화면에 따라 달력 배경이 흰색 또는 파란색 계열로 달라지던 문제를 수정했습니다.
* 상담 요청 화면의 중복 DatePicker 테마 코드를 제거했습니다.

---

## Commits

1. `b4f4482c` fix(ui): unify date picker backgrounds

---

## Notes

* 공용 날짜 선택기를 사용하는 일정 추가·식단 기록·상담 요청 화면에 동일한 흰 배경이 적용됩니다.
* 날짜 셀의 선택 색상과 기존 portrait 레이아웃은 변경하지 않았습니다.
* `flutter pub get`이 만든 `analysis_options.yaml`, `pubspec.lock` 자동 변경은 커밋에서 제외했습니다.

---

## Screenshots (Optional)

| Before | After |
| ------ | ----- |
| 호출 화면별 흰색/파란색 계열 배경 | 공통 흰색 배경 |

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [ ] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 사용자 앱에서 상담 요청 화면을 열고 희망 날짜를 누릅니다.
2. 달력 본문과 헤더 배경이 흰색인지 확인합니다.
3. 일정 추가·식단 기록의 날짜 선택기도 같은 흰 배경인지 확인합니다.
4. 넓은 화면에서도 달력이 기존처럼 세로 배치로 열리는지 확인합니다.

---

## Related Issues

Closes #1302

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인
