### PR TITLE
feat(exercise): 헬스장 찾기 지도·목록 드래그 시트 전환

### DIFF
--- a/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
@@ -75,52 +75,66 @@ class _ExercisePageState extends ConsumerState<ExercisePage> {
         child: Center(
           child: ConstrainedBox(
             constraints: const BoxConstraints(maxWidth: 720),
-            child: ListView(
-              padding: const EdgeInsets.only(bottom: 108),
-              children: <Widget>[
-                // 벨 배지는 서버 미읽음을 본다. 이 build 에는 ref 가 없어 여기서만
-                // 지역적으로 얻는다 — 헤더 전체를 다시 그리지 않는다.
-                Consumer(
-                  builder: (BuildContext context, WidgetRef ref, Widget? _) =>
-                      FigmaTabHeader(
-                        title: l.pageExerciseTitle,
-                        trailingAction: const TrainerChatHeaderButton(),
-                        onBell: () => context.push(AppRoutes.notification),
-                        bellHasUnread:
-                            (ref
-                                    .watch(notificationUnreadProvider)
-                                    .valueOrNull ??
-                                0) >
-                            0,
-                        onCalendar: () => showScheduleCalendarSheet(context),
-                      ),
-                ),
-                _SubTabs(
-                  active: _subTab,
-                  onChanged: (int i) => setState(() => _subTab = i),
-                ),
-                const SizedBox(height: 16),
-                if (_subTab == 0)
-                  const _RecordTab()
-                else
-                  GymTab(
-                    selectedSlot: ref.watch(
-                      exerciseSelectedReservationSlotProvider,
+            // 헬스장 탭은 **높이를 받아야 한다**. 헬스장 찾기 화면의 결과
+            // 시트가 제 자리 안에서 굴러야 지도가 따라 움직이지 않는데,
+            // 페이지 전체가 하나의 `ListView` 이면 그 자리가 열려 있어 바깥
+            // 페이지가 대신 구른다 (#1274). 그래서 헬스장 탭에서만 머리와 탭
+            // 줄을 고정하고 남는 높이를 탭에 넘긴다 — 운동 기록 탭은 여러
+            // 섹션을 이어 붙인 긴 화면이라 예전처럼 통째로 구른다.
+            child: _subTab == 0
+                ? ListView(
+                    padding: const EdgeInsets.only(bottom: 108),
+                    children: <Widget>[
+                      _header(context, l),
+                      _subTabs(),
+                      const SizedBox(height: 16),
+                      const _RecordTab(),
+                    ],
+                  )
+                : Padding(
+                    padding: const EdgeInsets.only(bottom: 108),
+                    child: Column(
+                      children: <Widget>[
+                        _header(context, l),
+                        _subTabs(),
+                        const SizedBox(height: 16),
+                        Expanded(child: _gymTab()),
+                      ],
                     ),
-                    onSlot: (String s) {
-                      final StateController<String?> notifier = ref.read(
-                        exerciseSelectedReservationSlotProvider.notifier,
-                      );
-                      notifier.state = notifier.state == s ? null : s;
-                    },
                   ),
-              ],
-            ),
           ),
         ),
       ),
     );
   }
