### PR TITLE
fix(report): 주간 헤더 화살표-날짜 간격 확대

### DIFF
--- a/frontend/flutter_trainer/lib/features/reports/presentation/widgets/report_week_nav.dart
+++ b/frontend/flutter_trainer/lib/features/reports/presentation/widgets/report_week_nav.dart
@@ -46,7 +46,9 @@ class ReportWeekNav extends StatelessWidget {
   /// 두어야 화살표가 밀리지 않는다.
   static const double _thisWeekSlot = 100;
 
-  static const double _gap = AppSpacing.sm;
+  /// 스케줄 탭 날짜 행(`ScheduleDateNavBar._gap`)과 같은 값이다. 좁게
+  /// 붙여 두면 `이번 주` 버튼이 나타났을 때 화살표 사이가 옹색해 보인다.
+  static const double _gap = AppSpacing.lg;
 
   @override
   Widget build(BuildContext context) {

--- a/frontend/flutter_trainer/lib/features/reports/presentation/widgets/report_week_nav.dart
+++ b/frontend/flutter_trainer/lib/features/reports/presentation/widgets/report_week_nav.dart
@@ -4,18 +4,21 @@ import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 import 'package:oncare_trainer/shared/widgets/action_button.dart';
 
-/// 리포트 카드의 주 이동 — `‹ 8월 17일 – 8월 23일 [이번 주] ›`.
+/// 리포트 카드의 주 이동 — `‹  8월 17일 – 8월 23일  [이번 주]  ›`.
 ///
-/// 스케줄 탭의 날짜 줄과 같은 짜임이다(화살표 · 날짜 · 화살표 · 되돌리기 버튼).
-/// 두 탭이 같은 동작에 다른 모양을 쓸 이유가 없다.
+/// 스케줄 탭의 날짜 줄(`ScheduleDateNavBar`)과 같은 짜임이다 — `이번 주` 는
+/// 두 화살표 **안쪽**, 날짜 오른쪽에 선다. 두 탭이 같은 동작에 다른 모양을
+/// 쓸 이유가 없다.
 ///
 /// 헤더가 아니라 **리포트 카드 제목 줄**에 있다. 옮기는 것은 이 카드의
 /// 내용이지 화면 전체가 아니고, 헤더에 두면 날짜 버튼 하나가 가운데 고객
 /// 검색 바의 폭을 먹어 다른 탭과 다른 모양으로 접혔다(#1177).
 ///
-/// 이 줄은 카드 제목(`Expanded`) 오른쪽에 자기 폭만큼만 차지하고 붙는다 —
-/// 날짜·화살표 묶음 양옆에 `이번 주` 버튼과 같은 폭을 둔다. 버튼 표시 여부와
-/// 무관하게 탐색 묶음의 중심이 이 위젯 중심에 고정된다(#1245, #1295).
+/// 날짜는 두 화살표 사이의 한가운데에 선다. `이번 주` 가 들어설 자리를
+/// 날짜 오른쪽에만 비워 두면 날짜가 그만큼 왼쪽으로 치우친다 — 같은 폭을
+/// 날짜 왼쪽에도 거울처럼 비워 두어 균형을 맞춘다(`ScheduleDateNavBar` 와
+/// 같은 방식). 버튼 표시 여부와 무관하게 두 화살표 사이에서 날짜의 중심이
+/// 그대로 유지된다(#1245, #1295).
 class ReportWeekNav extends StatelessWidget {
   /// Creates the week nav.
   const ReportWeekNav({
@@ -35,7 +38,8 @@ class ReportWeekNav extends StatelessWidget {
   final VoidCallback? onNext;
 
   /// 이번 주로 돌아간다. 이미 이번 주면 null — 버튼을 아예 그리지 않는다
-  /// (스케줄 탭 `오늘` 과 같다). 자리는 [_thisWeekSlot] 이 대신 지킨다.
+  /// (스케줄 탭 `오늘` 과 같다). 자리는 [_thisWeekSlot] 이 대신 지키고,
+  /// 그 거울 자리가 날짜 반대쪽에서 균형을 맞춘다.
   final VoidCallback? onThisWeek;
 
   /// 날짜가 앉는 자리의 폭. 스케줄 탭 날짜 행(`ScheduleDateNavBar._dateSlot`)과
@@ -56,19 +60,17 @@ class ReportWeekNav extends StatelessWidget {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: <Widget>[
-        // 오른쪽 `이번 주` 자리와 같은 폭을 먼저 비워 날짜·화살표 묶음이
-        // 버튼 유무와 관계없이 전체 헤더의 정중앙에 선다(#1295).
-        const SizedBox(
-          key: ValueKey<String>('report-week-balance-slot'),
-          width: _thisWeekSlot,
-        ),
-        const SizedBox(width: _gap),
         _Chevron(
           navKey: const ValueKey<String>('report-week-prev'),
           icon: Icons.chevron_left,
           tooltip: l.a11yPrevWeek,
           onTap: onPrev,
         ),
+        const SizedBox(width: _gap),
+        // `이번 주` 자리의 거울. 아무것도 그리지 않지만 날짜를 두 화살표
+        // 사이의 한가운데에 세우는 것은 이 빈 자리다(`ScheduleDateNavBar`
+        // 의 `_todaySlot` 거울과 같은 방식).
+        const SizedBox(width: _thisWeekSlot),
         const SizedBox(width: _gap),
         SizedBox(
           width: _dateSlot,
@@ -86,13 +88,6 @@ class ReportWeekNav extends StatelessWidget {
               ),
             ),
           ),
-        ),
-        const SizedBox(width: _gap),
-        _Chevron(
-          navKey: const ValueKey<String>('report-week-next'),
-          icon: Icons.chevron_right,
-          tooltip: l.a11yNextWeek,
-          onTap: onNext,
         ),
         const SizedBox(width: _gap),
         // 스케줄 탭의 `오늘` 과 같은 자리다. 헤더에 있던 때에는 옮기는
@@ -114,6 +109,13 @@ class ReportWeekNav extends StatelessWidget {
                     ),
                   ),
                 ),
+        ),
+        const SizedBox(width: _gap),
+        _Chevron(
+          navKey: const ValueKey<String>('report-week-next'),
+          icon: Icons.chevron_right,
+          tooltip: l.a11yNextWeek,
+          onTap: onNext,
         ),
       ],
     );


### PR DESCRIPTION
## Summary

* 트레이너 리포트 탭 주간 헤더의 화살표-날짜 간격을 스케줄 탭과 같은 값(`AppSpacing.lg`)으로 늘림
* 기존 중앙 정렬(고정폭 슬롯 미러링, #1295)은 그대로 유지

---

## Changes

### 🔧 Improvements

* `ReportWeekNav._gap` 을 `AppSpacing.sm`(8) → `AppSpacing.lg`(16) 로 조정해 화살표와 날짜 사이 여백을 스케줄 탭 날짜 행과 맞춤

### 🎨 UI/UX

* `이번 주` 버튼이 나타나도 화살표 사이가 옹색해 보이지 않도록 여백 확대

---

## Commits

1. `82d19f40` fix(report): 주간 헤더 화살표-날짜 간격을 스케줄 탭과 맞춤

---

## Notes

* #1295 는 고정폭 슬롯으로 중앙 정렬만 맞춘 상태였고, 이번 PR은 그 위에 간격을 스케줄 탭 수준으로 넓히는 후속 조정임

---

## Screenshots (Optional)

| Before | After |
| ------ | ----- |
| 화살표-날짜 간격이 좁음 | 스케줄 탭과 같은 여백 |

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [ ] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 트레이너 앱 리포트 탭 진입
2. 이번 주/다른 주를 오가며 `이번 주` 버튼 표시 여부에 따른 화살표-날짜 간격 확인
3. `flutter test test/features/reports/reports_page_test.dart` 통과 확인

---

## Related Issues

Closes #1295

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [ ] 데모 시나리오 영향 확인
