### PR TITLE
fix(ui): 프로그램·리포트 고객 목록 글자 크기 통일

### DIFF
--- a/frontend/flutter_trainer/lib/features/coaching/presentation/pages/coaching_page.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/pages/coaching_page.dart
@@ -1040,19 +1040,23 @@ class _MemberProgramListState extends State<_MemberProgramList> {
                             child: Column(
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: <Widget>[
+                                // 이름 타이포는 리포트 탭 고객 목록과 같은
+                                // 기준을 쓴다(#1423) — 같은 목록이 탭마다
+                                // 다른 크기로 보이지 않게.
                                 ClientIdentity(
                                   client: client,
-                                  nameStyle: const TextStyle(
-                                    fontSize: 13.5,
-                                    fontWeight: FontWeight.w800,
-                                    color: AppColors.foreground,
+                                  nameStyle: clientListNameStyle(
+                                    selected: selected,
                                   ),
                                 ),
                                 const SizedBox(height: 2),
                                 // 목표는 늘 보인다. 전에는 `lastRoutine` 이
                                 // 비었을 때만 그 자리를 빌려 써서, 루틴을 한
                                 // 번이라도 보낸 고객은 목표가 사라졌다(#898).
-                                ClientGoalLabel(client: client),
+                                ClientGoalLabel(
+                                  client: client,
+                                  fontSize: clientListGoalFontSize,
+                                ),
                               ],
                             ),
                           ),

--- a/frontend/flutter_trainer/lib/features/reports/presentation/widgets/report_client_picker.dart
+++ b/frontend/flutter_trainer/lib/features/reports/presentation/widgets/report_client_picker.dart
@@ -96,19 +96,19 @@ class _ReportClientPickerState extends State<ReportClientPicker> {
                               mainAxisSize: MainAxisSize.min,
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: <Widget>[
+                                // 프로그램 탭 고객 목록과 같은 기준이다(#1423).
                                 ClientIdentity(
                                   client: client,
-                                  nameStyle: TextStyle(
-                                    fontSize: 15,
-                                    fontWeight: selected
-                                        ? FontWeight.w800
-                                        : FontWeight.w600,
-                                    color: AppColors.foreground,
+                                  nameStyle: clientListNameStyle(
+                                    selected: selected,
                                   ),
                                 ),
                                 // 어느 고객의 리포트를 열지 고르는 자리다 —
                                 // 이름만으로는 고를 근거가 되지 않는다(#898).
-                                ClientGoalLabel(client: client, fontSize: 11),
+                                ClientGoalLabel(
+                                  client: client,
+                                  fontSize: clientListGoalFontSize,
+                                ),
                               ],
                             ),
                           ),

--- a/frontend/flutter_trainer/lib/shared/widgets/client_identity.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/client_identity.dart
@@ -56,6 +56,29 @@ bool isProspectClient(
   return true;
 }
 
+/// 프로그램·리포트 탭 왼쪽 고객 목록의 **이름 타이포**. (#1423)
+///
+/// 두 탭은 같은 구조(왼쪽 고객 목록 → 오른쪽 작업 영역)에 카드 제목과 아이콘
+/// 까지 같은데, 이름 글씨만 프로그램 13.5·리포트 15 로 갈려 있었다. 탭을
+/// 오갈 때마다 같은 목록이 다른 밀도로 보였다. 기준을 여기 한 벌만 두어
+/// 한쪽만 다시 달라지지 않게 한다.
+///
+/// 고른 고객은 굵기로만 도드라진다 — 글씨 크기가 함께 바뀌면 고를 때마다
+/// 행 높이가 흔들린다.
+TextStyle clientListNameStyle({required bool selected}) => TextStyle(
+  fontSize: clientListNameFontSize,
+  fontWeight: selected ? FontWeight.w800 : FontWeight.w600,
+  color: AppColors.foreground,
+);
+
+/// 고객 목록 이름 글씨 크기. 프로그램 탭 열은 세 열 중 가장 좁아 15 는 긴
+/// 이름에서 잘리기 쉬웠고, 13.5 는 리포트 탭에서 목표 줄과 위계가 붙었다.
+const double clientListNameFontSize = 14;
+
+/// 이름 아래 목표 한 줄의 글씨 크기. 이름보다 한 단계 작다 — 두 탭이 같은
+/// 위계를 쓰도록 [ClientGoalLabel] 의 기본값 대신 이 값을 함께 준다.
+const double clientListGoalFontSize = 11;
+
 /// 고객 목록 행에 붙는 목표 한 줄. (#898)
 ///
 /// 트레이너가 고객을 고르는 기준은 이름이 아니라 **무엇을 목표로 하는

--- a/frontend/flutter_trainer/test/shared/client_list_typography_test.dart
+++ b/frontend/flutter_trainer/test/shared/client_list_typography_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oncare_trainer/app/router/routes.dart';
+import 'package:oncare_trainer/shared/models/trainer_client.dart';
+import 'package:oncare_trainer/shared/services/client_repository.dart';
+import 'package:oncare_trainer/shared/widgets/client_identity.dart';
+
+import '../helpers/client_factory.dart';
+import '../helpers/pump_app.dart';
+
+/// 프로그램 탭과 리포트 탭의 고객 목록은 같은 타이포를 쓴다. (#1423)
+///
+/// 두 탭은 같은 구조(왼쪽 고객 목록 → 오른쪽 작업 영역)에 카드 제목·아이콘도
+/// 같은데, 이름 글씨만 13.5 와 15 로 갈려 있었다. 탭을 오갈 때 같은 목록이
+/// 다른 밀도로 보인다.
+void main() {
+  const String goal = '혈압 관리 · 체중 감량';
+
+  final List<TrainerClient> roster = <TrainerClient>[
+    makeClient(id: 'type-a', name: '가고객', goal: goal),
+    makeClient(id: 'type-b', name: '나고객', goal: goal),
+  ];
+
+  Future<void> openTab(WidgetTester tester, String at) async {
+    tester.view.devicePixelRatio = 1.0;
+    tester.view.physicalSize = const Size(1600, 1200);
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await pumpTrainerApp(
+      tester,
+      token: 'demo-trainer-token',
+      at: at,
+      extraOverrides: <Override>[
+        clientsProvider.overrideWith(
+          (ref) => Stream<List<TrainerClient>>.value(roster),
+        ),
+      ],
+    );
+    await tester.pumpAndSettle();
+  }
+
+  /// [rowKey] 행 안에서 [name] 을 그리는 텍스트의 스타일.
+  TextStyle nameStyleIn(WidgetTester tester, String rowKey, String name) {
+    final Finder row = find.byKey(ValueKey<String>(rowKey));
+    expect(row, findsOneWidget, reason: rowKey);
+    return tester
+        .widget<Text>(find.descendant(of: row, matching: find.text(name)))
+        .style!;
+  }
+
+  /// [rowKey] 행의 목표 한 줄 글씨 크기.
+  double goalSizeIn(WidgetTester tester, String rowKey) {
+    final Finder row = find.byKey(ValueKey<String>(rowKey));
+    return tester
+        .widget<Text>(find.descendant(of: row, matching: find.text(goal)))
+        .style!
+        .fontSize!;
+  }
+
+  testWidgets('프로그램 탭 고객명은 공용 크기·굵기를 쓴다', (tester) async {
+    await openTab(tester, AppRoutes.coaching);
+
+    // 첫 고객이 기본으로 선택된다 — 고른 쪽은 굵게, 나머지는 한 단계 얇게.
+    final TextStyle selected = nameStyleIn(
+      tester,
+      'program-client-type-a',
+      '가고객',
+    );
+    final TextStyle unselected = nameStyleIn(
+      tester,
+      'program-client-type-b',
+      '나고객',
+    );
+
+    expect(selected.fontSize, clientListNameFontSize);
+    expect(unselected.fontSize, clientListNameFontSize);
+    expect(selected.fontWeight, FontWeight.w800);
+    expect(unselected.fontWeight, FontWeight.w600);
+    expect(goalSizeIn(tester, 'program-client-type-a'), clientListGoalFontSize);
+  });
+
+  testWidgets('리포트 탭 고객명이 프로그램 탭과 같은 크기·굵기다', (tester) async {
+    await openTab(tester, AppRoutes.reports);
+
+    final TextStyle selected = nameStyleIn(
+      tester,
+      'report-client-type-a',
+      '가고객',
+    );
+    final TextStyle unselected = nameStyleIn(
+      tester,
+      'report-client-type-b',
+      '나고객',
+    );
+
+    expect(selected.fontSize, clientListNameFontSize);
+    expect(unselected.fontSize, clientListNameFontSize);
+    expect(selected.fontWeight, FontWeight.w800);
+    expect(unselected.fontWeight, FontWeight.w600);
+    expect(goalSizeIn(tester, 'report-client-type-a'), clientListGoalFontSize);
+  });
+
+  testWidgets('긴 이름과 큰 배율에서도 행이 넘치지 않는다', (tester) async {
+    final List<TrainerClient> longNames = <TrainerClient>[
+      makeClient(id: 'type-a', name: '아주아주긴이름의고객님입니다', goal: goal),
+    ];
+    tester.view.devicePixelRatio = 1.0;
+    tester.view.physicalSize = const Size(1280, 1200);
+    tester.platformDispatcher.textScaleFactorTestValue = 1.6;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
+    await pumpTrainerApp(
+      tester,
+      token: 'demo-trainer-token',
+      at: AppRoutes.reports,
+      extraOverrides: <Override>[
+        clientsProvider.overrideWith(
+          (ref) => Stream<List<TrainerClient>>.value(longNames),
+        ),
+      ],
+    );
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
Closes #1423

## Summary

트레이너 앱 프로그램 탭과 리포트 탭은 같은 구조(왼쪽 고객 목록 → 오른쪽 작업 영역)에 카드 제목·아이콘까지 같은데, 고객명 글씨만 프로그램 13.5·리포트 15 로 갈려 있었다. 탭을 오갈 때 같은 목록이 다른 크기·밀도로 보인다.

## Changes

- 고객 목록 이름 타이포 기준을 `shared/widgets/client_identity.dart` 한 곳에 둔다 — `clientListNameStyle(selected:)`, `clientListNameFontSize`(14), `clientListGoalFontSize`(11).
- 프로그램 탭 `program-client-*` 행과 리포트 탭 `report-client-*` 행이 같은 함수를 부른다. 한쪽만 다시 달라질 자리가 없다.
- 강조 규칙도 하나로 맞춘다 — 고른 고객만 `w800`, 나머지는 `w600`. 프로그램 탭은 선택과 무관하게 늘 `w800` 이었다.
- 목표 한 줄은 이름보다 한 단계 작은 11 로 두 탭이 같은 위계를 쓴다.
- 크기 14 는 두 값 사이다. 15 는 세 열 중 가장 좁은 프로그램 열에서 긴 이름이 쉽게 잘렸고, 13.5 는 리포트 탭에서 목표 줄과 위계가 붙었다. 아바타·행 높이는 각 탭의 배치 그대로다.

## Verification

- 새 테스트 `test/shared/client_list_typography_test.dart` 3건: 프로그램 탭 이름이 공용 크기·굵기를 쓴다 / 리포트 탭이 같은 값을 쓴다(선택·미선택 각각) / 긴 이름과 텍스트 배율 1.6 에서 예외·오버플로가 없다.
- `flutter analyze` 무경고, `flutter test` 전체 통과(로컬).
