### PR TITLE
fix(ui): 트레이너 앱 알림을 상단 토스트로 통일

### DIFF
--- a/frontend/flutter_trainer/lib/features/auth/presentation/pages/trainer_sign_in_page.dart
+++ b/frontend/flutter_trainer/lib/features/auth/presentation/pages/trainer_sign_in_page.dart
@@ -9,6 +9,7 @@ import 'package:oncare_trainer/features/auth/domain/repositories/trainer_auth_re
 import 'package:oncare_trainer/features/auth/presentation/controllers/session_controller.dart';
 import 'package:oncare_trainer/features/auth/presentation/widgets/auth_fields.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
+import 'package:oncare_trainer/shared/widgets/app_toast.dart';
 
 /// Trainer login screen — email/password login plus a "로그인 없이 데모
 /// 둘러보기" bypass. Layout follows the user app's sign-in page; the
@@ -52,7 +53,6 @@ class _TrainerSignInPageState extends ConsumerState<TrainerSignInPage> {
 
   Future<void> _social(String provider) async {
     if (_loading) return;
-    final messenger = ScaffoldMessenger.of(context);
     final destination = _destination;
     setState(() => _loading = true);
     try {
@@ -66,26 +66,21 @@ class _TrainerSignInPageState extends ConsumerState<TrainerSignInPage> {
       // 이미 해제된 context 를 조회하게 된다.
       if (!mounted) return;
       setState(() => _loading = false);
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text(AppLocalizations.of(context).authErrSocialFailed),
-        ),
+      showAppToast(
+        context,
+        AppLocalizations.of(context).authErrSocialFailed,
+        kind: AppToastKind.error,
       );
     }
   }
 
   Future<void> _login() async {
     if (_loading) return;
-    final messenger = ScaffoldMessenger.of(context);
     final destination = _destination;
     final email = _email.text.trim();
     final password = _password.text;
     if (email.isEmpty || password.isEmpty) {
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text(AppLocalizations.of(context).authErrEmptyCredentials),
-        ),
-      );
+      showAppToast(context, AppLocalizations.of(context).authErrEmptyCredentials);
       return;
     }
     setState(() => _loading = true);
@@ -99,14 +94,14 @@ class _TrainerSignInPageState extends ConsumerState<TrainerSignInPage> {
       if (!mounted) return;
       final AppLocalizations l = AppLocalizations.of(context);
       setState(() => _loading = false);
-      messenger.showSnackBar(SnackBar(content: Text(authFailureText(l, e))));
+      showAppToast(context, authFailureText(l, e), kind: AppToastKind.error);
     } catch (_) {
       if (!mounted) return;
       setState(() => _loading = false);
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text(AppLocalizations.of(context).authErrSignInFailed),
-        ),
+      showAppToast(
+        context,
+        AppLocalizations.of(context).authErrSignInFailed,
+        kind: AppToastKind.error,
       );
     }
   }

--- a/frontend/flutter_trainer/lib/features/auth/presentation/pages/trainer_sign_up_page.dart
+++ b/frontend/flutter_trainer/lib/features/auth/presentation/pages/trainer_sign_up_page.dart
@@ -10,6 +10,7 @@ import 'package:oncare_trainer/features/auth/domain/repositories/trainer_auth_re
 import 'package:oncare_trainer/features/auth/presentation/controllers/session_controller.dart';
 import 'package:oncare_trainer/features/auth/presentation/widgets/auth_fields.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
+import 'package:oncare_trainer/shared/widgets/app_toast.dart';
 
 /// 트레이너 회원가입 화면 — 사용자 앱 회원가입과 동일한 디자인. 이름/이메일/
 /// 비밀번호와 **헬스장 초대 코드**로 계정을 만들고, 성공 시 자동 로그인해 고객
@@ -57,7 +58,6 @@ class _TrainerSignUpPageState extends ConsumerState<TrainerSignUpPage> {
 
   Future<void> _register() async {
     if (_loading) return;
-    final messenger = ScaffoldMessenger.of(context);
     final name = _name.text.trim();
     final email = _email.text.trim();
     final password = _password.text;
@@ -66,34 +66,21 @@ class _TrainerSignUpPageState extends ConsumerState<TrainerSignUpPage> {
     final requiresInviteCode = !ref.read(appConfigProvider).useMockApi;
     final inviteCode = _inviteCode.text.trim();
     if (email.isEmpty || password.isEmpty) {
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text(AppLocalizations.of(context).authErrEmptyCredentials),
-        ),
-      );
+      showAppToast(context, AppLocalizations.of(context).authErrEmptyCredentials);
       return;
     }
     if (password.length < 8) {
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text(AppLocalizations.of(context).authErrPasswordTooShort),
-        ),
-      );
+      showAppToast(context, AppLocalizations.of(context).authErrPasswordTooShort);
       return;
     }
     if (password != confirm) {
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text(AppLocalizations.of(context).authErrPasswordMismatch),
-        ),
-      );
+      showAppToast(context, AppLocalizations.of(context).authErrPasswordMismatch);
       return;
     }
     if (requiresInviteCode && inviteCode.isEmpty) {
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text(AppLocalizations.of(context).authErrInviteCodeRequired),
-        ),
+      showAppToast(
+        context,
+        AppLocalizations.of(context).authErrInviteCodeRequired,
       );
       return;
     }
@@ -115,14 +102,14 @@ class _TrainerSignUpPageState extends ConsumerState<TrainerSignUpPage> {
       if (!mounted) return;
       final AppLocalizations l = AppLocalizations.of(context);
       setState(() => _loading = false);
-      messenger.showSnackBar(SnackBar(content: Text(authFailureText(l, e))));
+      showAppToast(context, authFailureText(l, e), kind: AppToastKind.error);
     } catch (_) {
       if (!mounted) return;
       setState(() => _loading = false);
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text(AppLocalizations.of(context).authErrSignUpFailed),
-        ),
+      showAppToast(
+        context,
+        AppLocalizations.of(context).authErrSignUpFailed,
+        kind: AppToastKind.error,
       );
     }
   }

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/chat_view.dart
@@ -18,6 +18,7 @@ import 'package:oncare_trainer/shared/models/client_chat_message.dart';
 import 'package:oncare_trainer/shared/services/chat_repository.dart';
 import 'package:oncare_trainer/shared/services/trainer_memo_repository.dart';
 import 'package:oncare_trainer/shared/widgets/action_button.dart';
+import 'package:oncare_trainer/shared/widgets/app_toast.dart';
 import 'package:oncare_trainer/shared/widgets/client_avatar.dart';
 import 'package:oncare_trainer/shared/widgets/icon_label.dart';
 import 'package:oncare_trainer/shared/widgets/section_card.dart';
