### PR TITLE
fix(consultations): 상담 확인 화면 필터·배지·시간 표기 정리

### DIFF
--- a/frontend/flutter_trainer/lib/features/consultations/data/dtos/consultation_dtos.dart
+++ b/frontend/flutter_trainer/lib/features/consultations/data/dtos/consultation_dtos.dart
@@ -47,19 +47,15 @@ String? preferredStartTime(String code) {
   return '${match.group(1)}:${match.group(2)}';
 }
 
+// 사용자 앱의 희망 시간 표시가 24시간 형식(`17:00–18:00`)이라 여기도 맞춘다
+// — 같은 데이터를 두 화면이 다른 형식(오전/오후 대 24시간)으로 보여주면
+// 트레이너가 회원과 통화·메시지로 시간을 맞출 때 헷갈린다.
 String preferredTimeLabel(AppLocalizations l, String code) {
   final RegExpMatch? match = _kPreferredTimePattern.firstMatch(code);
   if (match == null) return l.slotFlexible;
-  String label(String hourText, String minute) {
-    final int hour = int.parse(hourText);
-    final String period = hour < 12 ? l.slotAm : l.slotPm;
-    final int hour12 = hour % 12 == 0 ? 12 : hour % 12;
-    return '$period $hour12:$minute';
-  }
-
-  final String start = label(match.group(1)!, match.group(2)!);
+  final String start = '${match.group(1)}:${match.group(2)}';
   if (match.group(3) == null) return start;
-  return '$start–${label(match.group(3)!, match.group(4)!)}';
+  return '$start–${match.group(3)}:${match.group(4)}';
 }
 
 /// `GET /v1/trainer/consultations` element → [ConsultationRequest].