+
+  /// 페이지 머리. 벨 배지는 서버 미읽음을 본다 — 이 build 에는 ref 가 없어
+  /// 여기서만 지역적으로 얻는다. 헤더 전체를 다시 그리지 않는다.
+  Widget _header(BuildContext context, AppLocalizations l) => Consumer(
+    builder: (BuildContext context, WidgetRef ref, Widget? _) => FigmaTabHeader(
+      title: l.pageExerciseTitle,
+      trailingAction: const TrainerChatHeaderButton(),
+      onBell: () => context.push(AppRoutes.notification),
+      bellHasUnread:
+          (ref.watch(notificationUnreadProvider).valueOrNull ?? 0) > 0,
+      onCalendar: () => showScheduleCalendarSheet(context),
+    ),
+  );
+
+  Widget _subTabs() => _SubTabs(
+    active: _subTab,
+    onChanged: (int i) => setState(() => _subTab = i),
+  );
+
+  Widget _gymTab() => GymTab(
+    selectedSlot: ref.watch(exerciseSelectedReservationSlotProvider),
+    onSlot: (String s) {
+      final StateController<String?> notifier = ref.read(
+        exerciseSelectedReservationSlotProvider.notifier,
+      );
+      notifier.state = notifier.state == s ? null : s;
+    },
+  );
 }
 
 class _SubTabs extends StatelessWidget {

--- a/frontend/flutter/lib/features/exercise/presentation/pages/gym_list_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/gym_list_page.dart
@@ -55,10 +55,15 @@ class GymListPage extends ConsumerWidget {
 /// 헬스장이 없는 회원에게 이 탭에서 할 일은 헬스장을 찾는 것뿐이라, 지도만 띄운
 /// 빈 카드와 `헬스장 찾기` 버튼 대신 찾기 화면을 그대로 보여 준다(#1133).
 ///
-/// 지도는 **자리에 고정**하고 그 아래 목록만 스크롤한다(#1135). 예전에는 지도
-/// 위에 결과 시트를 얹어 두어, 목록을 밀면 시트가 먼저 커지며 지도까지 함께
-/// 밀려 올라갔다. 목록을 상자로 한 번 더 감싸지도 않는다 — 좁은 화면에서 상자
-/// 안의 상자가 되어 카드가 더 좁아졌다.
+/// 지도는 자리에 고정하고 그 위로 **목록 시트를 끌어 올리고 내린다**(#1274).
+/// 시트는 세 자리에 붙는다 — 목록만 / 지도·목록 반반 / 지도만. 예전에는 머리줄
+/// 화살표 하나로 두 상태를 오갈 뿐이라 폰에서 손으로 원하는 만큼 조절할 수
+/// 없었고, 운동 탭처럼 바깥이 스크롤 뷰인 자리에서는 목록을 밀면 지도까지 함께
+/// 밀려 올라갔다(#1135 가 막으려던 것이 이 배치에서는 지켜지지 않았다).
+///
+/// 그래서 이 위젯은 **높이를 스스로 정한다**. 바깥이 높이를 주면 그대로 쓰고,
+/// 열린 높이(스크롤 뷰 안)에 놓이면 화면에서 한 몫을 떼어 쓴다 — 시트가 구를
+/// 자리를 스스로 갖지 못하면 바깥 페이지가 대신 굴러 지도가 따라 움직인다.
 class GymFinderView extends ConsumerStatefulWidget {
   const GymFinderView({super.key});
 
@@ -69,10 +74,6 @@ class GymFinderView extends ConsumerStatefulWidget {
 class _GymFinderViewState extends ConsumerState<GymFinderView> {
   String _query = '';
   _GymSort _sort = _GymSort.recommended;
-
-  /// 목록을 접었는지 (#1186). 처음 들어오면 지도와 목록이 함께 보이고, 접으면
-  /// 목록이 사라지며 그 자리를 지도가 받는다.
-  bool _listCollapsed = false;
 
   List<Gym> _visibleGyms(List<Gym> gyms) {
     final String query = _query.trim().toLowerCase();
@@ -113,74 +114,65 @@ class _GymFinderViewState extends ConsumerState<GymFinderView> {
       builder: (BuildContext context, BoxConstraints outer) => Center(
         child: ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 720),
-          child: Padding(
-            padding: const EdgeInsets.fromLTRB(20, 12, 20, 0),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: <Widget>[
-                Row(
-                  children: <Widget>[
-                    Expanded(
-                      child: _SearchField(
-                        hintText: l.exGymSearchPlaceholder,
-                        onChanged: (String value) =>
-                            setState(() => _query = value),
+          child: SizedBox(
+            // 바깥이 높이를 주면 그대로 쓴다. 운동 탭처럼 **높이가 열린
+            // 자리**(바깥이 스크롤 뷰)에 놓이면 화면에서 한 몫을 떼어 쓴다 —
+            // 시트가 구를 자리를 스스로 갖지 못하면 바깥 페이지가 대신 굴러
+            // 지도가 따라 움직인다 (#1274).
+            height: outer.hasBoundedHeight
+                ? outer.maxHeight
+                : math.max(MediaQuery.sizeOf(context).height * 0.72, 460),
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(20, 12, 20, 0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  Row(
+                    children: <Widget>[
+                      Expanded(
+                        child: _SearchField(
+                          hintText: l.exGymSearchPlaceholder,
+                          onChanged: (String value) =>
+                              setState(() => _query = value),
+                        ),
                       ),
-                    ),
-                    const SizedBox(width: 10),
-                    // 헤더의 채팅 버튼과 같은 자리·배지 모양이다 — 대기 중인
-                    // 상담 요청이 있으면 점이 켜진다(#1257).
-                    Semantics(
-                      button: true,
-                      label: l.exViewConsultationRequest,
-                      child: FigmaCircleButton(
-                        key: const Key('consult-history-shortcut'),
-                        icon: Icons.assignment_outlined,
-                        showDot: hasPendingConsultation,
-                        onTap: () =>
-                            context.push(AppRoutes.consultationHistory),
+                      const SizedBox(width: 10),
+                      // 헤더의 채팅 버튼과 같은 자리·배지 모양이다 — 대기 중인
+                      // 상담 요청이 있으면 점이 켜진다(#1257).
+                      Semantics(
+                        button: true,
+                        label: l.exViewConsultationRequest,
+                        child: FigmaCircleButton(
+                          key: const Key('consult-history-shortcut'),
+                          icon: Icons.assignment_outlined,
+                          showDot: hasPendingConsultation,
+                          onTap: () =>
+                              context.push(AppRoutes.consultationHistory),
+                        ),
                       ),
+                    ],
+                  ),
+                  const SizedBox(height: 14),
+                  // 지도는 자리에 고정되고 그 위로 목록 시트가 오르내린다
+                  // (#1274). 시트가 화면 몫을 다 쓰므로 남는 높이를 그대로
+                  // 넘긴다.
+                  Expanded(
+                    child: _GymMapAndSheet(
+                      gyms: visible,
+                      header: l.exNearbyGyms,
+                      controls: gymsAsync.hasValue
+                          ? _ResultControls(
+                              countLabel: l.exResultCount(visible.length),
+                              sort: _sort,
+                              onSort: (_GymSort value) =>
+                                  setState(() => _sort = value),
+                            )
+                          : null,
+                      resultSliver: _resultSliver(context, gymsAsync, visible),
                     ),
-                  ],
-                ),
-                const SizedBox(height: 14),
-                // 지도는 자리에 고정된다 — 아래 목록을 아무리 밀어도 따라오지
-                // 않는다 (#1135). 목록을 접으면 그 자리를 지도가 받는다 (#1186).
-                _GymMap(gyms: visible, expanded: _listCollapsed),
-                const SizedBox(height: 16),
-                // 지도와 목록 사이의 구분 선 — 여기가 두 영역의 경계이고,
-                // 화살표가 그 경계에서 목록을 여닫는다 (#1186).
-                const Divider(height: 1, color: FigmaColors.hairline),
-                _NearbyHeader(
-                  title: l.exNearbyGyms,
-                  collapsed: _listCollapsed,
-                  onToggle: () =>
-                      setState(() => _listCollapsed = !_listCollapsed),
-                ),
-                if (!_listCollapsed) ...<Widget>[
-                  if (gymsAsync.hasValue)
-                    _ResultControls(
-                      countLabel: l.exResultCount(visible.length),
-                      sort: _sort,
-                      onSort: (_GymSort value) => setState(() => _sort = value),
-                    ),
-                  const SizedBox(height: 10),
-                  // 남는 높이를 목록이 쓴다. 운동 탭처럼 **높이가 열린
-                  // 자리**(바깥이 스크롤 뷰)에 놓이면 남는 높이가 없으므로,
-                  // 화면의 절반쯤을 목록 몫으로 떼어 준다 — 그래야 지도가 자리에
-                  // 남고 목록만 구른다.
-                  if (outer.hasBoundedHeight)
-                    Expanded(child: _results(context, gymsAsync, visible))
-                  else
-                    SizedBox(
-                      height: math.max(
-                        MediaQuery.sizeOf(context).height * 0.45,
-                        280,
-                      ),
-                      child: _results(context, gymsAsync, visible),
-                    ),
+                  ),
                 ],
-              ],
+              ),
             ),
           ),
         ),
@@ -188,31 +180,41 @@ class _GymFinderViewState extends ConsumerState<GymFinderView> {
     );
   }
 
-  /// 결과 목록. 상자로 감싸지 않고 배경 위에 카드를 바로 쌓는다 (#1135).
-  Widget _results(
+  /// 결과 목록 — 시트 하나가 통째로 구르는 스크롤 뷰의 조각이다 (#1274).
+  ///
+  /// 목록을 제 스크롤 뷰로 두면 시트를 끌 때와 목록을 밀 때가 서로 다른 손짓이
+  /// 된다. 머리줄·정렬 줄과 같은 스크롤 뷰에 얹어야, 목록이 맨 위에 닿은 채로
+  /// 계속 내리면 시트가 그대로 이어서 내려간다. 상자로 감싸지 않고 배경 위에
+  /// 카드를 바로 쌓는 것은 그대로다 (#1135).
+  Widget _resultSliver(
     BuildContext context,
     AsyncValue<List<Gym>> gymsAsync,
     List<Gym> visible,
   ) {
     final AppLocalizations l = AppLocalizations.of(context);
     return gymsAsync.when(
-      loading: () => const Padding(
-        padding: EdgeInsets.symmetric(vertical: 32),
-        child: Center(child: CircularProgressIndicator(strokeWidth: 3)),
+      loading: () => const SliverToBoxAdapter(
+        child: Padding(
+          padding: EdgeInsets.symmetric(vertical: 32),
+          child: Center(child: CircularProgressIndicator(strokeWidth: 3)),
+        ),
       ),
-      error: (Object _, StackTrace _) => _LoadError(
-        message: l.exGymsLoadError,
-        onRetry: () => ref.invalidate(gymFinderResultsProvider),
+      error: (Object _, StackTrace _) => SliverToBoxAdapter(
+        child: _LoadError(
+          message: l.exGymsLoadError,
+          onRetry: () => ref.invalidate(gymFinderResultsProvider),
+        ),
       ),
       data: (List<Gym> _) {
         if (visible.isEmpty) {
-          return Padding(
-            padding: const EdgeInsets.symmetric(vertical: 24),
-            child: _EmptyResults(message: l.exNoSearchResults),
+          return SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 24),
+              child: _EmptyResults(message: l.exNoSearchResults),
+            ),
           );
         }
-        return ListView.separated(
-          padding: const EdgeInsets.only(bottom: 20),
+        return SliverList.separated(
           itemCount: visible.length,
           separatorBuilder: (_, _) => const SizedBox(height: 10),
           itemBuilder: (BuildContext context, int index) => _GymListCard(
@@ -227,10 +229,212 @@ class _GymFinderViewState extends ConsumerState<GymFinderView> {
   }
 }
 
-/// `주변 헬스장` 머리줄 — 제목과 목록을 여닫는 화살표 (#1186).
+/// 지도 위에 얹혀 세 자리를 오가는 결과 목록 시트 (#1274).
 ///
-/// 화살표는 목록이 열려 있으면 아래를(내릴 수 있다), 접혀 있으면 위를(다시
-/// 올릴 수 있다) 가리킨다.
+/// **위 = 목록만 · 중간 = 반반 · 아래 = 지도만.** 손을 뗀 자리에서 가장 가까운
+/// 단계에 붙고, 뗄 때의 속도도 반영돼 짧게 튕겨도 다음 단계로 넘어간다 —
+/// [DraggableScrollableSheet] 의 스냅이 그 둘을 함께 해 준다.
+///
+/// 지도는 [Positioned.fill] 로 바닥에 깔려 **한 번도 움직이지 않는다.** 시트만
+/// 그 위를 오르내리므로, 목록을 아무리 밀어도 지도가 따라가지 않는다.
+///
+/// 머리줄·정렬 줄·카드가 **한 스크롤 뷰**에 얹혀 있다. 그래야 목록이 맨 위에
+/// 닿은 채로 계속 내리면 시트가 이어서 내려가고, 머리줄을 잡고 끌어도 시트가
+/// 움직인다.
+class _GymMapAndSheet extends StatefulWidget {
+  const _GymMapAndSheet({
+    required this.gyms,
+    required this.header,
+    required this.controls,
+    required this.resultSliver,
+  });
+
+  final List<Gym> gyms;
+  final String header;
+
+  /// 결과 수와 정렬 드롭다운. 아직 못 읽었으면 null 이라 자리도 없다.
+  final Widget? controls;
+  final Widget resultSliver;
+
+  /// 시트가 가장 낮을 때 남는 높이 — 손잡이와 머리줄만큼이다. 여기가 0 이 되면
+  /// 목록을 다시 올릴 자리가 사라진다.
+  static const double kCollapsedExtent = 76;
+
+  /// 반반 자리. 지도를 절반 남긴 채 여러 곳을 견주는 자리다.
+  static const double kMidSize = 0.5;
+
+  @override
+  State<_GymMapAndSheet> createState() => _GymMapAndSheetState();
+}
+
+class _GymMapAndSheetState extends State<_GymMapAndSheet> {
+  final DraggableScrollableController _sheet = DraggableScrollableController();
+
+  /// 지금 시트가 차지한 비율. 머리줄 화살표가 이 값을 보고 방향을 정한다 —
+  /// 드래그와 화살표가 같은 상태를 가리켜야 둘이 어긋나지 않는다.
+  double _size = _GymMapAndSheet.kMidSize;
+
+  @override
+  void initState() {
+    super.initState();
+    _sheet.addListener(_onSheetMoved);
+  }
+
+  void _onSheetMoved() {
+    if (!_sheet.isAttached) return;
+    final double next = _sheet.size;
+    if ((next - _size).abs() < 0.001) return;
+    setState(() => _size = next);
+  }
+
+  @override
+  void dispose() {
+    _sheet.removeListener(_onSheetMoved);
+    _sheet.dispose();
+    super.dispose();
+  }
+
+  /// 화살표를 눌렀을 때 갈 자리. 맨 아래에서는 위로, 그 밖에서는 한 단계
+  /// 아래로 간다 — 계속 누르면 지도만 남을 때까지 내려가고, 거기서 방향이
+  /// 뒤집힌다.
+  double _nextStop(double min) {
+    if (_size <= min + 0.01) return _GymMapAndSheet.kMidSize;
+    if (_size > _GymMapAndSheet.kMidSize + 0.01) {
+      return _GymMapAndSheet.kMidSize;
+    }
+    return min;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints box) {
+        final double height = box.maxHeight;
+        // 낮은 화면에서도 손잡이와 머리줄은 남아야 하고, 높은 화면에서 그
+        // 비율이 반반을 넘어서도 안 된다.
+        final double minSize = height <= 0
+            ? 0.2
+            : (_GymMapAndSheet.kCollapsedExtent / height).clamp(0.12, 0.45);
+        final bool collapsed = _size <= minSize + 0.01;
+        return Stack(
+          children: <Widget>[
+            // 지도는 바닥에 깔린 채 자리에 고정된다 — 시트만 그 위를 오간다.
+            Positioned.fill(child: _GymMap(gyms: widget.gyms)),
+            DraggableScrollableSheet(
+              controller: _sheet,
+              initialChildSize: _GymMapAndSheet.kMidSize.clamp(minSize, 1),
+              minChildSize: minSize,
+              snap: true,
+              snapSizes: <double>[_GymMapAndSheet.kMidSize.clamp(minSize, 1)],
+              builder:
+                  (BuildContext context, ScrollController scrollController) =>
+                      _SheetSurface(
+                        // 시트의 **겉면**이 이 키를 갖는다. 시트 위젯 자체는
+                        // 스택 전체를 덮고 있어, 그 자리를 재면 시트가 어디에
+                        // 붙어 있는지가 아니라 스택의 윗변이 나온다.
+                        key: const Key('gym-result-sheet'),
+                        child: CustomScrollView(
+                          controller: scrollController,
+                          slivers: <Widget>[
+                            SliverToBoxAdapter(
+                              child: _SheetHead(
+                                title: widget.header,
+                                collapsed: collapsed,
+                                onToggle: () => _sheet.animateTo(
+                                  _nextStop(minSize),
+                                  duration: const Duration(milliseconds: 220),
+                                  curve: Curves.easeOutCubic,
+                                ),
+                              ),
+                            ),
+                            if (widget.controls != null)
+                              SliverToBoxAdapter(
+                                child: Padding(
+                                  padding: const EdgeInsets.only(bottom: 10),
+                                  child: widget.controls,
+                                ),
+                              ),
+                            widget.resultSliver,
+                            const SliverToBoxAdapter(
+                              child: SizedBox(height: 20),
+                            ),
+                          ],
+                        ),
+                      ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+/// 시트의 바탕 — 지도 위에 얹히므로 제 배경과 위쪽 둥근 모서리를 가진다.
+class _SheetSurface extends StatelessWidget {
+  const _SheetSurface({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: const BoxDecoration(
+        color: FigmaColors.statBg,
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+        boxShadow: <BoxShadow>[
+          BoxShadow(
+            color: Color(0x14000000),
+            blurRadius: 16,
+            offset: Offset(0, -4),
+          ),
+        ],
+      ),
+      child: ClipRRect(
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+        child: child,
+      ),
+    );
+  }
+}
+
+/// 시트 머리 — 잡아 끄는 자리를 알리는 손잡이와, 제목·화살표 한 줄 (#1186).
+///
+/// 화살표는 시트가 맨 아래에 있으면 위를(올릴 수 있다), 그 밖에서는 아래를
+/// (내릴 수 있다) 가리킨다. 드래그와 같은 상태([_GymMapAndSheetState._size])를
+/// 읽으므로 손으로 끌어 놓은 자리와 화살표 방향이 어긋나지 않는다.
+class _SheetHead extends StatelessWidget {
+  const _SheetHead({
+    required this.title,
+    required this.collapsed,
+    required this.onToggle,
+  });
+
+  final String title;
+  final bool collapsed;
+  final VoidCallback onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: <Widget>[
+        const SizedBox(height: 8),
+        Center(
+          child: Container(
+            width: 40,
+            height: 4,
+            decoration: BoxDecoration(
+              color: FigmaColors.hairline,
+              borderRadius: BorderRadius.circular(999),
+            ),
+          ),
+        ),
+        _NearbyHeader(title: title, collapsed: collapsed, onToggle: onToggle),
+      ],
+    );
+  }
+}
+
+/// `주변 헬스장` 머리줄 — 제목과 시트를 오르내리는 화살표 (#1186, #1274).
 class _NearbyHeader extends StatelessWidget {
   const _NearbyHeader({
     required this.title,
@@ -609,12 +813,9 @@ class _EmptyResults extends StatelessWidget {
 /// 목록에 보이는 헬스장을 카카오맵 핀으로 찍는다. `KAKAO_JS_KEY` 가 없거나
 /// SDK 로드가 실패하면 [_GymMiniMap] 그래픽으로 폴백한다(#329).
 class _GymMap extends StatelessWidget {
-  const _GymMap({required this.gyms, this.expanded = false});
+  const _GymMap({required this.gyms});
 
   final List<Gym> gyms;
-
-  /// 목록을 접어 지도만 남은 상태인지 (#1186). 목록이 쓰던 높이를 지도가 받는다.
-  final bool expanded;
 
   @override
   Widget build(BuildContext context) {
@@ -622,15 +823,9 @@ class _GymMap extends StatelessWidget {
         .where((Gym g) => g.hasCoordinates)
         .toList(growable: false);
 
-    return SizedBox(
-      // 핀이 여러 개 들어가야 해서 폴백 그래픽(150)보다 1.5배 높게 잡되, 화면이
-      // 낮으면 그만큼 낮춘다 — 지도가 고정된 자리를 차지하므로(#1135) 여기서
-      // 높이를 양보하지 않으면 작은 화면에서 목록이 설 자리가 없다.
-      height: expanded
-          // 목록이 접혔으면 지도가 화면을 넉넉히 쓴다 — 목록을 내린 이유가
-          // 지도를 크게 보기 위해서다.
-          ? math.min(520, MediaQuery.sizeOf(context).height * 0.55)
-          : math.min(225, MediaQuery.sizeOf(context).height * 0.28),
+    // 높이를 스스로 정하지 않는다 — 지도는 시트 뒤를 가득 채운 채 자리에
+    // 고정되고, 얼마나 보일지는 시트가 어디에 있느냐가 정한다 (#1274).
+    return SizedBox.expand(
       child: ClipRRect(
         borderRadius: BorderRadius.circular(16),
         child: KakaoMapView(

--- a/frontend/flutter/lib/features/exercise/presentation/pages/gym_list_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/gym_list_page.dart
@@ -334,6 +334,10 @@ class _GymMapAndSheetState extends State<_GymMapAndSheet> {
                         // 붙어 있는지가 아니라 스택의 윗변이 나온다.
                         key: const Key('gym-result-sheet'),
                         child: CustomScrollView(
+                          // 시트 안에서 실제로 구르는 목록. 이 키로 가리킨다 —
+                          // `Scrollable` 이 시트에 둘(시트 자신과 이 목록)이라
+                          // "찾기 화면 안의 유일한 스크롤" 로는 집을 수 없다.
+                          key: const Key('gym-result-list'),
                           controller: scrollController,
                           slivers: <Widget>[
                             SliverToBoxAdapter(

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/gym_tab.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/gym_tab.dart
@@ -61,7 +61,10 @@ class GymTab extends ConsumerWidget {
     if (myGymAsync.isLoading) {
       return const Padding(
         padding: EdgeInsets.symmetric(horizontal: 20),
-        child: _SectionLoading(height: 180),
+        child: Align(
+          alignment: Alignment.topCenter,
+          child: _SectionLoading(height: 180),
+        ),
       );
     }
     if (!myGymAsync.hasError && myGymAsync.valueOrNull == null) {
@@ -70,7 +73,10 @@ class GymTab extends ConsumerWidget {
       return const GymFinderView();
     }
 
-    return Padding(
+    // 이 탭은 높이를 받아 놓인다 (#1274) — 연결된 헬스장 화면은 섹션이 여럿인
+    // 긴 화면이라 제 스크롤을 갖는다. 찾기 화면은 스스로 시트를 굴리므로 이
+    // 스크롤을 타지 않는다.
+    return SingleChildScrollView(
       padding: const EdgeInsets.symmetric(horizontal: 20),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/frontend/flutter/test/features/exercise/gym_results_panel_test.dart
+++ b/frontend/flutter/test/features/exercise/gym_results_panel_test.dart
@@ -1,8 +1,8 @@
-/// 헬스장 찾기 화면의 지도와 결과 목록. (#865 → #1135)
+/// 헬스장 찾기 화면의 지도와 결과 시트. (#865 → #1135 → #1274)
 ///
-/// 지도 위에 결과 시트를 얹어 두던 때에는, 목록을 밀면 시트가 먼저 커지며
-/// 지도까지 함께 밀려 올라갔다. 지금은 **지도가 자리에 고정**되고 그 아래
-/// 목록만 스크롤한다. 목록을 상자로 한 번 더 감싸지도 않는다.
+/// 지도는 **자리에 고정**되고 그 위로 목록 시트가 오르내린다. 목록을 밀어도
+/// 지도는 움직이지 않는다 — 예전에 지도까지 함께 밀려 올라가던 것이 이
+/// 화면에서 가장 다루기 나빴던 부분이다.
 library;
 
 import 'package:flutter/material.dart';
@@ -70,22 +70,21 @@ void main() {
     // 결과 개수와 정렬 줄, 그리고 카드가 함께 읽힌다.
     expect(find.textContaining('개'), findsWidgets);
     expect(find.text('주변 헬스장'), findsOneWidget);
-    // 지도를 덮던 시트는 없다 (#1135).
-    expect(find.byType(DraggableScrollableSheet), findsNothing);
+    // 처음 자리는 반반이다 — 지도와 목록이 함께 읽힌다 (#1274).
+    expect(find.byType(DraggableScrollableSheet), findsOneWidget);
   });
 
   testWidgets('목록을 밀어도 지도는 제자리다 (#1135)', (tester) async {
     await _pumpFinder(tester);
     final double before = _mapTop(tester);
 
-    await tester.drag(find.byType(ListView).first, const Offset(0, -260));
+    await tester.drag(
+      find.byKey(const Key('gym-result-sheet')),
+      const Offset(0, -260),
+    );
     await tester.pumpAndSettle();
 
-    expect(
-      _mapTop(tester),
-      before,
-      reason: '목록을 밀었더니 지도까지 따라 올라갔다',
-    );
+    expect(_mapTop(tester), before, reason: '목록을 밀었더니 지도까지 따라 올라갔다');
   });
 
   testWidgets('검색 결과가 없으면 빈 문구가 그 자리에 뜬다', (tester) async {

--- a/frontend/flutter/test/features/exercise/gym_trainer_line_test.dart
+++ b/frontend/flutter/test/features/exercise/gym_trainer_line_test.dart
@@ -3,7 +3,8 @@
 ///  * 찾기 목록의 헬스장 카드는 그곳 소속 트레이너를 전원 적는다 — 헬스장을
 ///    견주는 자리에서 누가 있는지가 카드 안에서 읽혀야 한다.
 ///  * 연결된 내 헬스장 카드는 담당 트레이너와 상세 이동을 한 줄로 적는다.
-///  * 지도와 목록 사이의 화살표로 목록을 접으면 그 자리를 지도가 받는다.
+///  * 지도 위의 결과 시트는 세 자리(목록만·반반·지도만)를 오가고, 머리줄
+///    화살표는 그 시트와 같은 자리를 가리킨다 (#1274).
 library;
 
 import 'package:flutter/material.dart';
@@ -18,6 +19,7 @@ import 'package:oncare/features/exercise/domain/entities/gym.dart';
 import 'package:oncare/features/exercise/domain/entities/trainer.dart';
 import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
 import 'package:oncare/features/exercise/presentation/pages/trainer_detail_page.dart';
+import 'package:oncare/features/exercise/presentation/widgets/kakao_map/kakao_map_view.dart';
 import 'package:oncare/features/member_coach/data/repositories/mock_member_coach_repository.dart';
 import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
@@ -178,11 +180,17 @@ void main() {
     });
   });
 
-  group('지도·목록 접기 (#1186)', () {
-    Finder map() => find.byWidgetPredicate(
-      (Widget widget) => widget.runtimeType.toString() == '_GymMap',
-    );
+  group('지도·목록 드래그 시트 (#1186 · #1274)', () {
+    final Finder sheet = find.byKey(const Key('gym-result-sheet'));
     final Finder toggle = find.byKey(const ValueKey<String>('gym-list-toggle'));
+
+    /// 지도의 윗변. 시트를 어디로 옮기든 이 값은 그대로여야 한다.
+    double mapTop(WidgetTester tester) =>
+        tester.getTopLeft(find.byType(KakaoMapView).first).dy;
+
+    /// 시트의 윗변 — 지금 시트가 어디에 붙어 있는지를 이 값으로 읽는다.
+    /// 작을수록 시트가 높이 올라와 목록이 많이 보인다.
+    double sheetTop(WidgetTester tester) => tester.getTopLeft(sheet).dy;
 
     testWidgets('처음에는 지도와 목록이 함께 보인다', (WidgetTester tester) async {
       await pumpGymTab(tester, hasMyGym: false);
@@ -190,35 +198,79 @@ void main() {
       expect(toggle, findsOneWidget);
       expect(find.text(_gym.name), findsWidgets);
       expect(find.text('1개 결과'), findsOneWidget);
+      expect(find.byType(KakaoMapView), findsOneWidget);
     });
 
-    testWidgets('화살표를 누르면 목록이 접히고 지도가 커진다', (WidgetTester tester) async {
+    testWidgets('위로 끌면 목록만, 아래로 끌면 지도만 남는다', (WidgetTester tester) async {
       await pumpGymTab(tester, hasMyGym: false);
-      final double before = tester.getSize(map()).height;
+      final double middle = sheetTop(tester);
 
-      await tester.tap(toggle);
+      await tester.drag(sheet, const Offset(0, -400));
       await tester.pumpAndSettle();
+      final double top = sheetTop(tester);
+      expect(top, lessThan(middle), reason: '위로 끌었는데 시트가 올라오지 않았다');
 
-      expect(tester.getSize(map()).height, greaterThan(before));
-      expect(find.text('1개 결과'), findsNothing);
-      expect(find.byKey(Key('gym-card-${_gym.id}')), findsNothing);
-      // 제목 줄은 남는다 — 다시 펼 자리가 사라지면 안 된다.
+      await tester.drag(sheet, const Offset(0, 700));
+      await tester.pumpAndSettle();
+      final double bottom = sheetTop(tester);
+      expect(bottom, greaterThan(middle), reason: '아래로 끌었는데 시트가 내려가지 않았다');
+      // 지도만 남은 자리에서도 다시 올릴 머리줄은 보인다.
       expect(find.text('주변 헬스장'), findsOneWidget);
       expect(toggle, findsOneWidget);
     });
 
-    testWidgets('다시 누르면 원래대로 돌아온다', (WidgetTester tester) async {
+    testWidgets('짧게 끌고 손을 떼면 가장 가까운 단계에 붙는다', (WidgetTester tester) async {
       await pumpGymTab(tester, hasMyGym: false);
-      final double before = tester.getSize(map()).height;
+      final double middle = sheetTop(tester);
 
+      // 어정쩡한 거리만 끌고 놓는다 — 그 자리에 멈추면 안 된다.
+      await tester.drag(sheet, const Offset(0, -40));
+      await tester.pumpAndSettle();
+
+      expect(sheetTop(tester), middle);
+    });
+
+    testWidgets('시트를 옮겨도 지도는 제자리다', (WidgetTester tester) async {
+      await pumpGymTab(tester, hasMyGym: false);
+      final double before = mapTop(tester);
+
+      await tester.drag(sheet, const Offset(0, -400));
+      await tester.pumpAndSettle();
+      expect(mapTop(tester), before);
+
+      await tester.drag(sheet, const Offset(0, 700));
+      await tester.pumpAndSettle();
+      expect(mapTop(tester), before);
+    });
+
+    testWidgets('화살표와 드래그가 같은 자리를 가리킨다', (WidgetTester tester) async {
+      await pumpGymTab(tester, hasMyGym: false);
+
+      // 손으로 맨 아래까지 내린다 — 화살표는 이제 위를 가리켜야 한다.
+      await tester.drag(sheet, const Offset(0, 700));
+      await tester.pumpAndSettle();
+      final double bottom = sheetTop(tester);
+      expect(
+        tester
+            .widget<Icon>(
+              find.descendant(of: toggle, matching: find.byType(Icon)),
+            )
+            .icon,
+        Icons.keyboard_arrow_up_rounded,
+      );
+
+      // 그 화살표를 누르면 반반 자리로 돌아온다.
       await tester.tap(toggle);
       await tester.pumpAndSettle();
-      await tester.tap(toggle);
-      await tester.pumpAndSettle();
-
-      expect(tester.getSize(map()).height, before);
-      expect(find.text('1개 결과'), findsOneWidget);
-      expect(find.byKey(Key('gym-card-${_gym.id}')), findsOneWidget);
+      expect(sheetTop(tester), lessThan(bottom));
+      expect(
+        tester
+            .widget<Icon>(
+              find.descendant(of: toggle, matching: find.byType(Icon)),
+            )
+            .icon,
+        Icons.keyboard_arrow_down_rounded,
+      );
     });
   });
 }

--- a/frontend/flutter/test_e2e/support/e2e_harness.dart
+++ b/frontend/flutter/test_e2e/support/e2e_harness.dart
@@ -662,12 +662,16 @@ Future<void> openConsultationForm(WidgetTester tester, String targetId) async {
 
   // 카드는 화면에 들어오기 전까지 **만들어지지 않는다**. `ensureVisible` 은 이미
   // 있는 위젯만 옮기므로, 지연 목록에서는 스크롤로 만들어 내야 한다.
+  //
+  // 목록을 키로 집는다 — 찾기 화면의 결과는 지도 위 시트 안에 있고(#1274) 그
+  // 시트에는 스크롤이 둘(시트 자신과 결과 목록)이라, "화면 안의 유일한 스크롤"
+  // 로는 어느 쪽인지 정해지지 않는다.
   if (card.evaluate().isEmpty) {
     await tester.scrollUntilVisible(
       card,
       240,
       scrollable: find.descendant(
-        of: find.byType(GymFinderView),
+        of: find.byKey(const Key('gym-result-list')),
         matching: find.byType(Scrollable),
       ),
       maxScrolls: 60,


### PR DESCRIPTION
Closes #1274

## Summary

헬스장 찾기의 지도와 목록을 **잡아 끌 수 있는 시트**로 바꿨다. 목록은 세 자리에 붙는다 — 위(목록만) · 중간(지도·목록 반반) · 아래(지도만). 손을 뗀 자리에서 가장 가까운 단계로 붙고, 뗄 때의 속도도 반영돼 짧게 튕겨도 다음 단계로 넘어간다.

예전에는 비율을 바꾸는 수단이 머리줄 화살표 하나뿐이라 두 상태만 오갈 수 있었고, 폰에서 손으로 원하는 만큼 올리거나 내릴 수 없었다.

## Changes

### 지도가 진짜로 자리에 고정된다
지도는 시트 뒤에 깔린 채 한 번도 움직이지 않는다. 예전에는 운동 탭처럼 **바깥이 스크롤 뷰**인 자리에서 목록이 제 높이를 갖지 못해, 목록을 밀면 바깥 페이지가 대신 굴러 지도까지 함께 올라갔다 — 지도를 자리에 고정하려던 #1135 의 의도가 그 배치에서는 지켜지지 않았다.

- 찾기 화면이 **높이를 스스로 정한다**. 바깥이 높이를 주면 그대로 쓰고, 열린 높이에 놓이면 화면에서 한 몫을 떼어 쓴다.
- 운동 탭은 헬스장 탭에서만 머리와 탭 줄을 고정하고 남는 높이를 탭에 넘긴다. 운동 기록 탭은 여러 섹션을 이어 붙인 긴 화면이라 예전처럼 통째로 구른다. 연결된 헬스장 화면은 제 스크롤을 갖는다.

### 드래그와 스크롤이 한 손짓으로 이어진다
머리줄·정렬 줄·카드가 **한 스크롤 뷰**에 얹혀 있다. 목록이 맨 위에 닿은 채로 계속 내리면 시트가 그대로 이어서 내려가고, 머리줄을 잡고 끌어도 시트가 움직인다. 잡는 자리를 알리는 손잡이를 시트 머리에 뒀다.

### 화살표는 시트와 같은 상태를 읽는다
머리줄 화살표(#1186)는 시트가 지금 어디에 있는지를 그대로 읽어 방향을 정한다 — 맨 아래에서는 위를, 그 밖에서는 아래를 가리키고, 누르면 한 단계씩 옮겨 간다. 손으로 끌어 놓은 자리와 화살표 방향이 어긋날 자리가 없다.

검색·정렬·헬스장 상세 이동은 그대로다.

## Notes

- 넓은 화면(`maxWidth: 720`)에서도 같은 배치다. 시트의 세 단계는 화면 높이에 대한 비율이라 폰·태블릿 모두 같은 규칙을 쓴다.
- 가장 낮은 단계는 손잡이와 머리줄만큼을 남긴다. 여기가 0 이 되면 목록을 다시 올릴 자리가 사라진다.

## Verification

- `flutter analyze` + 회원 앱 전체 테스트 통과.
- 드래그 제스처로 세 단계 전환, 짧게 끌었을 때의 스냅, 시트를 옮기는 동안 지도 위치 고정, 화살표와 드래그의 상태 일치를 위젯 테스트로 덮었다.
- 세 자리(목록만·반반·지도만)를 골든 스냅샷으로 눈으로 확인.
