### PR TITLE
chore(ci): PR 게이트에 AI 저작 표기 차단 검사 추가

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -36,3 +36,37 @@ jobs:
           echo "PR #${{ github.event.pull_request.number }}"
           echo "base: ${{ github.event.pull_request.base.ref }}"
           echo "이 검사는 브랜치 보호의 최신화 요구를 걸기 위한 앵커다(#807)."
+
+      - name: Check out the PR head with full history
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Reject AI co-author trailers
+        # 2026-08-25: 커밋 하나에 붙은 `Co-Authored-By: Claude …` 때문에 GitHub
+        # 기여자 그래프에 봇 계정이 잡혔고, 지우려고 main 이력을 재작성해야 했다.
+        # 게다가 옛 SHA 위에 쌓인 브랜치가 그대로 병합되면서 지운 커밋이 되살아났다.
+        # 사람이 매번 확인하는 대신 여기서 막는다 — base..head 를 보므로 새 커밋뿐
+        # 아니라 '옛 이력을 다시 끌고 들어오는 병합'도 함께 걸린다.
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          git fetch --quiet origin "$BASE_REF"
+          base=$(git merge-base FETCH_HEAD HEAD)
+
+          offenders=""
+          for sha in $(git log --format='%H' "$base..HEAD"); do
+            if git log -1 --format='%B' "$sha" \
+              | grep -qiE '^[[:space:]]*(co-authored-by:[[:space:]]*claude|co-authored-by:.*@anthropic\.com|(generated|created) with[[:space:]]+.*claude)'; then
+              offenders="$offenders$(git log -1 --format='  %h %an: %s' "$sha")"$'\n'
+            fi
+          done
+
+          if [ -n "$offenders" ]; then
+            echo "::error::AI 저작 표기가 남은 커밋이 있습니다. 아래 커밋의 메시지를 고치거나, 최신 $BASE_REF 위로 리베이스한 뒤 다시 푸시하세요."
+            printf '%s' "$offenders"
+            exit 1
+          fi
+          echo "AI 저작 표기 없음 ($base..HEAD)."


### PR DESCRIPTION
## Summary

커밋 메시지에 남은 AI 저작 표기(`Co-Authored-By: Claude …`)를 PR 단계에서 막는 검사를 `PR Gate` 워크플로에 추가한다.

Closes #1409

## Background

커밋 하나에 `Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>` 가 붙어 GitHub Insights 기여자 그래프에 봇 계정이 기여자로 잡혔다. 지우려면 이력 재작성이 필요한데, 재작성 뒤에도 **옛 SHA 위에 쌓여 있던 브랜치가 리베이스 없이 병합되면 지운 커밋이 되살아난다** — 실제로 재발했다. 사람이 매번 확인하는 방식으로는 막히지 않아 검사로 세운다.

## Changes

`PR Gate` 는 경로 필터 없이 모든 PR 에서 도는 유일한 필수 검사라 여기에 붙였다.

- PR head 를 전체 이력으로 체크아웃하고 `merge-base` 로 실제 기준점을 구한다
- `base..head` 의 커밋 메시지를 훑어 AI 저작 표기가 있으면 어떤 커밋인지 찍고 실패시킨다
- 범위가 `base..head` 라 새로 쓴 커밋뿐 아니라 **옛 이력을 다시 끌고 들어오는 병합**도 함께 걸린다

## Verification

기존 커밋에 실제로 돌려 확인했다.

| 대상 | 기대 | 결과 |
| --- | --- | --- |
| `Co-Authored-By: Claude …` 가 붙은 커밋 | 차단 | 차단 |
| 사람 공동저자 커밋(`Co-authored-by: 최지수 …`) | 통과 | 통과 |
| 본문에 Claude 를 언급하는 문서 커밋 | 통과 | 통과 |
| 평범한 커밋·머지 커밋 | 통과 | 통과 |
| 옛 이력을 되살린 병합을 같은 조건으로 재현 | 차단 | 차단 |

## Notes

재발 방지의 나머지 절반은 각자 로컬 Claude Code 설정의 `includeCoAuthoredBy: false` 다. 이 검사는 그 설정이 빠졌을 때의 안전망이다.