### PR TITLE
fix(consultation): 상담 요청 취소 확정 버튼을 붉은색으로 표시

### DIFF
--- a/frontend/flutter/lib/features/exercise/presentation/pages/consultation_history_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/consultation_history_page.dart
@@ -102,11 +102,12 @@ class ConsultationHistoryPage extends ConsumerWidget {
                           ),
                           const SizedBox(height: 12),
                         ],
-                        const SizedBox(height: 12),
                       ],
+                      // `지난 요청` 소제목은 두지 않는다(#1429). 완료·취소는
+                      // 카드가 상태로 말하고 있어, 소제목은 같은 목록을 한 겹
+                      // 더 나누기만 했다. 진행 중 묶음과 같은 간격으로 이어
+                      // 붙어 카드 흐름이 끊기지 않는다.
                       if (past.isNotEmpty) ...<Widget>[
-                        _SectionLabel(text: l.exConsultHistoryPast),
-                        const SizedBox(height: 10),
                         for (final ConsultationRequest r in past) ...<Widget>[
                           ConsultationRequestCard(
                             key: ValueKey<String>('consult-history-${r.id}'),

--- a/frontend/flutter/lib/features/exercise/presentation/pages/consultation_history_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/consultation_history_page.dart
@@ -79,8 +79,15 @@ class ConsultationHistoryPage extends ConsumerWidget {
                                       onPressed: () => Navigator.pop(dialogContext, false),
                                       child: const Text('유지'),
                                     ),
+                                    // 되돌릴 수 없는 쪽이다 — 카드의 취소
+                                    // 버튼과 같은 파괴적 색 토큰을 쓴다.
+                                    // 유지와 취소가 같은 색이면 두 동작의
+                                    // 위험도 차이가 보이지 않는다(#1429).
                                     TextButton(
                                       onPressed: () => Navigator.pop(dialogContext, true),
+                                      style: TextButton.styleFrom(
+                                        foregroundColor: AppColors.destructive,
+                                      ),
                                       child: Text(l.actionCancel),
                                     ),
                                   ],

--- a/frontend/flutter/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations.dart
@@ -2816,12 +2816,6 @@ abstract class AppLocalizations {
   /// **'In Progress'**
   String get exConsultHistoryInProgress;
 
-  /// No description provided for @exConsultHistoryPast.
-  ///
-  /// In en, this message translates to:
-  /// **'Past Requests'**
-  String get exConsultHistoryPast;
-
   /// No description provided for @exConsultRejectedReasonLabel.
   ///
   /// In en, this message translates to:

--- a/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
@@ -1513,9 +1513,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get exConsultHistoryInProgress => 'In Progress';
 
   @override
-  String get exConsultHistoryPast => 'Past Requests';
-
-  @override
   String get exConsultRejectedReasonLabel => 'Reason for decline';
 
   @override

--- a/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
@@ -1477,9 +1477,6 @@ class AppLocalizationsKo extends AppLocalizations {
   String get exConsultHistoryInProgress => '진행 중';
 
   @override
-  String get exConsultHistoryPast => '지난 요청';
-
-  @override
   String get exConsultRejectedReasonLabel => '거절 사유';
 
   @override

--- a/frontend/flutter/lib/l10n/app_en.arb
+++ b/frontend/flutter/lib/l10n/app_en.arb
@@ -758,7 +758,6 @@
   "exConsultHistoryTitle": "My Consultation Requests",
   "exConsultHistoryEmpty": "You haven't sent any consultation requests yet.",
   "exConsultHistoryInProgress": "In Progress",
-  "exConsultHistoryPast": "Past Requests",
   "exConsultRejectedReasonLabel": "Reason for decline",
   "exConsultRejectedNoReason": "No reason was given. Try requesting a consultation with another trainer.",
   "exConsultAcceptedGuide": "You're connected with your trainer. You can start chatting now.",

--- a/frontend/flutter/lib/l10n/app_ko.arb
+++ b/frontend/flutter/lib/l10n/app_ko.arb
@@ -524,7 +524,6 @@
   "exConsultHistoryTitle": "내 상담 요청",
   "exConsultHistoryEmpty": "아직 보낸 상담 요청이 없어요.",
   "exConsultHistoryInProgress": "진행 중",
-  "exConsultHistoryPast": "지난 요청",
   "exConsultRejectedReasonLabel": "거절 사유",
   "exConsultRejectedNoReason": "사유를 남기지 않았어요. 다른 트레이너에게 상담을 요청해 보세요.",
   "exConsultAcceptedGuide": "담당 트레이너와 연결되었어요. 이제 채팅으로 상담할 수 있어요.",

--- a/frontend/flutter/test/features/exercise/consultation_cancel_confirm_test.dart
+++ b/frontend/flutter/test/features/exercise/consultation_cancel_confirm_test.dart
@@ -1,8 +1,10 @@
-/// 상담 요청 취소 확인창의 색 계약 (#1429).
+/// 내 상담 요청 화면의 소제목과 취소 확인창의 색 계약 (#1429).
 ///
 /// 카드의 `취소` 는 파괴적 색인데 확인창의 확정 `취소` 만 기본 색이면, 되돌릴
 /// 수 없는 쪽과 요청을 그대로 두는 쪽이 같은 색으로 보인다. 확정 버튼은 카드와
 /// 같은 파괴적 토큰을, `유지` 는 중립 색을 쓴다.
+///
+/// `지난 요청` 소제목은 두지 않는다 — 완료·취소는 카드가 상태로 말한다.
 library;
 
 import 'package:flutter/material.dart';
@@ -15,6 +17,7 @@ import 'package:oncare/features/exercise/domain/entities/consultation_draft.dart
 import 'package:oncare/features/exercise/domain/entities/consultation_request.dart';
 import 'package:oncare/features/exercise/presentation/controllers/consultation_request_controller.dart';
 import 'package:oncare/features/exercise/presentation/pages/consultation_history_page.dart';
+import 'package:oncare/features/exercise/presentation/widgets/consultation_request_card.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
 
 import '../../support/consultation_test_support.dart';
@@ -113,6 +116,24 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(controller.state.single.status, ConsultationStatus.pending);
+  });
+
+  testWidgets('지난 요청 소제목은 표시되지 않는다', (WidgetTester tester) async {
+    await pumpHistory(tester);
+
+    // 요청 하나를 취소해 `지난 요청` 쪽으로 옮긴다.
+    await openConfirm(tester);
+    await tester.tap(
+      find.descendant(
+        of: find.byType(AlertDialog),
+        matching: find.widgetWithText(TextButton, '취소'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(controller.state.single.status, isNot(ConsultationStatus.pending));
+    expect(find.text('지난 요청'), findsNothing);
+    expect(find.byType(ConsultationRequestCard), findsOneWidget);
   });
 
   testWidgets('확정하면 요청이 취소 상태가 된다', (WidgetTester tester) async {

--- a/frontend/flutter/test/features/exercise/consultation_cancel_confirm_test.dart
+++ b/frontend/flutter/test/features/exercise/consultation_cancel_confirm_test.dart
@@ -1,0 +1,135 @@
+/// 상담 요청 취소 확인창의 색 계약 (#1429).
+///
+/// 카드의 `취소` 는 파괴적 색인데 확인창의 확정 `취소` 만 기본 색이면, 되돌릴
+/// 수 없는 쪽과 요청을 그대로 두는 쪽이 같은 색으로 보인다. 확정 버튼은 카드와
+/// 같은 파괴적 토큰을, `유지` 는 중립 색을 쓴다.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/design_system/tokens/colors.dart';
+import 'package:oncare/features/exercise/domain/entities/consultation_draft.dart';
+import 'package:oncare/features/exercise/domain/entities/consultation_request.dart';
+import 'package:oncare/features/exercise/presentation/controllers/consultation_request_controller.dart';
+import 'package:oncare/features/exercise/presentation/pages/consultation_history_page.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+
+import '../../support/consultation_test_support.dart';
+
+const AppConfig _config = AppConfig(
+  environment: Environment.dev,
+  apiBaseUrl: 'https://dev.api.test',
+  useMockApi: true,
+);
+
+ConsultationRequest _pending() => ConsultationRequest(
+  id: 'request-cancel',
+  trainerId: 'trainer-cancel',
+  trainerName: '김상담',
+  trainerRole: '전담 트레이너',
+  exerciseGoal: ExerciseGoal.weightLoss,
+  healthPurposeType: HealthPurposeType.general,
+  healthPurposeDetail: null,
+  preferredDate: DateTime(2026, 7, 28),
+  preferredTimeSlot: const PreferredTime.at(TimeOfDay(hour: 14, minute: 0)),
+  message: null,
+  status: ConsultationStatus.pending,
+  createdAt: DateTime(2026, 7, 26),
+);
+
+void main() {
+  late ConsultationRequestController controller;
+
+  Future<void> pumpHistory(WidgetTester tester) async {
+    await tester.binding.setSurfaceSize(const Size(600, 1200));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    controller = newTestConsultationController();
+    expect(await seedPending(controller, _pending()), isTrue);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          appConfigProvider.overrideWithValue(_config),
+          consultationRequestControllerProvider.overrideWith(
+            (_) => controller,
+          ),
+        ],
+        child: const MaterialApp(
+          locale: Locale('ko'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: ConsultationHistoryPage(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  /// 다이얼로그 버튼의 글자색. `TextButton` 은 스타일을 해석해 자식 텍스트에
+  /// 물려주므로, 눈에 보이는 색은 그려진 텍스트에서 읽는다.
+  Color? labelColorOf(WidgetTester tester, String label) {
+    final Finder button = find.ancestor(
+      of: find.text(label),
+      matching: find.byType(TextButton),
+    );
+    final TextButton widget = tester.widget<TextButton>(button);
+    return widget.style?.foregroundColor?.resolve(<WidgetState>{});
+  }
+
+  Future<void> openConfirm(WidgetTester tester) async {
+    await tester.tap(find.widgetWithText(TextButton, '취소').first);
+    await tester.pumpAndSettle();
+    expect(find.text('상담 요청을 취소할까요?'), findsOneWidget);
+  }
+
+  testWidgets('확정 취소는 붉은색, 유지는 중립색이다', (WidgetTester tester) async {
+    await pumpHistory(tester);
+    await openConfirm(tester);
+
+    // 확인창 안의 `취소` — 카드의 취소 버튼은 확인창이 덮고 있어도 트리에
+    // 남으므로, 다이얼로그 안으로 범위를 좁혀 찾는다.
+    final Finder confirm = find.descendant(
+      of: find.byType(AlertDialog),
+      matching: find.widgetWithText(TextButton, '취소'),
+    );
+    final TextButton confirmButton = tester.widget<TextButton>(confirm);
+    expect(
+      confirmButton.style?.foregroundColor?.resolve(<WidgetState>{}),
+      AppColors.destructive,
+    );
+
+    expect(labelColorOf(tester, '유지'), isNot(AppColors.destructive));
+  });
+
+  testWidgets('유지를 누르면 요청 상태가 그대로다', (WidgetTester tester) async {
+    await pumpHistory(tester);
+    await openConfirm(tester);
+
+    await tester.tap(find.text('유지'));
+    await tester.pumpAndSettle();
+
+    expect(controller.state.single.status, ConsultationStatus.pending);
+  });
+
+  testWidgets('확정하면 요청이 취소 상태가 된다', (WidgetTester tester) async {
+    await pumpHistory(tester);
+    await openConfirm(tester);
+
+    await tester.tap(
+      find.descendant(
+        of: find.byType(AlertDialog),
+        matching: find.widgetWithText(TextButton, '취소'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      controller.state.single.status,
+      isNot(ConsultationStatus.pending),
+    );
+  });
+}


### PR DESCRIPTION
Closes #1429

## Summary

`헬스장 → 상담 요청 → 내 상담 요청` 화면의 두 가지를 정리한다.

- 완료·취소된 요청 위의 `지난 요청` 소제목은 카드 상태가 이미 말하는 것을 한 겹 더 나누기만 했다.
- 대기 중 요청 카드의 `취소` 는 파괴적 색인데, 그 뒤 확인창의 확정 `취소` 는 기본 색이라 요청을 유지하는 쪽과 되돌릴 수 없는 쪽이 같은 계열로 보였다.

## Changes

- `지난 요청` 소제목과 진행 중 묶음 뒤의 여분 여백을 걷는다. 지난 요청 카드가 진행 중 카드와 같은 간격으로 이어진다. 쓰이지 않게 된 l10n 키 `exConsultHistoryPast` 도 함께 지운다.
- `상담 요청을 취소할까요?` 확인창의 확정 `취소` 버튼에 카드와 동일한 `AppColors.destructive` 를 적용한다. `유지` 는 중립 색 그대로, 문구·버튼 순서·접근성 의미도 그대로다.
- 다른 화면의 일반 닫기/취소 버튼은 건드리지 않는다.

## Verification

- 새 테스트 `test/features/exercise/consultation_cancel_confirm_test.dart` 4건: 확정 버튼이 파괴적 토큰이고 `유지` 는 아니다 / `유지` 를 누르면 대기 상태 그대로다 / 취소된 요청이 있어도 `지난 요청` 소제목이 없다 / 확정하면 취소 상태로 갱신된다.
- `flutter analyze` 무경고, `flutter test test/features/exercise` 전체 통과(로컬).
