### PR TITLE
fix(diet): 상세 식사 카드의 수정 동작 아이콘 정정

### DIFF
--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -1594,10 +1594,19 @@ class _MealCard extends StatelessWidget {
                     // 두면 어느 쪽이 무엇인지 되레 흐려진다(#761). 넘치지 않게
                     // 줄여 적던 처리(#743)도 함께 사라진다 — 적지 않으니 줄일
                     // 것도 없다.
-                    const Icon(
-                      Icons.chevron_right,
-                      size: 16,
-                      color: FigmaColors.textFaint,
+                    // `>` 는 '한 단계 더 들어가는 상세'로 읽힌다. 이 카드가
+                    // 여는 것은 상세가 아니라 같은 끼니의 **수정** 화면이라
+                    // 연필로 바꾼다(#1431). 아이콘 자체는 탭을 먹지 않는다 —
+                    // 카드 전체가 `InkWell` 이므로 아이콘을 눌러도 같은 수정
+                    // 화면으로 간다.
+                    Tooltip(
+                      message: l.dietEditMeal,
+                      child: Icon(
+                        Icons.edit_outlined,
+                        size: 16,
+                        color: FigmaColors.textFaint,
+                        semanticLabel: l.dietEditMeal,
+                      ),
                     ),
                   ],
                 ),

--- a/frontend/flutter/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations.dart
@@ -1022,6 +1022,12 @@ abstract class AppLocalizations {
   /// **'Delete Meal'**
   String get dietDeleteMeal;
 
+  /// No description provided for @dietEditMeal.
+  ///
+  /// In en, this message translates to:
+  /// **'Edit meal'**
+  String get dietEditMeal;
+
   /// No description provided for @exTypeCardio.
   ///
   /// In en, this message translates to:

--- a/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
@@ -519,6 +519,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get dietDeleteMeal => 'Delete Meal';
 
   @override
+  String get dietEditMeal => 'Edit meal';
+
+  @override
   String get exTypeCardio => 'Cardio';
 
   @override

--- a/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
@@ -509,6 +509,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get dietDeleteMeal => '식단 삭제';
 
   @override
+  String get dietEditMeal => '식사 수정';
+
+  @override
   String get exTypeCardio => '유산소';
 
   @override

--- a/frontend/flutter/lib/l10n/app_en.arb
+++ b/frontend/flutter/lib/l10n/app_en.arb
@@ -243,6 +243,7 @@
   "dietSodiumHint": "Recommended under 2,000mg/day",
   "dietSugarHint": "Recommended under 50g/day",
   "dietDeleteMeal": "Delete Meal",
+  "dietEditMeal": "Edit meal",
   "exTypeCardio": "Cardio",
   "exTypeStrength": "Strength",
   "exTypeFlexibility": "Stretching",

--- a/frontend/flutter/lib/l10n/app_ko.arb
+++ b/frontend/flutter/lib/l10n/app_ko.arb
@@ -164,6 +164,7 @@
   "dietSodiumHint": "하루 권장 2,000mg 이하",
   "dietSugarHint": "하루 권장 50g 이하",
   "dietDeleteMeal": "식단 삭제",
+  "dietEditMeal": "식사 수정",
   "exTypeCardio": "유산소",
   "exTypeStrength": "근력",
   "exTypeFlexibility": "스트레칭",

--- a/frontend/flutter/test/features/diet/diet_header_alignment_test.dart
+++ b/frontend/flutter/test/features/diet/diet_header_alignment_test.dart
@@ -96,7 +96,8 @@ void main() {
       );
     });
 