@@ -86,12 +87,9 @@ class _ChatViewState extends ConsumerState<ChatView> {
     if (_sending) return;
     final text = _input.text;
     if (text.trim().isEmpty) return;
-    final messenger = ScaffoldMessenger.of(context);
-    // messenger 와 같은 이유로 await 전에 잡아 둔다 — 뒤에서 context 를 다시
-    // 만지면 async gap 을 건너 쓰게 된다.
     final AppLocalizations l = AppLocalizations.of(context);
     if (text.trim().length > _maxMessageLength) {
-      messenger.showSnackBar(SnackBar(content: Text(l.chatTooLong)));
+      showAppToast(context, l.chatTooLong);
       return;
     }
     setState(() => _sending = true);
@@ -101,10 +99,10 @@ class _ChatViewState extends ConsumerState<ChatView> {
           .sendTrainerMessage(clientId: widget.clientId, text: text);
     } catch (_) {
       // Guard the failure path too: a slow send that fails after the
-      // user left would otherwise touch a disposed messenger.
+      // user left would otherwise touch a disposed context.
       if (!mounted) return;
       // Keep the draft in the input and tell the user it didn't go out.
-      messenger.showSnackBar(SnackBar(content: Text(l.chatSendFailed)));
+      showAppToast(context, l.chatSendFailed, kind: AppToastKind.error);
       return;
     } finally {
       if (mounted) setState(() => _sending = false);
@@ -136,7 +134,6 @@ class _ChatViewState extends ConsumerState<ChatView> {
   /// 데모에는 사진을 받을 백엔드가 없어 진입점 자체를 그리지 않는다.
   Future<void> _sendImage() async {
     if (_sending) return;
-    final messenger = ScaffoldMessenger.of(context);
     final AppLocalizations l = AppLocalizations.of(context);
     final XFile? picked = await _picker.pickImage(
       source: ImageSource.gallery,
@@ -151,7 +148,8 @@ class _ChatViewState extends ConsumerState<ChatView> {
     // 사진까지 다시 골라야 한다.
     final caption = _input.text.trim();
     if (caption.length > _maxMessageLength) {
-      messenger.showSnackBar(SnackBar(content: Text(l.chatTooLong)));
+      if (!mounted) return;
+      showAppToast(context, l.chatTooLong);
       return;
     }
     final bytes = await picked.readAsBytes();
@@ -170,12 +168,10 @@ class _ChatViewState extends ConsumerState<ChatView> {
       if (!mounted) return;
       // 용량·형식 거절은 서버가 이유를 문장으로 준다. 그 문장이 트레이너가
       // 다음에 할 일(줄여서 다시 보낼지)을 정한다.
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text(
-            serverDetailOr(l, error.message, l.chatImageSendFailed),
-          ),
-        ),
+      showAppToast(
+        context,
+        serverDetailOr(l, error.message, l.chatImageSendFailed),
+        kind: AppToastKind.error,
       );
       return;
     } finally {
@@ -297,19 +293,19 @@ class _ChatViewState extends ConsumerState<ChatView> {
           );
       ref.invalidate(trainerMemosProvider(widget.clientId));
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(AppLocalizations.of(context).chatInsightMemoSaved),
-        ),
+      showAppToast(
+        context,
+        AppLocalizations.of(context).chatInsightMemoSaved,
+        kind: AppToastKind.success,
       );
     } on Object {
       // The button stays in its unsaved state so the trainer can try again —
       // the list is only invalidated on a write that actually landed.
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(AppLocalizations.of(context).chatInsightMemoSaveFailed),
-        ),
+      showAppToast(
+        context,
+        AppLocalizations.of(context).chatInsightMemoSaveFailed,
+        kind: AppToastKind.error,
       );
     } finally {
       _savingInsights.remove(insight.id);
@@ -795,7 +791,6 @@ class _Bubble extends ConsumerWidget {
     ChatAttachment attachment,
   ) async {
     final l = AppLocalizations.of(context);
-    final messenger = ScaffoldMessenger.of(context);
     try {
       final bytes = await ref
           .read(trainerChatPdfRepositoryProvider)
@@ -816,7 +811,8 @@ class _Bubble extends ConsumerWidget {
         ),
       );
     } catch (_) {
-      messenger.showSnackBar(SnackBar(content: Text(l.chatPdfOpenFailed)));
+      if (!context.mounted) return;
+      showAppToast(context, l.chatPdfOpenFailed, kind: AppToastKind.error);
     }
   }
 }

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_connect_dialog.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_connect_dialog.dart
@@ -11,6 +11,7 @@ import 'package:oncare_trainer/features/clients/data/repositories/client_invite_
 import 'package:oncare_trainer/features/clients/domain/entities/client_invite.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 import 'package:oncare_trainer/shared/widgets/action_button.dart';
+import 'package:oncare_trainer/shared/widgets/app_toast.dart';
 
 /// 회원 ID로 기존 회원을 찾아 연결하는 신규 고객 등록 창. (#919)
 ///
@@ -97,7 +98,6 @@ class _ClientConnectDialogState extends ConsumerState<ClientConnectDialog> {
     final found = _found;
     if (_busy || found == null) return;
     final AppLocalizations l = AppLocalizations.of(context);
-    final messenger = ScaffoldMessenger.of(context);
     final navigator = Navigator.of(context);
     final repository = ref.read(clientInviteRepositoryProvider);
     setState(() {
@@ -109,14 +109,12 @@ class _ClientConnectDialogState extends ConsumerState<ClientConnectDialog> {
       ref.invalidate(pendingClientInvitesProvider);
       if (!mounted) return;
       navigator.pop();
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text(
-            repository.connectsImmediately
-                ? l.clientInviteConnected(found.name)
-                : l.clientInviteSent(found.name),
-          ),
-        ),
+      showAppToast(
+        context,
+        repository.connectsImmediately
+            ? l.clientInviteConnected(found.name)
+            : l.clientInviteSent(found.name),
+        kind: AppToastKind.success,
       );
     } on AppError catch (error) {
       if (!mounted) return;
@@ -131,21 +129,18 @@ class _ClientConnectDialogState extends ConsumerState<ClientConnectDialog> {
   Future<void> _cancel(ClientInvite invite) async {
     if (_busy) return;
     final AppLocalizations l = AppLocalizations.of(context);
-    final messenger = ScaffoldMessenger.of(context);
     setState(() => _busy = true);
     try {
       await ref.read(clientInviteRepositoryProvider).cancel(invite.id);
       ref.invalidate(pendingClientInvitesProvider);
       if (!mounted) return;
-      messenger.showSnackBar(SnackBar(content: Text(l.clientInviteCancelled)));
+      showAppToast(context, l.clientInviteCancelled, kind: AppToastKind.success);
     } on AppError catch (error) {
       if (!mounted) return;
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text(
-            serverDetailOr(l, error.message, l.clientInviteCancelFailed),
-          ),
-        ),
+      showAppToast(
+        context,
+        serverDetailOr(l, error.message, l.clientInviteCancelFailed),
+        kind: AppToastKind.error,
       );
     } finally {
       if (mounted) setState(() => _busy = false);

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_detail_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_detail_view.dart
@@ -18,6 +18,7 @@ import 'package:oncare_trainer/shared/services/chat_repository.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
 import 'package:oncare_trainer/shared/widgets/action_button.dart';
 import 'package:oncare_trainer/shared/widgets/alert_badge.dart';
+import 'package:oncare_trainer/shared/widgets/app_toast.dart';
 import 'package:oncare_trainer/shared/widgets/client_avatar.dart';
 import 'package:oncare_trainer/shared/widgets/status_dot_label.dart';
 
@@ -99,20 +100,18 @@ class _ClientDetailViewState extends ConsumerState<ClientDetailView> {
       if (!mounted) return;
       setState(() => _statusSaving = false);
       final AppLocalizations l = AppLocalizations.of(context);
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            serverDetailOr(l, error.message, l.clientStatusChangeFailed),
-          ),
-        ),
+      showAppToast(
+        context,
+        serverDetailOr(l, error.message, l.clientStatusChangeFailed),
+        kind: AppToastKind.error,
       );
     } on Object {
       if (!mounted) return;
       setState(() => _statusSaving = false);
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(AppLocalizations.of(context).clientStatusChangeFailed),
-        ),
+      showAppToast(
+        context,
+        AppLocalizations.of(context).clientStatusChangeFailed,
+        kind: AppToastKind.error,
       );
     }
   }

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_follow_up_dialog.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_follow_up_dialog.dart
@@ -13,6 +13,7 @@ import 'package:oncare_trainer/features/clients/domain/entities/follow_up_task.d
 import 'package:oncare_trainer/features/dashboard/presentation/widgets/follow_up_card.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 import 'package:oncare_trainer/shared/services/follow_up_task_repository.dart';
+import 'package:oncare_trainer/shared/widgets/app_toast.dart';
 
 /// [clientId] 의 후속 관리 목록을 연다.
 ///
@@ -76,9 +77,7 @@ class _ClientFollowUpDialogState extends ConsumerState<ClientFollowUpDialog> {
   }
 
   void _toast(String message) {
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(SnackBar(content: Text(message)));
+    showAppToast(context, message, kind: AppToastKind.error);
   }
 
   void _reload() {

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_profile_dialog.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_profile_dialog.dart
@@ -11,6 +11,7 @@ import 'package:oncare_trainer/features/clients/domain/entities/trainer_memo.dar
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
 import 'package:oncare_trainer/shared/services/trainer_memo_repository.dart';
+import 'package:oncare_trainer/shared/widgets/app_toast.dart';
 import 'package:oncare_trainer/shared/widgets/dialog_close_button.dart';
 
 /// Opens the merged 신체·목표·메모 dialog for [clientId].
@@ -239,20 +240,16 @@ class _HealthProfileSectionState extends ConsumerState<_HealthProfileSection> {
     } on AppError catch (error) {
       if (!mounted) return;
       final l = AppLocalizations.of(context);
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            serverDetailOr(l, error.message, l.memberHealthSaveFailed),
-          ),
-        ),
+      showAppToast(
+        context,
+        serverDetailOr(l, error.message, l.memberHealthSaveFailed),
+        kind: AppToastKind.error,
       );
       setState(() => _saving = false);
     } catch (_) {
       if (!mounted) return;
       final l = AppLocalizations.of(context);
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(l.memberHealthSaveFailed)));
+      showAppToast(context, l.memberHealthSaveFailed, kind: AppToastKind.error);
       setState(() => _saving = false);
     }
   }
