### PR TITLE
fix(trainer-web): 상담 목적 문구의 생성 l10n 누락 복구

### DIFF
--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
@@ -1886,6 +1886,12 @@ abstract class AppLocalizations {
   /// **'Training goal'**
   String get consultExerciseGoal;
 
+  /// No description provided for @consultHealthPurpose.
+  ///
+  /// In en, this message translates to:
+  /// **'Health management purpose'**
+  String get consultHealthPurpose;
+
   /// No description provided for @consultPreferredTime.
   ///
   /// In en, this message translates to:

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
@@ -1025,6 +1025,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get consultExerciseGoal => 'Training goal';
 
   @override
+  String get consultHealthPurpose => 'Health management purpose';
+
+  @override
   String get consultPreferredTime => 'Preferred time';
 
   @override

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
@@ -987,6 +987,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get consultExerciseGoal => '운동 목표';
 
   @override
+  String get consultHealthPurpose => '건강관리 목적';
+
+  @override
   String get consultPreferredTime => '희망 일시';
 
   @override


### PR DESCRIPTION
## Summary

main 의 트레이너 웹이 `flutter analyze` 에서 깨져 있다. `consultHealthPurpose` 가 arb(`app_ko.arb`)와 화면(`consultations_page.dart`)에는 있는데 생성된 `app_localizations` 에는 없다.

생성 파일은 병합에서 **한쪽 것이 통째로 이기기 쉽다.** 서로 다른 PR 이 비슷한 시점에 arb 에 키를 더하면 arb 는 양쪽이 합쳐지지만, 생성 파일은 한쪽 버전만 남아 방금 합쳐진 키가 사라진다.

## Changes

`flutter gen-l10n` 으로 다시 만들었다. 세 파일에 그 키 하나가 더해지는 것이 전부다.

## Verification

트레이너 앱 `flutter analyze` 통과 — 이 변경 전에는 `undefined_getter` 로 실패한다.