### PR TITLE
fix(diet): 이번 주 칼로리 그래프 막대를 회색으로 통일

### DIFF
--- a/frontend/flutter/lib/design_system/figma/figma_kit.dart
+++ b/frontend/flutter/lib/design_system/figma/figma_kit.dart
@@ -76,6 +76,15 @@ class FigmaColors {
   static const Color bannerStart = Color(0xFFEDF7FC);
   static const Color bannerEnd = Color(0xFFD6EEF8);
   static const Color track = Color(0xFFF2F4F7); // progress track
+
+  /// 기간 그래프의 **목표 이내 칼로리 막대** 한 색 (#1427). 탄단지 농담으로
+  /// 쌓던 자리다 — 막대에서 탄·단·지 수치를 읽을 수 없는데 색만 셋으로
+  /// 갈라져 있어, 없는 정확도를 있는 것처럼 보이게 했다. 탄단지는 카드 머리의
+  /// 상세와 막대 툴팁이 숫자와 함께 말한다.
+  ///
+  /// 회색은 트랙([track])보다 짙어 빈 칸과 구분되고, 초과([dangerRed])와도
+  /// 명도로 갈린다.
+  static const Color barNeutral = Color(0xFFB0BAC6);
   static const Color statBg = Color(0xFFF8FAFB);
   static const Color hairline = Color(0x14000000); // rgba(0,0,0,0.08)
   static const Color sheetScrim = Color(0x8008121C); // rgba(8,18,28,0.5)

--- a/frontend/flutter/lib/features/diet/presentation/widgets/diet_period_view.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/diet_period_view.dart
@@ -1,4 +1,3 @@
-import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -608,8 +607,14 @@ class _PeriodBars extends StatelessWidget {
   final Color color;
   final Object replayKey;
 
-  /// 칼로리를 볼 때의 원본. 탄단지가 있는 날은 막대를 셋으로 쌓는다.
+  /// 칼로리를 볼 때의 원본. 막대는 이 값으로 쌓지 않고(#1427) 툴팁이 그날의
+  /// 탄·단·지를 숫자로 적는 데 쓴다.
   final List<DietPeriodDay>? days;
+
+  /// 목표 이내 막대의 색. 칼로리는 회색 한 색이다 (#1427) — 막대에서 읽을 수
+  /// 없는 구성을 색으로 말하지 않는다. 나트륨·당류는 쌓을 성분이 없던 지표라
+  /// 지금까지 쓰던 브랜드 색 그대로다.
+  Color get _barColor => days == null ? color : FigmaColors.barNeutral;
 
   /// 툴팁이 부를 지표 이름(칼로리·나트륨·당류)과 단위, 그리고 카드 머리 숫자와
   /// 같은 숫자 서식.
@@ -686,7 +691,8 @@ class _PeriodBars extends StatelessWidget {
           height: 9,
           margin: const EdgeInsets.only(right: 6),
           decoration: BoxDecoration(
-            color: over ? FigmaColors.dangerRed : color,
+            // 막대와 같은 색이어야 툴팁의 첫 줄이 그 막대를 가리킨다.
+            color: over ? FigmaColors.dangerRed : _barColor,
             borderRadius: BorderRadius.circular(2),
           ),
         ),
@@ -840,11 +846,10 @@ class _PeriodBars extends StatelessWidget {
                       height:
                           chartHeight * (values[i] / maxValue).clamp(0.0, 1.0),
                       pending: _isPending(i),
-                      day: _dayAt(i),
-                      // 목표를 넘긴 날은 빨강으로 칠한다 — 탄단지가 있는 날은
-                      // 파랑 세 단계 대신 빨강 세 단계로 쌓는다 (#1201).
+                      // 목표를 넘긴 날만 빨강이다. 그 밖의 날은 지표에 따라
+                      // 회색(칼로리) 또는 브랜드 파랑(나트륨·당류) 한 색이다.
                       over: hasGoal && values[i] > goal,
-                      color: color,
+                      color: _barColor,
                     ),
                   ),
                 ),
@@ -857,16 +862,16 @@ class _PeriodBars extends StatelessWidget {
   }
 }
 