@@ -497,9 +494,7 @@ class _MemoSectionState extends ConsumerState<_MemoSection> {
   }
 
   void _toast(String message) {
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(SnackBar(content: Text(message)));
+    showAppToast(context, message, kind: AppToastKind.error);
   }
 
   Future<void> _add() async {

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/workout_view.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/workout_view.dart
@@ -21,6 +21,7 @@ import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 import 'package:oncare_trainer/shared/models/trainer_client.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
 import 'package:oncare_trainer/shared/widgets/action_button.dart';
+import 'package:oncare_trainer/shared/widgets/app_toast.dart';
 import 'package:oncare_trainer/shared/widgets/exercise_line.dart';
 import 'package:oncare_trainer/shared/widgets/icon_label.dart';
 import 'package:oncare_trainer/shared/widgets/section_card.dart' show EmptyHint;
@@ -155,25 +156,24 @@ class _HistoryCardState extends ConsumerState<_HistoryCard> {
     );
     if (feedback == null || !mounted) return;
 
-    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
     setState(() => _saving = true);
     try {
       await ref
           .read(clientRepositoryProvider)
           .updateHistoryFeedback(widget.clientId, widget.entry.id, feedback);
       ref.invalidate(clientHistoryProvider(widget.clientId));
-      messenger.showSnackBar(SnackBar(content: Text(l.routineFeedbackSaved)));
+      if (!mounted) return;
+      showAppToast(context, l.routineFeedbackSaved, kind: AppToastKind.success);
     } catch (error) {
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text(
-            serverDetailOr(
-              l,
-              error is AppError ? error.message : null,
-              l.routineFeedbackFailed,
-            ),
-          ),
+      if (!mounted) return;
+      showAppToast(
+        context,
+        serverDetailOr(
+          l,
+          error is AppError ? error.message : null,
+          l.routineFeedbackFailed,
         ),
+        kind: AppToastKind.error,
       );
     } finally {
       if (mounted) setState(() => _saving = false);
@@ -821,20 +821,22 @@ class _PendingRoutineRowState extends ConsumerState<_PendingRoutineRow> {
     );
     if (ok != true || !mounted) return;
 
-    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
     setState(() => _busy = true);
     try {
       // 프로그램 탭이 쓰는 것과 **같은** mutation 이다(#504, #1020).
       await ref
           .read(trainerRoutineRepositoryProvider)
           .deleteRoutine(widget.clientId, widget.routine.id);
-      messenger.showSnackBar(SnackBar(content: Text(l.routineDeleted)));
+      if (!mounted) return;
+      showAppToast(context, l.routineDeleted, kind: AppToastKind.success);
     } on StateError {
       // 404 — 이미 없는 것을 지우려 했다. 목적은 이뤄진 셈이라 목록만 다시 읽고
       // 그 줄을 화면에서 걷어낸다.
-      messenger.showSnackBar(SnackBar(content: Text(l.routineAlreadyGone)));
+      if (!mounted) return;
+      showAppToast(context, l.routineAlreadyGone);
     } on Object {
-      messenger.showSnackBar(SnackBar(content: Text(l.routineDeleteFailed)));
+      if (!mounted) return;
+      showAppToast(context, l.routineDeleteFailed, kind: AppToastKind.error);
     } finally {
       if (mounted) setState(() => _busy = false);
       ref.invalidate(assignedRoutinesProvider(widget.clientId));

--- a/frontend/flutter_trainer/lib/features/coaching/presentation/pages/ai_routine_options_flow.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/pages/ai_routine_options_flow.dart
@@ -12,6 +12,7 @@ import 'package:oncare_trainer/features/coaching/domain/entities/routine_options
 import 'package:oncare_trainer/features/coaching/presentation/widgets/routine_form_fields.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 import 'package:oncare_trainer/shared/models/trainer_client.dart';
+import 'package:oncare_trainer/shared/widgets/app_toast.dart';
 import 'package:oncare_trainer/shared/widgets/labeled_field.dart';
 
 /// Conversation-style AI routine builder.
@@ -140,7 +141,6 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
 
   Future<void> _generate() async {
     if (_generating) return;
-    final messenger = ScaffoldMessenger.of(context);
     setState(() => _generating = true);
     try {
       final options = await ref
@@ -178,14 +178,10 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
       final AppLocalizations l = AppLocalizations.of(context);
       // 한도 초과는 고장이 아니라 잠시 뒤 되는 상태다. 다른 오류와 같은 문구를
       // 쓰면 트레이너가 기능이 깨진 것으로 읽는다(#582).
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text(
-            e is RateLimitedError
-                ? l.aiGenerateRateLimited
-                : l.aiGenerateFailed,
-          ),
-        ),
+      showAppToast(
+        context,
+        e is RateLimitedError ? l.aiGenerateRateLimited : l.aiGenerateFailed,
+        kind: AppToastKind.error,
       );
     } finally {
       if (mounted) setState(() => _generating = false);
@@ -204,9 +200,7 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
     final name = _newExerciseName.text.trim();
     if (name.isEmpty) {
       final AppLocalizations l = AppLocalizations.of(context);
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(l.aiExerciseNameRequired)));
+      showAppToast(context, l.aiExerciseNameRequired);
       return;
     }
     final isStrength = _newExerciseType == '근력';
@@ -234,9 +228,7 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
   void _completeReview() {
     if (_edited.isEmpty) {
       final AppLocalizations l = AppLocalizations.of(context);
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(l.aiKeepOneExercise)));
+      showAppToast(context, l.aiKeepOneExercise);
       return;
     }
     setState(() {
@@ -291,15 +283,11 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
   void _applyToTemplate() {
     final AppLocalizations l = AppLocalizations.of(context);
     if (_edited.isEmpty) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(l.aiKeepOneExercise)));
+      showAppToast(context, l.aiKeepOneExercise);
       return;
     }
     widget.onReviewCompleted?.call(List<RoutineExercise>.unmodifiable(_edited));
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(SnackBar(content: Text(l.aiAppliedToTemplate)));
+    showAppToast(context, l.aiAppliedToTemplate, kind: AppToastKind.success);
   }
 
   @override

