### PR TITLE
feat(demo): 김민수 운동 데모 과거 보강과 고객앱 기준 정합성

### DIFF
--- a/backend/app/db/demo_fixture.py
+++ b/backend/app/db/demo_fixture.py
@@ -94,11 +94,18 @@ class FixtureMeal:
 @dataclass(frozen=True)
 class FixtureExercise:
     name: str
-    #: `cardio` | `strength` | `flexibility` — 표준 어휘 (#996, #997).
+    #: `cardio` | `strength` | `stretching` | `other` — 표준 어휘 (#996, #997).
     type: str
     minutes: int
     calories: int
     done: bool
+    #: 근력 항목의 세트 수와 한 세트당 횟수. 다른 유형은 None 이다.
+    #:
+    #: 예전에는 이 값을 읽지 않고 버렸다 — Dart 쪽 짝은 읽는데 백엔드만 버려서,
+    #: 실 API 로 붙이면 같은 회원의 같은 날 근력이 화면마다 다른 세트 수로
+    #: 보였다(분에서 되짚은 수와 픽스처가 적어 둔 수가 달랐다). (#1265)
+    sets: int | None = None
+    reps: int | None = None
 
     @property
     def label(self) -> str:
@@ -255,6 +262,8 @@ class DemoFixture:
                     minutes=item["minutes"],
                     calories=item["calories"],
                     done=item["done"],
+                    sets=item.get("sets"),
+                    reps=item.get("reps"),
                 )
                 for item in entry["exercises"]
             ),

--- a/backend/app/db/demo_fixture_data.json
+++ b/backend/app/db/demo_fixture_data.json
@@ -334,7 +334,8 @@
           "minutes": 12,
           "calories": 72,
           "done": true,
-          "sets": 4
+          "sets": 4,
+          "reps": 10
         },
         {
           "name": "덤벨 숄더프레스 10kg · 4세트",
@@ -342,7 +343,8 @@
           "minutes": 10,
           "calories": 60,
           "done": true,
-          "sets": 4
+          "sets": 4,
+          "reps": 12
         },
         {
           "name": "랫풀다운 45kg · 4세트",
@@ -350,7 +352,8 @@
           "minutes": 12,
           "calories": 72,
           "done": true,
-          "sets": 4
+          "sets": 4,
+          "reps": 12
         },
         {
           "name": "플랭크 60초 · 3세트",
@@ -358,7 +361,8 @@
           "minutes": 6,
           "calories": 36,
           "done": true,
-          "sets": 3
+          "sets": 3,
+          "reps": 3
         },
         {
           "name": "마무리 러닝머신 15분",
@@ -372,6 +376,13 @@
           "type": "stretching",
           "minutes": 12,
           "calories": 36,
+          "done": true
+        },
+        {
+          "name": "탁구 20분",
+          "type": "other",
+          "minutes": 20,
+          "calories": 100,
           "done": true
         }
       ],
@@ -416,7 +427,9 @@
           "type": "strength",
           "minutes": 10,
           "calories": 60,