-    testWidgets('끼니 카드 화살표는 카드 오른쪽 끝에 붙는다', (WidgetTester tester) async {
+    // 아이콘은 `>` 에서 연필로 바뀌었다(#1431) — 붙는 자리는 그대로다.
+    testWidgets('끼니 카드 수정 아이콘은 카드 오른쪽 끝에 붙는다', (WidgetTester tester) async {
       await pumpPage(tester);
 
       final Finder headers = find.byKey(
@@ -106,15 +107,15 @@ void main() {
 
       for (int i = 0; i < headers.evaluate().length; i++) {
         final Finder header = headers.at(i);
-        final Finder chevron = find.descendant(
+        final Finder editIcon = find.descendant(
           of: header,
-          matching: find.byIcon(Icons.chevron_right),
+          matching: find.byIcon(Icons.edit_outlined),
         );
-        expect(chevron, findsOneWidget);
+        expect(editIcon, findsOneWidget);
         expect(
-          tester.getRect(chevron).right,
+          tester.getRect(editIcon).right,
           moreOrLessEquals(tester.getRect(header).right, epsilon: 0.5),
-          reason: '$i 번째 끼니 카드의 화살표가 카드 오른쪽 끝에 붙지 않았다',
+          reason: '$i 번째 끼니 카드의 수정 아이콘이 카드 오른쪽 끝에 붙지 않았다',
         );
       }
     });

--- a/frontend/flutter/test/features/diet/meal_card_edit_icon_test.dart
+++ b/frontend/flutter/test/features/diet/meal_card_edit_icon_test.dart
@@ -1,0 +1,134 @@
+/// 끼니 카드의 오른쪽 위 아이콘은 '수정'을 뜻해야 한다 (#1431).
+///
+/// 카드를 누르면 하위 상세 화면이 아니라 그 끼니의 **수정** 화면이 열린다.
+/// `>` 는 더 볼 것이 남았다는 뜻으로 읽혀 데모에서 카드 밖에 더 많은 정보가
+/// 있는 것처럼 보였다. 연필로 바꾸고, 아이콘을 눌러도 카드 본문과 똑같이
+/// 수정 화면으로 가는지까지 확인한다.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
+import 'package:oncare/features/diet/presentation/pages/diet_record_page.dart';
+import 'package:oncare/features/diet/presentation/widgets/diet_flows.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+import '../../helpers/fake_diet_repository.dart';
+
+/// 끼니 카드 하나로 범위를 좁히는 검색자. 화면 위쪽 요약 카드에도 아이콘이
+/// 있어 좁히지 않으면 그쪽이 함께 잡힌다.
+Finder get _anyMealCard => find
+    .byWidgetPredicate(
+      (Widget w) =>
+          w.key is ValueKey<String> &&
+          (w.key! as ValueKey<String>).value.startsWith('mealCard-'),
+    )
+    .first;
+
+void main() {
+  Future<void> pumpDiet(WidgetTester tester) async {
+    await tester.binding.setSurfaceSize(const Size(900, 2400));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    // 수정 화면으로 실제로 이동하는지 보려면 라우터가 필요하다. 앱 전체
+    // 라우터 대신 이 흐름에 쓰이는 두 경로만 세운다.
+    final GoRouter router = GoRouter(
+      routes: <RouteBase>[
+        GoRoute(path: '/', builder: (_, _) => const DietRecordPage()),
+        GoRoute(
+          path: '/diet/entries/:entryId',
+          builder: (BuildContext context, GoRouterState state) =>
+              DietMealDetailPage(
+                entryId: state.pathParameters['entryId']!,
+                initialMeal: state.extra as DietMeal?,
+              ),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          dietRepositoryProvider.overrideWithValue(FakeDietRepository()),
+        ],
+        child: MaterialApp.router(
+          locale: const Locale('ko'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('끼니 카드에는 `>` 대신 연필 아이콘이 있다', (WidgetTester tester) async {
+    await pumpDiet(tester);
+
+    expect(
+      find.descendant(
+        of: _anyMealCard,
+        matching: find.byIcon(Icons.edit_outlined),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: _anyMealCard,
+        matching: find.byIcon(Icons.chevron_right),
+      ),
+      findsNothing,
+    );
+  });
+
+  testWidgets('연필 아이콘은 `식사 수정`으로 안내된다', (WidgetTester tester) async {
+    await pumpDiet(tester);
+
+    final Icon icon = tester.widget<Icon>(
+      find
+          .descendant(
+            of: _anyMealCard,
+            matching: find.byIcon(Icons.edit_outlined),
+          )
+          .first,
+    );
+    expect(icon.semanticLabel, '식사 수정');
+    expect(
+      find.descendant(of: _anyMealCard, matching: find.byType(Tooltip)),
+      findsWidgets,
+    );
+  });
+
+  testWidgets('아이콘을 눌러도 카드 본문과 같은 수정 화면이 열린다', (WidgetTester tester) async {
+    await pumpDiet(tester);
+
+    await tester.tap(
+      find
+          .descendant(
+            of: _anyMealCard,
+            matching: find.byIcon(Icons.edit_outlined),
+          )
+          .first,
+    );
+    await tester.pumpAndSettle();
+    expect(find.byType(DietMealDetailPage), findsOneWidget);
+
+    // 카드 본문 탭도 같은 화면이다 — 되돌아가 헤더를 눌러 확인한다.
+    tester.state<NavigatorState>(find.byType(Navigator).first).pop();
+    await tester.pumpAndSettle();
+    // 카드 본문 = 카드 전체를 덮는 `InkWell`. 헤더 줄을 직접 누르면 그
+    // 가운데가 `spaceBetween` 의 빈 틈이라 줄 자체는 히트되지 않는다.
+    final Finder body = find.descendant(
+      of: _anyMealCard,
+      matching: find.byType(InkWell),
+    );
+    await tester.ensureVisible(body.first);
+    await tester.pumpAndSettle();
+    await tester.tap(body.first);
+    await tester.pumpAndSettle();
+    expect(find.byType(DietMealDetailPage), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #1431

## Summary

식단 탭 상세 식사 카드의 오른쪽 위 아이콘이 동작과 어긋나 있었다. 카드를 누르면 한 단계 더 들어가는 상세 화면이 아니라 그 끼니의 **수정** 화면이 열리는데, 아이콘은 `chevron_right(>)` 라 "카드 밖에 더 볼 내용이 남아 있다"로 읽혔다.

## Changes

- 끼니 카드 헤더의 trailing 아이콘을 `Icons.chevron_right` → `Icons.edit_outlined` 로 바꾼다. 자리(카드 오른쪽 끝)·크기·색은 그대로다.
- 아이콘에 tooltip 과 `semanticLabel` 로 `식사 수정` 의미를 붙인다. 새 l10n 키 `dietEditMeal`(ko `식사 수정` / en `Edit meal`).
- 아이콘은 자기 탭 대상을 만들지 않는다 — 카드 전체가 `InkWell` 이므로 아이콘을 눌러도 카드 본문을 눌렀을 때와 같은 수정 화면으로 이어진다.
- 실제로 다음 단계로 이동하는 자리의 `>` 는 건드리지 않는다(주간 날짜 이동 화살표, 식사 추가 소스 선택 카드).

## Verification

- 새 테스트 `test/features/diet/meal_card_edit_icon_test.dart` 3건: 카드 안에 `>` 가 없고 연필 아이콘이 있다 / 접근성 라벨이 `식사 수정` 이다 / 아이콘 탭과 카드 본문 탭이 모두 같은 수정 화면을 연다.
- 기존 `diet_header_alignment_test.dart` 의 정렬 검사는 대상 아이콘만 연필로 바꿔 유지 — 오른쪽 끝 정렬 계약은 그대로 확인한다.
- `flutter analyze` 무경고, `flutter test` 전체 통과(로컬).