--- a/frontend/flutter_trainer/lib/features/coaching/presentation/pages/coaching_page.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/pages/coaching_page.dart
@@ -40,6 +40,7 @@ import 'package:oncare_trainer/features/search/presentation/widgets/client_searc
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 import 'package:oncare_trainer/shared/models/trainer_client.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
+import 'package:oncare_trainer/shared/widgets/app_toast.dart';
 import 'package:oncare_trainer/shared/widgets/client_avatar.dart';
 import 'package:oncare_trainer/shared/widgets/client_identity.dart';
 import 'package:oncare_trainer/shared/widgets/icon_label.dart';
@@ -177,7 +178,6 @@ class _CoachingPageState extends ConsumerState<CoachingPage> {
   /// 스낵바 안내는 그대로다.
   Future<bool> _saveTemplate(ProgramEditorState draft) async {
     if (_savingTemplate) return false;
-    final messenger = ScaffoldMessenger.of(context);
     final l = AppLocalizations.of(context);
     final exercises = <TemplateExercise>[
       for (final session in draft.sessions)
@@ -198,9 +198,7 @@ class _CoachingPageState extends ConsumerState<CoachingPage> {
             ),
     ];
     if (exercises.isEmpty) {
-      messenger.showSnackBar(
-        SnackBar(content: Text(l.coachTemplateExerciseRequired)),
-      );
+      showAppToast(context, l.coachTemplateExerciseRequired);
       return false;
     }
     setState(() => _savingTemplate = true);
@@ -215,19 +213,17 @@ class _CoachingPageState extends ConsumerState<CoachingPage> {
       ref.invalidate(programTemplatesProvider);
       if (!mounted) return false;
       setState(() => _savingTemplate = false);
-      messenger.showSnackBar(SnackBar(content: Text(l.programDraftSaved)));
+      showAppToast(context, l.programDraftSaved, kind: AppToastKind.success);
       return true;
     } on Object catch (error) {
       if (!mounted) return false;
       setState(() => _savingTemplate = false);
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text(
-            error is AppError
-                ? serverDetailOr(l, error.message, l.coachTemplateSaveFailed)
-                : l.coachTemplateSaveFailed,
-          ),
-        ),
+      showAppToast(
+        context,
+        error is AppError
+            ? serverDetailOr(l, error.message, l.coachTemplateSaveFailed)
+            : l.coachTemplateSaveFailed,
+        kind: AppToastKind.error,
       );
       return false;
     }
@@ -252,7 +248,6 @@ class _CoachingPageState extends ConsumerState<CoachingPage> {
       _sendRequestFor = sentFor;
     }
     setState(() => _sending = true);
-    final messenger = ScaffoldMessenger.of(context);
     final l = AppLocalizations.of(context);
     try {
       // 세션이 몇 개든 프로그램 배정 한 번으로 보낸다 — 세션당 루틴 한 건이
@@ -266,7 +261,7 @@ class _CoachingPageState extends ConsumerState<CoachingPage> {
     } catch (_) {
       if (!mounted || !_isStillSelected(sentFor)) return;
       setState(() => _sending = false);
-      messenger.showSnackBar(SnackBar(content: Text(l.coachSendFailed)));
+      showAppToast(context, l.coachSendFailed, kind: AppToastKind.error);
       return;
     }
     // 배정은 여기서 이미 끝났다 — 3열 `전송 이력`(`assignedRoutinesProvider`)
@@ -316,7 +311,6 @@ class _CoachingPageState extends ConsumerState<CoachingPage> {
     final time =
         '${_registerTime.hour.toString().padLeft(2, '0')}:'
         '${_registerTime.minute.toString().padLeft(2, '0')}';
-    final messenger = ScaffoldMessenger.of(context);
     final l = AppLocalizations.of(context);
     setState(() => _registeringClientIds.add(registeredFor));
     bool attachedToExisting;
@@ -334,7 +328,7 @@ class _CoachingPageState extends ConsumerState<CoachingPage> {
       if (!mounted) return;
       setState(() => _registeringClientIds.remove(registeredFor));
       if (_isStillSelected(registeredFor)) {
-        messenger.showSnackBar(SnackBar(content: Text(l.coachScheduleFailed)));
+        showAppToast(context, l.coachScheduleFailed, kind: AppToastKind.error);
       }
       return;
     }
@@ -1464,7 +1458,6 @@ class _TemplateCard extends ConsumerWidget {
     ProgramTemplate template,
   ) async {
     final AppLocalizations l = AppLocalizations.of(context);
-    final messenger = ScaffoldMessenger.of(context);
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (dialogContext) => AlertDialog(
@@ -1488,9 +1481,8 @@ class _TemplateCard extends ConsumerWidget {
           .delete(template.id);
       ref.invalidate(programTemplatesProvider);
     } on AppError {
-      messenger.showSnackBar(
-        SnackBar(content: Text(l.coachTemplateDeleteFailed)),
-      );
+      if (!context.mounted) return;
+      showAppToast(context, l.coachTemplateDeleteFailed, kind: AppToastKind.error);
     }
   }
 
@@ -1921,19 +1913,21 @@ class _CancelRoutineButtonState extends ConsumerState<_CancelRoutineButton> {
     );
     if (ok != true || !mounted) return;
 
-    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
     setState(() => _busy = true);
     try {
       await ref
           .read(trainerRoutineRepositoryProvider)
           .deleteRoutine(widget.clientId, widget.routine.id);
-      messenger.showSnackBar(SnackBar(content: Text(l.routineDeleted)));
+      if (!mounted) return;
+      showAppToast(context, l.routineDeleted, kind: AppToastKind.success);
     } on StateError {
       // 404 — 이미 없는 것을 지우려 했다. 목적은 이뤄진 셈이라 목록만 다시 읽고
       // 그 줄을 화면에서 걷어낸다.
-      messenger.showSnackBar(SnackBar(content: Text(l.routineAlreadyGone)));
+      if (!mounted) return;
+      showAppToast(context, l.routineAlreadyGone);
     } on Object {
-      messenger.showSnackBar(SnackBar(content: Text(l.routineDeleteFailed)));
+      if (!mounted) return;
+      showAppToast(context, l.routineDeleteFailed, kind: AppToastKind.error);
     } finally {
       if (mounted) setState(() => _busy = false);
       ref.invalidate(assignedRoutinesProvider(widget.clientId));

--- a/frontend/flutter_trainer/lib/features/coaching/presentation/widgets/routine_suggestion_review_card.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/widgets/routine_suggestion_review_card.dart
@@ -12,6 +12,7 @@ import 'package:oncare_trainer/features/coaching/domain/entities/routine_suggest
 import 'package:oncare_trainer/features/coaching/presentation/widgets/routine_suggestion_edit_dialog.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 import 'package:oncare_trainer/shared/widgets/action_button.dart';
+import 'package:oncare_trainer/shared/widgets/app_toast.dart';
 import 'package:oncare_trainer/shared/widgets/section_card.dart';
 
 /// The AI personal-exercise review area of the program tab (#790).
@@ -132,7 +133,6 @@ class _RoutineSuggestionReviewCardState
     String success,
   ) async {
     if (_busy.contains(suggestion.id)) return;
-    final messenger = ScaffoldMessenger.of(context);
     final AppLocalizations l = AppLocalizations.of(context);
     final reviewedFor = widget.clientId;
     setState(() => _busy.add(suggestion.id));
@@ -140,27 +140,23 @@ class _RoutineSuggestionReviewCardState
       await action();
       ref.invalidate(routineSuggestionsProvider(reviewedFor));
       if (!mounted) return;
-      messenger.showSnackBar(SnackBar(content: Text(success)));
+      showAppToast(context, success, kind: AppToastKind.success);
     } on RoutineSuggestionAlreadyReviewed {
       // 두 번 눌렀거나 다른 창에서 이미 처리했다. 실패로 말하면 트레이너는 자기
       // 판단이 반영되지 않았다고 읽는다 — 실제로는 반영돼 있다.
       ref.invalidate(routineSuggestionsProvider(reviewedFor));
       if (!mounted) return;
-      messenger.showSnackBar(
-        SnackBar(content: Text(l.suggestionAlreadyReviewed)),
-      );
+      showAppToast(context, l.suggestionAlreadyReviewed);
     } on AppError catch (error) {
       if (!mounted) return;
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text(
-            serverDetailOr(l, error.message, l.suggestionActionFailed),
-          ),
-        ),
+      showAppToast(
+        context,
+        serverDetailOr(l, error.message, l.suggestionActionFailed),
+        kind: AppToastKind.error,
       );
     } on Object {
       if (!mounted) return;
-      messenger.showSnackBar(SnackBar(content: Text(l.suggestionActionFailed)));
+      showAppToast(context, l.suggestionActionFailed, kind: AppToastKind.error);
     } finally {
       if (mounted) setState(() => _busy.remove(suggestion.id));
     }

--- a/frontend/flutter_trainer/lib/features/consultations/presentation/pages/consultations_page.dart
+++ b/frontend/flutter_trainer/lib/features/consultations/presentation/pages/consultations_page.dart
@@ -15,6 +15,7 @@ import 'package:oncare_trainer/features/consultations/domain/entities/consultati
 import 'package:oncare_trainer/features/schedule/domain/entities/schedule_status.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 import 'package:oncare_trainer/shared/widgets/action_button.dart';
+import 'package:oncare_trainer/shared/widgets/app_toast.dart';
 import 'package:oncare_trainer/shared/widgets/client_avatar.dart';
 import 'package:oncare_trainer/shared/widgets/page_scaffold.dart';
 import 'package:oncare_trainer/shared/widgets/section_card.dart';
@@ -233,13 +234,12 @@ class _RequestCardState extends ConsumerState<_RequestCard> {
       _busy = true;
       _conflict = null;
     });
-    final messenger = ScaffoldMessenger.of(context);
-    // messenger 와 같이 await 전에 잡아 둔다.
     final AppLocalizations l = AppLocalizations.of(context);
     final String failureText = l.consultActionFailed;
     try {
       await action();
-      messenger.showSnackBar(SnackBar(content: Text(success)));
+      if (!mounted) return;
+      showAppToast(context, success, kind: AppToastKind.success);
     } on AppError catch (e) {
       // A failed decision usually means the request moved on without us —
       // another trainer at the same gym accepted it first. Refresh before
@@ -247,10 +247,13 @@ class _RequestCardState extends ConsumerState<_RequestCard> {
       // can keep pressing 승인 on something already decided (review).
       ref.invalidate(consultationsProvider);
       ref.invalidate(consultationPendingCountProvider);
+      if (!mounted) return;
       // 409 carries the server's reason (이미 처리됨 / 다른 트레이너가 담당 중)
       // — that sentence is the whole point, so it is shown verbatim.
-      messenger.showSnackBar(
-        SnackBar(content: Text(serverDetailOr(l, e.message, failureText))),
+      showAppToast(
+        context,
+        serverDetailOr(l, e.message, failureText),
+        kind: AppToastKind.error,
       );
     } finally {
       if (mounted) setState(() => _busy = false);
@@ -273,7 +276,6 @@ class _RequestCardState extends ConsumerState<_RequestCard> {
       _conflict = null;
     });
     final AppLocalizations l = AppLocalizations.of(context);
-    final messenger = ScaffoldMessenger.of(context);
     final request = widget.request;
     final String? startTime = preferredStartTime(request.preferredTimeCode);
     try {
@@ -289,8 +291,11 @@ class _RequestCardState extends ConsumerState<_RequestCard> {
                 durationMinutes: _defaultConsultationDurationMinutes,
               ),
       );
-      messenger.showSnackBar(
-        SnackBar(content: Text(l.consultApproved(request.memberName))),
+      if (!mounted) return;
+      showAppToast(
+        context,
+        l.consultApproved(request.memberName),
+        kind: AppToastKind.success,
       );
     } on ConsultationScheduleConflictError catch (e) {
       if (mounted) {
@@ -301,10 +306,11 @@ class _RequestCardState extends ConsumerState<_RequestCard> {
     } on AppError catch (e) {
       ref.invalidate(consultationsProvider);
       ref.invalidate(consultationPendingCountProvider);
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text(serverDetailOr(l, e.message, l.consultActionFailed)),
-        ),
+      if (!mounted) return;
+      showAppToast(
+        context,
+        serverDetailOr(l, e.message, l.consultActionFailed),
+        kind: AppToastKind.error,
       );
     } finally {
       if (mounted) setState(() => _busy = false);

--- a/frontend/flutter_trainer/lib/features/dashboard/presentation/widgets/follow_up_card.dart
+++ b/frontend/flutter_trainer/lib/features/dashboard/presentation/widgets/follow_up_card.dart
@@ -13,6 +13,7 @@ import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/features/clients/domain/entities/follow_up_task.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 import 'package:oncare_trainer/shared/services/follow_up_task_repository.dart';
+import 'package:oncare_trainer/shared/widgets/app_toast.dart';
 import 'package:oncare_trainer/shared/widgets/section_card.dart';
 
 /// 오늘 처리해야 할 후속 관리 — 트레이너가 직접 남긴 업무 큐. (#869)
@@ -61,9 +62,7 @@ class _FollowUpCardState extends ConsumerState<FollowUpCard> {
   }
 
   void _toast(String message) {
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(SnackBar(content: Text(message)));
+    showAppToast(context, message, kind: AppToastKind.error);
   }
 
   @override

--- a/frontend/flutter_trainer/lib/features/my/presentation/pages/my_page.dart
+++ b/frontend/flutter_trainer/lib/features/my/presentation/pages/my_page.dart
@@ -23,6 +23,7 @@ import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 import 'package:oncare_trainer/shared/models/trainer_profile.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
 import 'package:oncare_trainer/shared/widgets/action_button.dart';
+import 'package:oncare_trainer/shared/widgets/app_toast.dart';
 import 'package:oncare_trainer/shared/widgets/page_scaffold.dart';
 import 'package:oncare_trainer/shared/widgets/section_card.dart';
 import 'package:oncare_trainer/shared/widgets/status_dot_label.dart';
@@ -131,9 +132,7 @@ class _MyPageState extends ConsumerState<MyPage> {
     final careerYears = int.tryParse(careerMatch?.group(1) ?? '');
     if (careerYears == null || careerYears < 0 || careerYears > 80) {
       final AppLocalizations l = AppLocalizations.of(context);
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(l.myCareerInvalid)));
+      showAppToast(context, l.myCareerInvalid);
       return;
     }
 
@@ -185,9 +184,7 @@ class _MyPageState extends ConsumerState<MyPage> {
       if (restored != null) _applyRestoredProfile(restored);
       setState(() => _saving = false);
       final message = _saveFailureMessage(error, profileSaved: profileSaved);
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(message)));
+      showAppToast(context, message, kind: AppToastKind.error);
       return;
     }
 
@@ -244,8 +241,6 @@ class _MyPageState extends ConsumerState<MyPage> {
   /// 계정 탈퇴. 이름 확인을 받은 뒤에만 나가고, 성공하면 로그아웃과 같은 경로로
   /// 로그인 화면에 도달한다(라우터의 인증 게이트). (#505)
   Future<void> _deleteAccount() async {
-    final messenger = ScaffoldMessenger.of(context);
-    // messenger 와 같이 await 전에 잡아 둔다.
     final AppLocalizations l = AppLocalizations.of(context);
     final confirmed = await showDialog<bool>(
       context: context,
@@ -257,8 +252,10 @@ class _MyPageState extends ConsumerState<MyPage> {
       await ref.read(trainerAccountRepositoryProvider).deleteAccount();
     } on AppError catch (e) {
       if (!mounted) return;
-      messenger.showSnackBar(
-        SnackBar(content: Text(serverDetailOr(l, e.message, l.myDeleteFailed))),
+      showAppToast(
+        context,
+        serverDetailOr(l, e.message, l.myDeleteFailed),
+        kind: AppToastKind.error,
       );
       return;
     }
@@ -402,16 +399,15 @@ class _MyPageState extends ConsumerState<MyPage> {
   /// so a failed write has to be visible — otherwise the screen shows a
   /// value the server never accepted.
   Future<void> _applySetting(Future<void> Function() change) async {
-    final messenger = ScaffoldMessenger.of(context);
     await change();
     if (!mounted) return;
     final controller = ref.read(trainerSettingsProvider.notifier);
     if (controller.lastError) {
       controller.clearError();
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text(AppLocalizations.of(context).mySettingsSaveFailed),
-        ),
+      showAppToast(
+        context,
+        AppLocalizations.of(context).mySettingsSaveFailed,
+        kind: AppToastKind.error,
       );
     }
   }
@@ -573,9 +569,7 @@ class _MyPageState extends ConsumerState<MyPage> {
     );
     if (changed == true && mounted) {
       final AppLocalizations l = AppLocalizations.of(context);
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(l.myPasswordChanged)));
+      showAppToast(context, l.myPasswordChanged, kind: AppToastKind.success);
     }
   }
 }

--- a/frontend/flutter_trainer/lib/features/notifications/presentation/pages/notifications_page.dart
+++ b/frontend/flutter_trainer/lib/features/notifications/presentation/pages/notifications_page.dart
@@ -12,6 +12,7 @@ import 'package:oncare_trainer/features/notifications/data/repositories/notifica
 import 'package:oncare_trainer/features/notifications/domain/entities/trainer_notification.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 import 'package:oncare_trainer/shared/widgets/action_button.dart';
+import 'package:oncare_trainer/shared/widgets/app_toast.dart';
 import 'package:oncare_trainer/shared/widgets/page_scaffold.dart';
 import 'package:oncare_trainer/shared/widgets/section_card.dart';
 
@@ -60,13 +61,12 @@ class NotificationsPage extends ConsumerWidget {
   }
 
   Future<void> _readAll(BuildContext context, WidgetRef ref) async {
-    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
-    // messenger 와 같이 await 전에 잡아 둔다.
     final AppLocalizations l = AppLocalizations.of(context);
     try {
       await ref.read(trainerNotificationRepositoryProvider).markAllRead();
     } catch (_) {
-      messenger.showSnackBar(SnackBar(content: Text(l.notifReadAllFailed)));
+      if (!context.mounted) return;
+      showAppToast(context, l.notifReadAllFailed, kind: AppToastKind.error);
       return;
     }
     ref

--- a/frontend/flutter_trainer/lib/features/reports/presentation/pages/reports_page.dart
+++ b/frontend/flutter_trainer/lib/features/reports/presentation/pages/reports_page.dart
@@ -133,7 +133,6 @@ class _ReportsPageState extends ConsumerState<ReportsPage> {
   Future<void> _saveFeedback(WeeklyReport report, String body) async {
     if (_savingFeedback) return;
     final AppLocalizations l = AppLocalizations.of(context);
-    final messenger = ScaffoldMessenger.of(context);
     setState(() => _savingFeedback = true);
     try {
       await ref
@@ -150,12 +149,10 @@ class _ReportsPageState extends ConsumerState<ReportsPage> {
         )),
       );
       if (!mounted) return;
-      messenger.showSnackBar(SnackBar(content: Text(l.reportsFeedbackSaved)));
+      showAppToast(context, l.reportsFeedbackSaved, kind: AppToastKind.success);
     } catch (_) {
       if (!mounted) return;
-      messenger.showSnackBar(
-        SnackBar(content: Text(l.reportsFeedbackSaveFailed)),
-      );
+      showAppToast(context, l.reportsFeedbackSaveFailed, kind: AppToastKind.error);
     } finally {
       if (mounted) setState(() => _savingFeedback = false);
     }
@@ -284,8 +281,6 @@ class _ReportsPageState extends ConsumerState<ReportsPage> {
     final AppLocalizations l = AppLocalizations.of(context);
     final id = report.client.id;
     if (_sending != null || _sent.contains(id)) return;
-    // messenger 와 마찬가지로 l 도 위에서 await 전에 잡아 뒀다.
-    final messenger = ScaffoldMessenger.of(context);
     setState(() => _sending = id);
     try {
       final bytes = await _generateReportPdf(l, report, message);
@@ -301,7 +296,7 @@ class _ReportsPageState extends ConsumerState<ReportsPage> {
     } catch (_) {
       if (!mounted) return;
       setState(() => _sending = null);
-      messenger.showSnackBar(SnackBar(content: Text(l.reportsSendFailed)));
+      showAppToast(context, l.reportsSendFailed, kind: AppToastKind.error);
       return;
     }
     if (!mounted) return;
@@ -324,9 +319,7 @@ class _ReportsPageState extends ConsumerState<ReportsPage> {
 
   Future<void> _openPdfExport(WeeklyReport report) async {
     if (_generatingPdf) return;
-    final messenger = ScaffoldMessenger.of(context);
-    // await 를 넘어 `context` 를 다시 읽지 않도록 messenger 와 함께 미리 잡아
-    // 둔다. PDF 문구도 화면과 같은 로케일이어야 한다 (#964).
+    // PDF 문구도 화면과 같은 로케일이어야 한다 (#964).
     final AppLocalizations l = AppLocalizations.of(context);
     final feedback = _messageFor(l, report, _savedDraftOf(report));
     setState(() => _generatingPdf = true);
@@ -339,9 +332,7 @@ class _ReportsPageState extends ConsumerState<ReportsPage> {
       );
     } catch (_) {
       if (mounted) {
-        messenger.showSnackBar(
-          SnackBar(content: Text(l.reportsPdfGenerationFailed)),
-        );
+        showAppToast(context, l.reportsPdfGenerationFailed, kind: AppToastKind.error);
       }
     } finally {
       if (mounted) setState(() => _generatingPdf = false);

--- a/frontend/flutter_trainer/lib/features/reports/presentation/widgets/report_pdf_export_dialog.dart
+++ b/frontend/flutter_trainer/lib/features/reports/presentation/widgets/report_pdf_export_dialog.dart
@@ -7,6 +7,7 @@ import 'package:oncare_trainer/features/reports/services/report_pdf_actions.dart
 import 'package:oncare_trainer/features/reports/services/report_pdf_file_name.dart';
 import 'package:oncare_trainer/features/reports/services/report_pdf_sender.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
+import 'package:oncare_trainer/shared/widgets/app_toast.dart';
 
 /// A generated report's explicit delivery actions.
 ///
@@ -32,15 +33,12 @@ class _ReportPdfExportDialogState extends ConsumerState<ReportPdfExportDialog> {
 
   Future<void> _run(Future<void> Function() action, String success) async {
     final l = AppLocalizations.of(context);
-    final messenger = ScaffoldMessenger.of(context);
     try {
       await action();
-      if (mounted) messenger.showSnackBar(SnackBar(content: Text(success)));
+      if (mounted) showAppToast(context, success, kind: AppToastKind.success);
     } catch (_) {
       if (mounted) {
-        messenger.showSnackBar(
-          SnackBar(content: Text(l.reportsPdfActionFailed)),
-        );
+        showAppToast(context, l.reportsPdfActionFailed, kind: AppToastKind.error);
       }
     }
   }

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/pages/schedule_page.dart
@@ -26,6 +26,7 @@ import 'package:oncare_trainer/features/search/presentation/widgets/client_searc
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
 import 'package:oncare_trainer/shared/widgets/action_button.dart';
+import 'package:oncare_trainer/shared/widgets/app_toast.dart';
 import 'package:oncare_trainer/shared/widgets/dialog_close_button.dart';
 import 'package:oncare_trainer/shared/widgets/page_scaffold.dart';
 
@@ -298,12 +299,11 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
       ),
     );
     if (ok != true || !mounted) return;
-    final messenger = ScaffoldMessenger.of(context);
     try {
       await ref.read(scheduleRepositoryProvider).deleteSession(s.id);
     } catch (_) {
       if (!mounted) return;
-      messenger.showSnackBar(SnackBar(content: Text(l.schedDeleteFailed)));
+      showAppToast(context, l.schedDeleteFailed, kind: AppToastKind.error);
     }
   }
 
@@ -343,7 +343,6 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
       ),
     );
     if (ok != true || !mounted) return;
-    final messenger = ScaffoldMessenger.of(context);
     try {
       await ref
           .read(scheduleRepositoryProvider)
@@ -352,7 +351,7 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
       // A DB or programJson-decode failure must not escape to the UI —
       // the session stays 예정 and the trainer is told (review PR 237).
       if (!mounted) return;
-      messenger.showSnackBar(SnackBar(content: Text(l.schedCompleteFailed)));
+      showAppToast(context, l.schedCompleteFailed, kind: AppToastKind.error);
     }
   }
 
@@ -367,7 +366,6 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
       builder: (context) => CancelSessionDialog(session: s),
     );
     if (result == null || !mounted) return;
-    final messenger = ScaffoldMessenger.of(context);
     final AppLocalizations l = AppLocalizations.of(context);
     try {
       await ref
@@ -375,7 +373,7 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
           .cancelSession(s.id, source: result.source, reason: result.reason);
     } catch (_) {
       if (!mounted) return;
-      messenger.showSnackBar(SnackBar(content: Text(l.schedCancelFailed)));
+      showAppToast(context, l.schedCancelFailed, kind: AppToastKind.error);
     }
   }
 
@@ -411,12 +409,11 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
       ),
     );
     if (ok != true || !mounted) return;