--- a/frontend/flutter_trainer/lib/features/consultations/presentation/pages/consultations_page.dart
+++ b/frontend/flutter_trainer/lib/features/consultations/presentation/pages/consultations_page.dart
@@ -53,27 +53,7 @@ class ConsultationsPage extends ConsumerWidget {
 
     final page = PageScaffold(
       title: l.consultTitle,
-      subtitle: pending == null
-          ? null
-          : (pending > 0 ? l.consultPendingCount(pending) : l.consultNoPending),
       actions: <Widget>[
-        // 메시지 탭 고객 리스트 상단의 `전체 / 읽지 않음 N` 필과 같은 언어다
-        // — 글자 토글(`전체 보기`/`대기 중만`) 대신 두 상태를 한눈에 본다.
-        _ConsultFilterChip(
-          key: const ValueKey<String>('consultation-filter-all'),
-          label: l.consultFilterAll,
-          selected: filter == 'all',
-          onTap: () =>
-              ref.read(consultationFilterProvider.notifier).state = 'all',
-        ),
-        const SizedBox(width: AppSpacing.xs),
-        _ConsultFilterChip(
-          key: const ValueKey<String>('consultation-filter-pending'),
-          label: l.consultFilterPendingCount(pending ?? 0),
-          selected: filter == 'pending',
-          onTap: () =>
-              ref.read(consultationFilterProvider.notifier).state = 'pending',
-        ),
         if (modal)
           IconButton(
             key: const ValueKey<String>('consultations-close'),
@@ -85,6 +65,34 @@ class ConsultationsPage extends ConsumerWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
+          // 메시지 탭 고객 리스트 상단의 `전체 / 읽지 않음 N` 칩과 같은 언어다
+          // — 글자 토글(`전체 보기`/`대기 중만`) 대신 두 상태를 한눈에 본다.
+          // 예전에는 헤더 우측 `actions` 자리에 있었는데, 그 자리는 액션마다
+          // 자동으로 여백을 더해 칩 사이가 메시지 탭보다 넓어 보였고, 바로
+          // 위 `대기 중 N건` 부제와 같은 정보를 두 번 말하고 있었다 — 부제를
+          // 없애고 그 자리로 옮긴다.
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              _ConsultFilterChip(
+                key: const ValueKey<String>('consultation-filter-all'),
+                label: l.consultFilterAll,
+                selected: filter == 'all',
+                onTap: () =>
+                    ref.read(consultationFilterProvider.notifier).state = 'all',
+              ),
+              const SizedBox(width: AppSpacing.xs),
+              _ConsultFilterChip(
+                key: const ValueKey<String>('consultation-filter-pending'),
+                label: l.consultFilterPendingCount(pending ?? 0),
+                selected: filter == 'pending',
+                onTap: () =>
+                    ref.read(consultationFilterProvider.notifier).state =
+                        'pending',
+              ),
+            ],
+          ),
+          const SizedBox(height: AppSpacing.lg),
           if (!modal) ...<Widget>[
             Align(
               alignment: AlignmentDirectional.centerStart,
@@ -311,9 +319,10 @@ class _RequestCardState extends ConsumerState<_RequestCard> {
       // 이름이 비어 오는 경우의 대체 문구는 화면이 붙인다 — DTO 는
       // 로케일을 모른다. (#501)
       title: request.memberName.isEmpty ? l.unknownMember : request.memberName,
-      // 대기·승인·거절을 카드 우측 상단 배지로 바로 보여준다 — 아래
-      // 액션 줄까지 읽어야 알 수 있던 상태를 제목과 같은 줄에서 읽는다.
-      trailing: _StatusBadge(status: request.status),
+      // 승인·거절 결과를 카드 우측 상단 배지로 바로 보여준다. 대기 중은
+      // 배지를 달지 않는다 — 위 `대기 N` 필터가 이미 그 상태를 말하고
+      // 있어, 카드마다 또 붙이면 같은 말을 반복하는 셈이다.
+      trailing: request.isPending ? null : _StatusBadge(status: request.status),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[


### PR DESCRIPTION
## Summary

* 트레이너 앱 상담 확인 화면(`ConsultationsPage`)의 `전체`/`대기 N` 필터 위치·간격, 상태 배지 노출 범위, 희망 시간 표기 형식을 정리했다.

---

## Changes

### 🎨 UI/UX

* `전체`/`대기 N` 필터 칩을 헤더 우측 `actions`에서 본문 상단(옛 `대기 중 N건` 부제 자리)으로 이동
* 중복이던 `대기 중 N건` 부제 제거 — `대기 N` 칩이 같은 정보를 이미 말한다
* 필터 칩 사이 간격을 메시지 탭 칩과 동일하게 정리(헤더 액션 자리의 이중 여백 제거)
* 상태 배지(승인됨/거절됨/대기중)를 승인·거절된 요청에만 표시, 대기 중 요청에는 표시하지 않음

### 🐛 Fixes

* 희망 시간 표시를 사용자 앱과 같은 24시간 형식(`17:00–18:00`)으로 통일 — 기존에는 오전/오후 12시간 형식이었다

---

## Commits

1. `101d8ccd` fix(consultations): 상담 확인 화면 필터·배지·시간 표기 정리

---

## Notes

* 간격 문제의 원인: `PageScaffold`가 `actions` 목록의 각 항목 사이에 자동으로 `AppSpacing.sm` 여백을 넣는데, 기존 코드가 칩 사이에 `AppSpacing.xs`를 추가로 넣어 총 여백이 메시지 탭보다 넓었다. 필터를 `actions` 밖(본문)으로 옮기면서 자동 여백 문제도 함께 해결됐다.
* 데모(목업) 빌드는 상담 인박스 자체를 숨기므로(`consultationInboxEnabledProvider`) 브라우저로 직접 화면을 띄워 확인하지 못했다 — 관련 위젯 테스트(`consultations_page_test.dart`, 16개 전부 통과)와 `dart analyze`로 검증했다.

---

## Screenshots (Optional)

| Before | After |
| ------ | ----- |
|        |       |

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [ ] UI 확인 (데모 빌드에서 화면 자체가 꺼져 있어 미검증, Notes 참고)
* [x] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 실 API 모드(`USE_MOCK_API=false`)로 트레이너 앱을 실행해 상담 요청 화면을 연다.
2. `전체`/`대기 N` 필터가 제목 바로 아래, 메시지 탭 칩과 비슷한 간격으로 보이는지 확인한다.
3. 대기 중인 요청 카드에는 상태 배지가 없고, 승인·거절된 요청 카드에만 배지가 보이는지 확인한다.
4. 희망 시간이 오전/오후 없이 24시간 형식으로 표시되는지 확인한다.

---

## Related Issues

Closes #1342
Closes #1343

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [ ] 데모 시나리오 영향 확인