### PR TITLE
feat(schedule): 예약 슬롯 관리 UI 통일 및 예약자 표시

### DIFF
--- a/backend/app/schemas/reservation_api.py
+++ b/backend/app/schemas/reservation_api.py
@@ -18,6 +18,10 @@ class TrainerSlotOut(BaseModel):
     remaining: int
     is_closed: bool = False
     session_type: SessionType = "1:1 PT"
+    #: 이 자리를 잡은 회원 이름. 트레이너용 목록(`GET /trainer/reservation-slots`)
+    #: 에서만 채운다 — 회원용 목록(`GET /trainers/{id}/slots`)은 다른 회원의
+    #: 이름을 알 이유가 없어 항상 null이다.
+    booked_by_name: str | None = None
 
 
 class TrainerSlotCreate(BaseModel):

--- a/backend/app/services/reservation_service.py
+++ b/backend/app/services/reservation_service.py
@@ -50,7 +50,9 @@ def _aware(value: datetime) -> datetime:
 _SESSION_DURATION_MINUTES = {"1:1 PT": 60, "상담": 30}
 
 
-def _slot_out(slot: TrainerReservationSlot) -> TrainerSlotOut:
+def _slot_out(
+    slot: TrainerReservationSlot, *, booked_by_name: str | None = None
+) -> TrainerSlotOut:
     return TrainerSlotOut(
         id=slot.id,
         trainer_id=slot.trainer_id,
@@ -60,7 +62,27 @@ def _slot_out(slot: TrainerReservationSlot) -> TrainerSlotOut:
         remaining=0 if slot.is_closed else slot.remaining,
         is_closed=slot.is_closed,
         session_type=slot.session_type,
+        booked_by_name=booked_by_name,
     )