-    final messenger = ScaffoldMessenger.of(context);
     try {
       await ref.read(scheduleRepositoryProvider).markNoShow(s.id);
     } catch (_) {
       if (!mounted) return;
-      messenger.showSnackBar(SnackBar(content: Text(l.schedNoShowFailed)));
+      showAppToast(context, l.schedNoShowFailed, kind: AppToastKind.error);
     }
   }
 
@@ -426,7 +423,6 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
   /// 않는다. 성공하면 세션 행에 남아, 화면이 '전송됨' 을 사실대로 말한다.
   Future<void> _sendProgram(ScheduleSession s) async {
     if (_sendingProgramId != null) return;
-    final messenger = ScaffoldMessenger.of(context);
     final AppLocalizations l = AppLocalizations.of(context);
     setState(() => _sendingProgramId = s.id);
     try {
@@ -438,12 +434,10 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
           );
       if (!mounted) return;
       _sendRequestIds.remove(s.id); // 다음 전송은 새 시도다.
-      messenger.showSnackBar(
-        SnackBar(content: Text(l.schedSentTo(s.clientName))),
-      );
+      showAppToast(context, l.schedSentTo(s.clientName), kind: AppToastKind.success);
     } catch (_) {
       if (!mounted) return;
-      messenger.showSnackBar(SnackBar(content: Text(l.coachSendFailed)));
+      showAppToast(context, l.coachSendFailed, kind: AppToastKind.error);
     } finally {
       if (mounted) setState(() => _sendingProgramId = null);
     }

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/reservation_slots_sheet.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/reservation_slots_sheet.dart
@@ -12,6 +12,7 @@ import 'package:oncare_trainer/features/schedule/domain/entities/reservation_slo
 import 'package:oncare_trainer/features/schedule/domain/entities/schedule_status.dart';
 import 'package:oncare_trainer/features/schedule/presentation/widgets/time_range_picker_dialog.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
