### PR TITLE
fix(e2e): 긴 채팅의 최신 메시지 표시 안정화

### DIFF
--- a/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_chat_sheet.dart
+++ b/frontend/flutter/lib/features/member_coach/presentation/widgets/coach_chat_sheet.dart
@@ -114,10 +114,21 @@ class _TrainerChatPageState extends ConsumerState<TrainerChatPage> {
   /// 없을 때는 스레드가 가장 오래된 메시지부터 보였다. 한 개짜리 데모에서는
   /// 티가 안 났지만 기록이 3일치로 늘자, 채팅을 열면 며칠 전 첫 인사가 뜨고
   /// 최근 대화는 직접 내려야 보였다. 트레이너 앱은 이미 같은 동작을 한다.
-  void _scrollToBottom() {
+  void _scrollToBottom({double? previousMax, int attemptsLeft = 12}) {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted || !_scroll.hasClients) return;
-      _scroll.jumpTo(_scroll.position.maxScrollExtent);
+      final double max = _scroll.position.maxScrollExtent;
+      _scroll.jumpTo(max);
+
+      // ListView는 긴 목록의 아직 만들지 않은 자식 높이를 추정한다. 첫 jump로
+      // 새 자식이 만들어지면 maxScrollExtent가 다음 프레임에 다시 늘 수 있다.
+      // 그 상태에서 멈추면 서버에서 최신 메시지를 받았어도 화면에는 이전 끝이
+      // 남는다. 범위가 한 프레임 동안 안정될 때까지 다시 끝을 맞춘다.
+      final bool stable =
+          previousMax != null && (max - previousMax).abs() < 0.5;
+      if (!stable && attemptsLeft > 1) {
+        _scrollToBottom(previousMax: max, attemptsLeft: attemptsLeft - 1);
+      }
     });
   }
 


### PR DESCRIPTION
## Summary

긴 채팅에서 최신 메시지가 위젯 트리에 나타나기 전에 E2E 검증이 타임아웃되는 문제를 수정합니다.

## Changes

- 채팅 하단 이동 시 lazy `ListView`의 최대 스크롤 범위가 안정될 때까지 재시도
- 긴 대화에서도 마지막으로 수신한 메시지가 확실히 렌더링되도록 개선
- 테스트 종료 시 노출되던 `Cannot add event while adding stream` 오류의 선행 타임아웃 원인 해소

## Test Plan

- [x] 사용자 채팅 관련 Flutter 테스트 30개 통과
- [x] 변경 파일 Flutter analyze 통과
- [ ] GitHub Actions E2E 통과 확인

## Notes

로그의 stream 종료 오류는 15분 타임아웃으로 Flutter 프로세스가 종료된 뒤 발생한 2차 오류였습니다. 실제 원인은 긴 메시지 목록에서 한 번의 `jumpTo(maxScrollExtent)`만으로 최종 스크롤 범위에 도달하지 못한 것이었습니다.

## Checklist

- [x] 변경 범위를 사용자 채팅 스크롤 처리로 제한했습니다.
- [x] 관련 테스트와 정적 분석을 실행했습니다.