-          "done": true
+          "done": true,
+          "sets": 3,
+          "reps": 15
         },
         {
           "name": "하체 스트레칭 15분",
@@ -469,7 +482,9 @@
           "type": "strength",
           "minutes": 10,
           "calories": 60,
-          "done": true
+          "done": true,
+          "sets": 3,
+          "reps": 15
         },
         {
           "name": "하체 스트레칭 15분",
@@ -523,7 +538,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -614,7 +631,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -688,7 +707,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -768,7 +789,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -859,7 +882,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -933,7 +958,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -1013,7 +1040,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -1107,7 +1136,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": false
+              "done": false,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -1184,7 +1215,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": false
+              "done": false,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -1264,7 +1297,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -1355,7 +1390,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -1429,7 +1466,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -1437,6 +1476,13 @@
               "minutes": 15,
               "calories": 45,
               "done": false
+            },
+            {
+              "name": "북한산 등산 90분",
+              "type": "other",
+              "minutes": 90,
+              "calories": 450,
+              "done": true
             }
           ],
           "meals": [
@@ -1509,7 +1555,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -1600,7 +1648,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -1674,7 +1724,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -1754,7 +1806,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -1810,9 +1864,53 @@
         },
         {
           "weekday": 2,
-          "label": "AI 루틴 · 자율 운동",
-          "pt": false,
-          "exercises": [],
+          "label": "PT 세션 · 트레이너 지도",
+          "pt": true,
+          "clientFeedback": "레그프레스 무게가 붙었어요. 마지막 세트가 힘들었어요.",
+          "trainerNote": "하체 근력 향상 확인. 다음 세션 레그프레스 5kg 증량.",
+          "exercises": [
+            {
+              "name": "레그프레스 70kg · 4세트",
+              "type": "strength",
+              "minutes": 12,
+              "calories": 72,
+              "done": true,
+              "sets": 4,
+              "reps": 12
+            },
+            {
+              "name": "레그컬 35kg · 3세트",
+              "type": "strength",
+              "minutes": 9,
+              "calories": 54,
+              "done": true,
+              "sets": 3,
+              "reps": 12
+            },
+            {
+              "name": "카프레이즈 자체중량 · 3세트",
+              "type": "strength",
+              "minutes": 6,
+              "calories": 36,
+              "done": true,
+              "sets": 3,
+              "reps": 20
+            },
+            {
+              "name": "마무리 러닝머신 15분",
+              "type": "cardio",
+              "minutes": 15,
+              "calories": 135,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
           "meals": [
             {
               "meal": "breakfast-egg-strawberry"
@@ -1842,7 +1940,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -1913,7 +2013,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -1993,7 +2095,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -2054,7 +2158,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": false
+              "done": false,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -2095,7 +2201,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": false
+              "done": false,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -2175,7 +2283,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -2266,7 +2376,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -2340,7 +2452,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -2420,7 +2534,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -2511,7 +2627,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -2585,7 +2703,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -2624,6 +2744,13 @@
               "type": "stretching",
               "minutes": 10,
               "calories": 30,
+              "done": true
+            },
+            {
+              "name": "탁구 40분",
+              "type": "other",
+              "minutes": 40,
+              "calories": 200,
               "done": true
             }
           ],
@@ -2665,7 +2792,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -2759,7 +2888,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": false
+              "done": false,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -2836,7 +2967,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": false
+              "done": false,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -2916,7 +3049,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -3007,7 +3142,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -3081,7 +3218,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -3161,7 +3300,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -3220,9 +3361,53 @@
         },
         {
           "weekday": 2,
-          "label": "AI 루틴 · 자율 운동",
-          "pt": false,
-          "exercises": [],
+          "label": "PT 세션 · 트레이너 지도",
+          "pt": true,
+          "clientFeedback": "데드리프트 자세를 잡아주셔서 허리가 편했어요.",
+          "trainerNote": "데드리프트 힙힌지 안정적. 중량 55kg 유지 후 다음 달 60kg.",
+          "exercises": [
+            {
+              "name": "데드리프트 55kg · 4세트",
+              "type": "strength",
+              "minutes": 12,
+              "calories": 72,
+              "done": true,
+              "sets": 4,
+              "reps": 8
+            },
+            {
+              "name": "루마니안 데드리프트 40kg · 3세트",
+              "type": "strength",
+              "minutes": 9,
+              "calories": 54,
+              "done": true,
+              "sets": 3,
+              "reps": 10
+            },
+            {
+              "name": "플랭크 45초 · 3세트",
+              "type": "strength",
+              "minutes": 6,
+              "calories": 36,
+              "done": true,
+              "sets": 3,
+              "reps": 3
+            },
+            {
+              "name": "마무리 러닝머신 12분",
+              "type": "cardio",
+              "minutes": 12,
+              "calories": 108,
+              "done": true
+            },
+            {
+              "name": "허리 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
           "meals": [
             {
               "meal": "breakfast-greek-yogurt-nuts"
@@ -3252,7 +3437,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -3326,7 +3513,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -3406,7 +3595,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -3494,7 +3685,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -3565,7 +3758,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -3645,7 +3840,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -3706,7 +3903,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": false
+              "done": false,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -3747,7 +3946,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": false
+              "done": false,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -3827,7 +4028,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -3918,7 +4121,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -3992,13 +4197,22 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
               "type": "stretching",
               "minutes": 15,
               "calories": 45,
+              "done": true
+            },
+            {
+              "name": "자전거 라이딩 60분",
+              "type": "other",
+              "minutes": 60,
+              "calories": 300,
               "done": true
             }
           ],
@@ -4072,7 +4286,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -4163,7 +4379,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -4237,7 +4455,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -4317,7 +4537,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -4411,7 +4633,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": false
+              "done": false,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -4488,7 +4712,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": false
+              "done": false,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -4568,7 +4794,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -4627,9 +4855,53 @@
         },
         {
           "weekday": 2,
-          "label": "AI 루틴 · 자율 운동",
-          "pt": false,
-          "exercises": [],
+          "label": "PT 세션 · 트레이너 지도",
+          "pt": true,
+          "clientFeedback": "어깨가 아직 조금 불편해서 무게를 낮췄어요.",
+          "trainerNote": "오른쪽 어깨 가동범위 제한. 숄더프레스 중량 낮추고 밴드 보강 병행.",
+          "exercises": [
+            {
+              "name": "숄더프레스 10kg · 4세트",
+              "type": "strength",
+              "minutes": 12,
+              "calories": 72,
+              "done": true,
+              "sets": 4,
+              "reps": 12
+            },
+            {
+              "name": "밴드 외전 · 3세트",
+              "type": "strength",
+              "minutes": 6,
+              "calories": 36,
+              "done": true,
+              "sets": 3,
+              "reps": 20
+            },
+            {
+              "name": "인클라인 푸시업 · 3세트",
+              "type": "strength",
+              "minutes": 9,
+              "calories": 54,
+              "done": true,
+              "sets": 3,
+              "reps": 12
+            },
+            {
+              "name": "마무리 러닝머신 10분",
+              "type": "cardio",
+              "minutes": 10,
+              "calories": 90,
+              "done": true
+            },
+            {
+              "name": "어깨 관절 보호 스트레칭 12분",
+              "type": "stretching",
+              "minutes": 12,
+              "calories": 36,
+              "done": true
+            }
+          ],
           "meals": [
             {
               "meal": "breakfast-egg-strawberry"
@@ -4659,7 +4931,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -4733,7 +5007,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -4813,7 +5089,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -4904,7 +5182,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -4978,7 +5258,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -5058,7 +5340,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -5146,7 +5430,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -5217,7 +5503,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -5297,7 +5585,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -5358,7 +5648,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": false
+              "done": false,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -5399,7 +5691,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": false
+              "done": false,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -5479,7 +5773,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -5570,7 +5866,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -5644,7 +5942,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -5724,7 +6024,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -5815,7 +6117,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -5889,7 +6193,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -5969,7 +6275,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -6031,9 +6339,53 @@
         },
         {
           "weekday": 2,
-          "label": "AI 루틴 · 자율 운동",
-          "pt": false,
-          "exercises": [],
+          "label": "PT 세션 · 트레이너 지도",
+          "pt": true,
+          "clientFeedback": "벤치프레스가 처음이라 어색했지만 재밌었어요 💪",
+          "trainerNote": "상체 근력 기초 확인. 벤치프레스 35kg 로 시작해 자세 우선.",
+          "exercises": [
+            {
+              "name": "벤치프레스 35kg · 4세트",
+              "type": "strength",
+              "minutes": 12,
+              "calories": 72,
+              "done": true,
+              "sets": 4,
+              "reps": 10
+            },
+            {
+              "name": "체스트프레스 25kg · 3세트",
+              "type": "strength",
+              "minutes": 9,
+              "calories": 54,
+              "done": true,
+              "sets": 3,
+              "reps": 12
+            },
+            {
+              "name": "랫풀다운 30kg · 3세트",
+              "type": "strength",
+              "minutes": 9,
+              "calories": 54,
+              "done": true,
+              "sets": 3,
+              "reps": 12
+            },
+            {
+              "name": "마무리 러닝머신 15분",
+              "type": "cardio",
+              "minutes": 15,
+              "calories": 135,
+              "done": true
+            },
+            {
+              "name": "상체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
           "meals": [
             {
               "meal": "breakfast-greek-yogurt-nuts"
@@ -6063,7 +6415,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": false
+              "done": false,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -6140,7 +6494,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": false
+              "done": false,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -6220,7 +6576,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -6311,7 +6669,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -6385,7 +6745,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -6465,7 +6827,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -6556,7 +6920,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -6630,7 +6996,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -6710,7 +7078,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -6798,7 +7168,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -6869,7 +7241,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -6949,7 +7323,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -7010,7 +7386,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": false
+              "done": false,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -7051,7 +7429,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": false
+              "done": false,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -7131,7 +7511,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -7222,7 +7604,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -7296,7 +7680,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -7376,7 +7762,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -7435,9 +7823,53 @@
         },
         {
           "weekday": 2,
-          "label": "AI 루틴 · 자율 운동",
-          "pt": false,
-          "exercises": [],
+          "label": "PT 세션 · 트레이너 지도",
+          "pt": true,
+          "clientFeedback": "첫 PT 라 긴장했는데 생각보다 할 만했어요.",
+          "trainerNote": "첫 세션. 체력 수준 점검 위주로 가볍게 진행.",
+          "exercises": [
+            {
+              "name": "고블릿 스쿼트 12kg · 3세트",
+              "type": "strength",
+              "minutes": 9,
+              "calories": 54,
+              "done": true,
+              "sets": 3,
+              "reps": 12
+            },
+            {
+              "name": "케틀벨 스윙 12kg · 3세트",
+              "type": "strength",
+              "minutes": 9,
+              "calories": 54,
+              "done": true,
+              "sets": 3,
+              "reps": 15
+            },
+            {
+              "name": "코어 서킷 · 2세트",
+              "type": "strength",
+              "minutes": 6,
+              "calories": 36,
+              "done": true,
+              "sets": 2,
+              "reps": 12
+            },
+            {
+              "name": "마무리 러닝머신 10분",
+              "type": "cardio",
+              "minutes": 10,
+              "calories": 90,
+              "done": true
+            },
+            {
+              "name": "전신 스트레칭 12분",
+              "type": "stretching",
+              "minutes": 12,
+              "calories": 36,
+              "done": true
+            }
+          ],
           "meals": [
             {
               "meal": "breakfast-oatmeal-banana"
@@ -7467,7 +7899,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -7541,7 +7975,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -7621,7 +8057,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -7715,7 +8153,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": false
+              "done": false,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -7792,7 +8232,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": false
+              "done": false,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -7872,7 +8314,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -7963,7 +8407,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -8037,7 +8483,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -8117,7 +8565,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -8208,7 +8658,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -8282,7 +8734,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -8362,7 +8816,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -8450,7 +8906,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -8521,7 +8979,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -8601,7 +9061,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -8662,7 +9124,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": false
+              "done": false,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -8703,7 +9167,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": false
+              "done": false,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",

--- a/backend/app/db/seed_member_data.py
+++ b/backend/app/db/seed_member_data.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import json
 import logging
 import time
+from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
 
 from sqlalchemy import or_, select
@@ -615,10 +616,25 @@ def _seed_routines(db: Session, member_id: str) -> None:
 _FIXTURE_ID_PREFIX = "seed-fix-"
 
 
+@dataclass(frozen=True)
+class _TypeTotals:
+    """하루·한 종류로 접은 값. 운동 기록 한 행이 되는 그대로다."""
+
+    minutes: int
+    calories: int
+    name: str
+    #: 근력이면 그날 한 세트 수의 **합**. 다른 유형은 None 이다.
+    sets: int | None = None
+    #: 근력이면 그날 한 횟수 중 가장 많은 수. 세트와 달리 더하지 않는다 — 한
+    #: 세트당 수라 합계는 아무도 한 적 없는 값이 된다(#1310 의 PT 파생 기록과
+    #: 같은 규칙).
+    reps: int | None = None
+
+
 def _by_type(
     exercises: tuple[FixtureExercise, ...],
-) -> dict[str, tuple[int, int, str]]:
-    """운동을 종류별로 합친다 — {종류: (분, 칼로리, 이름)}. 픽스처 순서를 유지한다.
+) -> dict[str, _TypeTotals]:
+    """운동을 종류별로 합친다. 픽스처 순서를 유지한다.
 
     종류는 표준 어휘로 접어서 센다 (#996). 픽스처가 아직 옛 이름을 쓰더라도
     DB 에는 표준 값만 들어가야 앱이 유형을 다시 매핑하지 않는다.
@@ -627,17 +643,57 @@ def _by_type(
     이름으로 적기 때문이다(#1288). 종류로 합치면서 이름까지 버리면 데모의 요일
     칸이 "유산소 · 근력" 두 줄로만 남는다. PT 완료가 만드는 기록도 여러 운동을
     쉼표로 잇는 같은 규칙을 쓴다.
+
+    세트·횟수도 함께 접는다 (#1265). 예전에는 픽스처가 적어 둔 세트를 버려서,
+    화면이 분에서 세트를 되짚었다 — 같은 회원의 같은 날 근력이 앱마다 다른 수로
+    보였다.
     """
-    totals: dict[str, tuple[int, int, str]] = {}
+    totals: dict[str, _TypeTotals] = {}
     for exercise in exercises:
         kind = exercise_types.normalize(exercise.type)
-        minutes, calories, names = totals.get(kind, (0, 0, ""))
-        totals[kind] = (
-            minutes + exercise.minutes,
-            calories + exercise.calories,
-            f"{names}, {exercise.name}" if names else exercise.name,
+        prev = totals.get(kind)
+        strength = kind == exercise_types.STRENGTH
+        totals[kind] = _TypeTotals(
+            minutes=(prev.minutes if prev else 0) + exercise.minutes,
+            calories=(prev.calories if prev else 0) + exercise.calories,
+            name=(
+                f"{prev.name}, {exercise.name}"
+                if prev and prev.name
+                else exercise.name
+            ),
+            sets=(
+                _add(prev.sets if prev else None, exercise.sets)
+                if strength
+                else None
+            ),
+            reps=(
+                _peak(prev.reps if prev else None, exercise.reps)
+                if strength
+                else None
+            ),
         )
     return totals
+
+
+def _add(left: int | None, right: int | None) -> int | None:
+    """둘 다 없으면 None. 하나만 있으면 그 값 — 0 으로 채우지 않는다.
+
+    0 은 "0세트를 했다" 가 되고, None 은 "적지 않았다" 다. 그래프가 둘을 다르게
+    읽는다.
+    """
+    if left is None:
+        return right
+    if right is None:
+        return left
+    return left + right
+
+
+def _peak(left: int | None, right: int | None) -> int | None:
+    if left is None:
+        return right
+    if right is None:
+        return left
+    return max(left, right)
 
 
 def _seed_from_fixture(db: Session, member_id: str) -> None:
@@ -728,16 +784,20 @@ def _seed_from_fixture(db: Session, member_id: str) -> None:
         # 하루에 같은 종류가 둘일 수 있어(PT 날의 레그프레스·레그컬은 둘 다 근력)
         # 종류로 합친다. 주간 활동 그래프가 하루·종류당 한 칸을 그리므로 나눠 넣을
         # 자리도 없다.
-        for kind, (minutes, calories, name) in _by_type(day.done_exercises).items():
+        for kind, totals in _by_type(day.done_exercises).items():
             db.add(models.ExerciseSession(
                 id=f"{_FIXTURE_ID_PREFIX}ex-{member_id}-{day.iso}-{kind}",
                 user_id=member_id,
                 week_start=day.week_start,
                 day_label=day.day_label,
                 type=kind,
-                name=name,
-                minutes=minutes,
-                calories=calories,
+                name=totals.name,
+                minutes=totals.minutes,
+                calories=totals.calories,
+                # 픽스처가 적어 둔 세트·횟수를 그대로 남긴다 — 없으면 화면이
+                # 분에서 세트를 되짚어 아무도 적은 적 없는 수를 그린다. (#1265)
+                sets=totals.sets,
+                reps=totals.reps,
                 intensity="moderate",
                 # 실제로 운동한 날의 시각을 함께 적는다 (#1264). `created_at` 은
                 # 재시드 시각이라, 이것이 없으면 35주 전 운동도 방금 만든 행으로

--- a/backend/tests/test_demo_exercise_consistency.py
+++ b/backend/tests/test_demo_exercise_consistency.py
@@ -9,10 +9,11 @@
 """
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import timedelta
 
 import pytest
 
+from app.core import clock
 from app.db.demo_fixture import load_fixture
 from app.services.exercise_service import monday_of_str
 
@@ -65,9 +66,14 @@ def _sessions(body: dict) -> list[tuple]:
 
 
 def _weeks_to_check() -> list[str]:
-    """이번 주 · 지난주 · 과거 PT 가 있는 주."""
+    """이번 주 · 지난주 · 과거 PT 가 있는 주.
+
+    오늘은 **서비스 기준 시각(KST)** 으로 센다. 시드가 그 시계로 날짜를 붙이는데
+    여기서 러너의 로컬 날짜를 쓰면, UTC 저녁(=KST 다음 날)에 도는 CI 에서 서로 다른
+    하루를 가리킨다. (#557)
+    """
     fixture = load_fixture()
-    today = date.today()
+    today = clock.today()
     weeks = [
         monday_of_str(today.isoformat()),
         monday_of_str((today - timedelta(days=7)).isoformat()),
@@ -122,7 +128,7 @@ def test_seeded_strength_keeps_the_sets_the_fixture_wrote(client):
     값)과 실 API(분 ÷ 3)에서 다른 수로 보였다.
     """
     fixture = load_fixture()
-    today = date.today()
+    today = clock.today()
     day = next(
         d
         for d in reversed(fixture.days_for(today))

--- a/backend/tests/test_demo_exercise_consistency.py
+++ b/backend/tests/test_demo_exercise_consistency.py
@@ -1,0 +1,145 @@
+"""데모 회원의 한 주 운동을 회원 앱과 트레이너 화면이 같은 수로 읽는가. (#1265)
+
+숫자의 기준은 **고객 앱 운동 계약**이다. 트레이너 API 는 그 값을 다시 해석하지
+않는다 — 두 화면을 나란히 놓고 시연하는 것이 이 데모의 전부라, 같은 회원의 같은
+날에 두 앱이 다른 수를 말하면 데모가 성립하지 않는다.
+
+두 응답이 실제로 같은지는 **응답을 직접 견주어** 확인한다. 같은 함수를 부르니까
+같을 것이라고 두면, 한쪽 라우터에 필터가 하나 붙는 순간 조용히 갈라진다.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+
+from app.db.demo_fixture import load_fixture
+from app.services.exercise_service import monday_of_str
+
+#: 두 API 가 **완전히 같아야 하는** 필드. 이행률·코치 문구처럼 화면마다 다른
+#: 말을 하는 값은 여기 없다.
+_SHARED_FIELDS = (
+    "day_labels",
+    "daily_minutes",
+    "daily_calories",
+    "cardio_minutes",
+    "strength_minutes",
+    "stretching_minutes",
+    "other_minutes",
+    "strength_sets",
+    "total_minutes",
+    "total_calories",
+    "streak_days",
+    "weekly_goal_minutes",
+    "weekly_goal_calories",
+)
+
+#: 세션 한 줄에서 견주는 값.
+_SESSION_FIELDS = ("date", "type", "minutes", "calories", "sets", "reps")
+
+
+def _trainer_token(client) -> str:
+    return client.post(
+        "/v1/auth/login",
+        data={"username": "trainer@oncare.com", "password": "oncare123"},
+    ).json()["access_token"]
+
+
+def _member_token(client) -> str:
+    return client.post(
+        "/v1/auth/login",
+        data={"username": "minsu@oncare.com", "password": "oncare123"},
+    ).json()["access_token"]
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _sessions(body: dict) -> list[tuple]:
+    """세션을 견주기 좋은 모양으로. 순서는 응답마다 다를 수 있어 정렬한다."""
+    return sorted(
+        tuple(session[field] for field in _SESSION_FIELDS)
+        for session in body["sessions"]
+    )
+
+
+def _weeks_to_check() -> list[str]:
+    """이번 주 · 지난주 · 과거 PT 가 있는 주."""
+    fixture = load_fixture()
+    today = date.today()
+    weeks = [
+        monday_of_str(today.isoformat()),
+        monday_of_str((today - timedelta(days=7)).isoformat()),
+    ]
+    pt_days = [day for day in fixture.days_for(today) if day.is_pt and day.day < today]
+    if pt_days:
+        weeks.append(pt_days[-1].week_start)
+    return weeks
+
+
+@pytest.mark.parametrize("week_start", _weeks_to_check())
+def test_member_and_trainer_read_the_same_week(client, week_start):
+    member_id = load_fixture().user_app_seed_id
+    member = client.get(
+        f"/v1/exercise/weeks/current?week_start={week_start}",
+        headers=_auth(_member_token(client)),
+    )
+    trainer = client.get(
+        f"/v1/trainer/clients/{member_id}/exercise-week?week_start={week_start}",
+        headers=_auth(_trainer_token(client)),
+    )
+    assert member.status_code == 200, member.text
+    assert trainer.status_code == 200, trainer.text
+
+    left, right = member.json(), trainer.json()
+    for field in _SHARED_FIELDS:
+        assert left[field] == right[field], f"{week_start} · {field}"
+    assert _sessions(left) == _sessions(right), week_start
+
+
+def test_the_week_totals_are_the_sum_of_their_days(client):
+    """합계가 요일 값에서 나온다 — 둘이 갈라지면 어느 쪽이 진짜인지 알 수 없다."""
+    body = client.get(
+        "/v1/exercise/weeks/current",
+        headers=_auth(_member_token(client)),
+    ).json()
+    assert body["total_minutes"] == sum(body["daily_minutes"])
+    assert body["total_calories"] == sum(body["daily_calories"])
+    for index in range(7):
+        assert body["daily_minutes"][index] == (
+            body["cardio_minutes"][index]
+            + body["strength_minutes"][index]
+            + body["stretching_minutes"][index]
+            + body["other_minutes"][index]
+        ), f"{index} 요일 합이 유형별 합과 다르다"
+
+
+def test_seeded_strength_keeps_the_sets_the_fixture_wrote(client):
+    """근력 기록의 세트는 픽스처가 적은 값이다 — 분에서 되짚은 수가 아니다.
+
+    예전에는 백엔드가 픽스처의 `sets` 를 버려서, 같은 날 근력이 회원 앱(픽스처
+    값)과 실 API(분 ÷ 3)에서 다른 수로 보였다.
+    """
+    fixture = load_fixture()
+    today = date.today()
+    day = next(
+        d
+        for d in reversed(fixture.days_for(today))
+        if any(e.type == "strength" and e.sets for e in d.done_exercises)
+    )
+    expected = sum(
+        e.sets or 0 for e in day.done_exercises if e.type == "strength"
+    )
+
+    body = client.get(
+        f"/v1/exercise/weeks/current?week_start={day.week_start}",
+        headers=_auth(_member_token(client)),
+    ).json()
+    strength = [
+        s
+        for s in body["sessions"]
+        if s["type"] == "strength" and s["date"] == day.iso
+    ]
+    assert strength, f"{day.iso} 근력 기록이 없다"
+    assert strength[0]["sets"] == expected

--- a/backend/tests/test_demo_fixture.py
+++ b/backend/tests/test_demo_fixture.py
@@ -84,3 +84,81 @@ def test_exercise_types_use_the_standard_vocabulary():
     for day in load_fixture().days_for(date(2026, 8, 16)):
         for exercise in day.exercises:
             assert exercise.type in exercise_types.CANONICAL_TYPES, exercise.type
+
+
+# ── 데모가 과거에도 서 있는가 (#1265) ──────────────────────────────────────
+#
+# 데모는 오늘 하루만 보는 것이 아니다. 지난주·전체로 넘겼을 때 PT 를 받은 날,
+# 그때 무엇을 몇 세트 했는지, 회원이 뭐라고 했고 트레이너가 뭘 적어 뒀는지가
+# 없으면 "운동 기능이 충분히 구현된 제품" 으로 읽히지 않는다.
+#
+# 시연 날짜를 미리 알 수 없으므로 **어느 요일에 열어도** 성립해야 한다. 아래
+# 검사는 월~일 일곱 요일과 연·월 경계, 윤년 하루를 함께 본다.
+_ANY_DAY = (
+    date(2026, 8, 10),   # 월
+    date(2026, 8, 11),   # 화
+    date(2026, 8, 12),   # 수
+    date(2026, 8, 13),   # 목
+    date(2026, 8, 14),   # 금
+    date(2026, 8, 15),   # 토
+    date(2026, 8, 16),   # 일
+    date(2026, 12, 31),  # 연말
+    date(2027, 1, 1),    # 연초
+    date(2028, 2, 29),   # 윤년
+)
+
+
+def test_the_past_has_pt_days_spread_across_the_history():
+    """과거에 PT 사례가 흩어져 있다 — 오늘 하나뿐이면 지난 기간이 비어 보인다."""
+    for today in _ANY_DAY:
+        days = load_fixture().days_for(today)
+        past_pt = [d for d in days if d.is_pt and d.day < today]
+        assert len(past_pt) >= 5, f"{today}: 과거 PT 가 {len(past_pt)}일뿐"
+        for day in past_pt:
+            assert day.client_feedback, f"{day.iso}: 고객 피드백이 없다"
+            assert day.trainer_note, f"{day.iso}: 트레이너 메모가 없다"
+            assert any(
+                e.type == exercise_types.STRENGTH and e.sets
+                for e in day.exercises
+            ), f"{day.iso}: 세트를 적은 근력이 없다"
+
+
+def test_every_exercise_type_shows_up_in_more_than_one_week():
+    """네 유형이 모두, 여러 주에 걸쳐 보인다.
+
+    `other` 가 하나도 없으면 유형별 분해 화면의 `기타` 칸이 늘 0 이라, 그 칸이
+    실제로 동작하는지 시연에서 볼 수가 없다.
+    """
+    days = load_fixture().days_for(date(2026, 8, 16))
+    weeks_by_type: dict[str, set[str]] = {}
+    for day in days:
+        for exercise in day.exercises:
+            kind = exercise_types.normalize(exercise.type)
+            weeks_by_type.setdefault(kind, set()).add(day.week_start)
+    for kind in exercise_types.CANONICAL_TYPES:
+        weeks = weeks_by_type.get(kind, set())
+        assert len(weeks) >= 2, f"{kind}: {len(weeks)}주에만 보인다"
+
+
+def test_today_alone_carries_the_whole_story():
+    """월요일에 열어도 이번 주 화면이 비지 않는다 — 오늘 하루가 다 담고 있다."""
+    for today in _ANY_DAY:
+        day = load_fixture().days_for(today)[-1]
+        assert day.day == today
+        kinds = {exercise_types.normalize(e.type) for e in day.exercises}
+        assert kinds == set(exercise_types.CANONICAL_TYPES), f"{today}: {kinds}"
+        assert day.is_pt, f"{today}: 오늘이 PT 날이 아니다"
+        assert day.client_feedback and day.trainer_note
+        assert any(
+            e.type == exercise_types.STRENGTH and e.sets for e in day.exercises
+        )
+
+
+def test_strength_always_says_how_many_sets():
+    """근력은 세트를 값으로 들고 다닌다 — 분에서 되짚으면 화면마다 수가 갈린다."""
+    for day in load_fixture().days_for(date(2026, 8, 16)):
+        for exercise in day.exercises:
+            if exercise_types.normalize(exercise.type) != exercise_types.STRENGTH:
+                assert exercise.sets is None, f"{day.iso}: {exercise.name}"
+                continue
+            assert exercise.sets, f"{day.iso}: {exercise.name} 에 세트가 없다"

--- a/frontend/flutter/lib/core/storage/seed_data.dart
+++ b/frontend/flutter/lib/core/storage/seed_data.dart
@@ -25,7 +25,7 @@ const String kDietDayMessagesKey = 'diet_day_messages';
 
 /// Date-aware idempotent seeder. Runs at bootstrap.
 ///
-/// **Flag format (v4+).** `AppKeyValues['seeded_v17']` stores the
+/// **Flag format (v4+).** `AppKeyValues['seeded_v18']` stores the
 /// *date string* the seed last ran with (`YYYY-MM-DD`). Behaviour:
 ///
 /// - `null` (first ever boot, or upgrading from v1/v2) — wipe any
@@ -53,7 +53,7 @@ Future<void> seedIfEmpty(AppDatabase db, {DemoFixture? fixture}) async {
   final now = nowKst();
   final today = _fmtDate(now);
 
-  final seedDate = await db.readValue('seeded_v17');
+  final seedDate = await db.readValue('seeded_v18');
   if (seedDate == today) {
     // Already seeded for today — leave both seed rows and user rows
     // untouched.
@@ -98,6 +98,10 @@ Future<void> seedIfEmpty(AppDatabase db, {DemoFixture? fixture}) async {
   // v17: 식단·운동이 공유 픽스처에서 온다(#757). 올리지 않으면 오늘 이미 시드된
   // 설치가 예전 값을 들고 있어 트레이너 앱과 나란히 놓았을 때 숫자가 어긋난다.
   await db.deleteValue('seeded_v16');
+  // v18: 과거에 PT·기타 운동이 생기고, 운동 기록이 이름·세트·횟수를 함께 든다
+  // (#1265). 올리지 않으면 오늘 이미 시드된 설치가 그 값 없이 남아 근력을
+  // 분에서 되짚은 수로 보여 준다.
+  await db.deleteValue('seeded_v17');
   // Also clear the curated KV advice so re-seed state is fully reset: this
   // version re-writes it below, but if a later seed drops or renames the key
   // an existing install would otherwise keep the stale text forever.
@@ -141,7 +145,7 @@ Future<void> seedIfEmpty(AppDatabase db, {DemoFixture? fixture}) async {
     await db.batch((Batch b) {
       b.insertAll(db.exerciseSessions, <ExerciseSessionsCompanion>[
         for (final FixtureDay day in days)
-          for (final MapEntry<String, ({int minutes, int calories})> entry
+          for (final MapEntry<String, _TypeTotals> entry
               in _byType(day.doneExercises).entries)
             ExerciseSessionsCompanion.insert(
               id: 'seed-ex-${day.date}-${entry.key}',
@@ -150,6 +154,12 @@ Future<void> seedIfEmpty(AppDatabase db, {DemoFixture? fixture}) async {
               type: entry.key,
               minutes: entry.value.minutes,
               calories: entry.value.calories,
+              // 픽스처가 적어 둔 이름·세트·횟수를 그대로 남긴다 — 백엔드 시드와
+              // **같은 규칙**이라야 mock 모드와 실 API 모드가 같은 수를
+              // 말한다. (#1265)
+              name: Value(entry.value.name),
+              sets: Value(entry.value.sets),
+              reps: Value(entry.value.reps),
             ),
       ]);
     });
@@ -257,24 +267,65 @@ Future<void> seedIfEmpty(AppDatabase db, {DemoFixture? fixture}) async {
     }),
   );
 
-  await db.putValue('seeded_v17', today);
+  await db.putValue('seeded_v18', today);
 }
 
-/// 운동을 종류별로 합친다 — {종류: (분, 칼로리)}. 픽스처 순서를 유지한다.
-Map<String, ({int minutes, int calories})> _byType(
-  List<FixtureExercise> exercises,
-) {
-  final Map<String, ({int minutes, int calories})> totals =
-      <String, ({int minutes, int calories})>{};
+/// 하루·한 종류로 접은 값. 운동 기록 한 행이 되는 그대로다.
+class _TypeTotals {
+  const _TypeTotals({
+    required this.minutes,
+    required this.calories,
+    required this.name,
+    this.sets,
+    this.reps,
+  });
+
+  final int minutes;
+  final int calories;
+  final String name;
+
+  /// 근력이면 그날 한 세트 수의 **합**. 다른 유형은 null 이다.
+  final int? sets;
+
+  /// 근력이면 그날 한 횟수 중 가장 많은 수. 세트와 달리 더하지 않는다 — 한
+  /// 세트당 수라 합계는 아무도 한 적 없는 값이 된다.
+  final int? reps;
+}
+
+/// 운동을 종류별로 합친다. 픽스처 순서를 유지한다.
+///
+/// 백엔드 시드(`seed_member_data._by_type`)와 **같은 규칙**이다 — 한쪽만 고치면
+/// mock 모드와 실 API 모드가 같은 날에 다른 수를 말한다. (#1265)
+Map<String, _TypeTotals> _byType(List<FixtureExercise> exercises) {
+  final Map<String, _TypeTotals> totals = <String, _TypeTotals>{};
   for (final FixtureExercise exercise in exercises) {
-    final ({int minutes, int calories}) prev =
-        totals[exercise.type] ?? (minutes: 0, calories: 0);
-    totals[exercise.type] = (
-      minutes: prev.minutes + exercise.minutes,
-      calories: prev.calories + exercise.calories,
+    final _TypeTotals? prev = totals[exercise.type];
+    final bool strength = exercise.type == 'strength';
+    totals[exercise.type] = _TypeTotals(
+      minutes: (prev?.minutes ?? 0) + exercise.minutes,
+      calories: (prev?.calories ?? 0) + exercise.calories,
+      name: prev == null || prev.name.isEmpty
+          ? exercise.name
+          : '${prev.name}, ${exercise.name}',
+      sets: strength ? _add(prev?.sets, exercise.sets) : null,
+      reps: strength ? _peak(prev?.reps, exercise.reps) : null,
     );
   }
   return totals;
+}
+
+/// 둘 다 없으면 null. 하나만 있으면 그 값 — 0 으로 채우지 않는다. 0 은
+/// "0세트를 했다" 가 되고 null 은 "적지 않았다" 다.
+int? _add(int? left, int? right) {
+  if (left == null) return right;
+  if (right == null) return left;
+  return left + right;
+}
+
+int? _peak(int? left, int? right) {
+  if (left == null) return right;
+  if (right == null) return left;
+  return left > right ? left : right;
 }
 
 String _fmtDate(DateTime d) =>

--- a/frontend/flutter/test/core/network/local_api_smoke_test.dart
+++ b/frontend/flutter/test/core/network/local_api_smoke_test.dart
@@ -98,6 +98,37 @@ void main() {
     );
   });
 
+  test('근력 세트는 픽스처가 적은 값 그대로다 (#1265)', () async {
+    // 예전에는 시드가 픽스처의 `sets` 를 버려서, 화면이 분에서 세트를 되짚었다 —
+    // 회원 앱과 트레이너 웹이 같은 날 근력을 다른 수로 말했다. 기대값은 여기
+    // 적지 않고 픽스처에서 계산한다.
+    final DateTime now = nowKst();
+    final String monday = _dateString(
+      DateTime(now.year, now.month, now.day - (now.weekday - 1)),
+    );
+    final DemoFixture fixture = DemoFixture.parse(
+      File('../../shared/demo_fixture/assets/kim_minsu.json').readAsStringSync(),
+    );
+    final List<int> expected = List<int>.filled(7, 0);
+    for (final FixtureDay day in fixture
+        .daysFor(now)
+        .where((FixtureDay d) => d.weekStart == monday)) {
+      final int index = DateTime.parse(day.date).weekday - 1;
+      for (final FixtureExercise e in day.doneExercises) {
+        if (e.type == 'strength') expected[index] += e.sets ?? 0;
+      }
+    }
+    expect(expected.reduce((int a, int b) => a + b), greaterThan(0));
+
+    final res = await dio.get<Map<String, Object?>>('/exercise/weeks/current');
+    expect(
+      (res.data!['strength_sets']! as List<Object?>)
+          .map((Object? v) => (v! as num).toInt())
+          .toList(),
+      expected,
+    );
+  });
+
   test('dio → LocalApi → DashboardSummary aggregates seeded data', () async {
     final res = await dio.get<Map<String, Object?>>('/dashboard/summary');
     final summary = DashboardSummary.fromJson(res.data!);

--- a/frontend/flutter/test/core/storage/seed_data_test.dart
+++ b/frontend/flutter/test/core/storage/seed_data_test.dart
@@ -141,7 +141,7 @@ void main() {
         reason: 'exercise sessions for the current week must be seeded',
       );
 
-      expect(await db.readValue('seeded_v17'), today);
+      expect(await db.readValue('seeded_v18'), today);
     });
 
     test('과거 식단은 날짜마다 값이 달라 추이가 직선이 되지 않는다', () async {
@@ -465,7 +465,7 @@ void main() {
     test('stale flag (different date) re-seeds with today', () async {
       // Pretend the seed last ran a week ago.
       await seedIfEmpty(db, fixture: _fixture);
-      await db.putValue('seeded_v17', '2020-01-01');
+      await db.putValue('seeded_v18', '2020-01-01');
 
       await seedIfEmpty(db, fixture: _fixture);
 
@@ -473,7 +473,7 @@ void main() {
       final diet = await db.select(db.dietEntries).get();
       expect(diet, isNotEmpty);
       expect(diet.where((r) => r.date == today).length, 3);
-      expect(await db.readValue('seeded_v17'), today);
+      expect(await db.readValue('seeded_v18'), today);
     });
 
     test('legacy seeded_v2=true flag is migrated and cleared', () async {
@@ -500,7 +500,7 @@ void main() {
 
       // Legacy flag cleared, current flag set to today.
       expect(await db.readValue('seeded_v2'), isNull);
-      expect(await db.readValue('seeded_v17'), _todayString());
+      expect(await db.readValue('seeded_v18'), _todayString());
 
       // Stale seed-prefixed row was wiped and replaced with today's
       // seed batch.
@@ -530,7 +530,7 @@ void main() {
 
       await seedIfEmpty(db, fixture: _fixture);
       // Force a re-seed by ageing the flag.
-      await db.putValue('seeded_v17', '2020-01-01');
+      await db.putValue('seeded_v18', '2020-01-01');
       await seedIfEmpty(db, fixture: _fixture);
 
       final diet = await db.select(db.dietEntries).get();

--- a/frontend/flutter_trainer/lib/core/storage/seed_data.dart
+++ b/frontend/flutter_trainer/lib/core/storage/seed_data.dart
@@ -14,10 +14,14 @@ part 'seed_clients.dart';
 
 /// Idempotent seeder for the trainer app's local DB. Runs at bootstrap.
 ///
-/// **Flag.** `AppKeyValues['trainer_seeded_v27']` stores the date string
+/// **Flag.** `AppKeyValues['trainer_seeded_v28']` stores the date string
 /// (`YYYY-MM-DD`) the seed last ran with. Bump the version suffix
 /// whenever the seeded *content* changes — otherwise a browser that
 /// already seeded today keeps the old data until the date rolls over.
+///
+/// `_v28` 은 과거에 PT·기타 운동이 생기고 근력이 세트를 값으로 들게 된
+/// 변경이다(#1265) — 올리지 않으면 오늘 이미 시드된 브라우저가 과거가 비어
+/// 있는 옛 데이터를 그대로 들고 있다.
 ///
 /// `_v27` 은 사용자 앱과 트레이너 웹의 김민수 대화 날짜를 일치시켰다(#1292).
 /// 다른 고객과의 상대적인 최신순은 그대로 유지한다.
@@ -110,7 +114,7 @@ Future<void> seedIfEmpty(
   // 주간 계열을 요일 자리에 놓기 위한 오늘의 인덱스(월=0).
   final todayIndex = now.weekday - 1;
 
-  if (await db.readValue('trainer_seeded_v27') == today) return;
+  if (await db.readValue('trainer_seeded_v28') == today) return;
 
   // 김민수의 하루는 픽스처가 정한다 — 이 앱은 날짜에 붙여 저장하기만 한다(#757).
   final DemoFixture demo = fixture ?? DemoFixture.load();
@@ -451,7 +455,7 @@ Future<void> seedIfEmpty(
     });
 
     // ---- Mark seeded (inside the txn so it commits atomically) ----
-    await db.putValue('trainer_seeded_v27', today);
+    await db.putValue('trainer_seeded_v28', today);
   });
 }
 

--- a/frontend/flutter_trainer/test/core/storage/seed_data_test.dart
+++ b/frontend/flutter_trainer/test/core/storage/seed_data_test.dart
@@ -65,7 +65,7 @@ void main() {
       }
 
       expect(await db.select(db.clientChatMessages).get(), isNotEmpty);
-      expect(await db.readValue('trainer_seeded_v27'), _todayString());
+      expect(await db.readValue('trainer_seeded_v28'), _todayString());
     });
 
     test(
@@ -414,13 +414,13 @@ void main() {
 
     test('stale flag (different date) re-seeds schedule onto today', () async {
       await seedIfEmpty(db);
-      await db.putValue('trainer_seeded_v27', '2020-01-01');
+      await db.putValue('trainer_seeded_v28', '2020-01-01');
 
       await seedIfEmpty(db);
 
       final schedule = await db.select(db.trainerScheduleEntries).get();
       expect(schedule.any((s) => s.date == _todayString()), isTrue);
-      expect(await db.readValue('trainer_seeded_v27'), _todayString());
+      expect(await db.readValue('trainer_seeded_v28'), _todayString());
     });
 
     test(
@@ -590,7 +590,7 @@ void main() {
         expect(week.length, 7);
         expect(week.any((v) => (v as num) > 0), isTrue);
 
-        expect(await db.readValue('trainer_seeded_v27'), today);
+        expect(await db.readValue('trainer_seeded_v28'), today);
       },
     );
 
@@ -699,7 +699,7 @@ void main() {
           );
 
       // Force a re-seed.
-      await db.putValue('trainer_seeded_v27', '2020-01-01');
+      await db.putValue('trainer_seeded_v28', '2020-01-01');
       await seedIfEmpty(db);
 
       final chat = await db.select(db.clientChatMessages).get();

--- a/frontend/flutter_trainer/test/features/clients/client_exercise_week_fixture_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_exercise_week_fixture_test.dart
@@ -1,0 +1,96 @@
+/// 트레이너 화면의 한 주 운동이 픽스처가 적은 값 그대로인가. (#1265)
+///
+/// 숫자의 기준은 **고객 앱 운동 계약**이다. 회원 앱 mock 도 같은 픽스처에서 같은
+/// 규칙으로 쌓으므로, 두 앱을 나란히 놓았을 때 같은 날의 같은 근력이 같은 세트
+/// 수로 읽혀야 한다 — 기대값을 여기 적지 않고 픽스처에서 계산하는 이유다.
+library;
+
+import 'dart:io';
+
+import 'package:demo_fixture/demo_fixture.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oncare_trainer/core/storage/app_database.dart';
+import 'package:oncare_trainer/core/storage/seed_data.dart';
+import 'package:oncare_trainer/core/utils/clock.dart';
+import 'package:oncare_trainer/core/utils/date_format.dart';
+import 'package:oncare_trainer/features/clients/domain/entities/client_exercise_week.dart';
+import 'package:oncare_trainer/shared/services/client_repository.dart';
+
+final DemoFixture _fixture = DemoFixture.parse(
+  File('../../shared/demo_fixture/assets/kim_minsu.json').readAsStringSync(),
+);
+
+/// 이번 주의 픽스처 하루들.
+List<FixtureDay> _thisWeek(DateTime now) {
+  final DateTime monday = DateTime(
+    now.year,
+    now.month,
+    now.day - (now.weekday - 1),
+  );
+  return _fixture
+      .daysFor(now)
+      .where((FixtureDay d) => d.weekStart == ymd(monday))
+      .toList();
+}
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    await seedIfEmpty(db, fixture: _fixture);
+  });
+
+  tearDown(() async => db.close());
+
+  test('요일별 근력 세트가 픽스처 합계와 같다', () async {
+    final DateTime now = nowKst();
+    final DateTime monday = DateTime(
+      now.year,
+      now.month,
+      now.day - (now.weekday - 1),
+    );
+    final List<int> expected = List<int>.filled(7, 0);
+    for (final FixtureDay day in _thisWeek(now)) {
+      final int index = DateTime.parse(day.date).weekday - 1;
+      for (final FixtureExercise e in day.doneExercises) {
+        if (e.type == 'strength') expected[index] += e.sets ?? 0;
+      }
+    }
+    expect(
+      expected.reduce((int a, int b) => a + b),
+      greaterThan(0),
+      reason: '이번 주에 근력이 하나도 없으면 검증이 빈다',
+    );
+
+    final ClientExerciseWeek week = await DriftClientRepository(
+      db,
+    ).fetchExerciseWeek('seed-client-1', weekStart: monday);
+
+    expect(week.strengthSets, expected);
+  });
+
+  test('요일 합계가 유형별 합과 같다', () async {
+    final DateTime now = nowKst();
+    final DateTime monday = DateTime(
+      now.year,
+      now.month,
+      now.day - (now.weekday - 1),
+    );
+    final ClientExerciseWeek week = await DriftClientRepository(
+      db,
+    ).fetchExerciseWeek('seed-client-1', weekStart: monday);
+
+    for (int i = 0; i < 7; i++) {
+      expect(
+        week.dailyMinutes[i],
+        week.cardioMinutes[i] +
+            week.strengthMinutes[i] +
+            week.stretchingMinutes[i] +
+            week.otherMinutes[i],
+        reason: '$i 요일 합이 유형별 합과 다르다',
+      );
+    }
+  });
+}

--- a/shared/demo_fixture/assets/kim_minsu.json
+++ b/shared/demo_fixture/assets/kim_minsu.json
@@ -334,7 +334,8 @@
           "minutes": 12,
           "calories": 72,
           "done": true,
-          "sets": 4
+          "sets": 4,
+          "reps": 10
         },
         {
           "name": "덤벨 숄더프레스 10kg · 4세트",
@@ -342,7 +343,8 @@
           "minutes": 10,
           "calories": 60,
           "done": true,
-          "sets": 4
+          "sets": 4,
+          "reps": 12
         },
         {
           "name": "랫풀다운 45kg · 4세트",
@@ -350,7 +352,8 @@
           "minutes": 12,
           "calories": 72,
           "done": true,
-          "sets": 4
+          "sets": 4,
+          "reps": 12
         },
         {
           "name": "플랭크 60초 · 3세트",
@@ -358,7 +361,8 @@
           "minutes": 6,
           "calories": 36,
           "done": true,
-          "sets": 3
+          "sets": 3,
+          "reps": 3
         },
         {
           "name": "마무리 러닝머신 15분",
@@ -372,6 +376,13 @@
           "type": "stretching",
           "minutes": 12,
           "calories": 36,
+          "done": true
+        },
+        {
+          "name": "탁구 20분",
+          "type": "other",
+          "minutes": 20,
+          "calories": 100,
           "done": true
         }
       ],
@@ -416,7 +427,9 @@
           "type": "strength",
           "minutes": 10,
           "calories": 60,
-          "done": true
+          "done": true,
+          "sets": 3,
+          "reps": 15
         },
         {
           "name": "하체 스트레칭 15분",
@@ -469,7 +482,9 @@
           "type": "strength",
           "minutes": 10,
           "calories": 60,
-          "done": true
+          "done": true,
+          "sets": 3,
+          "reps": 15
         },
         {
           "name": "하체 스트레칭 15분",
@@ -523,7 +538,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -614,7 +631,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -688,7 +707,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -768,7 +789,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -859,7 +882,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -933,7 +958,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -1013,7 +1040,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -1107,7 +1136,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": false
+              "done": false,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -1184,7 +1215,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": false
+              "done": false,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -1264,7 +1297,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -1355,7 +1390,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -1429,7 +1466,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -1437,6 +1476,13 @@
               "minutes": 15,
               "calories": 45,
               "done": false
+            },
+            {
+              "name": "북한산 등산 90분",
+              "type": "other",
+              "minutes": 90,
+              "calories": 450,
+              "done": true
             }
           ],
           "meals": [
@@ -1509,7 +1555,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -1600,7 +1648,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -1674,7 +1724,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -1754,7 +1806,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -1810,9 +1864,53 @@
         },
         {
           "weekday": 2,
-          "label": "AI 루틴 · 자율 운동",
-          "pt": false,
-          "exercises": [],
+          "label": "PT 세션 · 트레이너 지도",
+          "pt": true,
+          "clientFeedback": "레그프레스 무게가 붙었어요. 마지막 세트가 힘들었어요.",
+          "trainerNote": "하체 근력 향상 확인. 다음 세션 레그프레스 5kg 증량.",
+          "exercises": [
+            {
+              "name": "레그프레스 70kg · 4세트",
+              "type": "strength",
+              "minutes": 12,
+              "calories": 72,
+              "done": true,
+              "sets": 4,
+              "reps": 12
+            },
+            {
+              "name": "레그컬 35kg · 3세트",
+              "type": "strength",
+              "minutes": 9,
+              "calories": 54,
+              "done": true,
+              "sets": 3,
+              "reps": 12
+            },
+            {
+              "name": "카프레이즈 자체중량 · 3세트",
+              "type": "strength",
+              "minutes": 6,
+              "calories": 36,
+              "done": true,
+              "sets": 3,
+              "reps": 20
+            },
+            {
+              "name": "마무리 러닝머신 15분",
+              "type": "cardio",
+              "minutes": 15,
+              "calories": 135,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
           "meals": [
             {
               "meal": "breakfast-egg-strawberry"
@@ -1842,7 +1940,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -1913,7 +2013,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -1993,7 +2095,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -2054,7 +2158,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": false
+              "done": false,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -2095,7 +2201,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": false
+              "done": false,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -2175,7 +2283,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -2266,7 +2376,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -2340,7 +2452,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -2420,7 +2534,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -2511,7 +2627,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -2585,7 +2703,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -2624,6 +2744,13 @@
               "type": "stretching",
               "minutes": 10,
               "calories": 30,
+              "done": true
+            },
+            {
+              "name": "탁구 40분",
+              "type": "other",
+              "minutes": 40,
+              "calories": 200,
               "done": true
             }
           ],
@@ -2665,7 +2792,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -2759,7 +2888,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": false
+              "done": false,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -2836,7 +2967,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": false
+              "done": false,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -2916,7 +3049,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -3007,7 +3142,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -3081,7 +3218,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -3161,7 +3300,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -3220,9 +3361,53 @@
         },
         {
           "weekday": 2,
-          "label": "AI 루틴 · 자율 운동",
-          "pt": false,
-          "exercises": [],
+          "label": "PT 세션 · 트레이너 지도",
+          "pt": true,
+          "clientFeedback": "데드리프트 자세를 잡아주셔서 허리가 편했어요.",
+          "trainerNote": "데드리프트 힙힌지 안정적. 중량 55kg 유지 후 다음 달 60kg.",
+          "exercises": [
+            {
+              "name": "데드리프트 55kg · 4세트",
+              "type": "strength",
+              "minutes": 12,
+              "calories": 72,
+              "done": true,
+              "sets": 4,
+              "reps": 8
+            },
+            {
+              "name": "루마니안 데드리프트 40kg · 3세트",
+              "type": "strength",
+              "minutes": 9,
+              "calories": 54,
+              "done": true,
+              "sets": 3,
+              "reps": 10
+            },
+            {
+              "name": "플랭크 45초 · 3세트",
+              "type": "strength",
+              "minutes": 6,
+              "calories": 36,
+              "done": true,
+              "sets": 3,
+              "reps": 3
+            },
+            {
+              "name": "마무리 러닝머신 12분",
+              "type": "cardio",
+              "minutes": 12,
+              "calories": 108,
+              "done": true
+            },
+            {
+              "name": "허리 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
           "meals": [
             {
               "meal": "breakfast-greek-yogurt-nuts"
@@ -3252,7 +3437,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -3326,7 +3513,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -3406,7 +3595,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -3494,7 +3685,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -3565,7 +3758,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -3645,7 +3840,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -3706,7 +3903,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": false
+              "done": false,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -3747,7 +3946,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": false
+              "done": false,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -3827,7 +4028,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -3918,7 +4121,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -3992,13 +4197,22 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
               "type": "stretching",
               "minutes": 15,
               "calories": 45,
+              "done": true
+            },
+            {
+              "name": "자전거 라이딩 60분",
+              "type": "other",
+              "minutes": 60,
+              "calories": 300,
               "done": true
             }
           ],
@@ -4072,7 +4286,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -4163,7 +4379,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -4237,7 +4455,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -4317,7 +4537,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -4411,7 +4633,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": false
+              "done": false,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -4488,7 +4712,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": false
+              "done": false,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -4568,7 +4794,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -4627,9 +4855,53 @@
         },
         {
           "weekday": 2,
-          "label": "AI 루틴 · 자율 운동",
-          "pt": false,
-          "exercises": [],
+          "label": "PT 세션 · 트레이너 지도",
+          "pt": true,
+          "clientFeedback": "어깨가 아직 조금 불편해서 무게를 낮췄어요.",
+          "trainerNote": "오른쪽 어깨 가동범위 제한. 숄더프레스 중량 낮추고 밴드 보강 병행.",
+          "exercises": [
+            {
+              "name": "숄더프레스 10kg · 4세트",
+              "type": "strength",
+              "minutes": 12,
+              "calories": 72,
+              "done": true,
+              "sets": 4,
+              "reps": 12
+            },
+            {
+              "name": "밴드 외전 · 3세트",
+              "type": "strength",
+              "minutes": 6,
+              "calories": 36,
+              "done": true,
+              "sets": 3,
+              "reps": 20
+            },
+            {
+              "name": "인클라인 푸시업 · 3세트",
+              "type": "strength",
+              "minutes": 9,
+              "calories": 54,
+              "done": true,
+              "sets": 3,
+              "reps": 12
+            },
+            {
+              "name": "마무리 러닝머신 10분",
+              "type": "cardio",
+              "minutes": 10,
+              "calories": 90,
+              "done": true
+            },
+            {
+              "name": "어깨 관절 보호 스트레칭 12분",
+              "type": "stretching",
+              "minutes": 12,
+              "calories": 36,
+              "done": true
+            }
+          ],
           "meals": [
             {
               "meal": "breakfast-egg-strawberry"
@@ -4659,7 +4931,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -4733,7 +5007,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -4813,7 +5089,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -4904,7 +5182,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -4978,7 +5258,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -5058,7 +5340,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -5146,7 +5430,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -5217,7 +5503,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -5297,7 +5585,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -5358,7 +5648,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": false
+              "done": false,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -5399,7 +5691,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": false
+              "done": false,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -5479,7 +5773,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -5570,7 +5866,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -5644,7 +5942,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -5724,7 +6024,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -5815,7 +6117,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -5889,7 +6193,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -5969,7 +6275,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -6031,9 +6339,53 @@
         },
         {
           "weekday": 2,
-          "label": "AI 루틴 · 자율 운동",
-          "pt": false,
-          "exercises": [],
+          "label": "PT 세션 · 트레이너 지도",
+          "pt": true,
+          "clientFeedback": "벤치프레스가 처음이라 어색했지만 재밌었어요 💪",
+          "trainerNote": "상체 근력 기초 확인. 벤치프레스 35kg 로 시작해 자세 우선.",
+          "exercises": [
+            {
+              "name": "벤치프레스 35kg · 4세트",
+              "type": "strength",
+              "minutes": 12,
+              "calories": 72,
+              "done": true,
+              "sets": 4,
+              "reps": 10
+            },
+            {
+              "name": "체스트프레스 25kg · 3세트",
+              "type": "strength",
+              "minutes": 9,
+              "calories": 54,
+              "done": true,
+              "sets": 3,
+              "reps": 12
+            },
+            {
+              "name": "랫풀다운 30kg · 3세트",
+              "type": "strength",
+              "minutes": 9,
+              "calories": 54,
+              "done": true,
+              "sets": 3,
+              "reps": 12
+            },
+            {
+              "name": "마무리 러닝머신 15분",
+              "type": "cardio",
+              "minutes": 15,
+              "calories": 135,
+              "done": true
+            },
+            {
+              "name": "상체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
           "meals": [
             {
               "meal": "breakfast-greek-yogurt-nuts"
@@ -6063,7 +6415,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": false
+              "done": false,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -6140,7 +6494,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": false
+              "done": false,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -6220,7 +6576,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -6311,7 +6669,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -6385,7 +6745,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -6465,7 +6827,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -6556,7 +6920,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -6630,7 +6996,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -6710,7 +7078,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -6798,7 +7168,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -6869,7 +7241,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -6949,7 +7323,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -7010,7 +7386,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": false
+              "done": false,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -7051,7 +7429,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": false
+              "done": false,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -7131,7 +7511,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -7222,7 +7604,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -7296,7 +7680,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -7376,7 +7762,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -7435,9 +7823,53 @@
         },
         {
           "weekday": 2,
-          "label": "AI 루틴 · 자율 운동",
-          "pt": false,
-          "exercises": [],
+          "label": "PT 세션 · 트레이너 지도",
+          "pt": true,
+          "clientFeedback": "첫 PT 라 긴장했는데 생각보다 할 만했어요.",
+          "trainerNote": "첫 세션. 체력 수준 점검 위주로 가볍게 진행.",
+          "exercises": [
+            {
+              "name": "고블릿 스쿼트 12kg · 3세트",
+              "type": "strength",
+              "minutes": 9,
+              "calories": 54,
+              "done": true,
+              "sets": 3,
+              "reps": 12
+            },
+            {
+              "name": "케틀벨 스윙 12kg · 3세트",
+              "type": "strength",
+              "minutes": 9,
+              "calories": 54,
+              "done": true,
+              "sets": 3,
+              "reps": 15
+            },
+            {
+              "name": "코어 서킷 · 2세트",
+              "type": "strength",
+              "minutes": 6,
+              "calories": 36,
+              "done": true,
+              "sets": 2,
+              "reps": 12
+            },
+            {
+              "name": "마무리 러닝머신 10분",
+              "type": "cardio",
+              "minutes": 10,
+              "calories": 90,
+              "done": true
+            },
+            {
+              "name": "전신 스트레칭 12분",
+              "type": "stretching",
+              "minutes": 12,
+              "calories": 36,
+              "done": true
+            }
+          ],
           "meals": [
             {
               "meal": "breakfast-oatmeal-banana"
@@ -7467,7 +7899,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -7541,7 +7975,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -7621,7 +8057,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -7715,7 +8153,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": false
+              "done": false,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -7792,7 +8232,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": false
+              "done": false,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -7872,7 +8314,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -7963,7 +8407,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -8037,7 +8483,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -8117,7 +8565,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -8208,7 +8658,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -8282,7 +8734,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -8362,7 +8816,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -8450,7 +8906,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -8521,7 +8979,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -8601,7 +9061,9 @@
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -8662,7 +9124,9 @@
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": false
+              "done": false,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -8703,7 +9167,9 @@
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": false
+              "done": false,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",

--- a/shared/demo_fixture/lib/demo_fixture.dart
+++ b/shared/demo_fixture/lib/demo_fixture.dart
@@ -112,6 +112,7 @@ class FixtureExercise {
     required this.calories,
     required this.done,
     this.sets,
+    this.reps,
   });
 
   factory FixtureExercise.fromJson(Map<String, Object?> json) =>
@@ -122,6 +123,7 @@ class FixtureExercise {
         calories: (json['calories']! as num).toInt(),
         done: json['done']! as bool,
         sets: (json['sets'] as num?)?.toInt(),
+        reps: (json['reps'] as num?)?.toInt(),
       );
 
   final String name;
@@ -134,8 +136,12 @@ class FixtureExercise {
 
   /// 근력 항목의 **세트 수**. 이름에 적힌 `4세트` 를 화면이 다시 세거나 분에서
   /// 되짚어 계산하면 세 화면이 저마다 다른 수를 말한다 — 값으로 들고 다닌다.
-  /// 유산소·스트레칭은 분이 곧 값이라 null 이다.
+  /// 유산소·스트레칭·기타는 분이 곧 값이라 null 이다.
   final int? sets;
+
+  /// 근력 항목의 **한 세트당 횟수**. 세트·중량과 한 벌이다(#1310) — 셋이 다
+  /// 있어야 지난주에 무엇을 했는지 그대로 되짚는다.
+  final int? reps;
 
   /// 트레이너 화면이 쓰는 표기. 이행률과 이 목록이 같은 자리에서 나오므로
   /// "67%" 옆에 "3개 중 3개 완료" 가 놓이는 일이 없다(#754).

--- a/shared/demo_fixture/lib/src/fixture_json.g.dart
+++ b/shared/demo_fixture/lib/src/fixture_json.g.dart
@@ -342,7 +342,8 @@ const String kimMinsuFixtureJson = r'''
           "minutes": 12,
           "calories": 72,
           "done": true,
-          "sets": 4
+          "sets": 4,
+          "reps": 10
         },
         {
           "name": "덤벨 숄더프레스 10kg · 4세트",
@@ -350,7 +351,8 @@ const String kimMinsuFixtureJson = r'''
           "minutes": 10,
           "calories": 60,
           "done": true,
-          "sets": 4
+          "sets": 4,
+          "reps": 12
         },
         {
           "name": "랫풀다운 45kg · 4세트",
@@ -358,7 +360,8 @@ const String kimMinsuFixtureJson = r'''
           "minutes": 12,
           "calories": 72,
           "done": true,
-          "sets": 4
+          "sets": 4,
+          "reps": 12
         },
         {
           "name": "플랭크 60초 · 3세트",
@@ -366,7 +369,8 @@ const String kimMinsuFixtureJson = r'''
           "minutes": 6,
           "calories": 36,
           "done": true,
-          "sets": 3
+          "sets": 3,
+          "reps": 3
         },
         {
           "name": "마무리 러닝머신 15분",
@@ -380,6 +384,13 @@ const String kimMinsuFixtureJson = r'''
           "type": "stretching",
           "minutes": 12,
           "calories": 36,
+          "done": true
+        },
+        {
+          "name": "탁구 20분",
+          "type": "other",
+          "minutes": 20,
+          "calories": 100,
           "done": true
         }
       ],
@@ -424,7 +435,9 @@ const String kimMinsuFixtureJson = r'''
           "type": "strength",
           "minutes": 10,
           "calories": 60,
-          "done": true
+          "done": true,
+          "sets": 3,
+          "reps": 15
         },
         {
           "name": "하체 스트레칭 15분",
@@ -477,7 +490,9 @@ const String kimMinsuFixtureJson = r'''
           "type": "strength",
           "minutes": 10,
           "calories": 60,
-          "done": true
+          "done": true,
+          "sets": 3,
+          "reps": 15
         },
         {
           "name": "하체 스트레칭 15분",
@@ -531,7 +546,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -622,7 +639,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -696,7 +715,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -776,7 +797,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -867,7 +890,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -941,7 +966,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -1021,7 +1048,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -1115,7 +1144,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": false
+              "done": false,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -1192,7 +1223,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": false
+              "done": false,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -1272,7 +1305,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -1363,7 +1398,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -1437,7 +1474,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -1445,6 +1484,13 @@ const String kimMinsuFixtureJson = r'''
               "minutes": 15,
               "calories": 45,
               "done": false
+            },
+            {
+              "name": "북한산 등산 90분",
+              "type": "other",
+              "minutes": 90,
+              "calories": 450,
+              "done": true
             }
           ],
           "meals": [
@@ -1517,7 +1563,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -1608,7 +1656,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -1682,7 +1732,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -1762,7 +1814,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -1818,9 +1872,53 @@ const String kimMinsuFixtureJson = r'''
         },
         {
           "weekday": 2,
-          "label": "AI 루틴 · 자율 운동",
-          "pt": false,
-          "exercises": [],
+          "label": "PT 세션 · 트레이너 지도",
+          "pt": true,
+          "clientFeedback": "레그프레스 무게가 붙었어요. 마지막 세트가 힘들었어요.",
+          "trainerNote": "하체 근력 향상 확인. 다음 세션 레그프레스 5kg 증량.",
+          "exercises": [
+            {
+              "name": "레그프레스 70kg · 4세트",
+              "type": "strength",
+              "minutes": 12,
+              "calories": 72,
+              "done": true,
+              "sets": 4,
+              "reps": 12
+            },
+            {
+              "name": "레그컬 35kg · 3세트",
+              "type": "strength",
+              "minutes": 9,
+              "calories": 54,
+              "done": true,
+              "sets": 3,
+              "reps": 12
+            },
+            {
+              "name": "카프레이즈 자체중량 · 3세트",
+              "type": "strength",
+              "minutes": 6,
+              "calories": 36,
+              "done": true,
+              "sets": 3,
+              "reps": 20
+            },
+            {
+              "name": "마무리 러닝머신 15분",
+              "type": "cardio",
+              "minutes": 15,
+              "calories": 135,
+              "done": true
+            },
+            {
+              "name": "하체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
           "meals": [
             {
               "meal": "breakfast-egg-strawberry"
@@ -1850,7 +1948,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -1921,7 +2021,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -2001,7 +2103,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -2062,7 +2166,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": false
+              "done": false,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -2103,7 +2209,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": false
+              "done": false,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -2183,7 +2291,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -2274,7 +2384,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -2348,7 +2460,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -2428,7 +2542,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -2519,7 +2635,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -2593,7 +2711,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -2632,6 +2752,13 @@ const String kimMinsuFixtureJson = r'''
               "type": "stretching",
               "minutes": 10,
               "calories": 30,
+              "done": true
+            },
+            {
+              "name": "탁구 40분",
+              "type": "other",
+              "minutes": 40,
+              "calories": 200,
               "done": true
             }
           ],
@@ -2673,7 +2800,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -2767,7 +2896,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": false
+              "done": false,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -2844,7 +2975,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": false
+              "done": false,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -2924,7 +3057,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -3015,7 +3150,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -3089,7 +3226,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -3169,7 +3308,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -3228,9 +3369,53 @@ const String kimMinsuFixtureJson = r'''
         },
         {
           "weekday": 2,
-          "label": "AI 루틴 · 자율 운동",
-          "pt": false,
-          "exercises": [],
+          "label": "PT 세션 · 트레이너 지도",
+          "pt": true,
+          "clientFeedback": "데드리프트 자세를 잡아주셔서 허리가 편했어요.",
+          "trainerNote": "데드리프트 힙힌지 안정적. 중량 55kg 유지 후 다음 달 60kg.",
+          "exercises": [
+            {
+              "name": "데드리프트 55kg · 4세트",
+              "type": "strength",
+              "minutes": 12,
+              "calories": 72,
+              "done": true,
+              "sets": 4,
+              "reps": 8
+            },
+            {
+              "name": "루마니안 데드리프트 40kg · 3세트",
+              "type": "strength",
+              "minutes": 9,
+              "calories": 54,
+              "done": true,
+              "sets": 3,
+              "reps": 10
+            },
+            {
+              "name": "플랭크 45초 · 3세트",
+              "type": "strength",
+              "minutes": 6,
+              "calories": 36,
+              "done": true,
+              "sets": 3,
+              "reps": 3
+            },
+            {
+              "name": "마무리 러닝머신 12분",
+              "type": "cardio",
+              "minutes": 12,
+              "calories": 108,
+              "done": true
+            },
+            {
+              "name": "허리 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
           "meals": [
             {
               "meal": "breakfast-greek-yogurt-nuts"
@@ -3260,7 +3445,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -3334,7 +3521,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -3414,7 +3603,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -3502,7 +3693,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -3573,7 +3766,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -3653,7 +3848,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -3714,7 +3911,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": false
+              "done": false,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -3755,7 +3954,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": false
+              "done": false,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -3835,7 +4036,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -3926,7 +4129,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -4000,13 +4205,22 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
               "type": "stretching",
               "minutes": 15,
               "calories": 45,
+              "done": true
+            },
+            {
+              "name": "자전거 라이딩 60분",
+              "type": "other",
+              "minutes": 60,
+              "calories": 300,
               "done": true
             }
           ],
@@ -4080,7 +4294,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -4171,7 +4387,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -4245,7 +4463,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -4325,7 +4545,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -4419,7 +4641,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": false
+              "done": false,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -4496,7 +4720,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": false
+              "done": false,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -4576,7 +4802,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -4635,9 +4863,53 @@ const String kimMinsuFixtureJson = r'''
         },
         {
           "weekday": 2,
-          "label": "AI 루틴 · 자율 운동",
-          "pt": false,
-          "exercises": [],
+          "label": "PT 세션 · 트레이너 지도",
+          "pt": true,
+          "clientFeedback": "어깨가 아직 조금 불편해서 무게를 낮췄어요.",
+          "trainerNote": "오른쪽 어깨 가동범위 제한. 숄더프레스 중량 낮추고 밴드 보강 병행.",
+          "exercises": [
+            {
+              "name": "숄더프레스 10kg · 4세트",
+              "type": "strength",
+              "minutes": 12,
+              "calories": 72,
+              "done": true,
+              "sets": 4,
+              "reps": 12
+            },
+            {
+              "name": "밴드 외전 · 3세트",
+              "type": "strength",
+              "minutes": 6,
+              "calories": 36,
+              "done": true,
+              "sets": 3,
+              "reps": 20
+            },
+            {
+              "name": "인클라인 푸시업 · 3세트",
+              "type": "strength",
+              "minutes": 9,
+              "calories": 54,
+              "done": true,
+              "sets": 3,
+              "reps": 12
+            },
+            {
+              "name": "마무리 러닝머신 10분",
+              "type": "cardio",
+              "minutes": 10,
+              "calories": 90,
+              "done": true
+            },
+            {
+              "name": "어깨 관절 보호 스트레칭 12분",
+              "type": "stretching",
+              "minutes": 12,
+              "calories": 36,
+              "done": true
+            }
+          ],
           "meals": [
             {
               "meal": "breakfast-egg-strawberry"
@@ -4667,7 +4939,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -4741,7 +5015,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -4821,7 +5097,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -4912,7 +5190,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -4986,7 +5266,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -5066,7 +5348,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -5154,7 +5438,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -5225,7 +5511,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -5305,7 +5593,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -5366,7 +5656,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": false
+              "done": false,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -5407,7 +5699,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": false
+              "done": false,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -5487,7 +5781,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -5578,7 +5874,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -5652,7 +5950,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -5732,7 +6032,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -5823,7 +6125,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -5897,7 +6201,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -5977,7 +6283,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -6039,9 +6347,53 @@ const String kimMinsuFixtureJson = r'''
         },
         {
           "weekday": 2,
-          "label": "AI 루틴 · 자율 운동",
-          "pt": false,
-          "exercises": [],
+          "label": "PT 세션 · 트레이너 지도",
+          "pt": true,
+          "clientFeedback": "벤치프레스가 처음이라 어색했지만 재밌었어요 💪",
+          "trainerNote": "상체 근력 기초 확인. 벤치프레스 35kg 로 시작해 자세 우선.",
+          "exercises": [
+            {
+              "name": "벤치프레스 35kg · 4세트",
+              "type": "strength",
+              "minutes": 12,
+              "calories": 72,
+              "done": true,
+              "sets": 4,
+              "reps": 10
+            },
+            {
+              "name": "체스트프레스 25kg · 3세트",
+              "type": "strength",
+              "minutes": 9,
+              "calories": 54,
+              "done": true,
+              "sets": 3,
+              "reps": 12
+            },
+            {
+              "name": "랫풀다운 30kg · 3세트",
+              "type": "strength",
+              "minutes": 9,
+              "calories": 54,
+              "done": true,
+              "sets": 3,
+              "reps": 12
+            },
+            {
+              "name": "마무리 러닝머신 15분",
+              "type": "cardio",
+              "minutes": 15,
+              "calories": 135,
+              "done": true
+            },
+            {
+              "name": "상체 스트레칭 10분",
+              "type": "stretching",
+              "minutes": 10,
+              "calories": 30,
+              "done": true
+            }
+          ],
           "meals": [
             {
               "meal": "breakfast-greek-yogurt-nuts"
@@ -6071,7 +6423,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": false
+              "done": false,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -6148,7 +6502,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": false
+              "done": false,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -6228,7 +6584,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -6319,7 +6677,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -6393,7 +6753,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -6473,7 +6835,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -6564,7 +6928,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -6638,7 +7004,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -6718,7 +7086,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -6806,7 +7176,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -6877,7 +7249,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -6957,7 +7331,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -7018,7 +7394,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": false
+              "done": false,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -7059,7 +7437,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": false
+              "done": false,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -7139,7 +7519,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -7230,7 +7612,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -7304,7 +7688,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -7384,7 +7770,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -7443,9 +7831,53 @@ const String kimMinsuFixtureJson = r'''
         },
         {
           "weekday": 2,
-          "label": "AI 루틴 · 자율 운동",
-          "pt": false,
-          "exercises": [],
+          "label": "PT 세션 · 트레이너 지도",
+          "pt": true,
+          "clientFeedback": "첫 PT 라 긴장했는데 생각보다 할 만했어요.",
+          "trainerNote": "첫 세션. 체력 수준 점검 위주로 가볍게 진행.",
+          "exercises": [
+            {
+              "name": "고블릿 스쿼트 12kg · 3세트",
+              "type": "strength",
+              "minutes": 9,
+              "calories": 54,
+              "done": true,
+              "sets": 3,
+              "reps": 12
+            },
+            {
+              "name": "케틀벨 스윙 12kg · 3세트",
+              "type": "strength",
+              "minutes": 9,
+              "calories": 54,
+              "done": true,
+              "sets": 3,
+              "reps": 15
+            },
+            {
+              "name": "코어 서킷 · 2세트",
+              "type": "strength",
+              "minutes": 6,
+              "calories": 36,
+              "done": true,
+              "sets": 2,
+              "reps": 12
+            },
+            {
+              "name": "마무리 러닝머신 10분",
+              "type": "cardio",
+              "minutes": 10,
+              "calories": 90,
+              "done": true
+            },
+            {
+              "name": "전신 스트레칭 12분",
+              "type": "stretching",
+              "minutes": 12,
+              "calories": 36,
+              "done": true
+            }
+          ],
           "meals": [
             {
               "meal": "breakfast-oatmeal-banana"
@@ -7475,7 +7907,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -7549,7 +7983,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -7629,7 +8065,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -7723,7 +8161,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": false
+              "done": false,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -7800,7 +8240,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": false
+              "done": false,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -7880,7 +8322,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -7971,7 +8415,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -8045,7 +8491,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -8125,7 +8573,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -8216,7 +8666,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -8290,7 +8742,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -8370,7 +8824,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -8458,7 +8914,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": true
+              "done": true,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -8529,7 +8987,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": true
+              "done": true,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",
@@ -8609,7 +9069,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 10,
               "calories": 60,
-              "done": true
+              "done": true,
+              "sets": 3,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -8670,7 +9132,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 20,
               "calories": 120,
-              "done": false
+              "done": false,
+              "sets": 5,
+              "reps": 15
             },
             {
               "name": "하체 스트레칭 5분",
@@ -8711,7 +9175,9 @@ const String kimMinsuFixtureJson = r'''
               "type": "strength",
               "minutes": 30,
               "calories": 180,
-              "done": false
+              "done": false,
+              "sets": 8,
+              "reps": 12
             },
             {
               "name": "하체 스트레칭 15분",

--- a/shared/demo_fixture/test/demo_fixture_test.dart
+++ b/shared/demo_fixture/test/demo_fixture_test.dart
@@ -98,6 +98,65 @@ void main() {
     expect(days.where((FixtureDay d) => !d.hasRecord), isNotEmpty);
   });
 
+  test('과거에도 PT 사례가 흩어져 있다 (#1265)', () {
+    // 데모는 오늘 하루만 보는 것이 아니다. 지난주·전체로 넘겼을 때 PT 를 받은
+    // 날과 그때 무엇을 몇 세트 했는지가 없으면 과거가 통째로 비어 보인다.
+    for (final DateTime now in <DateTime>[
+      DateTime(2026, 8, 10), // 월
+      DateTime(2026, 8, 13), // 목
+      DateTime(2026, 8, 16), // 일
+      DateTime(2026, 12, 31), // 연말
+      DateTime(2028, 2, 29), // 윤년
+    ]) {
+      final List<FixtureDay> days = fixture.daysFor(now);
+      final List<FixtureDay> pastPt = days
+          .where((FixtureDay d) => d.isPt && d != days.last)
+          .toList();
+      expect(pastPt.length, greaterThanOrEqualTo(5), reason: '$now');
+      for (final FixtureDay day in pastPt) {
+        expect(day.clientFeedback, isNotEmpty, reason: day.date);
+        expect(day.trainerNote, isNotEmpty, reason: day.date);
+        expect(
+          day.exercises.any(
+            (FixtureExercise e) => e.type == 'strength' && e.sets != null,
+          ),
+          isTrue,
+          reason: '${day.date}: 세트를 적은 근력이 없다',
+        );
+      }
+    }
+  });
+
+  test('오늘 하루가 네 유형을 모두 담는다 (#1265)', () {
+    // 월요일에 열어도 이번 주 화면이 비지 않아야 한다 — 그날 하나로 네 유형과
+    // PT·피드백·메모가 모두 읽혀야 한다.
+    for (final DateTime now in <DateTime>[
+      DateTime(2026, 8, 10),
+      DateTime(2026, 8, 16),
+      DateTime(2027, 1, 1),
+    ]) {
+      final FixtureDay day = fixture.daysFor(now).last;
+      expect(
+        day.exercises.map((FixtureExercise e) => e.type).toSet(),
+        <String>{'cardio', 'strength', 'stretching', 'other'},
+        reason: '$now',
+      );
+      expect(day.isPt, isTrue, reason: '$now');
+    }
+  });
+
+  test('근력은 세트를 값으로 들고 다닌다 (#1262 · #1265)', () {
+    for (final FixtureDay day in fixture.daysFor(DateTime(2026, 8, 16))) {
+      for (final FixtureExercise e in day.exercises) {
+        if (e.type == 'strength') {
+          expect(e.sets, isNotNull, reason: '${day.date}: ${e.name}');
+        } else {
+          expect(e.sets, isNull, reason: '${day.date}: ${e.name}');
+        }
+      }
+    }
+  });
+
   test('주가 바뀌어도 하루가 사라지지 않는다', () {
     // 서머타임이 있는 지역에서 `Duration(days:)` 로 날짜를 옮기면 하루가 밀린다.
     // 픽스처는 날짜 연산만 쓰므로 어느 날에 열어도 연속이어야 한다.

--- a/tool/gen_demo_fixture.py
+++ b/tool/gen_demo_fixture.py
@@ -174,25 +174,91 @@ MEALS: dict[str, tuple[str, str, str, str, list[str]]] = {
 # 이행률은 여기 항목의 `done` 개수에서 나온다 — 퍼센트를 따로 적으면 화면의
 # "3개 중 2개 완료" 와 숫자가 갈라진다(#754).
 #
-# (이름, 종류, 분, 칼로리). 수요일은 휴식이라 항목이 없다 — 사용자앱의 주간
-# 활동 그래프와 백엔드 시드가 이미 쓰던 리듬이다.
-ROUTINE: dict[int, list[tuple[str, str, int]]] = {
+# (이름, 종류, 분) 또는 근력이면 (이름, 종류, 분, 세트, 횟수). 수요일은 휴식이라
+# 항목이 없다 — 사용자앱의 주간 활동 그래프와 백엔드 시드가 이미 쓰던 리듬이다.
+#
+# 근력에 세트·횟수를 적는 이유: 화면 여러 곳이 근력을 세트로 읽는데(#1262),
+# 픽스처가 분만 들고 있으면 저마다 분에서 되짚어 아무도 적은 적 없는 수를
+# 그린다. 이름에 적힌 `4세트` 를 화면이 다시 세게 두어도 마찬가지다.
+ROUTINE: dict[int, list[tuple]] = {
     0: [("저강도 유산소 (걷기) 30분", "cardio", 30),
-        ("코어 강화 10분", "strength", 10),
+        ("코어 강화 10분", "strength", 10, 3, 15),
         ("하체 스트레칭 5분", "stretching", 5)],
     1: [("저강도 유산소 (걷기) 40분", "cardio", 40),
         ("하체 스트레칭 10분", "stretching", 10)],
     2: [],
     3: [("저강도 유산소 (걷기) 35분", "cardio", 35),
-        ("코어 강화 20분", "strength", 20),
+        ("코어 강화 20분", "strength", 20, 5, 15),
         ("하체 스트레칭 5분", "stretching", 5)],
     4: [("저강도 유산소 (걷기) 45분", "cardio", 45),
         ("어깨 관절 보호 스트레칭 10분", "stretching", 10)],
     5: [("저강도 유산소 (걷기) 25분", "cardio", 25),
-        ("코어 강화 30분", "strength", 30),
+        ("코어 강화 30분", "strength", 30, 8, 12),
         ("하체 스트레칭 15분", "stretching", 15)],
     6: [("저강도 유산소 (걷기) 20분", "cardio", 20),
         ("하체 스트레칭 10분", "stretching", 10)],
+}
+
+# ── 과거의 PT 세션 ─────────────────────────────────────────────────────────
+# {몇 주 전: (요일, 라벨·피드백·메모, 운동들)}
+#
+# 데모는 오늘 하루만 보는 것이 아니다. 지난주·전체로 넘겨도 PT 를 받은 날과 그때
+# 무엇을 몇 세트 했는지, 회원이 뭐라고 했고 트레이너가 뭘 적어 뒀는지가 보여야
+# "충분히 구현된 제품"으로 읽힌다. 예전에는 과거 35주가 전부 `AI 루틴 · 자율 운동`
+# 한 줄이었고 PT 는 오늘 하나뿐이었다. (#1265)
+#
+# 수요일에 둔다 — 격자에서 비어 있는 요일이라 그날의 자율 운동과 겹치지 않는다.
+# 5~6주 간격으로 흩어 두어 어느 기간을 열어도 하나는 걸린다.
+PT_LABEL = "PT 세션 · 트레이너 지도"
+
+PT_SESSIONS: dict[int, tuple[int, str, str, list[tuple]]] = {
+    5: (2, "레그프레스 무게가 붙었어요. 마지막 세트가 힘들었어요.",
+        "하체 근력 향상 확인. 다음 세션 레그프레스 5kg 증량.",
+        [("레그프레스 70kg · 4세트", "strength", 12, 4, 12),
+         ("레그컬 35kg · 3세트", "strength", 9, 3, 12),
+         ("카프레이즈 자체중량 · 3세트", "strength", 6, 3, 20),
+         ("마무리 러닝머신 15분", "cardio", 15),
+         ("하체 스트레칭 10분", "stretching", 10)]),
+    11: (2, "데드리프트 자세를 잡아주셔서 허리가 편했어요.",
+         "데드리프트 힙힌지 안정적. 중량 55kg 유지 후 다음 달 60kg.",
+         [("데드리프트 55kg · 4세트", "strength", 12, 4, 8),
+          ("루마니안 데드리프트 40kg · 3세트", "strength", 9, 3, 10),
+          ("플랭크 45초 · 3세트", "strength", 6, 3, 3),
+          ("마무리 러닝머신 12분", "cardio", 12),
+          ("허리 스트레칭 10분", "stretching", 10)]),
+    17: (2, "어깨가 아직 조금 불편해서 무게를 낮췄어요.",
+         "오른쪽 어깨 가동범위 제한. 숄더프레스 중량 낮추고 밴드 보강 병행.",
+         [("숄더프레스 10kg · 4세트", "strength", 12, 4, 12),
+          ("밴드 외전 · 3세트", "strength", 6, 3, 20),
+          ("인클라인 푸시업 · 3세트", "strength", 9, 3, 12),
+          ("마무리 러닝머신 10분", "cardio", 10),
+          ("어깨 관절 보호 스트레칭 12분", "stretching", 12)]),
+    23: (2, "벤치프레스가 처음이라 어색했지만 재밌었어요 💪",
+         "상체 근력 기초 확인. 벤치프레스 35kg 로 시작해 자세 우선.",
+         [("벤치프레스 35kg · 4세트", "strength", 12, 4, 10),
+          ("체스트프레스 25kg · 3세트", "strength", 9, 3, 12),
+          ("랫풀다운 30kg · 3세트", "strength", 9, 3, 12),
+          ("마무리 러닝머신 15분", "cardio", 15),
+          ("상체 스트레칭 10분", "stretching", 10)]),
+    29: (2, "첫 PT 라 긴장했는데 생각보다 할 만했어요.",
+         "첫 세션. 체력 수준 점검 위주로 가볍게 진행.",
+         [("고블릿 스쿼트 12kg · 3세트", "strength", 9, 3, 12),
+          ("케틀벨 스윙 12kg · 3세트", "strength", 9, 3, 15),
+          ("코어 서킷 · 2세트", "strength", 6, 2, 12),
+          ("마무리 러닝머신 10분", "cardio", 10),
+          ("전신 스트레칭 12분", "stretching", 12)]),
+}
+
+# ── 그 밖의 운동 ───────────────────────────────────────────────────────────
+# {몇 주 전: (요일, (이름, 종류, 분))}
+#
+# `other` 는 목표가 없는 나머지 운동이다. 유형이 넷인데 데모에는 셋뿐이라, 유형별
+# 분해 화면에서 `기타` 칸이 늘 0 이었다 — 그 칸이 실제로 동작하는지 시연에서 볼 수
+# 없었다. 주말에 한 번씩, 서로 다른 주에 둔다. (#1265)
+OTHER_ACTIVITIES: dict[int, tuple[int, tuple[str, str, int]]] = {
+    3: (5, ("북한산 등산 90분", "other", 90)),
+    8: (6, ("탁구 40분", "other", 40)),
+    14: (5, ("자전거 라이딩 60분", "other", 60)),
 }
 
 #: 분당 칼로리. 종류마다 다르다 — 걷기와 스트레칭을 같은 값으로 두면 주간 활동
@@ -349,13 +415,16 @@ RECENT: list[dict] = [
         "clientFeedback": "무릎이 좀 당겼지만 트레이너님 덕분에 잘 마쳤어요 😊",
         "trainerNote": "무릎 가동범위 체크 필요. 다음 세션 중량 조절 예정.",
         "dayMessage": "점심 짬뽕으로 오늘 나트륨 섭취가 많았어요. 저녁은 양념을 줄인 채소와 단백질 위주로 구성해 보세요.",
+        # 오늘 하루가 네 유형을 모두 담는다 — 어느 날 데모를 열어도 유형별
+        # 분해 화면이 네 칸을 다 그린다. (#1265)
         "exercises": [
-            ("벤치프레스 40kg · 4세트", "strength", 12, True, 4),
-            ("덤벨 숄더프레스 10kg · 4세트", "strength", 10, True, 4),
-            ("랫풀다운 45kg · 4세트", "strength", 12, True, 4),
-            ("플랭크 60초 · 3세트", "strength", 6, True, 3),
+            ("벤치프레스 40kg · 4세트", "strength", 12, True, 4, 10),
+            ("덤벨 숄더프레스 10kg · 4세트", "strength", 10, True, 4, 12),
+            ("랫풀다운 45kg · 4세트", "strength", 12, True, 4, 12),
+            ("플랭크 60초 · 3세트", "strength", 6, True, 3, 3),
             ("마무리 러닝머신 15분", "cardio", 15, True),
             ("하체 스트레칭 12분", "stretching", 12, True),
+            ("탁구 20분", "other", 20, True),
         ],
         "meals": [
             (B_EGG, "seed-diet-breakfast", "08:20",
@@ -375,7 +444,7 @@ RECENT: list[dict] = [
         "dayMessage": "약속이 있어 칼로리와 당류가 목표를 넘은 하루예요. 오늘은 가볍게 시작해 보세요.",
         "exercises": [
             ("저강도 유산소 (걷기) 30분", "cardio", 30, True),
-            ("코어 강화 10분", "strength", 10, True),
+            ("코어 강화 10분", "strength", 10, True, 3, 15),
             ("하체 스트레칭 15분", "stretching", 15, False),
         ],
         "meals": [
@@ -396,7 +465,7 @@ RECENT: list[dict] = [
         "dayMessage": "연어와 현미밥으로 탄단지 균형을 잘 맞췄어요.",
         "exercises": [
             ("저강도 유산소 (걷기) 30분", "cardio", 30, True),
-            ("코어 강화 10분", "strength", 10, True),
+            ("코어 강화 10분", "strength", 10, True, 3, 15),
             ("하체 스트레칭 15분", "stretching", 15, True),
         ],
         "meals": [
@@ -434,7 +503,12 @@ def _meal_entry(
 
 
 def _exercise(
-    name: str, kind: str, minutes: int, done: bool, sets: int | None = None
+    name: str,
+    kind: str,
+    minutes: int,
+    done: bool,
+    sets: int | None = None,
+    reps: int | None = None,
 ) -> dict:
     entry = {
         "name": name,
@@ -443,24 +517,57 @@ def _exercise(
         "calories": round(minutes * KCAL_PER_MIN[kind]),
         "done": done,
     }
-    # 근력만 세트를 갖는다. 유산소·스트레칭은 분이 곧 값이다.
+    # 근력만 세트·횟수를 갖는다. 유산소·스트레칭·기타는 분이 곧 값이다.
     if sets is not None:
         entry["sets"] = sets
+    if reps is not None:
+        entry["reps"] = reps
     return entry
 
 
-def _grid_day(weekday: int, plan: list[str | None], skipped: int) -> dict:
+def _grid_day(
+    weeks_ago: int, weekday: int, plan: list[str | None], skipped: int
+) -> dict:
+    """주 격자의 하루. 그 자리에 PT 가 잡혀 있으면 PT 날이 된다.
+
+    PT 날은 자율 운동 대신 그날 실제로 한 운동이 들어가고, 라벨·피드백·메모가
+    함께 붙는다. 끼니는 그 주의 계획을 그대로 쓴다 — PT 를 받았다고 먹은 것이
+    달라지지는 않는다.
+    """
+    meals = [_meal_entry(meal) for meal in plan if meal is not None]
+    session = PT_SESSIONS.get(weeks_ago)
+    if session is not None and session[0] == weekday:
+        _, feedback, note, routine = session
+        return {
+            "weekday": weekday,
+            "label": PT_LABEL,
+            "pt": True,
+            "clientFeedback": feedback,
+            "trainerNote": note,
+            # PT 날은 트레이너와 함께 끝까지 한다 — 못 한 항목을 두지 않는다.
+            "exercises": [
+                _exercise(item[0], item[1], item[2], True, *item[3:])
+                for item in routine
+            ],
+            "meals": meals,
+        }
+
     routine = ROUTINE[weekday]
     kept = len(routine) - skipped
+    exercises = [
+        _exercise(item[0], item[1], item[2], index < kept, *item[3:])
+        for index, item in enumerate(routine)
+    ]
+    extra = OTHER_ACTIVITIES.get(weeks_ago)
+    if extra is not None and extra[0] == weekday:
+        name, kind, minutes = extra[1]
+        exercises.append(_exercise(name, kind, minutes, True))
     return {
         "weekday": weekday,
         "label": "AI 루틴 · 자율 운동",
         "pt": False,
-        "exercises": [
-            _exercise(name, kind, minutes, index < kept)
-            for index, (name, kind, minutes) in enumerate(routine)
-        ],
-        "meals": [_meal_entry(meal) for meal in plan if meal is not None],
+        "exercises": exercises,
+        "meals": meals,
     }
 
 
@@ -471,12 +578,16 @@ def build() -> dict:
         days = []
         for weekday in range(7):
             plan = plans[weekday]
-            if plan is None:
+            session = PT_SESSIONS.get(index)
+            if plan is None and not (session and session[0] == weekday):
                 # 기록이 아예 없는 날. 루틴도 남기지 않는다 — 식단만 비고 운동만
                 # 남으면 그날 화면이 반쪽으로 읽힌다.
                 days.append({"weekday": weekday, "exercises": [], "meals": []})
                 continue
-            days.append(_grid_day(weekday, plan, skips.get(weekday, 0)))
+            plan = plan or []
+            days.append(
+                _grid_day(index, weekday, plan, skips.get(weekday, 0))
+            )
         weeks.append({"weeksAgo": index, "note": note, "days": days})
 
     recent = []


### PR DESCRIPTION
Closes #1265

## Summary

김민수를 회원 앱과 트레이너 웹에 나란히 띄웠을 때, **오늘뿐 아니라 지난주·전체에서도** 운동 기능이 서 있게 만들었다. 예전에는 과거 35주가 전부 `AI 루틴 · 자율 운동` 한 줄이었고, PT·구체적인 세트·고객 피드백·트레이너 메모는 오늘 하나에만 있었다. 지난주로 넘기는 순간 화면이 밋밋해져 "여기까지가 만든 데까지" 로 읽혔다.

숫자의 기준은 **고객 앱 운동 계약**이다. 트레이너 API 는 그 값을 다시 해석하지 않는다 — 그리고 이제 그 사실을 두 응답을 직접 견주는 테스트가 지킨다.

## Changes

### 과거를 시연 가능한 서사로
- **PT 세션 다섯 날**을 5·11·17·23·29주 전에 흩어 뒀다. 각 날에 구체적인 근력 운동과 세트·횟수, 회원 피드백, 트레이너 메모가 함께 있다 — 어느 기간을 열어도 하나는 걸린다.
- **`기타` 유형**(등산·탁구·자전거)을 서로 다른 세 주의 주말에 뒀다. 유형이 넷인데 데모에는 셋뿐이라, 유형별 분해 화면의 `기타` 칸이 늘 0 이어서 그 칸이 실제로 동작하는지 볼 수가 없었다.
- **오늘 하루가 네 유형을 모두 담는다.** 월요일에 데모를 열어도 이번 주 화면이 한 날로 충분히 찬다.
- 근력 항목마다 **세트·횟수**를 값으로 적는다. 이름에 적힌 `4세트` 를 화면이 다시 세거나 분에서 되짚으면 화면마다 다른 수가 나온다.

### 픽스처 → 앱·백엔드를 끝까지 연결
- 백엔드가 픽스처의 `sets`(그리고 `reps`)를 **읽는다.** Dart 쪽 짝은 읽고 있었는데 백엔드만 버려서, 실 API 로 붙이면 같은 회원의 같은 날 근력이 mock 모드와 다른 세트 수로 보였다.
- 하루·종류로 접을 때 세트는 **합**, 횟수는 **가장 많은 수**로 접는다. 횟수는 한 세트당 수라 합계는 아무도 한 적 없는 값이 된다.
- 회원 앱 mock 시드도 같은 규칙으로 이름·세트·횟수를 남긴다. 예전에는 분과 칼로리만 옮겨, 같은 픽스처를 읽는 두 앱이 다른 값을 저장하고 있었다.
- 두 앱의 날짜 인식 시드 버전을 올렸다(`seeded_v18`, `trainer_seeded_v28`). 올리지 않으면 오늘 이미 시드된 설치가 과거가 빈 옛 데이터를 그대로 들고 있다.

## Verification

- **회원 API 와 트레이너 API 를 직접 견준다** — 같은 회원·같은 주로 두 응답을 부르고 요일 라벨·일별 분·일별 칼로리·유형별 분·근력 세트·주간 합계·연속일·주간 목표, 그리고 세션 한 줄의 날짜·유형·분·칼로리·세트·횟수가 모두 같은지 확인한다. 이번 주·지난주·과거 PT 가 있는 주 셋을 본다.
- 하루 합이 유형별 합과 같고 주간 합이 요일 합과 같다는 **산술 불변식**을 함께 본다.
- **어느 날 열어도 성립하는지**는 픽스처 층에서 월~일 일곱 요일과 연말·연초·윤년 하루를 넣어 본다 — 과거 PT 가 다섯 날 이상 남아 있고, 오늘 하루가 네 유형과 PT·피드백·메모를 모두 담고 있는지. 날짜를 하나만 박아 두면 그날에만 맞는 데이터를 만들게 된다.
- 두 앱의 mock 집계도 각각 픽스처에서 계산한 기대값과 견준다 — 기대 숫자를 테스트에 적지 않는다.
- 백엔드 전체 pytest, 회원 앱·트레이너 앱 `flutter analyze` + 전체 테스트, 공유 픽스처 패키지 테스트 통과.

## Notes

- 픽스처 두 복사본이 바이트까지 같고 Dart 내장 JSON 이 원본과 같다는 검사는 이미 있던 것이 그대로 지킨다.
- 다른 데모 고객의 빈 운동 상태는 의도된 빈 상태 데모로 그대로 뒀다.