+import 'package:oncare_trainer/shared/widgets/app_toast.dart';
 
 class ReservationSlotsSheet extends ConsumerStatefulWidget {
   const ReservationSlotsSheet({super.key, required this.selectedDay});
@@ -98,9 +99,9 @@ class _ReservationSlotsSheetState extends ConsumerState<ReservationSlotsSheet> {
             sessionType: _type,
           );
       ref.invalidate(reservationSlotsProvider);
-      _showMessage(l.slotOpened);
+      _showMessage(l.slotOpened, kind: AppToastKind.success);
     } catch (error) {
-      _showMessage(_errorMessage(l, error));
+      _showMessage(_errorMessage(l, error), kind: AppToastKind.error);
     } finally {
       if (mounted) setState(() => _saving = false);
     }
@@ -189,9 +190,9 @@ class _ReservationSlotsSheetState extends ConsumerState<ReservationSlotsSheet> {
             sessionType: changed.$3 == slot.sessionType ? null : changed.$3,
           );
       ref.invalidate(reservationSlotsProvider);
-      _showMessage(l.slotUpdated);
+      _showMessage(l.slotUpdated, kind: AppToastKind.success);
     } catch (error) {
-      _showMessage(_errorMessage(l, error));
+      _showMessage(_errorMessage(l, error), kind: AppToastKind.error);
     } finally {
       if (mounted) setState(() => _saving = false);
     }
