### PR TITLE
fix(coaching): AI 개인운동 제안의 근력 세트·횟수·중량 누락 보완

### DIFF
--- a/backend/app/api/v1/trainer.py
+++ b/backend/app/api/v1/trainer.py
@@ -783,6 +783,9 @@ def trainer_create_routine_suggestion(
         name=payload.name.strip(),
         minutes=payload.minutes,
         type_=payload.type,
+        sets=payload.sets,
+        reps=payload.reps,
+        weight=payload.weight,
         reason=payload.reason,
         evidence=payload.evidence,
         client_request_id=payload.client_request_id,
@@ -812,6 +815,9 @@ def trainer_approve_routine_suggestion(
             name=name.strip() if name is not None else None,
             minutes=fields.get("minutes"),
             type_=fields.get("type"),
+            sets=fields.get("sets"),
+            reps=fields.get("reps"),
+            weight=fields.get("weight"),
             reason=fields.get("reason"),
         )
     except trainer_service.RoutineNotFound as exc:

--- a/backend/app/schemas/trainer_api.py
+++ b/backend/app/schemas/trainer_api.py
@@ -445,6 +445,13 @@ class RoutineSuggestionCreateRequest(BaseModel):
     name: str = Field(min_length=1, max_length=100)
     minutes: int = Field(ge=0, le=600)
     type: RoutineType
+    #: 근력이면 세트 수·한 세트당 횟수·중량(kg). 배정(`RoutineAssignRequest`)과
+    #: 같은 계약이다 — 승인하는 순간 이 행이 그대로 배정이 되므로, 여기서 받지
+    #: 않으면 근력 제안은 세트가 빈 채로 회원에게 간다(#1321). 다른 유형에서
+    #: 와도 저장하지 않는다.
+    sets: int | None = Field(default=None, gt=0, le=99)
+    reps: int | None = Field(default=None, gt=0, le=999)
+    weight: float | None = Field(default=None, ge=0, le=1000)
     reason: str = Field(default="", max_length=200)
     #: 이 후보의 근거 문구. 트레이너가 승인 판단에 쓰는 재료이고 회원에게는
     #: 전달되지 않는다. 개수·길이를 묶는 이유는 카드 한 장이 읽히는 분량을
@@ -467,6 +474,12 @@ class RoutineSuggestionApproveRequest(PartialUpdate):
     name: str | None = Field(default=None, min_length=1, max_length=100)
     minutes: int | None = Field(default=None, ge=0, le=600)
     type: RoutineType | None = None
+    #: 근력이면 세트 수·한 세트당 횟수·중량(kg). 트레이너가 승인 직전에 고치는
+    #: 자리라, 유형을 근력으로 바꾸며 이 셋을 함께 채우는 것이 이 화면의 흔한
+    #: 흐름이다(#1321).
+    sets: int | None = Field(default=None, gt=0, le=99)
+    reps: int | None = Field(default=None, gt=0, le=999)
+    weight: float | None = Field(default=None, ge=0, le=1000)
     reason: str | None = Field(default=None, max_length=200)
 
 

--- a/backend/app/services/trainer_service.py
+++ b/backend/app/services/trainer_service.py
@@ -1203,6 +1203,9 @@ def create_routine_suggestion(
     minutes: int,
     type_: str,
     reason: str,
+    sets: int | None = None,
+    reps: int | None = None,
+    weight: float | None = None,
     evidence: Sequence[str] | None = None,
     client_request_id: str | None = None,
 ) -> RoutineOut:
@@ -1232,6 +1235,12 @@ def create_routine_suggestion(
         name=name,
         minutes=minutes,
         type=type_,
+        # 세트·횟수·중량은 근력에만 남긴다 — 배정([assign_routine])과 같은
+        # 규칙이다. 승인하면 이 행이 그대로 배정이 되므로 여기서 규칙이 갈리면
+        # 승인 전후로 값이 달라진다. (#1321)
+        sets=sets if type_ == "근력" else None,
+        reps=reps if type_ == "근력" else None,
+        weight=round(weight, 1) if weight is not None and type_ == "근력" else None,
         reason=reason,
         source="ai",
         status=ROUTINE_PENDING,
@@ -1309,6 +1318,9 @@ def approve_routine_suggestion(
     name: str | None = None,
     minutes: int | None = None,
     type_: str | None = None,
+    sets: int | None = None,
+    reps: int | None = None,
+    weight: float | None = None,
     reason: str | None = None,
 ) -> RoutineOut:
     """제안을 승인해 회원에게 배정한다. 준 값이 있으면 그것으로 고쳐서 승인한다.
@@ -1325,6 +1337,19 @@ def approve_routine_suggestion(
         row.type = type_
     if reason is not None:
         row.reason = reason
+    if sets is not None:
+        row.sets = sets
+    if reps is not None:
+        row.reps = reps
+    if weight is not None:
+        row.weight = round(weight, 1)
+    # 유형을 근력이 아닌 것으로 바꿔 승인하면 세트·횟수·중량을 지운다 — 남겨
+    # 두면 유산소 배정이 세트를 들고 회원에게 간다. 판단 기준은 **고친 뒤의**
+    # 유형이다. (#1321)
+    if row.type != "근력":
+        row.sets = None
+        row.reps = None
+        row.weight = None
     row.status = ROUTINE_APPROVED
     row.reviewed_at = clock.now()
     row.reviewed_by = trainer_id

--- a/backend/tests/test_routine_suggestion_review.py
+++ b/backend/tests/test_routine_suggestion_review.py
@@ -233,3 +233,140 @@ def test_existing_assignments_stay_visible(client):
     client.delete(
         f"/v1/trainer/clients/{MEMBER}/routines/{row['id']}", headers=_h(token)
     )
+
+
+# ── 근력 제안의 세트·횟수·중량 (#1321) ─────────────────────────────────────
+#
+# 제안은 승인하는 순간 **같은 행이 배정이 된다.** 그래서 근력을 세트·횟수·중량
+# 없이 만들면, 회원이 그 운동을 완료할 때 서버가 남길 값이 없고 그래프는 분에서
+# 세트를 되짚어 아무도 적은 적 없는 수를 그린다.
+
+
+def _create(client, token: str, **overrides) -> dict:
+    body = {
+        "name": f"힙 브리지 {uuid4().hex[:6]}",
+        "minutes": 12,
+        "type": "근력",
+        "sets": 4,
+        "reps": 12,
+        "weight": 20.5,
+        "reason": "하체 근력 보강",
+    }
+    body.update(overrides)
+    created = client.post(
+        f"/v1/trainer/clients/{MEMBER}/routine-suggestions",
+        headers=_h(token),
+        json=body,
+    )
+    assert created.status_code == 201, created.text
+    return created.json()
+
+
+def test_a_strength_suggestion_keeps_its_sets_reps_and_weight(client):
+    token = _trainer_token(client)
+    row = _create(client, token)
+    try:
+        assert (row["sets"], row["reps"], row["weight"]) == (4, 12, 20.5)
+
+        pending = client.get(
+            f"/v1/trainer/clients/{MEMBER}/routine-suggestions",
+            headers=_h(token),
+        ).json()
+        mine = next(r for r in pending if r["id"] == row["id"])
+        assert (mine["sets"], mine["reps"], mine["weight"]) == (4, 12, 20.5)
+    finally:
+        client.delete(
+            f"/v1/trainer/clients/{MEMBER}/routines/{row['id']}",
+            headers=_h(token),
+        )
+
+
+def test_approving_carries_the_strength_values_into_the_assignment(client):
+    """승인은 새 행을 만들지 않는다 — 그래도 값이 살아 있는지 배정 목록에서 본다."""
+    token = _trainer_token(client)
+    row = _create(client, token)
+    try:
+        approved = client.post(
+            f"/v1/trainer/routine-suggestions/{row['id']}/approve",
+            headers=_h(token),
+            json={},
+        )
+        assert approved.status_code == 200, approved.text
+        assert (
+            approved.json()["sets"],
+            approved.json()["reps"],
+            approved.json()["weight"],
+        ) == (4, 12, 20.5)
+
+        assigned = client.get(
+            f"/v1/trainer/clients/{MEMBER}/routines", headers=_h(token)
+        ).json()
+        mine = next(r for r in assigned if r["id"] == row["id"])
+        assert (mine["sets"], mine["reps"], mine["weight"]) == (4, 12, 20.5)
+    finally:
+        client.delete(
+            f"/v1/trainer/clients/{MEMBER}/routines/{row['id']}",
+            headers=_h(token),
+        )
+
+
+def test_editing_the_strength_values_while_approving(client):
+    """승인 직전에 고친 값이 배정에 남는다 — 수정 창이 하는 일이 이것이다."""
+    token = _trainer_token(client)
+    row = _create(client, token)
+    try:
+        approved = client.post(
+            f"/v1/trainer/routine-suggestions/{row['id']}/approve",
+            headers=_h(token),
+            json={"sets": 5, "reps": 8, "weight": 32.5},
+        )
+        assert approved.status_code == 200, approved.text
+        body = approved.json()
+        assert (body["sets"], body["reps"], body["weight"]) == (5, 8, 32.5)
+    finally:
+        client.delete(
+            f"/v1/trainer/clients/{MEMBER}/routines/{row['id']}",
+            headers=_h(token),
+        )
+
+
+def test_a_non_strength_suggestion_drops_the_values(client):
+    """유산소를 세트로 세는 화면은 없다 — 값이 와도 남기지 않는다."""
+    token = _trainer_token(client)
+    row = _create(client, token, type="유산소", name=f"걷기 {uuid4().hex[:6]}")
+    try:
+        assert row["sets"] is None
+        assert row["reps"] is None
+        assert row["weight"] is None
+    finally:
+        client.delete(
+            f"/v1/trainer/clients/{MEMBER}/routines/{row['id']}",
+            headers=_h(token),
+        )
+
+
+def test_approving_as_another_type_clears_the_strength_values(client):
+    """근력이던 제안을 유산소로 바꿔 승인하면 세트가 남지 않는다.
+
+    남겨 두면 유산소 배정이 세트를 들고 회원에게 간다. 판단 기준은 고친 뒤의
+    유형이다.
+    """
+    token = _trainer_token(client)
+    row = _create(client, token)
+    try:
+        approved = client.post(
+            f"/v1/trainer/routine-suggestions/{row['id']}/approve",
+            headers=_h(token),
+            json={"type": "유산소", "minutes": 25},
+        )
+        assert approved.status_code == 200, approved.text
+        body = approved.json()
+        assert body["type"] == "유산소"
+        assert body["sets"] is None
+        assert body["reps"] is None
+        assert body["weight"] is None
+    finally:
+        client.delete(
+            f"/v1/trainer/clients/{MEMBER}/routines/{row['id']}",
+            headers=_h(token),
+        )

--- a/frontend/flutter_trainer/lib/features/coaching/data/dtos/routine_suggestion_dtos.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/data/dtos/routine_suggestion_dtos.dart
@@ -12,6 +12,9 @@ RoutineSuggestion routineSuggestionFromJson(Map<String, Object?> json) {
     name: _str(json['name']),
     minutes: json['minutes'] is num ? (json['minutes']! as num).toInt() : 0,
     type: _str(json['type']),
+    sets: (json['sets'] as num?)?.toInt(),
+    reps: (json['reps'] as num?)?.toInt(),
+    weight: (json['weight'] as num?)?.toDouble(),
     reason: _str(json['reason']),
     evidence: _strings(json['evidence']),
   );
@@ -26,15 +29,25 @@ Map<String, Object?> routineSuggestionApproveToJson({
   String? name,
   int? minutes,
   String? type,
+  int? sets,
+  int? reps,
+  double? weight,
   String? reason,
 }) {
   final trimmedName = name?.trim();
+  // 세트·횟수·중량은 **근력으로 승인할 때만** 싣는다. 서버도 다른 유형에서는
+  // 버리지만, 보내지 않는 편이 화면이 무엇을 정했는지와 payload 가 어긋날
+  // 자리를 아예 없앤다. (#1321)
+  final bool strength = type == '근력';
   return <String, Object?>{
     // 빈 이름은 서버가 400 으로 거른다. 보내지 않는 것이 곧 '이름은 그대로'다.
     if (trimmedName != null && trimmedName.isNotEmpty)
       'name': _truncate(trimmedName, 100),
     if (minutes != null) 'minutes': minutes.clamp(0, 600),
     if (type != null && kRoutineTypes.contains(type)) 'type': type,
+    if (strength && sets != null) 'sets': sets.clamp(1, 99),
+    if (strength && reps != null) 'reps': reps.clamp(1, 999),
+    if (strength && weight != null) 'weight': weight.clamp(0, 1000),
     if (reason != null) 'reason': _truncate(reason.trim(), 200),
   };
 }

--- a/frontend/flutter_trainer/lib/features/coaching/data/repositories/dio_trainer_routine_suggestion_repository.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/data/repositories/dio_trainer_routine_suggestion_repository.dart
@@ -39,6 +39,9 @@ class DioTrainerRoutineSuggestionRepository
     String? name,
     int? minutes,
     String? type,
+    int? sets,
+    int? reps,
+    double? weight,
     String? reason,
   }) async {
     await _review(
@@ -48,6 +51,9 @@ class DioTrainerRoutineSuggestionRepository
         name: name,
         minutes: minutes,
         type: type,
+        sets: sets,
+        reps: reps,
+        weight: weight,
         reason: reason,
       ),
     );

--- a/frontend/flutter_trainer/lib/features/coaching/data/repositories/trainer_routine_suggestion_repository.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/data/repositories/trainer_routine_suggestion_repository.dart
@@ -33,6 +33,9 @@ abstract interface class TrainerRoutineSuggestionRepository {
     String? name,
     int? minutes,
     String? type,
+    int? sets,
+    int? reps,
+    double? weight,
     String? reason,
   });
 
@@ -92,6 +95,19 @@ class MockTrainerRoutineSuggestionRepository
       reason: '등 위쪽을 돌려 어깨 부담을 줄이는 스트레칭이에요. 통증이 있으면 멈추세요.',
       evidence: <String>['최근 PT 피드백 반영'],
     ),
+    // 근력 후보를 하나 둔다 — 세트·횟수·중량을 묻는 자리가 데모에서도 보여야
+    // 그 칸이 실제로 동작하는지 시연에서 확인할 수 있다. (#1321)
+    RoutineSuggestion(
+      id: 'demo-suggestion-hip-bridge',
+      name: '힙 브리지',
+      minutes: 12,
+      type: '근력',
+      sets: 3,
+      reps: 15,
+      weight: 0,
+      reason: '누워서 엉덩이를 들어 올리는 하체 근력 운동이에요. 허리가 아프면 범위를 줄이세요.',
+      evidence: <String>['최근 근력운동 비중 높음'],
+    ),
   ];
 
   List<RoutineSuggestion> _listFor(String memberId) =>
@@ -107,6 +123,9 @@ class MockTrainerRoutineSuggestionRepository
     String? name,
     int? minutes,
     String? type,
+    int? sets,
+    int? reps,
+    double? weight,
     String? reason,
   }) async => _review(suggestionId);
 

--- a/frontend/flutter_trainer/lib/features/coaching/domain/entities/routine_suggestion.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/domain/entities/routine_suggestion.dart
@@ -13,6 +13,9 @@ class RoutineSuggestion {
     required this.minutes,
     required this.type,
     required this.reason,
+    this.sets,
+    this.reps,
+    this.weight,
     this.evidence = const <String>[],
   });
 
@@ -32,6 +35,15 @@ class RoutineSuggestion {
   /// 추천 카드에 이 글이 뜬다.
   final String reason;
 
+  /// 근력 제안의 세트 수·한 세트당 횟수·중량(kg). 다른 유형은 null 이다.
+  ///
+  /// 승인하면 이 행이 그대로 배정이 된다 — 여기 값이 없으면 회원이 그 운동을
+  /// 완료할 때 서버가 남길 세트가 없고, 그래프가 분에서 세트를 되짚어 아무도
+  /// 적은 적 없는 수를 그린다. (#1321)
+  final int? sets;
+  final int? reps;
+  final double? weight;
+
   /// 이 제안이 무엇을 보고 만들어졌나(`최근 PT 피드백 반영` 등). 트레이너의
   /// 판단 재료이고 회원에게는 가지 않는다. 서버가 만든 문구이므로 번역하지 않고
   /// 그대로 보여 준다.
@@ -42,6 +54,9 @@ class RoutineSuggestion {
     String? name,
     int? minutes,
     String? type,
+    int? sets,
+    int? reps,
+    double? weight,
     String? reason,
   }) {
     return RoutineSuggestion(
@@ -49,6 +64,9 @@ class RoutineSuggestion {
       name: name ?? this.name,
       minutes: minutes ?? this.minutes,
       type: type ?? this.type,
+      sets: sets ?? this.sets,
+      reps: reps ?? this.reps,
+      weight: weight ?? this.weight,
       reason: reason ?? this.reason,
       evidence: evidence,
     );

--- a/frontend/flutter_trainer/lib/features/coaching/presentation/widgets/routine_suggestion_edit_dialog.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/widgets/routine_suggestion_edit_dialog.dart
@@ -9,10 +9,16 @@ import 'package:oncare_trainer/features/coaching/presentation/widgets/routine_fo
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 
 /// 수정 후 추천으로 나가는 값. 취소는 null 이다.
+///
+/// 근력이면 [sets]·[reps]·[weight] 가 실리고 [minutes] 는 쓰이지 않는다. 그
+/// 밖의 유형은 반대다 — 서버도 같은 규칙으로 받는다(#1321).
 typedef RoutineSuggestionEdit = ({
   String name,
   int minutes,
   String type,
+  int? sets,
+  int? reps,
+  double? weight,
   String reason,
 });
 
@@ -25,6 +31,11 @@ typedef RoutineSuggestionEdit = ({
 /// **강도 필드는 없다.** 배정 루틴에는 강도가 없고(회원 화면도 보여 주지 않는다),
 /// 넣더라도 어디에도 닿지 않는 값이 된다. 강도 조절은 시간·운동 유형과 회원에게
 /// 전달할 메모로 표현한다.
+///
+/// 다만 **근력은 시간으로 재지 않는다.** 유형이 근력이면 세트·횟수·중량을 묻고,
+/// 그 밖이면 시간을 묻는다 — 앱의 다른 운동 입력 화면과 같은 스펙이고 같은
+/// 위젯을 쓴다(#1276, #1310). 예전에는 여기만 시간을 물어, 근력 제안을 승인하면
+/// 세트가 빈 배정이 회원에게 갔다(#1321).
 Future<RoutineSuggestionEdit?> showRoutineSuggestionEditDialog(
   BuildContext context,
   RoutineSuggestion suggestion,
@@ -39,8 +50,9 @@ Future<RoutineSuggestionEdit?> showRoutineSuggestionEditDialog(
 ///
 /// `true` 로 닫히면 트레이너가 나갈 내용을 그대로 보고 확인한 것이다. 취소·
 /// 바깥 탭은 null 이고, 그때는 아무 mutation 도 일어나지 않는다. 여기 그리는
-/// 값(이름·시간·유형·메모)이 곧 `approve` 가 보낼 값이라, 확인한 내용과
-/// payload 가 어긋날 자리가 없다.
+/// 값(이름·양·유형·메모)이 곧 `approve` 가 보낼 값이라, 확인한 내용과
+/// payload 가 어긋날 자리가 없다. 근력은 시간이 아니라 세트·횟수·중량으로
+/// 적는다 — 수정 창이 물은 것과 같은 칸이어야 한다(#1321).
 Future<bool?> showRoutineSuggestionConfirmDialog(
   BuildContext context, {
   required RoutineSuggestion suggestion,
@@ -86,7 +98,8 @@ Future<bool?> showRoutineSuggestionConfirmDialog(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: <Widget>[
                     Text(
-                      '${suggestion.name} · ${l.minutesShort(suggestion.minutes)}',
+                      '${suggestion.name} · '
+                      '${routineSuggestionAmountLabel(l, suggestion)}',
                       style: const TextStyle(
                         fontSize: 13,
                         fontWeight: FontWeight.w800,
@@ -137,6 +150,32 @@ Future<bool?> showRoutineSuggestionConfirmDialog(
   );
 }
 
+/// 제안 한 줄이 말하는 **양**. 근력은 세트·횟수·중량, 나머지는 시간이다.
+///
+/// 검토 카드와 최종 검토 dialog 가 **같은 함수**를 쓴다 — 목록에서 읽은 값과
+/// 승인 직전에 확인하는 값이 다르면 트레이너가 무엇을 보고 눌렀는지가 흐려진다.
+/// 그래서 수정 창 옆에 둔다(그 셋이 같은 칸을 말해야 한다).
+///
+/// 중량은 적었을 때만 붙인다 — 맨몸 운동에 `0kg` 이 붙으면 트레이너가 적지
+/// 않은 값을 적은 것처럼 읽힌다.
+String routineSuggestionAmountLabel(
+  AppLocalizations l,
+  RoutineSuggestion suggestion,
+) {
+  if (suggestion.type != '근력') return l.minutesShort(suggestion.minutes);
+  final List<String> parts = <String>[
+    if (suggestion.sets != null) l.progSetsValue(suggestion.sets!),
+    if (suggestion.reps != null) l.progRepsValue(suggestion.reps!),
+    if (suggestion.weight != null && suggestion.weight! > 0)
+      '${_trimZero(suggestion.weight!)}${l.routineUnitKg}',
+  ];
+  return parts.isEmpty ? l.minutesShort(suggestion.minutes) : parts.join(' · ');
+}
+
+/// 20.0 → `20`, 62.5 → `62.5`.
+String _trimZero(double value) =>
+    value == value.roundToDouble() ? '${value.round()}' : '$value';
+
 /// The minimal edit form for a pending suggestion.
 class RoutineSuggestionEditDialog extends StatefulWidget {
   /// Creates the dialog for [suggestion].
@@ -165,6 +204,14 @@ class _RoutineSuggestionEditDialogState
   );
   late String _type = widget.suggestion.type;
   late int _minutes = widget.suggestion.minutes;
+  // 근력의 세 값. 시간과 따로 들고 있어야 유형을 오갈 때 각자의 값이 남는다 —
+  // 하나로 쓰면 30분이 30세트가 되어 돌아온다. 제안이 값을 들고 있지 않으면
+  // 다른 입력 화면과 같은 기본값으로 시작한다.
+  late int _sets = widget.suggestion.sets ?? 3;
+  late int _reps = widget.suggestion.reps ?? 10;
+  late double _weight = widget.suggestion.weight ?? 20;
+
+  bool get _isStrength => _type == '근력';
 
   @override
   void dispose() {
@@ -182,6 +229,10 @@ class _RoutineSuggestionEditDialogState
       name: name,
       minutes: _minutes,
       type: _type,
+      // 근력이 아니면 세 값을 싣지 않는다 — 유산소를 세트로 세는 화면은 없다.
+      sets: _isStrength ? _sets : null,
+      reps: _isStrength ? _reps : null,
+      weight: _isStrength ? _weight : null,
       reason: _reason.text.trim(),
     ));
   }
@@ -220,16 +271,38 @@ class _RoutineSuggestionEditDialogState
                 ),
               ),
               const SizedBox(height: AppSpacing.md),
-              RoutineMinutesField(
-                minutes: _minutes,
-                onChanged: (next) => setState(() => _minutes = next),
-              ),
-              const SizedBox(height: AppSpacing.sm),
+              // 유형을 먼저 고른다 — 아래 칸이 세트·횟수·중량인지 시간인지를
+              // 이 값이 정한다.
               RoutineCategoryChips(
                 keyPrefix: 'suggestion-edit-type',
                 value: _type,
                 onChanged: (next) => setState(() => _type = next),
               ),
+              const SizedBox(height: AppSpacing.md),
+              if (_isStrength) ...<Widget>[
+                RoutineSetsField(
+                  keyPrefix: 'suggestion-edit-sets',
+                  sets: _sets,
+                  onChanged: (next) => setState(() => _sets = next),
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                RoutineRepsField(
+                  keyPrefix: 'suggestion-edit-reps',
+                  reps: _reps,
+                  onChanged: (next) => setState(() => _reps = next),
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                RoutineWeightField(
+                  keyPrefix: 'suggestion-edit-weight',
+                  weight: _weight,
+                  onChanged: (next) => setState(() => _weight = next),
+                ),
+              ] else
+                RoutineMinutesField(
+                  keyPrefix: 'suggestion-edit-minutes',
+                  minutes: _minutes,
+                  onChanged: (next) => setState(() => _minutes = next),
+                ),
               const SizedBox(height: AppSpacing.md),
               _FieldLabel(l.suggestionEditMemo),
               TextField(

--- a/frontend/flutter_trainer/lib/features/coaching/presentation/widgets/routine_suggestion_review_card.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/widgets/routine_suggestion_review_card.dart
@@ -91,6 +91,12 @@ class _RoutineSuggestionReviewCardState
             name: edit?.name,
             minutes: edit?.minutes,
             type: edit?.type,
+            // 근력이면 수정 창이 채운 세 값이 함께 간다. 그대로 승인(edit 이
+            // null)이면 아무것도 보내지 않고, 서버가 제안 행에 이미 들고 있는
+            // 값을 그대로 배정으로 옮긴다. (#1321)
+            sets: edit?.sets,
+            reps: edit?.reps,
+            weight: edit?.weight,
             reason: edit?.reason,
           ),
       l.suggestionApproved(edit?.name ?? suggestion.name, widget.clientName),
@@ -316,7 +322,9 @@ class _SuggestionCard extends StatelessWidget {
               ),
               const SizedBox(width: AppSpacing.sm),
               Text(
-                l.minutesShort(suggestion.minutes),
+                // 근력은 시간이 아니라 세트·횟수·중량으로 적는다 — 최종 검토
+                // dialog·수정 창과 같은 함수를 쓴다. (#1321)
+                routineSuggestionAmountLabel(l, suggestion),
                 style: const TextStyle(
                   fontSize: 12.5,
                   fontWeight: FontWeight.w800,

--- a/frontend/flutter_trainer/test/features/coaching/routine_suggestion_review_test.dart
+++ b/frontend/flutter_trainer/test/features/coaching/routine_suggestion_review_test.dart
@@ -46,6 +46,9 @@ class _FakeSuggestionRepository implements TrainerRoutineSuggestionRepository {
     String? name,
     int? minutes,
     String? type,
+    int? sets,
+    int? reps,
+    double? weight,
     String? reason,
   }) async {
     approvals.add(suggestionId);
@@ -53,6 +56,9 @@ class _FakeSuggestionRepository implements TrainerRoutineSuggestionRepository {
       'name': name,
       'minutes': minutes,
       'type': type,
+      'sets': sets,
+      'reps': reps,
+      'weight': weight,
       'reason': reason,
     });
     await Future<void>.delayed(delay);
@@ -94,6 +100,19 @@ const RoutineSuggestion _walking = RoutineSuggestion(
   type: '유산소',
   reason: '대화할 수 있는 속도로 걸어 보세요',
   evidence: <String>['혈압 관리 목표'],
+);
+
+/// 근력 제안 — 시간이 아니라 세트·횟수·중량으로 재는 것 (#1321).
+const RoutineSuggestion _bridge = RoutineSuggestion(
+  id: 's-bridge',
+  name: '힙 브리지',
+  minutes: 12,
+  type: '근력',
+  sets: 3,
+  reps: 15,
+  weight: 0,
+  reason: '허리가 아프면 범위를 줄이세요',
+  evidence: <String>['최근 근력운동 비중 높음'],
 );
 
 void main() {
@@ -328,6 +347,93 @@ void main() {
     expect(edit['reason'], '오른쪽 어깨에 통증이 생기면 중단하세요');
     expect(edit['type'], '스트레칭');
     expect(edit['minutes'], _shoulder.minutes);
+  });
+
+  testWidgets('근력 제안은 시간 대신 세트·횟수·중량을 묻는다 (#1321)', (tester) async {
+    final repo = await openProgramTab(
+      tester,
+      byMember: <String, List<RoutineSuggestion>>{
+        firstClient: <RoutineSuggestion>[_bridge],
+      },
+    );
+
+    await tester.ensureVisible(editButton(_bridge));
+    await tester.pump();
+    await tester.tap(editButton(_bridge));
+    await tester.pumpAndSettle();
+
+    expect(find.text('세트 수'), findsOneWidget);
+    expect(find.text('횟수'), findsOneWidget);
+    expect(find.text('중량'), findsOneWidget);
+    expect(find.text('운동 시간'), findsNothing);
+
+    await tester.tap(
+      find.byKey(const ValueKey<String>('suggestion-edit-submit')),
+    );
+    await tester.pumpAndSettle();
+
+    final edit = repo.approvalEdits.single;
+    expect(edit['type'], '근력');
+    expect(edit['sets'], _bridge.sets);
+    expect(edit['reps'], _bridge.reps);
+    expect(edit['weight'], _bridge.weight);
+  });
+
+  testWidgets('유형을 근력이 아닌 것으로 바꾸면 세 값을 싣지 않는다 (#1321)', (tester) async {
+    final repo = await openProgramTab(
+      tester,
+      byMember: <String, List<RoutineSuggestion>>{
+        firstClient: <RoutineSuggestion>[_bridge],
+      },
+    );
+
+    await tester.ensureVisible(editButton(_bridge));
+    await tester.pump();
+    await tester.tap(editButton(_bridge));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const ValueKey<String>('suggestion-edit-type-유산소')),
+    );
+    await tester.pumpAndSettle();
+
+    // 유산소는 시간으로 잰다 — 칸이 바뀐다.
+    expect(find.text('운동 시간'), findsOneWidget);
+    expect(find.text('세트 수'), findsNothing);
+
+    await tester.tap(
+      find.byKey(const ValueKey<String>('suggestion-edit-submit')),
+    );
+    await tester.pumpAndSettle();
+
+    final edit = repo.approvalEdits.single;
+    expect(edit['type'], '유산소');
+    expect(edit['sets'], isNull);
+    expect(edit['reps'], isNull);
+    expect(edit['weight'], isNull);
+  });
+
+  testWidgets('검토 카드와 최종 검토가 근력을 세트·횟수로 적는다 (#1321)', (tester) async {
+    await openProgramTab(
+      tester,
+      byMember: <String, List<RoutineSuggestion>>{
+        firstClient: <RoutineSuggestion>[_bridge],
+      },
+    );
+
+    // 목록 카드부터 세트·횟수로 읽힌다 — 근력을 시간으로 말하는 자리가 없다.
+    expect(find.textContaining('3세트'), findsOneWidget);
+    expect(find.textContaining('12분'), findsNothing);
+
+    await tester.ensureVisible(approveButton(_bridge));
+    await tester.pump();
+    await tester.tap(approveButton(_bridge));
+    await tester.pumpAndSettle();
+
+    // 수정 창이 물은 것과 같은 칸으로 적혀야 확인한 내용과 나갈 값이 같다.
+    // 카드와 dialog 가 함께 떠 있으므로 둘이 같은 문구를 말한다.
+    expect(find.textContaining('3세트'), findsNWidgets(2));
+    expect(find.textContaining('15회'), findsNWidgets(2));
+    expect(find.textContaining('12분'), findsNothing);
   });
 
   testWidgets('cancelling the edit does not recommend anything', (


### PR DESCRIPTION
Closes #1321

## Summary

AI 개인운동 제안이 근력이어도 **시간만 받고 있었다.** 제안 계약에 세트·횟수·중량을 담을 자리가 없어서, 근력 제안을 승인하면 그 셋이 빈 배정이 회원에게 갔다. 회원이 그 루틴을 완료하면 서버는 트레이너가 정한 값이 없으니 아무것도 기록하지 못하고, 그래프는 분에서 세트를 되짚어 **아무도 적은 적 없는 수**를 그린다 — #1276 이 배정 경로에서 막아 둔 문제가 제안 경로에만 그대로 남아 있었다.

제안은 승인하는 순간 **같은 행이 배정이 된다.** 그래서 배정과 같은 칸을 처음부터 받는 것이 맞다.

## Changes

### Backend
- 제안 생성·승인 계약에 세트·횟수·중량을 더했다. 값 범위는 배정(`RoutineAssignRequest`)과 같다.
- 근력에만 남긴다 — 다른 유형에서 와도 버린다. 배정과 같은 규칙이라야 승인 전후로 값이 달라지지 않는다.
- **유형을 근력이 아닌 것으로 바꿔 승인하면 세 값을 지운다.** 판단 기준은 고친 뒤의 유형이다 — 남겨 두면 유산소 배정이 세트를 들고 회원에게 간다.

### 트레이너 앱
- 제안 수정 창이 유형에 따라 칸을 가른다: 근력이면 **세트·횟수·중량**, 그 밖이면 시간. 앱의 다른 운동 입력 화면과 **같은 공용 위젯**을 쓴다(#1276, #1310). 유형을 먼저 고르게 순서도 맞췄다.
- 시간과 세 값을 따로 들고 있어 유형을 오갈 때 각자의 값이 남는다 — 하나로 쓰면 30분이 30세트가 되어 돌아온다.
- **검토 카드와 최종 검토 dialog 도 근력을 세트·횟수·중량으로 적는다.** 둘이 같은 함수를 쓴다 — 목록에서 읽은 값과 승인 직전에 확인하는 값이 다르면 트레이너가 무엇을 보고 눌렀는지가 흐려진다. 예전에는 근력 제안도 `12분` 으로 적혀 있었다.
- 데모 목록에 근력 후보를 하나 뒀다. 세 칸이 실제로 동작하는지 시연에서 볼 수 있어야 한다.

## Notes

- 강도는 여전히 제안에 두지 않는다 — 배정 루틴에 강도 자리가 이미 있고, 그 논의는 이 이슈 범위가 아니다.
- **그대로 승인**(수정 없이)은 아무 필드도 보내지 않는다. 서버가 제안 행에 이미 들고 있는 값을 그대로 배정으로 옮긴다.

## Verification

- 백엔드 전체 pytest 통과. 새 테스트가 덮는 것: 근력 제안이 세 값을 그대로 되돌려주는지, 승인이 그것을 배정으로 옮기는지, 승인 직전에 고친 값이 남는지, 비근력에서는 값이 버려지는지, **유형을 바꿔 승인하면 지워지는지**.
- 트레이너 앱 `flutter analyze` + 전체 테스트 통과. 새 위젯 테스트가 덮는 것: 근력이면 세트·횟수·중량을 묻고 시간 칸이 없는지, 유형을 바꾸면 칸이 바뀌고 세 값이 실리지 않는지, 카드·최종 검토가 같은 문구를 말하는지.
- 회원 앱 `flutter analyze` + 전체 테스트 통과(계약 변경이 회원 쪽에 닿지 않는지 확인).
- 근력 제안 수정 창을 골든 스냅샷으로 눈으로 확인.