+
+
+def _booked_names(db: Session, slot_ids: list[str]) -> dict[str, str]:
+    """예약 슬롯 id → 그 자리를 잡은 회원 이름.
+
+    트레이너용 슬롯 목록에서만 쓴다(#1394) — 회원용 목록은 남의 이름을 알 이유가
+    없다. 취소된 예약(`status != "booked"`)은 자리를 비워 준 것이라 빼고 본다.
+    """
+    if not slot_ids:
+        return {}
+    rows = db.execute(
+        select(TrainerReservation.slot_id, User.name)
+        .join(User, User.id == TrainerReservation.member_id)
+        .where(
+            TrainerReservation.slot_id.in_(slot_ids),
+            TrainerReservation.status == "booked",
+        )
+    ).all()
+    return {slot_id: name for slot_id, name in rows}
 
 
 def list_member_slots(
@@ -89,7 +111,10 @@ def list_trainer_slots(
             TrainerReservationSlot.starts_at > datetime.now(timezone.utc)
         )
     rows = db.scalars(query.order_by(TrainerReservationSlot.starts_at)).all()
-    return [_slot_out(row) for row in rows]
+    booked_names = _booked_names(db, [row.id for row in rows])
+    return [
+        _slot_out(row, booked_by_name=booked_names.get(row.id)) for row in rows
+    ]
 
 
 def create_slot(

--- a/backend/tests/test_reservations.py
+++ b/backend/tests/test_reservations.py
@@ -225,6 +225,41 @@ def test_reservation_persists_and_appears_in_trainer_schedule(
     assert any(row["id"] == schedule.id for row in timeline.json())
 
 
+def test_trainer_slot_list_shows_booker_name_but_member_list_does_not(
+    client, created_slots
+):
+    """트레이너는 자기 슬롯 목록에서 예약자 이름을 본다(#1394).
+
+    같은 정보를 회원용 목록에는 싣지 않는다 — 남의 예약을 볼 이유가 없다.
+    """
+    trainer_token = _login(client, "trainer@oncare.com")
+    member_token = _login(client, "jisu@oncare.com")
+    slot = _create_slot(client, trainer_token, created_slots)
+
+    booked = client.post(
+        "/v1/reservations",
+        headers=_headers(member_token),
+        json={"slot_id": slot["id"]},
+    )
+    assert booked.status_code == 201, booked.text
+
+    trainer_view = client.get(
+        "/v1/trainer/reservation-slots", headers=_headers(trainer_token)
+    )
+    assert trainer_view.status_code == 200, trainer_view.text
+    trainer_row = next(
+        row for row in trainer_view.json() if row["id"] == slot["id"]
+    )
+    assert trainer_row["booked_by_name"] == "이지수"
+
+    member_view = client.get(
+        "/v1/trainers/trainer-demo/slots", headers=_headers(member_token)
+    )
+    assert member_view.status_code == 200, member_view.text
+    member_row = next(row for row in member_view.json() if row["id"] == slot["id"])
+    assert member_row["booked_by_name"] is None
+
+
 def test_reserved_schedule_cannot_be_updated_or_deleted_as_regular_schedule(
     client, db_session, created_slots
 ):

--- a/frontend/flutter_trainer/lib/features/schedule/domain/entities/reservation_slot.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/domain/entities/reservation_slot.dart
@@ -11,6 +11,7 @@ class ReservationSlot {
     required this.booked,
     required this.isClosed,
     required this.sessionType,
+    this.bookedByName,
   });
 
   final String id;
@@ -26,6 +27,10 @@ class ReservationSlot {
   /// (`상담`) — 스케줄 탭의 세션 종류와 같은 계약값이다(#1083).
   final String sessionType;
 
+  /// 이 자리를 잡은 회원 이름. [booked] 인 트레이너용 슬롯에서만 채워진다
+  /// (#1394) — 서버가 트레이너 목록에서만 이 값을 내려준다.
+  final String? bookedByName;
+
   factory ReservationSlot.fromJson(Map<String, dynamic> json) {
     return ReservationSlot(
       id: json['id'] as String,
@@ -36,6 +41,7 @@ class ReservationSlot {
       booked: ((json['remaining'] as num?) ?? 0).toInt() <= 0,
       isClosed: json['is_closed'] as bool? ?? false,
       sessionType: json['session_type'] as String? ?? '1:1 PT',
+      bookedByName: json['booked_by_name'] as String?,
     );
   }
 }

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/reservation_slots_sheet.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/reservation_slots_sheet.dart
@@ -107,97 +107,6 @@ class _ReservationSlotsSheetState extends ConsumerState<ReservationSlotsSheet> {
     }
   }
 
-  Future<void> _edit(ReservationSlot slot) async {
-    final AppLocalizations l = AppLocalizations.of(context);
-    var time = TimeOfDay.fromDateTime(slot.startsAt);
-    var endTime = TimeOfDay.fromDateTime(
-      slot.startsAt.add(Duration(minutes: slot.durationMinutes)),
-    );
-    var type = slot.sessionType;
-    // 이미 예약이 걸린 자리는 종류를 고칠 수 없다 — 서버가 409 로 막는
-    // 동작을 아예 내놓지 않는다(#871 과 같은 규약).
-    final typeLocked = slot.booked;
-    final changed = await showDialog<(TimeOfDay, TimeOfDay, String)?>(
-      context: context,
-      builder: (dialogContext) => StatefulBuilder(
-        builder: (context, setDialogState) => AlertDialog(
-          title: Text(l.slotEditTitle),
-          content: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              ListTile(
-                contentPadding: EdgeInsets.zero,
-                title: Text('${l.schedFieldStart} – ${l.schedFieldEnd}'),
-                trailing: Text('${_hhmm(time)} – ${_hhmm(endTime)}'),
-                onTap: () async {
-                  final picked = await showScheduleTimeRangePicker(
-                    context: context,
-                    start: time,
-                    end: endTime,
-                  );
-                  if (picked != null) {
-                    setDialogState(() {
-                      time = picked.start;
-                      endTime = picked.end;
-                    });
-                  }
-                },
-              ),
-              ListTile(
-                contentPadding: EdgeInsets.zero,
-                title: Text(l.slotSessionType),
-                trailing: typeLocked
-                    ? Text(sessionTypeLabel(l, type))
-                    : DropdownButton<String>(
-                        value: type,
-                        underline: const SizedBox.shrink(),
-                        items: <DropdownMenuItem<String>>[
-                          for (final t in SessionType.all)
-                            DropdownMenuItem<String>(
-                              value: t,
-                              child: Text(sessionTypeLabel(l, t)),
-                            ),
-                        ],
-                        onChanged: (v) =>
-                            setDialogState(() => type = v ?? type),
-                      ),
-              ),
-            ],
-          ),
-          actions: <Widget>[
-            TextButton(
-              onPressed: () => Navigator.pop(dialogContext),
-              child: Text(l.actionCancel),
-            ),
-            FilledButton(
-              onPressed: () =>
-                  Navigator.pop(dialogContext, (time, endTime, type)),
-              child: Text(l.actionSave),
-            ),
-          ],
-        ),
-      ),
-    );
-    if (changed == null || !mounted) return;
-    setState(() => _saving = true);
-    try {
-      await ref
-          .read(reservationSlotRepositoryProvider)
-          .update(
-            slot.id,
-            startsAt: _startsAt(changed.$1),
-            durationMinutes: _duration(changed.$1, changed.$2),
-            sessionType: changed.$3 == slot.sessionType ? null : changed.$3,
-          );
-      ref.invalidate(reservationSlotsProvider);
-      _showMessage(l.slotUpdated, kind: AppToastKind.success);
-    } catch (error) {
-      _showMessage(_errorMessage(l, error), kind: AppToastKind.error);
-    } finally {
-      if (mounted) setState(() => _saving = false);
-    }
-  }
-
   Future<void> _close(ReservationSlot slot) async {
     final AppLocalizations l = AppLocalizations.of(context);
     final confirmed = await showDialog<bool>(
@@ -448,11 +357,15 @@ class _ReservationSlotsSheetState extends ConsumerState<ReservationSlotsSheet> {
                           const SizedBox(height: AppSpacing.sm),
                       itemBuilder: (context, index) {
                         final slot = daySlots[index];
+                        // 닫혔거나 이미 예약된 자리는 "골라 쓸 수 없는 자리"라
+                        // 같은 회색으로 눌러 둔다 — 비어 있는 자리(흰 카드)와
+                        // 구분된다.
+                        final taken = slot.isClosed || slot.booked;
                         return Container(
                           key: ValueKey<String>('slot-row-${slot.id}'),
                           padding: const EdgeInsets.all(AppSpacing.md),
                           decoration: BoxDecoration(
-                            color: slot.isClosed
+                            color: taken
                                 ? AppColors.inputBackground
                                 : AppColors.card,
                             border: Border.all(color: AppColors.borderStrong),
@@ -460,9 +373,30 @@ class _ReservationSlotsSheetState extends ConsumerState<ReservationSlotsSheet> {
                           ),
                           child: Row(
                             children: <Widget>[
+                              // 종류 → 시간 순서다 — 새 일정 모달과 위 열기
+                              // 폼(종류 → 날짜 → 시간)이 같은 순서로 읽힌다.
                               Container(
-                                width: 132,
-                                alignment: Alignment.center,
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: AppSpacing.sm,
+                                  vertical: 3,
+                                ),
+                                decoration: const BoxDecoration(
+                                  color: AppColors.accentSurface,
+                                  borderRadius: BorderRadius.all(
+                                    AppRadius.pill,
+                                  ),
+                                ),
+                                child: Text(
+                                  sessionTypeLabel(l, slot.sessionType),
+                                  style: const TextStyle(
+                                    fontSize: 11.5,
+                                    fontWeight: FontWeight.w700,
+                                    color: AppColors.accent,
+                                  ),
+                                ),
+                              ),
+                              const SizedBox(width: AppSpacing.md),
+                              Expanded(
                                 child: Text(
                                   '${_hhmm(TimeOfDay.fromDateTime(slot.startsAt))} – '
                                   '${_hhmm(TimeOfDay.fromDateTime(slot.startsAt.add(Duration(minutes: slot.durationMinutes))))}',
@@ -471,53 +405,37 @@ class _ReservationSlotsSheetState extends ConsumerState<ReservationSlotsSheet> {
                                   ),
                                 ),
                               ),
-                              const SizedBox(width: AppSpacing.md),
-                              Expanded(
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: <Widget>[
-                                    Text(
-                                      sessionTypeLabel(l, slot.sessionType),
-                                      style: const TextStyle(
-                                        fontSize: 11.5,
-                                        fontWeight: FontWeight.w700,
-                                        color: AppColors.primary,
-                                      ),
-                                    ),
-                                    Text(
-                                      // 한 사람 몫뿐인 자리라 인원수를 셀
-                                      // 것이 없다 — 상태만 적는다(#1072).
-                                      slot.isClosed
-                                          ? l.slotClosedSummary
-                                          : (slot.booked
-                                                ? l.slotBookedSummary
-                                                : l.slotOpenSummary),
-                                      style: TextStyle(
-                                        color: slot.isClosed
-                                            ? AppColors.subtleForeground
-                                            : AppColors.foreground,
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ),
-                              if (!slot.isClosed) ...<Widget>[
-                                IconButton(
-                                  tooltip: l.actionEdit,
-                                  onPressed: _saving ? null : () => _edit(slot),
-                                  icon: const Icon(Icons.edit_outlined),
-                                ),
+                              if (slot.isClosed)
+                                Text(
+                                  l.slotClosedSummary,
+                                  style: const TextStyle(
+                                    color: AppColors.subtleForeground,
+                                  ),
+                                )
+                              else if (slot.booked)
+                                // 예약자 이름을 보여 준다(#1394) — 예전
+                                // 수정·닫기 아이콘 자리다. 이름이 아직 없으면
+                                // (오래된 데이터 등) 상태 문구로 대신한다.
+                                Text(
+                                  slot.bookedByName ?? l.slotBookedSummary,
+                                  style: const TextStyle(
+                                    fontWeight: FontWeight.w700,
+                                    color: AppColors.foreground,
+                                  ),
+                                )
+                              else
+                                // 아직 아무도 잡지 않은 자리만 지울 수 있다 —
+                                // 수정 대신 삭제다(#1394).
                                 IconButton(
                                   tooltip: l.slotCloseAction,
                                   onPressed: _saving
                                       ? null
                                       : () => _close(slot),
                                   icon: const Icon(
-                                    Icons.lock_outline,
+                                    Icons.delete_outline,
                                     color: AppColors.destructive,
                                   ),
                                 ),
-                              ],
                             ],
                           ),
                         );


### PR DESCRIPTION
## Summary

* 트레이너용 예약 슬롯 목록(`GET /trainer/reservation-slots`)에 예약자 이름(`booked_by_name`)을 실어 보냅니다. 회원용 목록에는 노출하지 않습니다.
* 예약 슬롯 관리 모달의 목록 항목을 종류 → 시간 순으로 재배치해 새 일정 모달과 같은 언어로 맞췄습니다.
* 아직 예약되지 않은 슬롯의 수정(연필) 아이콘을 삭제 아이콘(휴지통)으로 바꿨습니다 — 실제로는 이미 있던 닫기 API를 그대로 씁니다(회원 앱에는 이미 남은 자리 0인 슬롯으로 보여 동작 차이가 없습니다).
* 예약된 슬롯은 행을 회색으로 표시하고, 예전 아이콘 자리에 예약자 이름을 보여줍니다.

---

## Changes

### ✨ Features

* `TrainerSlotOut.booked_by_name` 추가 — 트레이너 목록 조회에서 `TrainerReservation`+`User` 조인으로 채웁니다.

### 🎨 UI/UX

* 예약 슬롯 목록 항목 재배치, 삭제 아이콘 교체, 예약된 슬롯 회색 표시 + 예약자 이름.

### 🐛 Fixes

* 이미 예약이 걸려 사실상 손댈 수 없는 슬롯에 "수정" 아이콘이 떠 있던 것을 정리했습니다.

---

## Notes

* 백엔드 테스트(`test_trainer_slot_list_shows_booker_name_but_member_list_does_not`)는 로컬에 Postgres 가 없어 CI에서만 실행됩니다(다른 DB 연동 테스트와 동일).
* 슬롯을 "삭제"한다고 표현하지만 서버 쪽 동작은 기존 닫기(`close`, 신규 예약만 막음)를 그대로 씁니다 — 이미 예약된 자리는 이 화면에서 아예 이 액션을 보여주지 않으므로 실질적으로 삭제와 같은 효과입니다.

---

## Test Plan

* [x] 기능 정상 동작 확인 (`flutter analyze`, `reservation_slots_sheet_test.dart` 3건 통과)
* [x] UI 확인
* [ ] 관련 테스트 통과 — 백엔드 신규 테스트는 CI(Postgres)에서 실행됩니다.

### Manual Test Steps

1. 트레이너로 예약 슬롯을 열고, 회원 앱(또는 API)으로 예약한다.
2. 예약 슬롯 관리 모달에서 해당 행이 회색으로 바뀌고 예약자 이름이 보이는지 확인.
3. 아직 비어 있는 다른 슬롯에서 휴지통 아이콘으로 닫히는지 확인.

---

## Related Issues

Closes #1394

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인