@@ -224,9 +225,9 @@ class _ReservationSlotsSheetState extends ConsumerState<ReservationSlotsSheet> {
     try {
       await ref.read(reservationSlotRepositoryProvider).close(slot.id);
       ref.invalidate(reservationSlotsProvider);
-      _showMessage(l.slotClosed);
+      _showMessage(l.slotClosed, kind: AppToastKind.success);
     } catch (error) {
-      _showMessage(_errorMessage(l, error));
+      _showMessage(_errorMessage(l, error), kind: AppToastKind.error);
     } finally {
       if (mounted) setState(() => _saving = false);
     }
@@ -252,11 +253,9 @@ class _ReservationSlotsSheetState extends ConsumerState<ReservationSlotsSheet> {
     return l.slotActionFailed;
   }
 
-  void _showMessage(String message) {
+  void _showMessage(String message, {AppToastKind kind = AppToastKind.info}) {
     if (!mounted) return;
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(SnackBar(content: Text(message)));
+    showAppToast(context, message, kind: kind);
   }
 
   /// 종류·날짜·시간 세 필드가 한 줄에서 같은 무게로 보이도록 쓰는 옅은

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/session_program_editor.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/session_program_editor.dart
@@ -9,6 +9,7 @@ import 'package:oncare_trainer/features/schedule/data/repositories/schedule_repo
 import 'package:oncare_trainer/features/schedule/domain/entities/schedule_session.dart';
 import 'package:oncare_trainer/features/schedule/presentation/models/program_draft.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
+import 'package:oncare_trainer/shared/widgets/app_toast.dart';
 
 /// 세션 하나의 프로그램을 그 자리에서 고치는 편집기.
 ///
@@ -73,9 +74,7 @@ class _SessionProgramEditorState extends ConsumerState<SessionProgramEditor> {
       // 숫자 칸은 스테퍼가 이미 범위 안으로 묶어 둔다 — 여기서 막을 것은
       // 비워 둔 이름뿐이다.
       if (item.name.text.trim().isEmpty) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text(l.progInvalid)));
+        showAppToast(context, l.progInvalid);
         return;
       }
       program.add(item.toItem());