-/// 한 칸의 막대. 탄단지가 있으면 아래에서부터 탄·단·지 순으로 쌓는다.
+/// 한 칸의 막대. **한 색**이다 (#1427).
 ///
-/// 쌓는 기준은 **칼로리**다(탄·단 4kcal/g, 지 9kcal/g). 그램으로 쌓으면 지방
-/// 1g 이 탄수화물 1g 과 같은 높이를 차지해, 칼로리 막대인데 칼로리와 다른
-/// 이야기를 하게 된다.
+/// 탄·단·지 농담으로 쌓던 자리다. 막대에서 탄·단·지 수치를 읽을 수는 없는데
+/// 색만 셋으로 갈라져 있어, 구성까지 정확히 말해 주는 그림처럼 보였다. 구성은
+/// 카드 머리의 상세와 이 막대의 툴팁이 **숫자와 함께** 말한다 — 색만 남기지
+/// 않는다.
 class _Bar extends StatelessWidget {
   const _Bar({
     super.key,
     required this.height,
-    required this.day,
     required this.over,
     required this.color,
     this.pending = false,
@@ -878,15 +883,15 @@ class _Bar extends StatelessWidget {
   /// 트레이너 리포트가 `pendingFromIndex` 에 쓰는 규칙과 같다(#754, #950).
   final bool pending;
 
-  final DietPeriodDay? day;
-
-  /// 목표를 넘긴 날인가. 쌓을 성분이 없을 때만 색으로 말한다.
+  /// 목표를 넘긴 날인가. 넘긴 날만 색으로 말한다.
   final bool over;
+
+  /// 목표 이내 막대의 색. 칼로리는 회색([FigmaColors.barNeutral]), 나트륨·당류는
+  /// 지금까지처럼 브랜드 파랑이다.
   final Color color;
 
   @override
   Widget build(BuildContext context) {
-    final DietPeriodDay? d = day;
     const BorderRadius radius = BorderRadius.vertical(top: Radius.circular(3));
     if (pending) {
       // 아직 오지 않은 날은 **빈 트랙**이다. 지나간 빈 날과 같은 그루터기를
@@ -899,77 +904,13 @@ class _Bar extends StatelessWidget {
         ),
       );
     }
-    // 목표를 넘긴 날은 **통으로 빨강** 한 색이다 (#1352). 탄단지를 빨강 세
-    // 단계로 쌓아 봤지만(#1201), 같은 카드의 나트륨·당류는 초과를 한 색으로
-    // 말하고 있어 칼로리만 초과의 생김새가 달랐다 — 지표마다 다른 문법으로
-    // 넘김을 말하면 눈이 매번 다시 배워야 한다. 넘기지 않은 날은 지금처럼
-    // 탄·단·지 파랑 세 단계로 쌓는다.
-    if (over || d == null || !d.hasMacros) {
-      return Container(
-        height: height,
-        decoration: BoxDecoration(
-          color: (over ? FigmaColors.dangerRed : color).withValues(alpha: 0.85),
-          borderRadius: radius,
-        ),
-      );
-    }
-    final double total = d.carbsKcal + d.proteinKcal + d.fatKcal;
-    if (total <= 0) {
-      return Container(
-        height: height,
-        decoration: BoxDecoration(
-          color: color.withValues(alpha: 0.85),
-          borderRadius: radius,
-        ),
-      );
-    }
-    // 막대 **높이**는 칼로리를 따른다(목표선과 견주려면 그래야 한다). 그런데
-    // 구간 비율만 탄단지 합계로 잡으면, 둘이 어긋나는 날에 세 색이 막대를 꽉
-    // 채워 **없는 기여분을 지어내는 셈**이 된다 — 1,800kcal 인 날의 탄단지가
-    // 1,200kcal 어치뿐이어도 "이 1,800kcal 이 전부 탄·단·지에서 왔다" 고
-    // 말하게 된다. 실서버 값은 음식 DB 에서 오므로 딱 맞지 않는 날이 흔하다.
-    //
-    // 그래서 분모를 **둘 중 큰 값**으로 둔다. 탄단지가 칼로리에 못 미치면 남는
-    // 만큼이 `나머지` 로 위에 남고, 넘치면 탄단지 합계에 맞춰 꽉 찬다(#956).
-    final double basis = math.max(d.calories.toDouble(), total);
-    final double rest = basis - total;
-    // 값이 있는 구간만 만든다. `flex: 0` 이 터지지는 않지만(확인함), 셋이 모두
-    // 0 으로 반올림되면 높이만 있고 아무것도 그려지지 않은 막대가 남는다 —
-    // #947 과 같은 종류의 사라짐이다. 그래서 남는 구간에는 **최소 1** 을 준다:
-    // 아주 적게 먹은 영양소는 실오라기로라도 보이는 편이 없는 것보다 낫다.
-    //
-    // 위에서부터 나머지·지방·단백질·탄수화물 — 아래가 탄수화물이라 눈이 바닥부터
-    // 읽는 순서가 라벨 순서(탄·단·지)와 같아진다.
-    // 여기까지 온 날은 목표 안이다 — 넘긴 날은 위에서 한 색으로 끝냈다.
-    final List<({Color color, double kcal})>
-    parts = <({Color color, double kcal})>[
-      // 어느 영양소로도 설명되지 않는 칼로리. 반올림 때문에 생기는
-      // 실오라기는 그리지 않는다 — 1% 를 넘을 때만 자리를 준다.
-      if (rest / basis > 0.01) (color: FigmaColors.track, kcal: rest),
-      if (d.fatKcal > 0) (color: FigmaColors.macroFat, kcal: d.fatKcal),
-      if (d.proteinKcal > 0)
-        (color: FigmaColors.macroProtein, kcal: d.proteinKcal),
-      if (d.carbsKcal > 0) (color: FigmaColors.macroCarbs, kcal: d.carbsKcal),
-    ];
-    return ClipRRect(
-      borderRadius: radius,
-      child: SizedBox(
-        height: height,
-        child: Column(
-          // **stretch 여야 한다.** 기본값(center)이면 자식이 가로로 느슨하게
-          // 제약되는데, 자식 없는 `ColoredBox` 의 고유 너비는 0 이라 구간이
-          // 통째로 사라진다(#947). 한 색 막대가 멀쩡했던 이유는 그쪽이
-          // `Container` 라서다 — 자식도 크기도 없는 Container 는 들어온 제약만큼
-          // 커지려고 하므로 폭을 다 채운다.
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: <Widget>[
-            for (final ({Color color, double kcal}) part in parts)
-              Expanded(
-                flex: math.max(1, (part.kcal / basis * 1000).round()),
-                child: ColoredBox(color: part.color),
-              ),
-          ],
-        ),
+    // 목표를 넘긴 날은 통으로 빨강이다 (#1352) — 같은 카드의 나트륨·당류가
+    // 초과를 한 색으로 말하는 것과 같은 문법이다.
+    return Container(
+      height: height,
+      decoration: BoxDecoration(
+        color: (over ? FigmaColors.dangerRed : color).withValues(alpha: 0.85),
+        borderRadius: radius,
       ),
     );
   }

--- a/frontend/flutter/test/features/diet/diet_donut_and_over_color_test.dart
+++ b/frontend/flutter/test/features/diet/diet_donut_and_over_color_test.dart
@@ -127,21 +127,21 @@ void main() {
     await tester.tap(find.byKey(const Key('diet-period-tab-month')));
     await tester.pumpAndSettle();
 
-    final Iterable<Color> painted = tester
-        .widgetList<ColoredBox>(find.byType(ColoredBox))
-        .map((ColoredBox box) => box.color);
     final Iterable<Color?> filled = tester
         .widgetList<Container>(find.byType(Container))
         .map((Container box) => (box.decoration as BoxDecoration?)?.color);
 
-    // 초과한 날은 탄단지로 쪼개지 않는다 — 나트륨·당류와 같은 한 색 덩어리다.
-    // 쌓여 있었다면 이 색은 나오지 않는다(쌓는 쪽은 `ColoredBox` 를 쓴다).
     expect(
       filled.contains(FigmaColors.dangerRed.withValues(alpha: 0.85)),
       isTrue,
       reason: '초과한 날의 막대가 아직 통짜 빨강이 아니다',
     );
-    // 넘기지 않은 날은 그대로 파랑 세 단계다 — 전부 빨개지면 초과가 무의미해진다.
-    expect(painted.contains(FigmaColors.macroCarbs), isTrue);
+    // 넘기지 않은 날은 회색 한 색이다 (#1427). 전부 빨개지면 초과가
+    // 무의미해지고, 색이 회색뿐이면 초과를 말할 수 없다 — 둘 다 있어야 한다.
+    expect(
+      filled.contains(FigmaColors.barNeutral.withValues(alpha: 0.85)),
+      isTrue,
+      reason: '목표 이내인 날의 막대가 회색이 아니다',
+    );
   });
 }

--- a/frontend/flutter/test/features/diet/diet_macro_bar_basis_test.dart
+++ b/frontend/flutter/test/features/diet/diet_macro_bar_basis_test.dart
@@ -11,11 +11,16 @@ import 'package:oncare/gen/l10n/app_localizations.dart';
 
 import '../../helpers/fake_diet_repository.dart';
 
-/// 탄단지 누적 막대가 **어떤 하루에도** 사실만 말하는지. (#956)
+/// 기간 그래프의 칼로리 막대가 **어떤 하루에도** 사실만 말하는지. (#956, #1427)
 ///
-/// 시드는 늘 셋이 다 있고 합계도 맞는 하루를 준다. 실서버 값은 음식 DB 에서
-/// 오므로 그렇지 않다 — 탄수화물만 적힌 날도, 하루 칼로리와 탄단지 합계가
-/// 어긋나는 날도, 영양이 아예 없는 날도 온다.
+/// 한때 이 막대는 탄단지 농담으로 쌓았다(#956 은 그 분모를 다룬 이슈다).
+/// 지금은 한 색이다 — 막대에서 탄·단·지 수치를 읽을 수 없는데 색만 셋으로
+/// 갈라져 있어, 구성까지 정확히 말해 주는 그림처럼 보였기 때문이다(#1427).
+/// 탄단지는 카드 머리의 상세가 숫자와 함께 말한다.
+///
+/// 실서버 값은 음식 DB 에서 온다 — 탄수화물만 적힌 날도, 하루 칼로리와 탄단지
+/// 합계가 어긋나는 날도, 영양이 아예 없는 날도 온다. 어느 쪽이든 막대는
+/// 총칼로리 하나만 말해야 한다.
 class _FixedDietRepository extends FakeDietRepository {
   _FixedDietRepository(this.day);
 
@@ -89,87 +94,65 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  /// 첫 칸 구간들의 색과 그려진 높이.
-  List<(Color, double)> segmentsOf(WidgetTester tester) => <(Color, double)>[
-    for (final Element e
-        in find
-            .descendant(
-              of: find.byKey(const Key('diet-period-bar-0')),
-              matching: find.byType(ColoredBox),
-            )
-            .evaluate())
-      (
-        (e.widget as ColoredBox).color,
-        (e.renderObject! as RenderBox).size.height,
-      ),
-  ];
+  /// 첫 칸 막대에 칠해진 색. 한 색 막대라 `Container` 의 배경이 곧 그 색이다.
+  Color? barColorOf(WidgetTester tester) {
+    final Container box = tester.widget<Container>(
+      find
+          .descendant(
+            of: find.byKey(const Key('diet-period-bar-0')),
+            matching: find.byType(Container),
+          )
+          .first,
+    );
+    return (box.decoration! as BoxDecoration).color;
+  }
 
-  testWidgets('칼로리와 탄단지 합계가 어긋나면 나머지가 남는다', (WidgetTester tester) async {
+  /// 막대 안에 쌓인 구간. 쌓지 않으므로 언제나 비어 있어야 한다.
+  Iterable<Element> segmentsOf(WidgetTester tester) => find
+      .descendant(
+        of: find.byKey(const Key('diet-period-bar-0')),
+        matching: find.byType(ColoredBox),
+      )
+      .evaluate();
+
+  testWidgets('탄단지가 다 있는 날도 막대는 회색 한 색이다', (WidgetTester tester) async {
+    await openMonth(
+      tester,
+      _day(calories: 1560, carbsG: 200, proteinG: 100, fatG: 40),
+    );
+
+    expect(segmentsOf(tester), isEmpty, reason: '막대를 셋으로 쌓지 않는다');
+    expect(barColorOf(tester), FigmaColors.barNeutral.withValues(alpha: 0.85));
+  });
+
+  testWidgets('칼로리와 탄단지 합계가 어긋나도 막대는 총칼로리만 말한다', (
+    WidgetTester tester,
+  ) async {
     // 탄 100g(400) + 단 50g(200) + 지 20g(180) = 780kcal 인데 하루는 1,560kcal.
-    // 세 색이 막대를 꽉 채우면 없는 기여분을 지어내는 셈이다.
+    // 쌓던 시절에는 이 어긋남이 분모 문제였다(#956) — 이제는 그릴 구간 자체가
+    // 없으므로 막대는 1,560kcal 높이 하나다.
     await openMonth(
       tester,
       _day(calories: 1560, carbsG: 100, proteinG: 50, fatG: 20),
     );
 
-    final List<(Color, double)> segments = segmentsOf(tester);
-    final double total = segments.fold<double>(
-      0,
-      (double a, (Color, double) s) => a + s.$2,
-    );
-
-    final Iterable<(Color, double)> rest = segments.where(
-      ((Color, double) s) => s.$1 == FigmaColors.track,
-    );
-    expect(rest, hasLength(1), reason: '설명되지 않는 칼로리가 자리를 차지해야 한다');
-    expect(rest.single.$2 / total, closeTo((1560 - 780) / 1560, 0.03));
-
-    // 탄수화물은 400/1560 만큼만 차지한다 — 780 을 분모로 잡으면 0.51 이 된다.
-    final (Color, double) carbs = segments.firstWhere(
-      ((Color, double) s) => s.$1 == FigmaColors.macroCarbs,
-    );
-    expect(carbs.$2 / total, closeTo(400 / 1560, 0.03));
+    expect(segmentsOf(tester), isEmpty);
+    expect(barColorOf(tester), FigmaColors.barNeutral.withValues(alpha: 0.85));
   });
 
-  testWidgets('탄단지 합계가 칼로리를 넘으면 나머지 없이 꽉 찬다', (WidgetTester tester) async {
-    // 음수 나머지는 그릴 수 없으므로 탄단지 합계에 맞춰 채운다.
-    await openMonth(
-      tester,
-      _day(calories: 500, carbsG: 200, proteinG: 100, fatG: 40),
-    );
-
-    final List<(Color, double)> segments = segmentsOf(tester);
-    expect(
-      segments.where(((Color, double) s) => s.$1 == FigmaColors.track),
-      isEmpty,
-    );
-    expect(segments, hasLength(3));
-  });
-
-  testWidgets('탄수화물만 있는 날도 막대가 그려진다', (WidgetTester tester) async {
-    // `hasMacros` 는 셋 중 하나만 양수여도 참이다. 0 인 성분까지 구간을 만들면
-    // 아무것도 안 보이는 칸이 섞인다.
+  testWidgets('탄수화물만 있는 날도 같은 회색 막대다', (WidgetTester tester) async {
     await openMonth(tester, _day(calories: 800, carbsG: 200));
 
-    final List<(Color, double)> segments = segmentsOf(tester);
-    expect(segments, hasLength(1), reason: '0 인 성분은 구간을 만들지 않는다');
-    expect(segments.single.$1, FigmaColors.macroCarbs);
-    expect(segments.single.$2, greaterThan(0));
+    expect(segmentsOf(tester), isEmpty);
+    expect(barColorOf(tester), FigmaColors.barNeutral.withValues(alpha: 0.85));
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('아주 적게 먹은 성분도 실오라기로 남는다', (WidgetTester tester) async {
-    // 반올림으로 셋이 모두 0 이 되면 높이만 있고 아무것도 그려지지 않은 막대가
-    // 남는다 — #947 과 같은 종류의 사라짐이다.
-    await openMonth(
-      tester,
-      _day(calories: 2000, carbsG: 0.05, proteinG: 0.05, fatG: 0.05),
-    );
+  testWidgets('영양이 아예 없는 날도 같은 회색 막대다', (WidgetTester tester) async {
+    await openMonth(tester, _day(calories: 1500));
 
-    for (final (Color _, double h) in segmentsOf(tester)) {
-      expect(h, greaterThan(0));
-    }
-    expect(tester.takeException(), isNull);
+    expect(segmentsOf(tester), isEmpty);
+    expect(barColorOf(tester), FigmaColors.barNeutral.withValues(alpha: 0.85));
   });
 
   testWidgets('영양이 하나도 없는 기간에는 탄단지 범례가 없다', (WidgetTester tester) async {

--- a/frontend/flutter/test/features/diet/diet_period_macro_bars_test.dart
+++ b/frontend/flutter/test/features/diet/diet_period_macro_bars_test.dart
@@ -13,10 +13,12 @@ import 'package:oncare/gen/l10n/app_localizations.dart';
 
 import '../../helpers/fake_diet_repository.dart';
 
-/// 이번 달 칼로리 막대는 **탄단지로 쌓아** 그린다.
+/// 칼로리 막대는 **한 색**이고, 탄단지는 툴팁이 숫자로 말한다 (#1427).
 ///
-/// 같은 2,000kcal 이라도 밥에서 온 것과 기름에서 온 것은 다른 하루다. 숫자
-/// 하나만으로는 그 차이가 화면에 없었다.
+/// 같은 2,000kcal 이라도 밥에서 온 것과 기름에서 온 것은 다른 하루다. 한때는
+/// 그 차이를 막대의 농담 세 단계로 그렸지만, 막대에서 수치를 읽을 수는 없어
+/// 색만 정확한 척했다. 지금은 막대가 총칼로리 하나를 말하고, 구성은 툴팁과
+/// 카드 머리의 상세가 숫자와 함께 말한다.
 class _MacroRepository extends FakeDietRepository {
   @override
   Future<DietDay> fetchByDate(DateTime date) async => _day;
@@ -137,61 +139,21 @@ void main() {
         .map((ColoredBox b) => b.color)
         .toList();
 
-    /// 구간의 **그려진 사각형**. 색만 확인하면 폭 0 을 그대로 통과시킨다 —
-    /// 실제로 #947 이 그렇게 새어 나갔다.
-    List<Rect> segmentRectsOf(WidgetTester tester, int index) => <Rect>[
-      // `find.byWidget` 은 쓸 수 없다 — 세 구간이 const 라 서른한 칸의 같은
-      // 색 구간이 전부 같은 위젯으로 잡힌다. Element 의 RenderBox 에서 직접
-      // 잰다.
-      for (final Element e
-          in find
-              .descendant(
-                of: find.byKey(Key('diet-period-bar-$index')),
-                matching: find.byType(ColoredBox),
-              )
-              .evaluate())
-        (e.renderObject! as RenderBox).localToGlobal(Offset.zero) &
-            (e.renderObject! as RenderBox).size,
-    ];
-
-    testWidgets('쌓은 구간이 막대 폭을 채운다 (#947)', (WidgetTester tester) async {
+    testWidgets('막대가 칸 폭을 채우고 높이를 갖는다 (#947)', (WidgetTester tester) async {
       await openMonth(tester);
 
+      // 폭 0 으로 그려져 통째로 사라진 적이 있다(#947) — 색만 확인하면 그
+      // 사라짐을 그대로 통과시킨다.
       final Rect bar = tester.getRect(
-        find.byKey(const Key('diet-period-bar-0')),
+        find
+            .descendant(
+              of: find.byKey(const Key('diet-period-bar-0')),
+              matching: find.byType(Container),
+            )
+            .first,
       );
-      final List<Rect> segments = segmentRectsOf(tester, 0);
-      expect(segments, hasLength(3));
-
-      for (final Rect seg in segments) {
-        // Column 의 기본 정렬(center)이면 자식 없는 ColoredBox 가 폭 0 으로
-        // 그려져 막대가 통째로 사라진다.
-        expect(seg.width, greaterThan(0));
-        expect(seg.width, closeTo(bar.width, 0.5));
-      }
-
-      // 세 구간을 합치면 막대 높이가 된다 — 한 조각이 빠지면 여기서 드러난다.
-      final double stacked = segments.fold<double>(
-        0,
-        (double a, Rect r) => a + r.height,
-      );
-      expect(stacked, closeTo(bar.height, 0.5));
+      expect(bar.width, greaterThan(0));
       expect(bar.height, greaterThan(0));
-    });
-
-    testWidgets('구간 높이가 칼로리 기여분을 따른다 (#947)', (WidgetTester tester) async {
-      await openMonth(tester);
-
-      // 탄 200g(800kcal) · 단 100g(400kcal) · 지 40g(360kcal) = 1,560kcal.
-      // 위에서부터 지방 · 단백질 · 탄수화물 순으로 쌓인다.
-      final List<Rect> segments = segmentRectsOf(tester, 0);
-      final double total = segments.fold<double>(
-        0,
-        (double a, Rect r) => a + r.height,
-      );
-      expect(segments[0].height / total, closeTo(360 / 1560, 0.02));
-      expect(segments[1].height / total, closeTo(400 / 1560, 0.02));
-      expect(segments[2].height / total, closeTo(800 / 1560, 0.02));
     });
 
     /// 막대 툴팁의 글자.
@@ -226,42 +188,32 @@ void main() {
     });
 
 
-    testWidgets('막대가 탄단지 3색으로 쌓인다', (WidgetTester tester) async {
+    testWidgets('막대는 회색 한 색이다 (#1427)', (WidgetTester tester) async {
       await openMonth(tester);
 
-      // 위에서부터 지방 · 단백질 · 탄수화물 — 바닥부터 읽으면 라벨 순서와 같다.
-      expect(segmentColorsOf(tester, 0), <Color>[
-        FigmaColors.macroFat,
-        FigmaColors.macroProtein,
-        FigmaColors.macroCarbs,
-      ]);
+      expect(segmentColorsOf(tester, 0), isEmpty, reason: '쌓지 않는다');
+      final Container bar = tester.widget<Container>(
+        find
+            .descendant(
+              of: find.byKey(const Key('diet-period-bar-0')),
+              matching: find.byType(Container),
+            )
+            .first,
+      );
+      expect(
+        (bar.decoration! as BoxDecoration).color,
+        FigmaColors.barNeutral.withValues(alpha: 0.85),
+      );
     });
 
-    testWidgets('세 색은 브랜드 색의 농담이다 (#953)', (WidgetTester tester) async {
-      // `오늘` 뷰가 칼로리 링도 탄단지 진행 바도 브랜드 색 하나로 그린다.
-      // 기간 뷰만 다른 색상환을 쓰면 토글로 두 뷰를 오갈 때 색이 튄다.
-      expect(FigmaColors.macroCarbs, FigmaColors.primary);
-
-      // 위로 갈수록 옅어진다 — 한 칼로리를 나눈 것이라 색상보다 농담으로
-      // 가르는 편이 뜻에 맞는다.
-      double lum(Color c) => 0.2126 * c.r + 0.7152 * c.g + 0.0722 * c.b;
-      expect(
-        lum(FigmaColors.macroProtein),
-        greaterThan(lum(FigmaColors.macroCarbs)),
-      );
-      expect(
-        lum(FigmaColors.macroFat),
-        greaterThan(lum(FigmaColors.macroProtein)),
-      );
-
-      // 목표선 위에 겹쳐 그리므로 반투명이면 선이 비친다.
-      for (final Color macro in <Color>[
-        FigmaColors.macroCarbs,
-        FigmaColors.macroProtein,
-        FigmaColors.macroFat,
-      ]) {
-        expect(macro.a, 1.0, reason: '$macro');
-      }
+    testWidgets('막대 회색은 빈 트랙·초과와 갈린다 (#1427)', (WidgetTester tester) async {
+      // 기록 없는 칸의 그루터기·아직 오지 않은 날의 빈 트랙과 같은 색이면
+      // 기록한 날과 비운 날이 한 그림에서 구분되지 않는다.
+      expect(FigmaColors.barNeutral, isNot(FigmaColors.track));
+      expect(FigmaColors.barNeutral, isNot(FigmaColors.hairline));
+      expect(FigmaColors.barNeutral, isNot(FigmaColors.dangerRed));
+      // 목표선 위에 겹쳐 그리므로 색 자체는 불투명해야 한다.
+      expect(FigmaColors.barNeutral.a, 1.0);
     });
 
     testWidgets('툴팁이 탄단지 수치를 함께 적는다', (WidgetTester tester) async {
@@ -286,7 +238,7 @@ void main() {
       expect(text, contains('40'));
     });
 
-    testWidgets('나트륨으로 바꾸면 쌓지 않는다', (WidgetTester tester) async {
+    testWidgets('나트륨 막대는 지금까지 쓰던 브랜드 색 그대로다', (WidgetTester tester) async {
       await openMonth(tester);
 
       final AppLocalizations l = AppLocalizations.of(
@@ -295,8 +247,20 @@ void main() {
       await tester.tap(find.text(l.dietSodium));
       await tester.pumpAndSettle();
 
-      // 나트륨에는 쌓을 성분이 없다 — 한 색 막대로 돌아간다.
-      expect(segmentColorsOf(tester, 0), isEmpty);
+      // 회색은 칼로리 막대의 규칙이다 — 나트륨·당류까지 회색으로 바꾸지
+      // 않는다(#1427).
+      final Container bar = tester.widget<Container>(
+        find
+            .descendant(
+              of: find.byKey(const Key('diet-period-bar-0')),
+              matching: find.byType(Container),
+            )
+            .first,
+      );
+      expect(
+        (bar.decoration! as BoxDecoration).color,
+        FigmaColors.primary.withValues(alpha: 0.85),
+      );
     });
   });
 }


### PR DESCRIPTION
Closes #1427

## Summary

식단 탭 기간 그래프의 칼로리 막대를 목표 이내일 때 회색 한 색으로 통일한다. 지금까지는 탄·단·지를 브랜드 색 농담 세 단계로 쌓았는데, 막대에서 그 세 수치를 읽을 수는 없어 색만 구성을 정확히 말해 주는 그림처럼 보였다.

## Changes

- 기간 그래프의 칼로리 막대에서 탄단지 누적을 걷고, 목표 이내 막대를 새 토큰 `FigmaColors.barNeutral` 한 색으로 그린다.
- 막대 툴팁의 지표 스와치도 막대와 같은 색을 쓴다. 탄·단·지 색 스와치와 그램 수치는 그대로 남는다.
- 유지되는 규칙: 막대 높이 = 그날 총칼로리 / 목표 초과 = 통짜 빨강 / 기록 없는 날 = 높이 없는 그루터기 / 아직 오지 않은 날 = 빈 트랙.
- 나트륨·당류 막대와 `오늘` 카드의 탄단지 색, 카드 머리의 탄단지 상세는 건드리지 않는다.

## Notes

이슈 본문은 `이번 주` 그래프를 가리키지만, 현재 코드에서 식단 탭 `이번 주` 는 꺾은선(`MetricTrendChart`)이라 막대가 없다. 탄·단·지 색으로 쌓던 막대는 이슈가 참고 파일로 지목한 `diet_period_view.dart` 의 `_Bar` — `전체` 그래프의 일별 막대 하나뿐이라, 그 막대에 규칙을 적용했다. 두 화면 모두 같은 위젯을 쓰므로 `이번 주` 가 나중에 막대로 바뀌어도 같은 색 규칙을 따른다.

## Verification

- 기존 누적 막대 계약 테스트(#947, #956)를 새 계약으로 갈아끼웠다: 탄단지가 있어도/어긋나도/없어도 막대는 회색 한 색, 칸 폭과 높이는 그대로, 나트륨은 브랜드 색 유지, 목표 초과는 빨강 유지, 툴팁의 탄단지 수치 유지.
- `flutter analyze` 무경고, `flutter test` 전체 통과(로컬).
