### PR TITLE
fix(exercise): 헬스장 찾기 목록 스크롤과 지도·목록 두 자리 고정

### DIFF
--- a/frontend/flutter/lib/features/exercise/presentation/pages/gym_list_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/gym_list_page.dart
@@ -167,7 +167,7 @@ class _GymFinderViewState extends ConsumerState<GymFinderView> {
                 // (#1274). 시트가 화면 몫을 다 쓰므로 남는 높이를 그대로
                 // 넘긴다.
                 Expanded(
-                  child: _GymMapAndSheet(
+                  child: _GymMapAndList(
                     gyms: visible,
                     header: l.exNearbyGyms,
                     controls: gymsAsync.hasValue
@@ -238,22 +238,21 @@ class _GymFinderViewState extends ConsumerState<GymFinderView> {
   }
 }
 
-/// 지도 위에 얹혀 세 자리를 오가는 결과 목록 시트 (#1274).
+/// 위에 고정된 지도와 그 아래 결과 목록 (#1274 → #1362 → #1370).
 ///
-/// **위 = 목록만 · 중간 = 반반 · 아래 = 지도만.** 손을 뗀 자리에서 가장 가까운
-/// 단계에 붙고, 뗄 때의 속도도 반영돼 짧게 튕겨도 다음 단계로 넘어간다 —
-/// [DraggableScrollableSheet] 의 스냅이 그 둘을 함께 해 준다.
+/// **자리는 둘뿐이다 — 반반 / 목록만.** 머리줄의 화살표로만 오간다. 예전에는
+/// 시트를 손으로 끌어 크기를 바꿨는데([DraggableScrollableSheet]), 그 손짓이
+/// 목록 스크롤과 같은 방향이라 폰에서 목록이 넘어가지 않았다. 끄는 동작을
+/// 없애면 목록에 닿은 손은 언제나 목록의 것이다.
 ///
-/// 지도는 **윗변이 자리에 못 박힌 채** 시트가 남긴 만큼만 차지한다. 시트가
-/// 오르내려도 지도가 따라 움직이지 않고, 둘이 겹치는 자리가 없다 — 겹쳐 두면
-/// 웹에서 시트 위의 터치가 아래 지도(플랫폼 뷰, DOM 요소)로 새어 나가 폰에서
-/// 시트를 끌 수도 목록을 밀 수도 없었다 (#1362).
+/// 지도와 목록은 **자리를 나눠 갖는다** — 겹치지 않는다. 겹쳐 두면 웹에서
+/// 목록 위의 터치가 아래 지도(플랫폼 뷰, DOM 요소)로 새어 나간다 (#1362).
+/// 그래서 목록을 굴려도 지도는 움직이지 않고, 지도를 끌어도 목록은 그대로다.
 ///
-/// 머리줄·정렬 줄·카드가 **한 스크롤 뷰**에 얹혀 있다. 그래야 목록이 맨 위에
-/// 닿은 채로 계속 내리면 시트가 이어서 내려가고, 머리줄을 잡고 끌어도 시트가
-/// 움직인다.
-class _GymMapAndSheet extends StatefulWidget {
-  const _GymMapAndSheet({
+/// 머리줄·정렬 줄은 목록 **위에 고정**되고, 구르는 것은 카드뿐이다. 접는
+/// 화살표가 목록과 함께 굴러 사라지면 다시 펼 데가 없다.
+class _GymMapAndList extends StatefulWidget {
+  const _GymMapAndList({
     required this.gyms,
     required this.header,
     required this.controls,
@@ -267,132 +266,86 @@ class _GymMapAndSheet extends StatefulWidget {
   final Widget? controls;
   final Widget resultSliver;
 
-  /// 시트가 가장 낮을 때 남는 높이 — 손잡이와 머리줄만큼이다. 여기가 0 이 되면
-  /// 목록을 다시 올릴 자리가 사라진다.
-  static const double kCollapsedExtent = 76;
+  /// 반반 자리에서 지도가 갖는 몫. 위에 **가로로 길게** 눕는 띠다 — 절반을 다
+  /// 주면 목록에 카드 한 장 반이 남는다.
+  static const double kMapFraction = 0.42;
 
-  /// 반반 자리. 지도를 절반 남긴 채 여러 곳을 견주는 자리다.
-  static const double kMidSize = 0.5;
+  /// 그 몫의 위·아래 한계. 낮은 화면에서 지도가 띠도 못 되게 얇아지지 않고,
+  /// 큰 화면에서 목록을 밀어내지도 않는다.
+  static const double kMapMin = 150;
+  static const double kMapMax = 280;
 
   @override
-  State<_GymMapAndSheet> createState() => _GymMapAndSheetState();
+  State<_GymMapAndList> createState() => _GymMapAndListState();
 }
 
-class _GymMapAndSheetState extends State<_GymMapAndSheet> {
-  final DraggableScrollableController _sheet = DraggableScrollableController();
-
-  /// 지금 시트가 차지한 비율. 머리줄 화살표가 이 값을 보고 방향을 정한다 —
-  /// 드래그와 화살표가 같은 상태를 가리켜야 둘이 어긋나지 않는다.
-  double _size = _GymMapAndSheet.kMidSize;
-
-  @override
-  void initState() {
-    super.initState();
-    _sheet.addListener(_onSheetMoved);
-  }
-
-  void _onSheetMoved() {
-    if (!_sheet.isAttached) return;
-    final double next = _sheet.size;
-    if ((next - _size).abs() < 0.001) return;
-    setState(() => _size = next);
-  }
-
-  @override
-  void dispose() {
-    _sheet.removeListener(_onSheetMoved);
-    _sheet.dispose();
-    super.dispose();
-  }
-
-  /// 화살표를 눌렀을 때 갈 자리. 맨 아래에서는 위로, 그 밖에서는 한 단계
-  /// 아래로 간다 — 계속 누르면 지도만 남을 때까지 내려가고, 거기서 방향이
-  /// 뒤집힌다.
-  double _nextStop(double min) {
-    if (_size <= min + 0.01) return _GymMapAndSheet.kMidSize;
-    if (_size > _GymMapAndSheet.kMidSize + 0.01) {
-      return _GymMapAndSheet.kMidSize;
-    }
-    return min;
-  }
+class _GymMapAndListState extends State<_GymMapAndList> {
+  /// 목록만 보는 자리인가. 화살표가 이 값 하나를 뒤집는다.
+  bool _listOnly = false;
 
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints box) {
         final double height = box.maxHeight;
-        // 낮은 화면에서도 손잡이와 머리줄은 남아야 하고, 높은 화면에서 그
-        // 비율이 반반을 넘어서도 안 된다.
-        final double minSize = height <= 0
-            ? 0.2
-            : (_GymMapAndSheet.kCollapsedExtent / height).clamp(0.12, 0.45);
-        final bool collapsed = _size <= minSize + 0.01;
-        // 지도는 **시트가 덮지 않는 자리에만** 놓는다 (#1362). 웹에서 카카오
-        // 지도는 플랫폼 뷰(DOM 요소)라, 그 위를 덮은 Flutter 시트에서 시작한
-        // 터치가 아래 지도로 새어 나간다 — 폰에서 시트를 끌면 시트 대신 지도가
-        // 끌리고, 목록을 밀면 목록 대신 지도가 움직였다. 겹치는 자리를 아예
-        // 없애면 그 새는 길이 사라진다. 지도의 **윗변은 그대로** 있으므로 시트가
-        // 오르내려도 지도는 제자리다 (#1135).
-        final double mapHeight = (height * (1 - _size)).clamp(0.0, height);
-        return Stack(
+        // 자리 자체가 좁으면 한계보다 그 자리를 따른다 — 지도가 부모를 넘겨
+        // 목록을 밀어내면 안 된다.
+        final double cap = math.min(_GymMapAndList.kMapMax, height * 0.6);
+        final double floor = math.min(_GymMapAndList.kMapMin, cap);
+        final double mapHeight = _listOnly
+            ? 0
+            : (height * _GymMapAndList.kMapFraction).clamp(floor, cap);
+        return Column(
           children: <Widget>[
-            Positioned(
-              top: 0,
-              left: 0,
-              right: 0,
-              height: mapHeight,
-              child: _GymMap(gyms: widget.gyms),
+            // 지도는 위에 붙박이다. 높이만 두 자리 사이에서 바뀐다.
+            AnimatedSize(
+              duration: const Duration(milliseconds: 220),
+              curve: Curves.easeOutCubic,
+              alignment: Alignment.topCenter,
+              child: SizedBox(
+                key: const Key('gym-map-slot'),
+                height: mapHeight,
+                width: double.infinity,
+                child: mapHeight == 0 ? null : _GymMap(gyms: widget.gyms),
+              ),
             ),
-            DraggableScrollableSheet(
-              controller: _sheet,
-              initialChildSize: _GymMapAndSheet.kMidSize.clamp(minSize, 1),
-              minChildSize: minSize,
-              snap: true,
-              snapSizes: <double>[_GymMapAndSheet.kMidSize.clamp(minSize, 1)],
-              builder:
-                  (
-                    BuildContext context,
-                    ScrollController scrollController,
-                  ) => _SheetSurface(
-                    // 시트의 **겉면**이 이 키를 갖는다. 시트 위젯 자체는
-                    // 스택 전체를 덮고 있어, 그 자리를 재면 시트가 어디에
-                    // 붙어 있는지가 아니라 스택의 윗변이 나온다.
-                    key: const Key('gym-result-sheet'),
-                    child: CustomScrollView(
-                      // 시트 안에서 실제로 구르는 목록. 이 키로 가리킨다 —
-                      // `Scrollable` 이 시트에 둘(시트 자신과 이 목록)이라
-                      // "찾기 화면 안의 유일한 스크롤" 로는 집을 수 없다.
-                      key: const Key('gym-result-list'),
-                      controller: scrollController,
-                      slivers: <Widget>[
-                        SliverToBoxAdapter(
-                          child: _SheetHead(
-                            title: widget.header,
-                            collapsed: collapsed,
-                            onToggle: () => _sheet.animateTo(
-                              _nextStop(minSize),
-                              duration: const Duration(milliseconds: 220),
-                              curve: Curves.easeOutCubic,
-                            ),
-                          ),
-                        ),
-                        if (widget.controls != null)
-                          SliverToBoxAdapter(
-                            child: Padding(
-                              padding: const EdgeInsets.fromLTRB(20, 0, 20, 10),
-                              child: widget.controls,
-                            ),
-                          ),
-                        // 시트는 화면 가로를 다 쓰고, 여백은 그 안에서
-                        // 준다 (#1362).
-                        SliverPadding(
-                          padding: const EdgeInsets.symmetric(horizontal: 20),
-                          sliver: widget.resultSliver,
-                        ),
-                        const SliverToBoxAdapter(child: SizedBox(height: 20)),
-                      ],
+            Expanded(
+              child: _SheetSurface(
+                key: const Key('gym-result-sheet'),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: <Widget>[
+                    _SheetHead(
+                      title: widget.header,
+                      // 반반 자리가 곧 **접힌** 목록이다 — 여기서 화살표는
+                      // 위를 가리키고, 누르면 목록이 화면을 다 쓴다.
+                      collapsed: !_listOnly,
+                      onToggle: () => setState(() => _listOnly = !_listOnly),
                     ),
-                  ),
+                    if (widget.controls != null)
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(20, 0, 20, 10),
+                        child: widget.controls,
+                      ),
+                    // 구르는 것은 카드뿐이다. 제 자리 안에서 구르므로 지도도,
+                    // 바깥 화면도 따라 움직이지 않는다.
+                    Expanded(
+                      child: CustomScrollView(
+                        key: const Key('gym-result-list'),
+                        slivers: <Widget>[
+                          // 시트는 화면 가로를 다 쓰고, 여백은 그 안에서
+                          // 준다 (#1362).
+                          SliverPadding(
+                            padding: const EdgeInsets.symmetric(horizontal: 20),
+                            sliver: widget.resultSliver,
+                          ),
+                          const SliverToBoxAdapter(child: SizedBox(height: 20)),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
             ),
           ],
         );
@@ -429,11 +382,13 @@ class _SheetSurface extends StatelessWidget {
   }
 }
 
-/// 시트 머리 — 잡아 끄는 자리를 알리는 손잡이와, 제목·화살표 한 줄 (#1186).
+/// 목록 머리 — 제목과 화살표 한 줄 (#1186, #1370).
 ///
-/// 화살표는 시트가 맨 아래에 있으면 위를(올릴 수 있다), 그 밖에서는 아래를
-/// (내릴 수 있다) 가리킨다. 드래그와 같은 상태([_GymMapAndSheetState._size])를
-/// 읽으므로 손으로 끌어 놓은 자리와 화살표 방향이 어긋나지 않는다.
+/// 손잡이 표시는 없다. 자리를 바꾸는 길이 화살표 하나뿐이라, 끌 수 있다는
+/// 뜻으로 읽히는 표시를 두면 되지 않는 손짓을 부른다.
+///
+/// 화살표는 목록만 보고 있으면 아래를(지도를 다시 부를 수 있다), 반반이면
+/// 위를(목록을 크게 볼 수 있다) 가리킨다.
 class _SheetHead extends StatelessWidget {
   const _SheetHead({
     required this.title,
@@ -447,28 +402,13 @@ class _SheetHead extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: <Widget>[
-        const SizedBox(height: 8),
-        Center(
-          child: Container(
-            width: 40,
-            height: 4,
-            decoration: BoxDecoration(
-              color: FigmaColors.hairline,
-              borderRadius: BorderRadius.circular(999),
-            ),
-          ),
-        ),
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 20),
-          child: _NearbyHeader(
-            title: title,
-            collapsed: collapsed,
-            onToggle: onToggle,
-          ),
-        ),
-      ],
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 12, 20, 0),
+      child: _NearbyHeader(
+        title: title,
+        collapsed: collapsed,
+        onToggle: onToggle,
+      ),
     );
   }
 }

--- a/frontend/flutter/test/features/exercise/gym_results_panel_test.dart
+++ b/frontend/flutter/test/features/exercise/gym_results_panel_test.dart
@@ -1,7 +1,8 @@
-/// 헬스장 찾기 화면의 지도와 결과 시트. (#865 → #1135 → #1274)
+/// 헬스장 찾기 화면의 지도와 결과 목록. (#865 → #1135 → #1274 → #1362 → #1370)
 ///
-/// 지도는 **자리에 고정**되고 그 위로 목록 시트가 오르내린다. 목록을 밀어도
-/// 지도는 움직이지 않는다 — 예전에 지도까지 함께 밀려 올라가던 것이 이
+/// 지도는 위에 **가로로 길게 고정**되고, 자리는 둘뿐이다 — 반반 / 목록만.
+/// 오가는 길은 머리줄의 화살표 하나이고, 목록은 제 자리 안에서 구른다. 목록을
+/// 굴려도 지도는 움직이지 않는다 — 예전에 지도까지 함께 밀려 올라가던 것이 이
 /// 화면에서 가장 다루기 나빴던 부분이다.
 library;
 
@@ -70,21 +71,49 @@ void main() {
     // 결과 개수와 정렬 줄, 그리고 카드가 함께 읽힌다.
     expect(find.textContaining('개'), findsWidgets);
     expect(find.text('주변 헬스장'), findsOneWidget);
-    // 처음 자리는 반반이다 — 지도와 목록이 함께 읽힌다 (#1274).
-    expect(find.byType(DraggableScrollableSheet), findsOneWidget);
+    // 처음 자리는 반반이다 — 지도와 목록이 함께 읽힌다 (#1274, #1370).
+    expect(
+      tester.getSize(find.byKey(const Key('gym-map-slot'))).height,
+      greaterThan(0),
+    );
   });
 
-  testWidgets('목록을 밀어도 지도는 제자리다 (#1135)', (tester) async {
+  testWidgets('목록은 제 자리에서 구르고 지도는 그대로다 (#1135, #1370)', (tester) async {
     await _pumpFinder(tester);
     final double before = _mapTop(tester);
+    final Finder list = find.byKey(const Key('gym-result-list'));
+    final double listTop = tester.getTopLeft(list).dy;
 
-    await tester.drag(
-      find.byKey(const Key('gym-result-sheet')),
-      const Offset(0, -260),
-    );
+    // 목록을 민다. 카드가 넘어가야 하고(스크롤 위치가 움직인다), 지도와 목록
+    // 자리는 그대로여야 한다.
+    await tester.drag(list, const Offset(0, -200));
     await tester.pumpAndSettle();
 
+    final ScrollPosition position = tester
+        .state<ScrollableState>(
+          find.descendant(of: list, matching: find.byType(Scrollable)).first,
+        )
+        .position;
+    expect(position.pixels, greaterThan(0), reason: '목록이 구르지 않았다');
     expect(_mapTop(tester), before, reason: '목록을 밀었더니 지도까지 따라 올라갔다');
+    expect(tester.getTopLeft(list).dy, listTop, reason: '목록 자리가 함께 움직였다');
+  });
+
+  testWidgets('화살표로 반반 ↔ 목록만 두 자리를 오간다 (#1370)', (tester) async {
+    await _pumpFinder(tester);
+
+    // 처음은 반반 — 지도가 위에 띠로 눕는다.
+    final double half = tester.getSize(find.byKey(const Key('gym-map-slot'))).height;
+    expect(half, greaterThan(0));
+
+    await tester.tap(find.byKey(const ValueKey<String>('gym-list-toggle')));
+    await tester.pumpAndSettle();
+    // 목록만 — 지도 자리가 사라진다.
+    expect(tester.getSize(find.byKey(const Key('gym-map-slot'))).height, 0);
+
+    await tester.tap(find.byKey(const ValueKey<String>('gym-list-toggle')));
+    await tester.pumpAndSettle();
+    expect(tester.getSize(find.byKey(const Key('gym-map-slot'))).height, half);
   });
 
   testWidgets('시트는 화면 가로를 다 쓰고 지도와 겹치지 않는다 (#1362)', (tester) async {
@@ -99,11 +128,10 @@ void main() {
     Rect map() => tester.getRect(find.byType(KakaoMapView).first);
     expect(map().bottom, lessThanOrEqualTo(tester.getTopLeft(sheet).dy + 0.5));
 
-    // 시트를 끌어 올린 뒤에도 겹치지 않는다 — 지도는 시트가 남긴 자리만큼만
-    // 차지한다.
-    await tester.drag(sheet, const Offset(0, -260));
+    // 목록만 보는 자리로 옮긴 뒤에도 겹치지 않는다.
+    await tester.tap(find.byKey(const ValueKey<String>('gym-list-toggle')));
     await tester.pumpAndSettle();
-    expect(map().bottom, lessThanOrEqualTo(tester.getTopLeft(sheet).dy + 0.5));
+    expect(find.byType(KakaoMapView), findsNothing);
   });
 
   testWidgets('검색 결과가 없으면 빈 문구가 그 자리에 뜬다', (tester) async {

--- a/frontend/flutter/test/features/exercise/gym_trainer_line_test.dart
+++ b/frontend/flutter/test/features/exercise/gym_trainer_line_test.dart
@@ -180,17 +180,18 @@ void main() {
     });
   });
 
-  group('지도·목록 드래그 시트 (#1186 · #1274)', () {
+  group('지도·목록 두 자리 (#1186 · #1274 · #1370)', () {
     final Finder sheet = find.byKey(const Key('gym-result-sheet'));
+    final Finder mapSlot = find.byKey(const Key('gym-map-slot'));
     final Finder toggle = find.byKey(const ValueKey<String>('gym-list-toggle'));
 
-    /// 지도의 윗변. 시트를 어디로 옮기든 이 값은 그대로여야 한다.
+    /// 지도의 윗변. 자리를 어떻게 바꾸든 이 값은 그대로여야 한다.
     double mapTop(WidgetTester tester) =>
         tester.getTopLeft(find.byType(KakaoMapView).first).dy;
 
-    /// 시트의 윗변 — 지금 시트가 어디에 붙어 있는지를 이 값으로 읽는다.
-    /// 작을수록 시트가 높이 올라와 목록이 많이 보인다.
-    double sheetTop(WidgetTester tester) => tester.getTopLeft(sheet).dy;
+    IconData? arrow(WidgetTester tester) => tester
+        .widget<Icon>(find.descendant(of: toggle, matching: find.byType(Icon)))
+        .icon;
 
     testWidgets('처음에는 지도와 목록이 함께 보인다', (WidgetTester tester) async {
       await pumpGymTab(tester, hasMyGym: false);
@@ -199,78 +200,48 @@ void main() {
       expect(find.text(_gym.name), findsWidgets);
       expect(find.text('1개 결과'), findsOneWidget);
       expect(find.byType(KakaoMapView), findsOneWidget);
+      // 지도는 위에 가로로 길게 눕고, 목록이 그 아래를 잇는다.
+      expect(tester.getSize(mapSlot).height, greaterThan(0));
+      expect(tester.getTopLeft(sheet).dy, tester.getBottomLeft(mapSlot).dy);
+      expect(arrow(tester), Icons.keyboard_arrow_up_rounded);
     });
 
-    testWidgets('위로 끌면 목록만, 아래로 끌면 지도만 남는다', (WidgetTester tester) async {
+    testWidgets('화살표로 목록만 보고 다시 지도를 부른다', (WidgetTester tester) async {
       await pumpGymTab(tester, hasMyGym: false);
-      final double middle = sheetTop(tester);
+      final double sheetTop = tester.getTopLeft(sheet).dy;
 
-      await tester.drag(sheet, const Offset(0, -400));
-      await tester.pumpAndSettle();
-      final double top = sheetTop(tester);
-      expect(top, lessThan(middle), reason: '위로 끌었는데 시트가 올라오지 않았다');
-
-      await tester.drag(sheet, const Offset(0, 700));
-      await tester.pumpAndSettle();
-      final double bottom = sheetTop(tester);
-      expect(bottom, greaterThan(middle), reason: '아래로 끌었는데 시트가 내려가지 않았다');
-      // 지도만 남은 자리에서도 다시 올릴 머리줄은 보인다.
-      expect(find.text('주변 헬스장'), findsOneWidget);
-      expect(toggle, findsOneWidget);
-    });
-
-    testWidgets('짧게 끌고 손을 떼면 가장 가까운 단계에 붙는다', (WidgetTester tester) async {
-      await pumpGymTab(tester, hasMyGym: false);
-      final double middle = sheetTop(tester);
-
-      // 어정쩡한 거리만 끌고 놓는다 — 그 자리에 멈추면 안 된다.
-      await tester.drag(sheet, const Offset(0, -40));
-      await tester.pumpAndSettle();
-
-      expect(sheetTop(tester), middle);
-    });
-
-    testWidgets('시트를 옮겨도 지도는 제자리다', (WidgetTester tester) async {
-      await pumpGymTab(tester, hasMyGym: false);
-      final double before = mapTop(tester);
-
-      await tester.drag(sheet, const Offset(0, -400));
-      await tester.pumpAndSettle();
-      expect(mapTop(tester), before);
-
-      await tester.drag(sheet, const Offset(0, 700));
-      await tester.pumpAndSettle();
-      expect(mapTop(tester), before);
-    });
-
-    testWidgets('화살표와 드래그가 같은 자리를 가리킨다', (WidgetTester tester) async {
-      await pumpGymTab(tester, hasMyGym: false);
-
-      // 손으로 맨 아래까지 내린다 — 화살표는 이제 위를 가리켜야 한다.
-      await tester.drag(sheet, const Offset(0, 700));
-      await tester.pumpAndSettle();
-      final double bottom = sheetTop(tester);
-      expect(
-        tester
-            .widget<Icon>(
-              find.descendant(of: toggle, matching: find.byType(Icon)),
-            )
-            .icon,
-        Icons.keyboard_arrow_up_rounded,
-      );
-
-      // 그 화살표를 누르면 반반 자리로 돌아온다.
       await tester.tap(toggle);
       await tester.pumpAndSettle();
-      expect(sheetTop(tester), lessThan(bottom));
-      expect(
-        tester
-            .widget<Icon>(
-              find.descendant(of: toggle, matching: find.byType(Icon)),
-            )
-            .icon,
-        Icons.keyboard_arrow_down_rounded,
-      );
+      // 목록만 — 지도 자리가 사라지고 목록이 그 자리를 받는다.
+      expect(tester.getSize(mapSlot).height, 0);
+      expect(find.byType(KakaoMapView), findsNothing);
+      expect(tester.getTopLeft(sheet).dy, lessThan(sheetTop));
+      // 다시 부를 머리줄은 남아 있고, 화살표가 방향을 뒤집는다.
+      expect(find.text('주변 헬스장'), findsOneWidget);
+      expect(arrow(tester), Icons.keyboard_arrow_down_rounded);
+
+      await tester.tap(toggle);
+      await tester.pumpAndSettle();
+      expect(find.byType(KakaoMapView), findsOneWidget);
+      expect(tester.getTopLeft(sheet).dy, sheetTop);
+    });
+
+    testWidgets('끌어서는 자리가 바뀌지 않는다 (#1370)', (WidgetTester tester) async {
+      await pumpGymTab(tester, hasMyGym: false);
+      final double sheetTop = tester.getTopLeft(sheet).dy;
+      final double before = mapTop(tester);
+
+      // 자리를 바꾸는 길은 화살표뿐이다 — 끄는 손짓은 목록 스크롤의 것이라,
+      // 시트가 그 손짓을 가져가면 목록이 넘어가지 않는다.
+      await tester.drag(sheet, const Offset(0, -400));
+      await tester.pumpAndSettle();
+      expect(tester.getTopLeft(sheet).dy, sheetTop);
+      expect(mapTop(tester), before);
+
+      await tester.drag(sheet, const Offset(0, 700));
+      await tester.pumpAndSettle();
+      expect(tester.getTopLeft(sheet).dy, sheetTop);
+      expect(mapTop(tester), before);
     });
   });
 }


### PR DESCRIPTION
Closes #1370

## Summary

헬스장 찾기에서 **목록이 스크롤되지 않던 것**을 고쳤다. 원인은 목록을 미는 손짓과 시트를 끄는 손짓이 같은 방향이라 시트가 그것을 먼저 가져간 것이다. 끌어서 크기를 바꾸는 방식을 걷어내고, 화면을 **두 자리**로만 못 박았다.

## Changes

- 지도는 **화면 위쪽에 가로로 길게 고정**한다. `지도만 크게` 자리는 없앴다.
- 자리는 둘뿐이다 — **반반**과 **목록만**. 머리줄의 화살표로만 오간다(`DraggableScrollableSheet` 제거). 끌 수 있다는 뜻으로 놓았던 손잡이 표시도 뺐다 — 이제 끄는 동작이 없다.
- 반반일 때도 목록은 **제 자리에 고정된 채 그 안에서** 구른다. 목록을 굴려도 지도는 움직이지 않고, 지도를 끌면 지도만 움직인다. 지도와 목록은 자리를 나눠 가지므로 어떤 경우에도 함께 움직이지 않는다(겹치면 웹에서 목록 위 터치가 지도로 샌다, #1362).
- `주변 헬스장` 머리줄과 결과 수·정렬 줄은 목록 **위에 고정**했다. 함께 굴러 사라지면 다시 접을 화살표가 없어진다.
- 반반 자리의 지도 높이는 남는 자리의 42%(150~280 사이)다. 자리가 좁으면 한계보다 그 자리를 따라 목록을 밀어내지 않는다.

## Commits

- `fix(exercise): 헬스장 찾기 목록 스크롤과 지도·목록 두 자리 고정`

## Notes

- 테스트를 새 규칙으로 다시 세웠다: **목록은 제 자리에서 구르고 지도는 그대로**(스크롤 위치가 실제로 움직이는지까지 본다), **화살표로 두 자리를 오간다**, **끌어서는 자리가 바뀌지 않는다**.
- 폴백 그래픽(카카오 키가 없는 환경)도 같은 자리를 차지한다.