@@ -94,9 +93,7 @@ class _SessionProgramEditorState extends ConsumerState<SessionProgramEditor> {
     } catch (_) {
       if (mounted) setState(() => _saving = false);
       if (!mounted) return;
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(l.progSaveFailed)));
+      showAppToast(context, l.progSaveFailed, kind: AppToastKind.error);
       return;
     }
     if (!mounted) return;

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/session_sheet.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/session_sheet.dart
@@ -14,6 +14,7 @@ import 'package:oncare_trainer/features/schedule/domain/entities/schedule_status
 import 'package:oncare_trainer/features/schedule/presentation/widgets/session_repeat_preview.dart';
 import 'package:oncare_trainer/features/schedule/presentation/widgets/time_range_picker_dialog.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
+import 'package:oncare_trainer/shared/widgets/app_toast.dart';
 import 'package:oncare_trainer/shared/widgets/number_stepper.dart';
 
 /// Bottom sheet for booking or editing a session: client, type, time
@@ -174,15 +175,12 @@ class _SessionSheetState extends ConsumerState<SessionSheet> {
     final AppLocalizations l = AppLocalizations.of(context);
     final int duration = _endTotalMinutes - _startTotalMinutes;
     if (duration <= 0) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(l.schedEndBeforeStart)));
+      showAppToast(context, l.schedEndBeforeStart);
       return;
     }
     setState(() => _saving = true);
     final repo = ref.read(scheduleRepositoryProvider);
     final navigator = Navigator.of(context);
-    final messenger = ScaffoldMessenger.of(context);
     try {
       final e = widget.existing;
       if (e == null && _repeatDays.isNotEmpty) {
@@ -246,8 +244,9 @@ class _SessionSheetState extends ConsumerState<SessionSheet> {
     } catch (_) {
       // Surface the failure and keep the sheet open so the input isn't
       // lost (review PR 218).
-      if (mounted) setState(() => _saving = false);
-      messenger.showSnackBar(SnackBar(content: Text(l.schedSaveFailed)));
+      if (!mounted) return;
+      setState(() => _saving = false);
+      showAppToast(context, l.schedSaveFailed, kind: AppToastKind.error);
       return;
     }
     if (mounted) setState(() => _saving = false);


### PR DESCRIPTION
## Summary

* 트레이너 앱 21개 파일의 하단 SnackBar 알림을 전부 #1378의 상단 토스트로 교체했다
* 토스트 배경은 검정이 아니라 기존 알림과 같은 남색(`AppColors.secondary`)으로 맞췄다
* 실패/성공/안내 맥락에 맞춰 `AppToastKind`를 골랐다

---

## Changes

### 🎨 UI/UX

* `auth`, `clients`, `coaching`, `consultations`, `dashboard`, `my`, `notifications`, `reports`, `schedule` 전 영역의 알림이 화면 상단 토스트로 뜬다
* `design_system/tokens/toast.dart`의 배경색을 남색(`AppColors.secondary`)으로 조정 — 위치만 위로 옮기는 것이지 브랜드 색까지 바꾸는 게 아니다

### 🔧 Improvements

* 여러 알림을 한 헬퍼로 묶어 보내던 자리(`_showMessage`, `_toast` 등)에 `AppToastKind` 파라미터를 추가해 호출부마다 알맞은 색을 고르게 했다

---

## Commits

1. `4e050838` fix(ui): 트레이너 앱 알림을 상단 토스트로 통일

---

## Notes

* 이 PR은 **#1378 위에 쌓은 브랜치**(`fix/issue-1389-trainer-toast-top` ← `fix/issue-1378-report-pdf-send-toast`)다 — `app_toast.dart`가 #1378에서 처음 생겨서, base를 `main`이 아니라 #1378 브랜치로 잡았다. #1378(PR #1390)이 먼저 머지된 뒤 이 PR의 base를 `main`으로 바꿔야 diff가 21개 파일만 깔끔하게 보인다.
* `SnackBarAction`이 있던 자리는 없었다 — 전부 `content: Text(...)` 뿐인 단순 SnackBar였다.

---

## Screenshots (Optional)

<!-- UI 변경 시 첨부 -->

| Before | After |
| ------ | ----- |
|        |       |

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [ ] UI 확인
* [ ] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 각 탭(로그인, 고객, 코칭, 상담, MY, 알림, 리포트, 일정)에서 저장·전송·실패 등 알림이 뜨는 동작을 하나씩 해 본다
2. 알림이 화면 하단이 아니라 상단에, 남색 배경으로 뜨는지 확인

---

## Related Issues

Closes #1389

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [ ] Merge 충돌 없음
* [ ] 데모 시나리오 영향 확인