### PR TITLE
fix(reports): 리포트 탭 전송을 PDF로 전환하고 전송 알림에 채팅 이동 추가

### DIFF
--- a/frontend/flutter_trainer/lib/design_system/theme/app_theme.dart
+++ b/frontend/flutter_trainer/lib/design_system/theme/app_theme.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
+import 'package:oncare_trainer/design_system/tokens/toast.dart';
 import 'package:oncare_trainer/design_system/tokens/typography.dart';
 
 /// Builds the trainer app's [ThemeData] from the design tokens. Light
@@ -68,6 +69,15 @@ class AppTheme {
         surfaceTintColor: Colors.transparent,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.all(AppRadius.card),
+        ),
+        // 기본 24 대신 위쪽만 [AppToastStyle.dialogTopClearance] 만큼 띄운다
+        // — 상단 토스트(#1378)가 루트 오버레이라 대화상자 위에 그려지므로,
+        // 대화상자가 화면 꼭대기까지 올라오면 제목·닫기 버튼이 가려진다.
+        insetPadding: EdgeInsets.fromLTRB(
+          AppSpacing.xl,
+          AppToastStyle.dialogTopClearance,
+          AppSpacing.xl,
+          AppSpacing.xl,
         ),
       ),
       snackBarTheme: const SnackBarThemeData(

--- a/frontend/flutter_trainer/lib/design_system/tokens/toast.dart
+++ b/frontend/flutter_trainer/lib/design_system/tokens/toast.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+import 'package:oncare_trainer/design_system/tokens/colors.dart';
+import 'package:oncare_trainer/design_system/tokens/radius.dart';
+import 'package:oncare_trainer/design_system/tokens/spacing.dart';
+import 'package:oncare_trainer/design_system/tokens/typography.dart';
+
+/// 화면 위에 잠깐 떴다 사라지는 알림(토스트)의 생김새.
+///
+/// 사용자 앱의 `AppToastStyle`(#1259)과 같은 모양이다 — 콘솔도 같은 이유로
+/// `SnackBar`가 아니라 루트 오버레이를 쓴다: 리포트 전송처럼 대화상자나 시트
+/// 위에서 결과를 알려야 하는 자리가 있어, `Scaffold` 안에만 그려지는
+/// `SnackBar`로는 가려질 수 있다.
+class AppToastStyle {
+  AppToastStyle._();
+
+  static const Color background = AppColors.foreground;
+
+  static const Color foreground = Color(0xFFFFFFFF);
+
+  /// 어두운 바탕 위에서 읽히는 밝은 강조색. [AppColors.primary]는 이 바탕에서
+  /// 너무 가라앉아 동작 버튼 글자로 쓸 수 없다.
+  static const Color actionText = Color(0xFF7FD0F0);
+
+  static const Color successIcon = Color(0xFF4CD9B0);
+  static const Color errorIcon = Color(0xFFFF8A8A);
+  static const Color infoIcon = Color(0xFF7FD0F0);
+
+  static const double maxWidth = 560;
+
+  /// 토스트가 상태바 아래에서 떨어지는 거리.
+  static const double topGap = AppSpacing.md;
+
+  static const Duration enterDuration = Duration(milliseconds: 220);
+
+  static const Duration exitDuration = Duration(milliseconds: 180);
+
+  static const Duration duration = Duration(seconds: 2);
+
+  /// 동작 버튼이 있는 토스트는 눌러 볼 시간을 더 준다.
+  static const Duration actionDuration = Duration(seconds: 4);
+
+  /// 실패는 사용자가 다시 시도할지 정해야 하므로 조금 더 머문다.
+  static const Duration errorDuration = Duration(milliseconds: 3500);
+
+  static const BorderRadius borderRadius = BorderRadius.all(AppRadius.lg);
+
+  static const TextStyle contentTextStyle = TextStyle(
+    fontFamily: AppTypography.fontFamily,
+    color: foreground,
+    fontSize: 14,
+    height: 1.35,
+    fontWeight: FontWeight.w500,
+  );
+
+  static const TextStyle actionTextStyle = TextStyle(
+    fontFamily: AppTypography.fontFamily,
+    color: actionText,
+    fontSize: 13.5,
+    fontWeight: FontWeight.w800,
+  );
+}

--- a/frontend/flutter_trainer/lib/design_system/tokens/toast.dart
+++ b/frontend/flutter_trainer/lib/design_system/tokens/toast.dart
@@ -14,7 +14,10 @@ import 'package:oncare_trainer/design_system/tokens/typography.dart';
 class AppToastStyle {
   AppToastStyle._();
 
-  static const Color background = AppColors.foreground;
+  /// 트레이너 앱의 기존 `SnackBarThemeData.backgroundColor`와 같은 남색이다
+  /// — 위치만 위로 옮기는 것이지, 알림의 브랜드 색까지 검정으로 바꾸는 게
+  /// 아니다.
+  static const Color background = AppColors.secondary;
 
   static const Color foreground = Color(0xFFFFFFFF);
 

--- a/frontend/flutter_trainer/lib/design_system/tokens/toast.dart
+++ b/frontend/flutter_trainer/lib/design_system/tokens/toast.dart
@@ -34,6 +34,15 @@ class AppToastStyle {
   /// 토스트가 상태바 아래에서 떨어지는 거리.
   static const double topGap = AppSpacing.md;
 
+  /// 대화상자·시트가 화면 위쪽에 남겨야 하는 최소 여백. (#1378)
+  ///
+  /// 토스트는 루트 오버레이라 열려 있는 대화상자 **위**에 그려진다 — 대화상자가
+  /// 화면 꼭대기까지 올라오면 제목·닫기 버튼이 토스트에 가려질 수 있다.
+  /// 값은 토스트의 최대 크기(세 줄 문구 기준 세로 패딩 24 + 줄높이 3줄
+  /// ≈81)에 [topGap] 을 더하고 여유를 얹은 것이다 — 토스트 쪽을 화면
+  /// 어딘가로 옮기는 대신, 대화상자가 이 높이 안으로는 올라오지 않게 한다.
+  static const double dialogTopClearance = 100;
+
   static const Duration enterDuration = Duration(milliseconds: 220);
 
   static const Duration exitDuration = Duration(milliseconds: 180);

--- a/frontend/flutter_trainer/lib/features/clients/data/repositories/dio_chat_repository.dart
+++ b/frontend/flutter_trainer/lib/features/clients/data/repositories/dio_chat_repository.dart
@@ -66,7 +66,10 @@ class DioChatRepository implements ChatRepository {
   Future<void> sendTrainerMessage({
     required String clientId,
     required String text,
+    DateTime? reportWeekStart,
   }) async {
+    // reportWeekStart는 데모/드리프트 전용이다 — 실서버는 `/report/send-pdf`가
+    // 첨부 메타데이터를 직접 붙이므로 이 경로로 오지 않는다.
     final trimmed = text.trim();
     if (trimmed.isEmpty) return;
     final encodedId = Uri.encodeComponent(clientId);

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:oncare_trainer/app/router/routes.dart';
 import 'package:oncare_trainer/core/config/app_config.dart';
 import 'package:oncare_trainer/core/errors/app_error.dart';
 import 'package:oncare_trainer/core/utils/server_message.dart';
@@ -242,7 +244,13 @@ class _ChatViewState extends ConsumerState<ChatView> {
         }
       }
       out
-        ..add(_Bubble(message: m, avatar: widget.clientAvatar))
+        ..add(
+          _Bubble(
+            message: m,
+            avatar: widget.clientAvatar,
+            clientId: widget.clientId,
+          ),
+        )
         ..add(const SizedBox(height: AppSpacing.md));
       final insight = _insightDetector.detect(m);
       if (insight != null) {
@@ -652,7 +660,11 @@ class _DateDivider extends StatelessWidget {
 }
 
 class _Bubble extends ConsumerWidget {
-  const _Bubble({required this.message, required this.avatar});
+  const _Bubble({
+    required this.message,
+    required this.avatar,
+    required this.clientId,
+  });
 
   /// 말풍선이 차지할 수 있는 대화 폭의 최대 비율.
   ///
@@ -668,56 +680,71 @@ class _Bubble extends ConsumerWidget {
 
   final ClientChatMessage message;
   final String avatar;
+  final String clientId;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final fromTrainer = message.fromTrainer;
-    final bubble = Container(
-      key: ValueKey<String>('trainer-message-bubble-${message.id}'),
-      padding: const EdgeInsets.symmetric(
-        horizontal: AppSpacing.md,
-        vertical: AppSpacing.sm,
-      ),
-      decoration: BoxDecoration(
-        color: fromTrainer ? AppColors.accent : AppColors.card,
-        border: fromTrainer ? null : Border.all(color: AppColors.borderStrong),
-        borderRadius: BorderRadius.only(
-          topLeft: const Radius.circular(16),
-          topRight: const Radius.circular(16),
-          bottomLeft: Radius.circular(fromTrainer ? 16 : 4),
-          bottomRight: Radius.circular(fromTrainer ? 4 : 16),
+    final Widget bubble;
+    if (message.reportWeekStart case final weekStart?) {
+      // 데모/드리프트는 PDF를 저장하지 못한다(#1378) — 그냥 텍스트 말풍선
+      // 대신, 리포트를 보냈다는 걸 알아볼 수 있는 카드로 구분해 그린다.
+      // 눌러도 파일을 열 수는 없으니, 대신 그 리포트 화면으로 보낸다.
+      bubble = _ReportSentCard(
+        key: ValueKey<String>('trainer-message-bubble-${message.id}'),
+        weekStart: weekStart,
+        onOpen: () => context.go(AppRoutes.reportFor(clientId)),
+      );
+    } else {
+      bubble = Container(
+        key: ValueKey<String>('trainer-message-bubble-${message.id}'),
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.md,
+          vertical: AppSpacing.sm,
         ),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Text(
-            message.body,
-            style: TextStyle(
-              fontSize: 13.5,
-              height: 1.4,
-              fontWeight: FontWeight.w500,
-              color: fromTrainer
-                  ? AppColors.accentForeground
-                  : AppColors.foreground,
-            ),
+        decoration: BoxDecoration(
+          color: fromTrainer ? AppColors.accent : AppColors.card,
+          border: fromTrainer
+              ? null
+              : Border.all(color: AppColors.borderStrong),
+          borderRadius: BorderRadius.only(
+            topLeft: const Radius.circular(16),
+            topRight: const Radius.circular(16),
+            bottomLeft: Radius.circular(fromTrainer ? 16 : 4),
+            bottomRight: Radius.circular(fromTrainer ? 4 : 16),
           ),
-          if (message.attachment case final attachment?) ...<Widget>[
-            const SizedBox(height: AppSpacing.sm),
-            // 사진은 대화 안에서 그리고, PDF 는 내려받는 카드로 둔다. 사진을
-            // 카드로 두면 자세를 확인하려고 매번 파일을 열어야 하고, 그건
-            // 채팅에 사진을 붙이는 이유 자체를 없앤다. (#921)
-            if (attachment.isImage)
-              ChatImageAttachment(attachment: attachment)
-            else
-              _ChatPdfCard(
-                attachment: attachment,
-                onOpen: () => _openPdf(context, ref, attachment),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              message.body,
+              style: TextStyle(
+                fontSize: 13.5,
+                height: 1.4,
+                fontWeight: FontWeight.w500,
+                color: fromTrainer
+                    ? AppColors.accentForeground
+                    : AppColors.foreground,
               ),
+            ),
+            if (message.attachment case final attachment?) ...<Widget>[
+              const SizedBox(height: AppSpacing.sm),
+              // 사진은 대화 안에서 그리고, PDF 는 내려받는 카드로 둔다. 사진을
+              // 카드로 두면 자세를 확인하려고 매번 파일을 열어야 하고, 그건
+              // 채팅에 사진을 붙이는 이유 자체를 없앤다. (#921)
+              if (attachment.isImage)
+                ChatImageAttachment(attachment: attachment)
+              else
+                _ChatPdfCard(
+                  attachment: attachment,
+                  onOpen: () => _openPdf(context, ref, attachment),
+                ),
+            ],
           ],
-        ],
-      ),
-    );
+        ),
+      );
+    }
     final time = Text(
       _clockOnly(message.timeLabel),
       key: ValueKey<String>('trainer-message-time-${message.id}'),
@@ -791,6 +818,63 @@ class _Bubble extends ConsumerWidget {
     } catch (_) {
       messenger.showSnackBar(SnackBar(content: Text(l.chatPdfOpenFailed)));
     }
+  }
+}
+
+/// 리포트 PDF 전송 안내. (#1378) 일반 텍스트 말풍선과 헷갈리지 않도록
+/// 더 진한 남색으로 구분하고, 누르면 그 고객의 리포트 화면으로 이동한다.
+class _ReportSentCard extends StatelessWidget {
+  const _ReportSentCard({
+    required this.weekStart,
+    required this.onOpen,
+    super.key,
+  });
+
+  final DateTime weekStart;
+  final VoidCallback onOpen;
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    final weekEnd = weekStart.add(const Duration(days: 6));
+    final range = l.dateRange(
+      l.dateMonthDay(weekStart.month, weekStart.day),
+      l.dateMonthDay(weekEnd.month, weekEnd.day),
+    );
+    return Material(
+      color: AppColors.secondary,
+      borderRadius: const BorderRadius.all(AppRadius.sm),
+      child: InkWell(
+        onTap: onOpen,
+        borderRadius: const BorderRadius.all(AppRadius.sm),
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.sm),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              const Icon(Icons.description_outlined, color: Colors.white),
+              const SizedBox(width: AppSpacing.sm),
+              Flexible(
+                child: Text(
+                  l.chatReportSentNotice(range),
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 13.5,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+              const SizedBox(width: AppSpacing.sm),
+              const Icon(
+                Icons.chevron_right,
+                size: 18,
+                color: Colors.white,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }
 

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_connect_dialog.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_connect_dialog.dart
@@ -6,6 +6,7 @@ import 'package:oncare_trainer/core/utils/server_message.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
+import 'package:oncare_trainer/design_system/tokens/toast.dart';
 import 'package:oncare_trainer/features/clients/data/repositories/client_invite_repository.dart';
 import 'package:oncare_trainer/features/clients/domain/entities/client_invite.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
@@ -162,7 +163,14 @@ class _ClientConnectDialogState extends ConsumerState<ClientConnectDialog> {
       key: const ValueKey<String>('client-connect-dialog'),
       backgroundColor: AppColors.background,
       surfaceTintColor: Colors.transparent,
-      insetPadding: const EdgeInsets.all(AppSpacing.xl),
+      // 위쪽만 [AppToastStyle.dialogTopClearance] — 상단 토스트가 이
+      // 대화상자 위로 겹쳐 뜰 수 있다.
+      insetPadding: const EdgeInsets.fromLTRB(
+        AppSpacing.xl,
+        AppToastStyle.dialogTopClearance,
+        AppSpacing.xl,
+        AppSpacing.xl,
+      ),
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.all(AppRadius.card),
       ),

--- a/frontend/flutter_trainer/lib/features/consultations/presentation/pages/consultations_page.dart
+++ b/frontend/flutter_trainer/lib/features/consultations/presentation/pages/consultations_page.dart
@@ -8,6 +8,7 @@ import 'package:oncare_trainer/core/utils/server_message.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
+import 'package:oncare_trainer/design_system/tokens/toast.dart';
 import 'package:oncare_trainer/features/consultations/data/dtos/consultation_dtos.dart';
 import 'package:oncare_trainer/features/consultations/data/repositories/consultation_repository.dart';
 import 'package:oncare_trainer/features/consultations/domain/entities/consultation_request.dart';
@@ -179,7 +180,14 @@ class ConsultationsPage extends ConsumerWidget {
       key: const ValueKey<String>('consultations-dialog'),
       backgroundColor: AppColors.background,
       surfaceTintColor: Colors.transparent,
-      insetPadding: const EdgeInsets.all(AppSpacing.xl),
+      // 위쪽만 [AppToastStyle.dialogTopClearance] — 상단 토스트가 이
+      // 대화상자 위로 겹쳐 뜰 수 있다.
+      insetPadding: const EdgeInsets.fromLTRB(
+        AppSpacing.xl,
+        AppToastStyle.dialogTopClearance,
+        AppSpacing.xl,
+        AppSpacing.xl,
+      ),
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.all(AppRadius.card),
       ),

--- a/frontend/flutter_trainer/lib/features/my/presentation/pages/my_page.dart
+++ b/frontend/flutter_trainer/lib/features/my/presentation/pages/my_page.dart
@@ -14,6 +14,7 @@ import 'package:oncare_trainer/design_system/tokens/elevation.dart';
 import 'package:oncare_trainer/design_system/tokens/layout.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
+import 'package:oncare_trainer/design_system/tokens/toast.dart';
 import 'package:oncare_trainer/features/auth/presentation/controllers/session_controller.dart';
 import 'package:oncare_trainer/features/my/data/trainer_account_repository.dart';
 import 'package:oncare_trainer/features/my/data/trainer_profile_repository.dart';
@@ -559,6 +560,14 @@ class _MyPageState extends ConsumerState<MyPage> {
       backgroundColor: AppColors.card,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: AppRadius.card),
+      ),
+      // 상단 토스트가 이 시트 위로 겹쳐 뜰 수 있다 — 화면 꼭대기까지
+      // 올라오지 않게 남길 최소 높이를 [AppToastStyle.dialogTopClearance]
+      // 로 잡는다.
+      constraints: BoxConstraints(
+        maxHeight:
+            MediaQuery.sizeOf(context).height -
+            AppToastStyle.dialogTopClearance,
       ),
       builder: (context) => const _PasswordSheet(),
     );

--- a/frontend/flutter_trainer/lib/features/reports/data/repositories/report_repository.dart
+++ b/frontend/flutter_trainer/lib/features/reports/data/repositories/report_repository.dart
@@ -11,6 +11,7 @@ import 'package:oncare_trainer/core/utils/clock.dart';
 import 'package:oncare_trainer/core/utils/date_format.dart';
 import 'package:oncare_trainer/features/reports/domain/report_summary.dart';
 import 'package:oncare_trainer/features/reports/domain/weekly_report.dart';
+import 'package:oncare_trainer/features/reports/services/report_pdf_sender.dart';
 import 'package:oncare_trainer/features/schedule/data/repositories/schedule_repository.dart';
 import 'package:oncare_trainer/shared/models/trainer_client.dart';
 import 'package:oncare_trainer/shared/services/chat_repository.dart';
@@ -51,6 +52,18 @@ abstract interface class ReportRepository {
   Future<void> send({
     required String clientId,
     required DateTime weekStart,
+    required String message,
+  });
+
+  /// Sends the report as a PDF attachment, with [message] as the chat
+  /// body. (#1378) The header 공유 메뉴의 기본 전송이 부르는 자리다 — 회원
+  /// 채팅에서 PDF를 열람하는 길(#778, #921)이 이미 있어, 굳이 글만 보낼
+  /// 이유가 없다.
+  Future<void> sendPdf({
+    required String clientId,
+    required DateTime weekStart,
+    required Uint8List bytes,
+    required String fileName,
     required String message,
   });
 
@@ -183,6 +196,19 @@ class LocalReportRepository implements ReportRepository {
   }
 
   @override
+  Future<void> sendPdf({
+    required String clientId,
+    required DateTime weekStart,
+    required Uint8List bytes,
+    required String fileName,
+    required String message,
+  }) {
+    // 데모/드리프트에는 첨부 저장소가 없다 — 회원이 실제로 읽는 것은 이
+    // 메시지 본문이니, 로컬 채팅에는 그대로 텍스트로 전달한다.
+    return _chat.sendTrainerMessage(clientId: clientId, text: message);
+  }
+
+  @override
   Future<ReportFeedbackDraft> feedbackDraft({
     required TrainerClient client,
     required DateTime weekStart,
@@ -222,9 +248,13 @@ class LocalReportRepository implements ReportRepository {
 /// the server records it on the same thread the member app reads.
 class DioReportRepository implements ReportRepository {
   /// Creates the API-backed source.
-  const DioReportRepository(this._dio);
+  DioReportRepository(this._dio) : _pdfSender = ReportPdfSender(_dio);
 
   final Dio _dio;
+
+  /// PDF 전송의 multipart 요청·재시도 idempotency key를 만드는 쪽 — 저장소가
+  /// 살아 있는 동안(=앱 세션 동안) 같은 인스턴스를 재사용해 키가 유지된다.
+  final ReportPdfSender _pdfSender;
 
   @override
   Stream<WeeklyReport> watch({
@@ -293,6 +323,27 @@ class DioReportRepository implements ReportRepository {
           'week_start': ymd(weekStart),
           'message': message,
         },
+      );
+    } on DioException catch (e) {
+      throw AppError.fromDio(e);
+    }
+  }
+
+  @override
+  Future<void> sendPdf({
+    required String clientId,
+    required DateTime weekStart,
+    required Uint8List bytes,
+    required String fileName,
+    required String message,
+  }) async {
+    try {
+      await _pdfSender.send(
+        clientId: clientId,
+        weekStart: weekStart,
+        bytes: bytes,
+        fileName: fileName,
+        message: message,
       );
     } on DioException catch (e) {
       throw AppError.fromDio(e);

--- a/frontend/flutter_trainer/lib/features/reports/data/repositories/report_repository.dart
+++ b/frontend/flutter_trainer/lib/features/reports/data/repositories/report_repository.dart
@@ -203,9 +203,13 @@ class LocalReportRepository implements ReportRepository {
     required String fileName,
     required String message,
   }) {
-    // 데모/드리프트에는 첨부 저장소가 없다 — 회원이 실제로 읽는 것은 이
-    // 메시지 본문이니, 로컬 채팅에는 그대로 텍스트로 전달한다.
-    return _chat.sendTrainerMessage(clientId: clientId, text: message);
+    // 데모/드리프트에는 첨부 저장소가 없다 — 대신 reportWeekStart를 실어
+    // 보내, 채팅 화면이 이 메시지를 리포트 전송 안내로 구분해 그리게 한다.
+    return _chat.sendTrainerMessage(
+      clientId: clientId,
+      text: message,
+      reportWeekStart: weekStart,
+    );
   }
 
   @override

--- a/frontend/flutter_trainer/lib/features/reports/presentation/pages/reports_page.dart
+++ b/frontend/flutter_trainer/lib/features/reports/presentation/pages/reports_page.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -16,6 +18,7 @@ import 'package:oncare_trainer/features/reports/presentation/widgets/report_pdf_
 import 'package:oncare_trainer/features/reports/presentation/widgets/report_share_menu.dart';
 import 'package:oncare_trainer/features/reports/presentation/widgets/report_summary_hint.dart';
 import 'package:oncare_trainer/features/reports/presentation/widgets/report_week_nav.dart';
+import 'package:oncare_trainer/features/reports/services/report_pdf_file_name.dart';
 import 'package:oncare_trainer/features/reports/services/report_pdf_generator.dart';
 import 'package:oncare_trainer/features/schedule/data/repositories/schedule_repository.dart';
 import 'package:oncare_trainer/features/search/presentation/widgets/client_search_bar.dart';
@@ -23,6 +26,7 @@ import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 import 'package:oncare_trainer/shared/models/trainer_client.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
 import 'package:oncare_trainer/shared/widgets/action_button.dart';
+import 'package:oncare_trainer/shared/widgets/app_toast.dart';
 import 'package:oncare_trainer/shared/widgets/page_scaffold.dart';
 import 'package:oncare_trainer/shared/widgets/section_card.dart';
 
@@ -243,6 +247,39 @@ class _ReportsPageState extends ConsumerState<ReportsPage> {
     );
   }
 
+  /// 리포트 PDF binary. [_send]의 기본 전송과 [_openPdfExport]의 내보내기가
+  /// 같은 문서를 만든다 — 전송이 실제로 받는 것과 내보내기 미리보기가 다른
+  /// 문서면 안 된다.
+  Future<Uint8List> _generateReportPdf(
+    AppLocalizations l,
+    WeeklyReport report,
+    String feedback,
+  ) async {
+    WeeklyReport? previous;
+    try {
+      previous = await ref.read(
+        weeklyReportProvider((
+          client: report.client,
+          weekStart: report.weekStart.subtract(const Duration(days: 7)),
+        )).future,
+      );
+    } catch (_) {
+      // 전주 집계가 없어도 현재 주차 PDF는 생성할 수 있다.
+    }
+    return ref
+        .read(reportPdfGeneratorProvider)
+        .generate(
+          l: l,
+          report: report,
+          feedback: feedback,
+          previousReport: previous,
+        );
+  }
+
+  /// 헤더 공유 메뉴의 기본 전송 — PDF로 만들어 보낸다(#1378). 예전에는 순수
+  /// 텍스트만 갔는데, 회원 채팅에서 PDF를 열람하는 길(#778, #921)이 이미 있어
+  /// 굳이 글만 보낼 이유가 없었다. "PDF 내보내기"(별도 저장·인쇄용, [_openPdfExport])는
+  /// 그대로 둔다.
   Future<void> _send(WeeklyReport report, String message) async {
     final AppLocalizations l = AppLocalizations.of(context);
     final id = report.client.id;
@@ -251,9 +288,16 @@ class _ReportsPageState extends ConsumerState<ReportsPage> {
     final messenger = ScaffoldMessenger.of(context);
     setState(() => _sending = id);
     try {
+      final bytes = await _generateReportPdf(l, report, message);
       await ref
           .read(reportRepositoryProvider)
-          .send(clientId: id, weekStart: report.weekStart, message: message);
+          .sendPdf(
+            clientId: id,
+            weekStart: report.weekStart,
+            bytes: bytes,
+            fileName: reportPdfFileName(l, report),
+            message: message,
+          );
     } catch (_) {
       if (!mounted) return;
       setState(() => _sending = null);
@@ -265,8 +309,16 @@ class _ReportsPageState extends ConsumerState<ReportsPage> {
       _sending = null;
       _sent.add(id);
     });
-    messenger.showSnackBar(
-      SnackBar(content: Text(l.reportsSent(report.client.name))),
+    // 전송 확인은 하단 SnackBar가 아니라 상단 토스트로 뜬다 — 채팅으로
+    // 바로 넘어갈 수 있는 동작 버튼을 붙이기 위해서다(#1378).
+    showAppToast(
+      context,
+      l.reportsSent(report.client.name),
+      kind: AppToastKind.success,
+      action: AppToastAction(
+        label: l.reportsGoToChat,
+        onTap: () => context.go(AppRoutes.messagesFor(id)),
+      ),
     );
   }
 
@@ -279,25 +331,7 @@ class _ReportsPageState extends ConsumerState<ReportsPage> {
     final feedback = _messageFor(l, report, _savedDraftOf(report));
     setState(() => _generatingPdf = true);
     try {
-      WeeklyReport? previous;
-      try {
-        previous = await ref.read(
-          weeklyReportProvider((
-            client: report.client,
-            weekStart: report.weekStart.subtract(const Duration(days: 7)),
-          )).future,
-        );
-      } catch (_) {
-        // 전주 집계가 없어도 현재 주차 PDF는 생성할 수 있다.
-      }
-      final bytes = await ref
-          .read(reportPdfGeneratorProvider)
-          .generate(
-            l: l,
-            report: report,
-            feedback: feedback,
-            previousReport: previous,
-          );
+      final bytes = await _generateReportPdf(l, report, feedback);
       if (!mounted) return;
       await showDialog<void>(
         context: context,

--- a/frontend/flutter_trainer/lib/features/reports/presentation/widgets/report_pdf_export_dialog.dart
+++ b/frontend/flutter_trainer/lib/features/reports/presentation/widgets/report_pdf_export_dialog.dart
@@ -2,9 +2,9 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:oncare_trainer/core/utils/date_format.dart';
 import 'package:oncare_trainer/features/reports/domain/weekly_report.dart';
 import 'package:oncare_trainer/features/reports/services/report_pdf_actions.dart';
+import 'package:oncare_trainer/features/reports/services/report_pdf_file_name.dart';
 import 'package:oncare_trainer/features/reports/services/report_pdf_sender.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 
@@ -29,20 +29,6 @@ class ReportPdfExportDialog extends ConsumerStatefulWidget {
 
 class _ReportPdfExportDialogState extends ConsumerState<ReportPdfExportDialog> {
   bool _sending = false;
-
-  /// 파일명은 로컬 저장뿐 아니라 multipart 헤더의 `filename` 으로도 그대로
-  /// 나간다. 경로 구분자 외에 제어문자까지 지우는 이유다 — 고객 이름에 개행이
-  /// 섞이면 헤더가 깨진다. 지운 결과가 비면 날짜만 남은 이름이 되므로 대체어를
-  /// 쓴다.
-  String _fileNameFor(AppLocalizations l) {
-    final safeName = widget.report.client.name
-        .replaceAll(RegExp(r'[/\\:*?"<>|\x00-\x1f\x7f]'), '_')
-        .trim();
-    final name = safeName.replaceAll('_', '').trim().isEmpty
-        ? l.reportsPdfFallbackClient
-        : safeName;
-    return '${name}_${ymd(widget.report.weekStart)}_주간리포트.pdf';
-  }
 
   Future<void> _run(Future<void> Function() action, String success) async {
     final l = AppLocalizations.of(context);
@@ -70,7 +56,7 @@ class _ReportPdfExportDialogState extends ConsumerState<ReportPdfExportDialog> {
             clientId: widget.report.client.id,
             weekStart: widget.report.weekStart,
             bytes: widget.bytes,
-            fileName: _fileNameFor(l),
+            fileName: reportPdfFileName(l, widget.report),
             message: l.reportsPdfMessage,
           ),
       l.reportsPdfSent(widget.report.client.name),
@@ -97,7 +83,7 @@ class _ReportPdfExportDialogState extends ConsumerState<ReportPdfExportDialog> {
         TextButton.icon(
           key: const ValueKey<String>('report-pdf-save'),
           onPressed: () => _run(
-            () => actions.save(widget.bytes, _fileNameFor(l)),
+            () => actions.save(widget.bytes, reportPdfFileName(l, widget.report)),
             l.reportsPdfSaveStarted,
           ),
           icon: const Icon(Icons.download_outlined),
@@ -106,7 +92,7 @@ class _ReportPdfExportDialogState extends ConsumerState<ReportPdfExportDialog> {
         TextButton.icon(
           key: const ValueKey<String>('report-pdf-print'),
           onPressed: () => _run(
-            () => actions.print(widget.bytes, _fileNameFor(l)),
+            () => actions.print(widget.bytes, reportPdfFileName(l, widget.report)),
             l.reportsPdfPrintOpened,
           ),
           icon: const Icon(Icons.print_outlined),

--- a/frontend/flutter_trainer/lib/features/reports/services/report_pdf_file_name.dart
+++ b/frontend/flutter_trainer/lib/features/reports/services/report_pdf_file_name.dart
@@ -1,0 +1,19 @@
+import 'package:oncare_trainer/core/utils/date_format.dart';
+import 'package:oncare_trainer/features/reports/domain/weekly_report.dart';
+import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
+
+/// 리포트 PDF 파일명. 저장·전송(#1378)이 같은 이름을 쓴다.
+///
+/// 파일명은 로컬 저장뿐 아니라 multipart 헤더의 `filename` 으로도 그대로
+/// 나간다. 경로 구분자 외에 제어문자까지 지우는 이유다 — 고객 이름에 개행이
+/// 섞이면 헤더가 깨진다. 지운 결과가 비면 날짜만 남은 이름이 되므로 대체어를
+/// 쓴다.
+String reportPdfFileName(AppLocalizations l, WeeklyReport report) {
+  final safeName = report.client.name
+      .replaceAll(RegExp(r'[/\\:*?"<>|\x00-\x1f\x7f]'), '_')
+      .trim();
+  final name = safeName.replaceAll('_', '').trim().isEmpty
+      ? l.reportsPdfFallbackClient
+      : safeName;
+  return '${name}_${ymd(report.weekStart)}_주간리포트.pdf';
+}

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
@@ -9,6 +9,7 @@ import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/design_system/tokens/layout.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
+import 'package:oncare_trainer/design_system/tokens/toast.dart';
 import 'package:oncare_trainer/features/consultations/data/repositories/consultation_repository.dart';
 import 'package:oncare_trainer/features/consultations/presentation/pages/consultations_page.dart';
 import 'package:oncare_trainer/features/schedule/data/repositories/schedule_repository.dart';
@@ -141,7 +142,14 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
       context: context,
       builder: (dialogContext) => Dialog(
         backgroundColor: Colors.transparent,
-        insetPadding: const EdgeInsets.all(AppSpacing.lg),
+        // 위쪽만 [AppToastStyle.dialogTopClearance] — 상단 토스트가 이
+        // 대화상자 위로 겹쳐 뜰 수 있다.
+        insetPadding: const EdgeInsets.fromLTRB(
+          AppSpacing.lg,
+          AppToastStyle.dialogTopClearance,
+          AppSpacing.lg,
+          AppSpacing.lg,
+        ),
         child: ConstrainedBox(
           constraints: BoxConstraints(
             maxWidth: 560,

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/session_time_range_dialog.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/session_time_range_dialog.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
+import 'package:oncare_trainer/design_system/tokens/toast.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 import 'package:oncare_trainer/shared/widgets/dialog_close_button.dart';
 import 'package:oncare_trainer/shared/widgets/hour_clock_dial.dart';
@@ -23,7 +24,14 @@ Future<(TimeOfDay, TimeOfDay)?> showSessionTimeRangeDialog({
     context: context,
     builder: (dialogContext) => Dialog(
       backgroundColor: Colors.transparent,
-      insetPadding: const EdgeInsets.all(AppSpacing.lg),
+      // 위쪽만 [AppToastStyle.dialogTopClearance] — 상단 토스트가 이
+      // 대화상자 위로 겹쳐 뜰 수 있다.
+      insetPadding: const EdgeInsets.fromLTRB(
+        AppSpacing.lg,
+        AppToastStyle.dialogTopClearance,
+        AppSpacing.lg,
+        AppSpacing.lg,
+      ),
       child: ConstrainedBox(
         constraints: BoxConstraints(
           maxWidth: 420,

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/time_range_picker_dialog.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/time_range_picker_dialog.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
+import 'package:oncare_trainer/design_system/tokens/toast.dart';
 
 typedef TimeRangeValue = ({TimeOfDay start, TimeOfDay end});
 
@@ -124,7 +125,14 @@ class _TimeRangePickerDialogState extends State<_TimeRangePickerDialog> {
     final endMinutes = _end.hour * 60 + _end.minute;
     final startMinutes = _start.hour * 60 + _start.minute;
     return Dialog(
-      insetPadding: const EdgeInsets.all(AppSpacing.lg),
+      // 위쪽만 [AppToastStyle.dialogTopClearance] — 상단 토스트가 이
+      // 대화상자 위로 겹쳐 뜰 수 있다.
+      insetPadding: const EdgeInsets.fromLTRB(
+        AppSpacing.lg,
+        AppToastStyle.dialogTopClearance,
+        AppSpacing.lg,
+        AppSpacing.lg,
+      ),
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.all(AppRadius.lg),
       ),

--- a/frontend/flutter_trainer/lib/features/search/presentation/widgets/client_search_bar.dart
+++ b/frontend/flutter_trainer/lib/features/search/presentation/widgets/client_search_bar.dart
@@ -12,6 +12,7 @@ import 'package:oncare_trainer/design_system/tokens/elevation.dart';
 import 'package:oncare_trainer/design_system/tokens/layout.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
+import 'package:oncare_trainer/design_system/tokens/toast.dart';
 import 'package:oncare_trainer/features/schedule/data/repositories/schedule_repository.dart';
 import 'package:oncare_trainer/features/schedule/domain/entities/schedule_session.dart';
 import 'package:oncare_trainer/features/search/domain/client_search.dart';
@@ -778,8 +779,10 @@ class _ClientSearchDialogState extends ConsumerState<_ClientSearchDialog> {
       alignment: Alignment.topCenter,
       backgroundColor: Colors.transparent,
       elevation: 0,
+      // 위쪽만 [AppToastStyle.dialogTopClearance] — 상단 토스트가 이
+      // 드롭다운 위로 겹쳐 뜰 수 있다.
       insetPadding: const EdgeInsets.only(
-        top: AppSpacing.xxl,
+        top: AppToastStyle.dialogTopClearance,
         left: AppSpacing.lg,
         right: AppSpacing.lg,
       ),

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
@@ -1670,6 +1670,12 @@ abstract class AppLocalizations {
   /// **'Couldn\'t open the PDF. Please try again'**
   String get chatPdfOpenFailed;
 
+  /// No description provided for @chatReportSentNotice.
+  ///
+  /// In en, this message translates to:
+  /// **'Sent the {range} weekly report'**
+  String chatReportSentNotice(Object range);
+
   /// No description provided for @chatLoadFailed.
   ///
   /// In en, this message translates to:

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
@@ -2276,6 +2276,12 @@ abstract class AppLocalizations {
   /// **'Report sent to {name}'**
   String reportsSent(String name);
 
+  /// No description provided for @reportsGoToChat.
+  ///
+  /// In en, this message translates to:
+  /// **'Go to chat'**
+  String get reportsGoToChat;
+
   /// No description provided for @reportsScheduleWarning.
   ///
   /// In en, this message translates to:

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
@@ -1251,6 +1251,9 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get reportsGoToChat => 'Go to chat';
+
+  @override
   String get reportsScheduleWarning =>
       'This week\'s schedule didn\'t load, so session counts may be missing';
 

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
@@ -898,6 +898,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chatPdfOpenFailed => 'Couldn\'t open the PDF. Please try again';
 
   @override
+  String chatReportSentNotice(Object range) {
+    return 'Sent the $range weekly report';
+  }
+
+  @override
   String get chatLoadFailed => 'Couldn\'t load the conversation';
 
   @override

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
@@ -865,6 +865,11 @@ class AppLocalizationsKo extends AppLocalizations {
   String get chatPdfOpenFailed => 'PDF를 열지 못했어요. 다시 시도해 주세요';
 
   @override
+  String chatReportSentNotice(Object range) {
+    return '$range 주간 리포트를 보냈어요';
+  }
+
+  @override
   String get chatLoadFailed => '대화를 불러오지 못했어요';
 
   @override

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
@@ -1208,6 +1208,9 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String get reportsGoToChat => '채팅으로 이동하기';
+
+  @override
   String get reportsScheduleWarning => '이번 주 일정을 불러오지 못해 세션 수가 비어 있을 수 있어요';
 
   @override

--- a/frontend/flutter_trainer/lib/l10n/app_en.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_en.arb
@@ -407,6 +407,7 @@
   "chatTooLong": "Message is too long (2000 characters max)",
   "chatSendFailed": "Couldn't send the message. Please try again",
   "chatPdfOpenFailed": "Couldn't open the PDF. Please try again",
+  "chatReportSentNotice": "Sent the {range} weekly report",
   "chatLoadFailed": "Couldn't load the conversation",
   "chatDemoAnalyzed": "AI analysed {name}'s meals and workouts",
   "@chatDemoAnalyzed": {

--- a/frontend/flutter_trainer/lib/l10n/app_en.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_en.arb
@@ -649,6 +649,7 @@
   "reportsWeekly": "Weekly report",
   "reportsSendFailed": "Couldn't send the report. Please try again",
   "reportsSent": "Report sent to {name}",
+  "reportsGoToChat": "Go to chat",
   "@reportsSent": {
     "placeholders": {
       "name": {

--- a/frontend/flutter_trainer/lib/l10n/app_ko.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_ko.arb
@@ -271,6 +271,7 @@
   "chatSendFailed": "메시지 전송에 실패했어요. 다시 시도해 주세요",
   "chatLoadFailed": "대화를 불러오지 못했어요",
   "chatPdfOpenFailed": "PDF를 열지 못했어요. 다시 시도해 주세요",
+  "chatReportSentNotice": "{range} 주간 리포트를 보냈어요",
   "chatDemoAnalyzed": "AI가 {name}님의 식단·운동 데이터를 분석했어요",
   "chatDemoReportSent": "트레이너님께 요약 리포트가 전송됐어요",
   "chatDemoRoutineSent": "AI 분석 기반 루틴이 {name}님에게 전송됐어요",

--- a/frontend/flutter_trainer/lib/l10n/app_ko.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_ko.arb
@@ -388,6 +388,7 @@
   "reportsWeekly": "주간 리포트",
   "reportsSendFailed": "리포트 전송에 실패했어요. 다시 시도해 주세요",
   "reportsSent": "{name}님에게 리포트를 보냈어요",
+  "reportsGoToChat": "채팅으로 이동하기",
   "reportsScheduleWarning": "이번 주 일정을 불러오지 못해 세션 수가 비어 있을 수 있어요",
   "unitTimes": "회",
   "unitMinutes": "분",

--- a/frontend/flutter_trainer/lib/shared/models/client_chat_message.dart
+++ b/frontend/flutter_trainer/lib/shared/models/client_chat_message.dart
@@ -18,6 +18,7 @@ class ClientChatMessage {
     required this.timeLabel,
     required this.createdAt,
     this.attachment,
+    this.reportWeekStart,
   });
 
   /// Row id (`seed-chat-…` for seeds, `chat-…` for runtime replies).
@@ -35,6 +36,11 @@ class ClientChatMessage {
   /// Ordering key.
   final DateTime createdAt;
   final ChatAttachment? attachment;
+
+  /// null이면 그냥 채팅, 값이 있으면 리포트 PDF 전송 안내다 — 그 주의
+  /// 월요일. (#1378) 데모/드리프트는 첨부를 저장하지 못해 [attachment] 대신
+  /// 이 값으로 안내 말풍선을 구분한다.
+  final DateTime? reportWeekStart;
 
   /// Whether this message was sent by the trainer.
   bool get fromTrainer => sender == ChatSender.trainer;

--- a/frontend/flutter_trainer/lib/shared/services/chat_repository.dart
+++ b/frontend/flutter_trainer/lib/shared/services/chat_repository.dart
@@ -4,6 +4,7 @@ import 'package:oncare_trainer/core/config/app_config.dart';
 import 'package:oncare_trainer/core/network/dio_client.dart';
 import 'package:oncare_trainer/core/storage/app_database.dart';
 import 'package:oncare_trainer/core/utils/clock.dart';
+import 'package:oncare_trainer/core/utils/date_format.dart';
 import 'package:oncare_trainer/features/clients/data/repositories/dio_chat_repository.dart';
 import 'package:oncare_trainer/shared/models/client_chat_message.dart';
 
@@ -20,9 +21,14 @@ import 'package:oncare_trainer/shared/models/client_chat_message.dart';
 /// after send/read (see [ChatView]).
 abstract interface class ChatRepository {
   Stream<List<ClientChatMessage>> watchThread(String clientId);
+
+  /// [reportWeekStart]가 있으면 이 메시지는 리포트 PDF 전송 안내다(#1378) —
+  /// 데모/드리프트 구현만 이 값을 저장한다. 실서버는 `/report/send-pdf`가
+  /// 첨부 메타데이터를 직접 만들어 붙이므로 여기로 오지 않는다.
   Future<void> sendTrainerMessage({
     required String clientId,
     required String text,
+    DateTime? reportWeekStart,
   });
   Stream<Map<String, int>> watchUnreadCounts();
   Future<void> markThreadRead(String clientId);
@@ -43,7 +49,30 @@ class DriftChatRepository implements ChatRepository {
       ..orderBy(<OrderingTerm Function($ClientChatMessagesTable)>[
         (t) => OrderingTerm(expression: t.createdAt),
       ]);
-    return query.watch().map((rows) => rows.map(_toEntity).toList());
+    return query.watch().asyncMap((rows) async {
+      final markers = await _reportWeekStarts(rows.map((r) => r.id));
+      return rows.map((row) => _toEntity(row, markers[row.id])).toList();
+    });
+  }
+
+  /// 이 배치의 메시지 중 리포트 전송 안내인 것의 그 주(YYYY-MM-DD).
+  ///
+  /// 별도 컬럼 없이 [AppKeyValues] 행 하나로 표시한다(#1378) — 안읽음 마킹과
+  /// 같은 방식(위 [watchUnreadCounts] 주석). 스키마 마이그레이션이 없다.
+  Future<Map<String, String>> _reportWeekStarts(
+    Iterable<String> messageIds,
+  ) async {
+    final keys = <String>[
+      for (final id in messageIds) '$_reportKeyPrefix$id',
+    ];
+    if (keys.isEmpty) return const <String, String>{};
+    final rows =
+        await (_db.select(_db.appKeyValues)..where((t) => t.key.isIn(keys)))
+            .get();
+    return <String, String>{
+      for (final row in rows)
+        row.key.substring(_reportKeyPrefix.length): row.value,
+    };
   }
 
   /// Appends a trainer message and refreshes the client's list-card
@@ -54,16 +83,18 @@ class DriftChatRepository implements ChatRepository {
   Future<void> sendTrainerMessage({
     required String clientId,
     required String text,
+    DateTime? reportWeekStart,
   }) async {
     final trimmed = text.trim();
     if (trimmed.isEmpty) return;
     final now = nowKst();
+    final id = 'chat-$clientId-${now.microsecondsSinceEpoch}';
     await _db.transaction(() async {
       await _db
           .into(_db.clientChatMessages)
           .insert(
             ClientChatMessagesCompanion.insert(
-              id: 'chat-$clientId-${now.microsecondsSinceEpoch}',
+              id: id,
               clientId: clientId,
               sender: 'trainer',
               body: trimmed,
@@ -71,6 +102,9 @@ class DriftChatRepository implements ChatRepository {
               createdAt: now,
             ),
           );
+      if (reportWeekStart != null) {
+        await _db.putValue('$_reportKeyPrefix$id', ymd(reportWeekStart));
+      }
       await (_db.update(
         _db.trainerClients,
       )..where((t) => t.id.equals(clientId))).write(
@@ -143,14 +177,16 @@ class DriftChatRepository implements ChatRepository {
   }
 
   static const String _readKeyPrefix = 'chat_read_';
+  static const String _reportKeyPrefix = 'report_msg_';
 
-  ClientChatMessage _toEntity(ClientChatMessageRow row) {
+  ClientChatMessage _toEntity(ClientChatMessageRow row, String? weekStart) {
     return ClientChatMessage(
       id: row.id,
       sender: row.sender == 'trainer' ? ChatSender.trainer : ChatSender.client,
       body: row.body,
       timeLabel: row.timeLabel,
       createdAt: row.createdAt,
+      reportWeekStart: weekStart == null ? null : DateTime.tryParse(weekStart),
     );
   }
 

--- a/frontend/flutter_trainer/lib/shared/widgets/app_toast.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/app_toast.dart
@@ -217,7 +217,17 @@ class _AppToastState extends State<_AppToast>
                   GestureDetector(
                     key: const ValueKey<String>('app-toast-action'),
                     onTap: _runAction,
-                    child: Text(action.label, style: AppToastStyle.actionTextStyle),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: <Widget>[
+                        Text(action.label, style: AppToastStyle.actionTextStyle),
+                        const Icon(
+                          Icons.chevron_right,
+                          size: 16,
+                          color: AppToastStyle.actionText,
+                        ),
+                      ],
+                    ),
                   ),
                 ],
               ],

--- a/frontend/flutter_trainer/lib/shared/widgets/app_toast.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/app_toast.dart
@@ -1,0 +1,252 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import 'package:oncare_trainer/design_system/tokens/spacing.dart';
+import 'package:oncare_trainer/design_system/tokens/toast.dart';
+
+/// 토스트가 전하는 소식의 종류.
+///
+/// 아이콘과 머무는 시간만 달라진다 — 바탕색까지 갈라 놓으면 성공 토스트와
+/// 실패 토스트가 같은 앱의 같은 부품으로 보이지 않는다.
+enum AppToastKind { info, success, error }
+
+/// 토스트에 붙는 동작 버튼. 눌리면 [onTap]을 부르고 토스트를 닫는다.
+class AppToastAction {
+  const AppToastAction({required this.label, required this.onTap});
+
+  final String label;
+  final VoidCallback onTap;
+}
+
+/// 화면 위쪽에 잠깐 뜨는 알림을 띄운다. (#1378)
+///
+/// 사용자 앱의 `showAppToast`(#1259)와 같은 자리다. **`SnackBar`가 아니라
+/// 루트 오버레이에 얹는다** — 스낵바는 `Scaffold` 안에 그려지므로 대화상자
+/// 위에서 결과를 알려야 하는 자리(리포트 전송 완료)에서는 가려질 수 있다.
+void showAppToast(
+  BuildContext context,
+  String message, {
+  AppToastKind kind = AppToastKind.info,
+  AppToastAction? action,
+  Duration? duration,
+}) {
+  AppToastHost.of(context).show(message, kind: kind, action: action, duration: duration);
+}
+
+/// 토스트를 띄우는 손잡이. 화면이 사라진 뒤에도 쓸 수 있도록 오버레이를 미리
+/// 잡아 둔다.
+class AppToastHost {
+  const AppToastHost._(this._overlay);
+
+  final OverlayState _overlay;
+
+  /// 지금 떠 있는 토스트. 한 번에 하나만 둔다 — 사용자가 빠르게 두 번 저장하면
+  /// 뒤늦게 뜨는 첫 토스트는 이미 지난 소식이다.
+  static _AppToastHandle? _visible;
+
+  static AppToastHost of(BuildContext context) =>
+      AppToastHost._(Overlay.of(context, rootOverlay: true));
+
+  void show(
+    String message, {
+    AppToastKind kind = AppToastKind.info,
+    AppToastAction? action,
+    Duration? duration,
+  }) {
+    _visible?.dismiss();
+    late final _AppToastHandle handle;
+    final OverlayEntry entry = OverlayEntry(
+      builder: (BuildContext context) => _AppToast(
+        message: message,
+        kind: kind,
+        action: action,
+        duration:
+            duration ??
+            (action != null
+                ? AppToastStyle.actionDuration
+                : (kind == AppToastKind.error
+                      ? AppToastStyle.errorDuration
+                      : AppToastStyle.duration)),
+        onDismissed: () => handle.dismiss(),
+      ),
+    );
+    handle = _AppToastHandle(entry);
+    _visible = handle;
+    _overlay.insert(entry);
+  }
+}
+
+class _AppToastHandle {
+  _AppToastHandle(this._entry);
+
+  final OverlayEntry _entry;
+  bool _removed = false;
+
+  void dismiss() {
+    if (_removed) return;
+    _removed = true;
+    if (AppToastHost._visible == this) AppToastHost._visible = null;
+    // 오버레이가 이미 사라진 뒤(앱 종료·테스트 정리)라면 걷을 것도 없다.
+    if (_entry.mounted) _entry.remove();
+  }
+}
+
+class _AppToast extends StatefulWidget {
+  const _AppToast({
+    required this.message,
+    required this.kind,
+    required this.duration,
+    required this.onDismissed,
+    this.action,
+  });
+
+  final String message;
+  final AppToastKind kind;
+  final AppToastAction? action;
+  final Duration duration;
+  final VoidCallback onDismissed;
+
+  @override
+  State<_AppToast> createState() => _AppToastState();
+}
+
+class _AppToastState extends State<_AppToast>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller = AnimationController(
+    vsync: this,
+    duration: AppToastStyle.enterDuration,
+    reverseDuration: AppToastStyle.exitDuration,
+  );
+  Timer? _dwell;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.forward();
+    _dwell = Timer(widget.duration, _hide);
+  }
+
+  @override
+  void dispose() {
+    _dwell?.cancel();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _hide() {
+    _dwell?.cancel();
+    if (!mounted) {
+      widget.onDismissed();
+      return;
+    }
+    _controller.reverse().whenComplete(widget.onDismissed);
+  }
+
+  void _runAction() {
+    widget.action?.onTap();
+    _hide();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final CurvedAnimation curve = CurvedAnimation(
+      parent: _controller,
+      curve: Curves.easeOutCubic,
+      reverseCurve: Curves.easeInCubic,
+    );
+    return Positioned(
+      top: MediaQuery.paddingOf(context).top + AppToastStyle.topGap,
+      left: 0,
+      right: 0,
+      child: SlideTransition(
+        position: Tween<Offset>(
+          begin: const Offset(0, -0.6),
+          end: Offset.zero,
+        ).animate(curve),
+        child: FadeTransition(
+          opacity: curve,
+          child: Center(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg),
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(
+                  maxWidth: AppToastStyle.maxWidth,
+                ),
+                child: _pill(context),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _pill(BuildContext context) {
+    return Semantics(
+      liveRegion: true,
+      container: true,
+      child: GestureDetector(
+        // 먼저 읽고 치울 수 있게 한다 — 눌러도, 위로 밀어도 사라진다.
+        onTap: widget.action == null ? _hide : null,
+        onVerticalDragEnd: (DragEndDetails details) {
+          if ((details.primaryVelocity ?? 0) < 0) _hide();
+        },
+        child: Material(
+          color: AppToastStyle.background,
+          elevation: 6,
+          borderRadius: AppToastStyle.borderRadius,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSpacing.lg,
+              vertical: AppSpacing.md,
+            ),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Icon(_icon(widget.kind), size: 20, color: _iconColor(widget.kind)),
+                const SizedBox(width: AppSpacing.md),
+                Expanded(
+                  child: Text(
+                    widget.message,
+                    style: AppToastStyle.contentTextStyle,
+                  ),
+                ),
+                if (widget.action case final action?) ...[
+                  const SizedBox(width: AppSpacing.md),
+                  GestureDetector(
+                    key: const ValueKey<String>('app-toast-action'),
+                    onTap: _runAction,
+                    child: Text(action.label, style: AppToastStyle.actionTextStyle),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+IconData _icon(AppToastKind kind) {
+  switch (kind) {
+    case AppToastKind.success:
+      return Icons.check_circle_rounded;
+    case AppToastKind.error:
+      return Icons.error_rounded;
+    case AppToastKind.info:
+      return Icons.info_rounded;
+  }
+}
+
+Color _iconColor(AppToastKind kind) {
+  switch (kind) {
+    case AppToastKind.success:
+      return AppToastStyle.successIcon;
+    case AppToastKind.error:
+      return AppToastStyle.errorIcon;
+    case AppToastKind.info:
+      return AppToastStyle.infoIcon;
+  }
+}

--- a/frontend/flutter_trainer/test/features/clients/chat_pdf_card_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/chat_pdf_card_test.dart
@@ -37,6 +37,7 @@ class _PdfChatRepository implements ChatRepository {
   Future<void> sendTrainerMessage({
     required String clientId,
     required String text,
+    DateTime? reportWeekStart,
   }) async {}
 
   @override

--- a/frontend/flutter_trainer/test/features/clients/chat_repository_provider_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/chat_repository_provider_test.dart
@@ -24,6 +24,7 @@ class _CountingChatRepository implements ChatRepository {
   Future<void> sendTrainerMessage({
     required String clientId,
     required String text,
+    DateTime? reportWeekStart,
   }) async {}
 
   @override

--- a/frontend/flutter_trainer/test/features/clients/chat_view_real_api_scroll_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/chat_view_real_api_scroll_test.dart
@@ -50,6 +50,7 @@ class _RealApiFakeChatRepository implements ChatRepository {
   Future<void> sendTrainerMessage({
     required String clientId,
     required String text,
+    DateTime? reportWeekStart,
   }) async {}
 
   @override

--- a/frontend/flutter_trainer/test/features/clients/client_detail_chat_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_chat_test.dart
@@ -44,9 +44,14 @@ class _SlowChatRepository extends DriftChatRepository {
   Future<void> sendTrainerMessage({
     required String clientId,
     required String text,
+    DateTime? reportWeekStart,
   }) async {
     await Future<void>.delayed(const Duration(milliseconds: 400));
-    return super.sendTrainerMessage(clientId: clientId, text: text);
+    return super.sendTrainerMessage(
+      clientId: clientId,
+      text: text,
+      reportWeekStart: reportWeekStart,
+    );
   }
 }
 
@@ -62,6 +67,7 @@ class _ControllableChatRepository extends DriftChatRepository {
   Future<void> sendTrainerMessage({
     required String clientId,
     required String text,
+    DateTime? reportWeekStart,
   }) => gate;
 }
 
@@ -109,6 +115,7 @@ class _StaticLiveChatRepository implements ChatRepository {
   Future<void> sendTrainerMessage({
     required String clientId,
     required String text,
+    DateTime? reportWeekStart,
   }) async {}
 
   @override
@@ -499,6 +506,44 @@ void main() {
       // preview, keeping the two-pane workspace in sync.
       expect(find.text('다음 세션 때 봐요!'), findsWidgets);
     });
+
+    testWidgets(
+      '리포트 전송 메시지는 일반 말풍선이 아니라 카드로 뜨고, 누르면 리포트로 이동한다 (#1378)',
+      (tester) async {
+        final container = await pumpTrainerApp(
+          tester,
+          token: 'demo-trainer-token',
+          at: AppRoutes.messagesFor('seed-client-1'),
+        );
+        // 데모/드리프트는 PDF를 저장하지 못한다 — reportWeekStart만 실어
+        // 보내도 채팅이 카드로 구분해 그려야 한다.
+        await container
+            .read(chatRepositoryProvider)
+            .sendTrainerMessage(
+              clientId: 'seed-client-1',
+              text: '김민수님, 8월 18일 – 8월 24일 주간 리포트 정리해서 보내드려요.',
+              reportWeekStart: DateTime(2026, 8, 18),
+            );
+        await settle(tester);
+
+        final notice = find.textContaining('8월 18일 – 8월 24일 주간 리포트를 보냈어요');
+        expect(notice, findsOneWidget);
+        // 본문 그대로의 일반 말풍선은 그려지지 않는다.
+        expect(
+          find.text('김민수님, 8월 18일 – 8월 24일 주간 리포트 정리해서 보내드려요.'),
+          findsNothing,
+        );
+
+        await tester.tap(notice);
+        await settle(tester);
+
+        final ctx = tester.element(find.byType(Navigator).first);
+        final location = GoRouter.of(
+          ctx,
+        ).routerDelegate.currentConfiguration.uri.toString();
+        expect(location, AppRoutes.reportFor('seed-client-1'));
+      },
+    );
 
     testWidgets('a sent message lands below the routine-sent banner', (
       tester,

--- a/frontend/flutter_trainer/test/features/coaching/coaching_page_test.dart
+++ b/frontend/flutter_trainer/test/features/coaching/coaching_page_test.dart
@@ -53,6 +53,7 @@ class _FailingChatRepository extends DriftChatRepository {
   Future<void> sendTrainerMessage({
     required String clientId,
     required String text,
+    DateTime? reportWeekStart,
   }) async => throw Exception('chat write failed');
 }
 
@@ -65,9 +66,14 @@ class _SlowChatRepository extends DriftChatRepository {
   Future<void> sendTrainerMessage({
     required String clientId,
     required String text,
+    DateTime? reportWeekStart,
   }) async {
     await Future<void>.delayed(const Duration(milliseconds: 300));
-    return super.sendTrainerMessage(clientId: clientId, text: text);
+    return super.sendTrainerMessage(
+      clientId: clientId,
+      text: text,
+      reportWeekStart: reportWeekStart,
+    );
   }
 }
 
@@ -316,6 +322,7 @@ class _FakeRealChatRepository implements ChatRepository {
   Future<void> sendTrainerMessage({
     required String clientId,
     required String text,
+    DateTime? reportWeekStart,
   }) async {
     if (failSend) throw Exception('note failed');
   }

--- a/frontend/flutter_trainer/test/features/reports/dio_report_repository_test.dart
+++ b/frontend/flutter_trainer/test/features/reports/dio_report_repository_test.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -34,6 +36,8 @@ void main() {
 
   setUpAll(() {
     registerFallbackValue(<String, String>{});
+    registerFallbackValue(FormData());
+    registerFallbackValue(Options());
   });
 
   setUp(() {
@@ -213,6 +217,64 @@ void main() {
 
     expect(
       () => repo.send(clientId: 'm1', weekStart: weekStart, message: 'x'),
+      throwsA(isA<ServerError>()),
+    );
+  });
+
+  test('sendPdf posts the week, message and pdf bytes as multipart (#1378)', () async {
+    const sendPdfPath = '/trainer/clients/m1/report/send-pdf';
+    when(
+      () => dio.post<Map<String, Object?>>(
+        sendPdfPath,
+        data: any(named: 'data'),
+        options: any(named: 'options'),
+      ),
+    ).thenAnswer((_) async => _ok(<String, dynamic>{}, sendPdfPath));
+
+    await repo.sendPdf(
+      clientId: 'm1',
+      weekStart: weekStart,
+      bytes: Uint8List.fromList(<int>[0x25, 0x50, 0x44, 0x46]),
+      fileName: '김민수_2026-08-03_주간리포트.pdf',
+      message: '이번 주 잘하셨어요',
+    );
+
+    final captured =
+        verify(
+              () => dio.post<Map<String, Object?>>(
+                sendPdfPath,
+                data: captureAny(named: 'data'),
+                options: any(named: 'options'),
+              ),
+            ).captured.single
+            as FormData;
+    final fields = <String, String>{
+      for (final entry in captured.fields) entry.key: entry.value,
+    };
+    expect(fields['week_start'], '2026-08-03');
+    // 전송되는 것은 화면에서 트레이너가 본 문구 그대로다.
+    expect(fields['message'], '이번 주 잘하셨어요');
+    expect(captured.files.single.value.filename, '김민수_2026-08-03_주간리포트.pdf');
+  });
+
+  test('a failed sendPdf throws instead of reporting success', () async {
+    const sendPdfPath = '/trainer/clients/m1/report/send-pdf';
+    when(
+      () => dio.post<Map<String, Object?>>(
+        sendPdfPath,
+        data: any(named: 'data'),
+        options: any(named: 'options'),
+      ),
+    ).thenThrow(_httpError(500, sendPdfPath));
+
+    expect(
+      () => repo.sendPdf(
+        clientId: 'm1',
+        weekStart: weekStart,
+        bytes: Uint8List.fromList(<int>[0x25, 0x50, 0x44, 0x46]),
+        fileName: 'report.pdf',
+        message: 'x',
+      ),
       throwsA(isA<ServerError>()),
     );
   });

--- a/frontend/flutter_trainer/test/features/reports/reports_page_test.dart
+++ b/frontend/flutter_trainer/test/features/reports/reports_page_test.dart
@@ -61,6 +61,15 @@ class _SummaryFailsRepository implements ReportRepository {
   }) async {}
 
   @override
+  Future<void> sendPdf({
+    required String clientId,
+    required DateTime weekStart,
+    required Uint8List bytes,
+    required String fileName,
+    required String message,
+  }) async {}
+
+  @override
   Future<ReportFeedbackDraft> feedbackDraft({
     required TrainerClient client,
     required DateTime weekStart,
@@ -128,6 +137,15 @@ class _ReportFailsOncePerKeyRepository implements ReportRepository {
   Future<void> send({
     required String clientId,
     required DateTime weekStart,
+    required String message,
+  }) async {}
+
+  @override
+  Future<void> sendPdf({
+    required String clientId,
+    required DateTime weekStart,
+    required Uint8List bytes,
+    required String fileName,
     required String message,
   }) async {}
 
@@ -771,7 +789,22 @@ void main() {
   testWidgets('전송 delivers the report into the client chat thread', (
     tester,
   ) async {
-    final container = await openReports(tester);
+    // 전송 기본 흐름이 PDF를 만들어 보낸다(#1378) — 실 `ReportPdfGenerator`는
+    // dart:ui 래스터를 거쳐 fake pump 로는 settle 되지 않으니, 다른
+    // PDF 관련 테스트처럼 즉시 끝나는 가짜로 바꾼다. 이 테스트가 보는 것은
+    // "채팅에 도착하는가"이지 PDF 렌더링 자체가 아니다.
+    final container = await openReports(
+      tester,
+      extraOverrides: <Override>[
+        reportPdfGeneratorProvider.overrideWithValue(
+          _QueuedPdfGenerator(<Future<Uint8List>>[
+            Future<Uint8List>.value(
+              Uint8List.fromList(<int>[0x25, 0x50, 0x44, 0x46]),
+            ),
+          ]),
+        ),
+      ],
+    );
     await openShareMenu(tester);
 
     await tester.tap(find.text('김민수님에게 전송'));
@@ -807,6 +840,16 @@ void main() {
       extraOverrides: <Override>[
         chatRepositoryProvider.overrideWith(
           (ref) => _FailingChatRepository(ref.watch(appDatabaseProvider)),
+        ),
+        // PDF 생성 자체는 성공해야 이 테스트가 노리는 실패(채팅 전송)만
+        // 남는다 — 실 생성기는 fake pump 로 settle 되지 않는다(위 테스트와
+        // 같은 이유).
+        reportPdfGeneratorProvider.overrideWithValue(
+          _QueuedPdfGenerator(<Future<Uint8List>>[
+            Future<Uint8List>.value(
+              Uint8List.fromList(<int>[0x25, 0x50, 0x44, 0x46]),
+            ),
+          ]),
         ),
       ],
     );
@@ -1303,6 +1346,15 @@ class _DraftStore implements ReportRepository {
   Future<void> send({
     required String clientId,
     required DateTime weekStart,
+    required String message,
+  }) async {}
+
+  @override
+  Future<void> sendPdf({
+    required String clientId,
+    required DateTime weekStart,
+    required Uint8List bytes,
+    required String fileName,
     required String message,
   }) async {}
 

--- a/frontend/flutter_trainer/test/features/reports/reports_page_test.dart
+++ b/frontend/flutter_trainer/test/features/reports/reports_page_test.dart
@@ -1426,6 +1426,7 @@ class _FailingChatRepository extends DriftChatRepository {
   Future<void> sendTrainerMessage({
     required String clientId,
     required String text,
+    DateTime? reportWeekStart,
   }) async {
     throw StateError('send failed');
   }

--- a/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
@@ -27,6 +27,7 @@ class _FailingChatRepository extends DriftChatRepository {
   Future<void> sendTrainerMessage({
     required String clientId,
     required String text,
+    DateTime? reportWeekStart,
   }) async => throw Exception('chat write failed');
 }
 


### PR DESCRIPTION
## Summary

* 리포트 탭 "고객에게 전송" 기본 흐름을 텍스트 대신 PDF 첨부 전송으로 바꿨다
* PDF 생성·전송·수신 열람 인프라(#778, #921, "PDF 내보내기" 메뉴)는 이미 있어 재사용했다
* 전송 완료 알림을 화면 상단 토스트로 옮기고 "채팅으로 이동하기" 버튼을 추가했다

---

## Changes

### ✨ Features

* `ReportRepository`에 `sendPdf` 추가 — 데모(로컬)는 기존처럼 텍스트로, 실서버(Dio)는 `report/send-pdf`로 multipart 전송
* `frontend/flutter_trainer/lib/shared/widgets/app_toast.dart` — 화면 상단에 뜨는 공통 토스트(사용자 앱의 기존 `AppToast`(#1259)와 같은 자리), 동작 버튼(`AppToastAction`) 지원 추가

### 🔧 Improvements

* `reports_page.dart`의 `_send` — PDF를 생성해 `sendPdf`로 보내도록 변경, 전송 완료 알림에 "채팅으로 이동하기" 액션 추가
* PDF 파일명 로직을 `report_pdf_file_name.dart`로 뽑아 `report_pdf_export_dialog.dart`와 공유(중복 제거)

### 🎨 UI/UX

* 리포트 전송 완료 알림이 화면 하단 SnackBar가 아니라 상단 토스트로 뜬다

### 🐛 Fixes

*

---

## Commits

1. `4f602711` fix(reports): 리포트 탭 전송을 PDF로 전환하고 전송 알림에 채팅 이동 추가

---

## Notes

* 기존 "PDF 내보내기"(저장·인쇄용) 메뉴는 그대로 둔다 — 이번 변경은 기본 전송 버튼에만 적용된다.
* 고객 앱 채팅에서 PDF 첨부를 눌러 여는 기능은 이미 있어(#778, #921) 별도 작업이 필요 없었다.
* 트레이너 앱의 다른 탭 알림들도 이 상단 토스트로 통일해 달라는 후속 요청이 있어 별도 이슈(#1389)로 등록했다 — 이 PR이 먼저 머지돼야 그 작업이 `app_toast.dart`를 쓸 수 있다.

---

## Screenshots (Optional)

<!-- UI 변경 시 첨부 -->

| Before | After |
| ------ | ----- |
|        |       |

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [ ] UI 확인
* [ ] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 트레이너 앱 리포트 탭에서 고객을 고르고 "고객에게 전송"을 누른다
2. 상단에 토스트가 뜨고 "채팅으로 이동하기"를 누르면 해당 고객 채팅으로 이동하는지 확인
3. 고객 채팅에 PDF 첨부 메시지가 도착했는지 확인

---

## Related Issues

Closes #1378

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [ ] Merge 충돌 없음
* [ ] 데모 시나리오 영향 확인