### PR TITLE
fix(program): AI 개인 운동 제안 카드 버튼·정보 레이아웃 정리

### DIFF
--- a/frontend/flutter_trainer/lib/features/coaching/presentation/widgets/routine_suggestion_review_card.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/widgets/routine_suggestion_review_card.dart
@@ -308,24 +308,57 @@ class _SuggestionCard extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
               Expanded(
-                child: Text(
-                  suggestion.name,
-                  style: const TextStyle(
-                    fontSize: 13,
-                    fontWeight: FontWeight.w800,
-                    color: AppColors.foreground,
+                // 이름 - 종류 - 시간/분/회 를 한 줄에 둔다. 이름/종류/설명처럼
+                // 줄을 나누면 셋을 훑는 데 시선이 세 번 움직였다.
+                child: Text.rich(
+                  TextSpan(
+                    children: <InlineSpan>[
+                      TextSpan(
+                        text: suggestion.name,
+                        style: const TextStyle(
+                          fontSize: 13,
+                          fontWeight: FontWeight.w800,
+                          color: AppColors.foreground,
+                        ),
+                      ),
+                      const TextSpan(
+                        text: ' · ',
+                        style: TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                          color: AppColors.subtleForeground,
+                        ),
+                      ),
+                      TextSpan(
+                        text: routineTypeLabel(l, suggestion.type),
+                        style: const TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.w700,
+                          color: AppColors.subtleForeground,
+                        ),
+                      ),
+                      const TextSpan(
+                        text: ' · ',
+                        style: TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                          color: AppColors.subtleForeground,
+                        ),
+                      ),
+                      TextSpan(
+                        // 근력은 시간이 아니라 세트·횟수·중량으로 적는다 — 최종
+                        // 검토 dialog·수정 창과 같은 함수를 쓴다. (#1321)
+                        text: routineSuggestionAmountLabel(l, suggestion),
+                        style: const TextStyle(
+                          fontSize: 12.5,
+                          fontWeight: FontWeight.w800,
+                          color: AppColors.accent,
+                        ),
+                      ),
+                    ],
                   ),
-                ),
-              ),
-              const SizedBox(width: AppSpacing.sm),
-              Text(
-                // 근력은 시간이 아니라 세트·횟수·중량으로 적는다 — 최종 검토
-                // dialog·수정 창과 같은 함수를 쓴다. (#1321)
-                routineSuggestionAmountLabel(l, suggestion),
-                style: const TextStyle(
-                  fontSize: 12.5,
-                  fontWeight: FontWeight.w800,
-                  color: AppColors.accent,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
                 ),
               ),
               // `수정` 은 판단이 아니라 **보조 동작**이다(#939). 아래 줄에 같은
@@ -352,15 +385,6 @@ class _SuggestionCard extends StatelessWidget {
                 ),
               ),
             ],
-          ),
-          const SizedBox(height: 2),
-          Text(
-            routineTypeLabel(l, suggestion.type),
-            style: const TextStyle(
-              fontSize: 11.5,
-              fontWeight: FontWeight.w700,
-              color: AppColors.subtleForeground,
-            ),
           ),
           if (suggestion.reason.isNotEmpty) ...<Widget>[
             const SizedBox(height: AppSpacing.sm),
@@ -389,27 +413,29 @@ class _SuggestionCard extends StatelessWidget {
           ],
           const SizedBox(height: AppSpacing.md),
           // 아래 줄에는 **결정 둘만** 남는다 — 이 제안을 고객에게 줄 것인가.
-          //
-          // 라벨은 로케일을 크게 탄다. 한국어 `추천 안 함`·`고객에게 추천` 은 한
+          // 둘 다 오른쪽에 붙여 카드 하나의 결정처럼 읽히게 한다. 라벨은
+          // 로케일을 크게 탄다. 한국어 `추천 안 함`·`고객에게 추천` 은 한
           // 줄에 들어가지만 영어 `Don't recommend`·`Recommend to client` 는 배율
           // 1.3 에서 카드를 크게 넘겼다(#849). `Row` + `Spacer` 대신
-          // `OverflowBar` 를 쓰면 넓을 때는 좌우 배치를 그대로 두고, 좁아지면
+          // `OverflowBar` 를 쓰면 넓을 때는 오른쪽 배치를 그대로 두고, 좁아지면
           // 세로로 흘려 준다.
           OverflowBar(
-            alignment: MainAxisAlignment.spaceBetween,
+            alignment: MainAxisAlignment.end,
             overflowAlignment: OverflowBarAlignment.end,
             spacing: AppSpacing.sm,
             overflowSpacing: AppSpacing.xs,
             children: <Widget>[
               // 다른 카드들과 같은 공용 버튼([ActionButton]) 이다 — 이
               // 카드만 기본 Material 버튼을 쓰면 높이·글꼴·테두리가 조금씩
-              // 달라 눈에 띈다.
+              // 달라 눈에 띈다. 카드 한 장에 여러 제안이 쌓이는 자리라 `dense`
+              // 로 줄인다.
               ActionButton(
                 key: ValueKey<String>(
                   'routine-suggestion-dismiss-${suggestion.id}',
                 ),
                 label: l.suggestionDismiss,
                 tone: AppColors.subtleForeground,
+                dense: true,
                 onPressed: busy ? null : onDismiss,
               ),
               // 진행 표시와 추천은 한 덩어리다 — 흘러넘쳐도 서로 떨어지지
@@ -431,6 +457,7 @@ class _SuggestionCard extends StatelessWidget {
                     ),
                     label: l.suggestionApprove,
                     primary: true,
+                    dense: true,
                     onPressed: busy ? null : onApprove,
                   ),
                 ],

--- a/frontend/flutter_trainer/lib/shared/widgets/action_button.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/action_button.dart
@@ -19,6 +19,7 @@ class ActionButton extends StatelessWidget {
     this.icon,
     this.primary = false,
     this.tone,
+    this.dense = false,
   });
 
   /// Button text.
@@ -35,6 +36,10 @@ class ActionButton extends StatelessWidget {
 
   /// Overrides the accent colour (e.g. destructive actions).
   final Color? tone;
+
+  /// Smaller variant for tight rows (e.g. per-card decisions) — same shape,
+  /// less height/padding/font.
+  final bool dense;
 
   @override
   Widget build(BuildContext context) {
@@ -53,8 +58,10 @@ class ActionButton extends StatelessWidget {
         onTap: onPressed,
         borderRadius: const BorderRadius.all(AppRadius.md),
         child: Container(
-          height: 36,
-          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
+          height: dense ? 28 : 36,
+          padding: EdgeInsets.symmetric(
+            horizontal: dense ? AppSpacing.sm : AppSpacing.md,
+          ),
           decoration: BoxDecoration(
             borderRadius: const BorderRadius.all(AppRadius.md),
             border: primary
@@ -69,13 +76,13 @@ class ActionButton extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
               if (icon != null) ...<Widget>[
-                Icon(icon, size: 15, color: fg),
+                Icon(icon, size: dense ? 13 : 15, color: fg),
                 const SizedBox(width: AppSpacing.xs),
               ],
               Text(
                 label,
                 style: TextStyle(
-                  fontSize: 13.5,
+                  fontSize: dense ? 12 : 13.5,
                   fontWeight: FontWeight.w700,
                   color: fg,
                 ),

--- a/frontend/flutter_trainer/test/features/coaching/routine_suggestion_review_test.dart
+++ b/frontend/flutter_trainer/test/features/coaching/routine_suggestion_review_test.dart
@@ -176,6 +176,7 @@ void main() {
       await tester.pump();
     }
   }
+
   Finder dismissButton(RoutineSuggestion s) =>
       find.byKey(ValueKey<String>('routine-suggestion-dismiss-${s.id}'));
   Finder editButton(RoutineSuggestion s) =>
@@ -193,7 +194,7 @@ void main() {
 
       // 손볼 대상(운동 이름·시간) 옆에 있다 — 아래 판단 줄이 아니다.
       final Rect editRect = tester.getRect(editButton(_shoulder));
-      final Rect nameRect = tester.getRect(find.text(_shoulder.name));
+      final Rect nameRect = tester.getRect(find.textContaining(_shoulder.name));
       final Rect approveRect = tester.getRect(approveButton(_shoulder));
       expect(editRect.left, greaterThan(nameRect.right));
       expect(editRect.center.dy, lessThan(approveRect.top));
@@ -206,11 +207,7 @@ void main() {
       // 글자만 있는 `TextButton` 이면 카드 안의 설명 문구와 구별되지 않아,
       // 누를 수 있는 것인지 알 수 없었다.
       final dismiss = tester.widget<ActionButton>(dismissButton(_shoulder));
-      expect(
-        dismiss.primary,
-        isFalse,
-        reason: '채워진 버튼이 아니라 테두리만 있는 보조 버튼이다',
-      );
+      expect(dismiss.primary, isFalse, reason: '채워진 버튼이 아니라 테두리만 있는 보조 버튼이다');
       expect(dismiss.tone, AppColors.subtleForeground);
       // 카드 안만 본다. 프로그램 탭 전체를 뒤지면 다른 영역에 `TextButton`
       // 하나만 생겨도, 이 카드의 거절 버튼이 멀쩡한데 테스트가 깨진다.
@@ -260,8 +257,8 @@ void main() {
     await openProgramTab(tester);
 
     expect(find.text('AI 개인운동 제안'), findsOneWidget);
-    expect(find.text(_shoulder.name), findsOneWidget);
-    expect(find.text('8분'), findsWidgets);
+    expect(find.textContaining(_shoulder.name), findsOneWidget);
+    expect(find.textContaining('8분'), findsWidgets);
     expect(find.text(_shoulder.reason), findsOneWidget);
     // 근거가 함께 있어야 트레이너가 승인 여부를 판단할 수 있다.
     expect(find.text('최근 PT 피드백 반영'), findsOneWidget);
@@ -467,7 +464,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(repo.approvals, isEmpty);
-    expect(find.text(_shoulder.name), findsOneWidget);
+    expect(find.textContaining(_shoulder.name), findsOneWidget);
   });
 
   testWidgets('a double tap approves once', (tester) async {
@@ -534,8 +531,8 @@ void main() {
       },
     );
 
-    expect(find.text(_shoulder.name), findsOneWidget);
-    expect(find.text(_walking.name), findsNothing);
+    expect(find.textContaining(_shoulder.name), findsOneWidget);
+    expect(find.textContaining(_walking.name), findsNothing);
 
     await tester.tap(
       find.byKey(const ValueKey<String>('program-client-$secondClient')),
@@ -543,8 +540,8 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(repo.reads, contains(secondClient));
-    expect(find.text(_walking.name), findsOneWidget);
-    expect(find.text(_shoulder.name), findsNothing);
+    expect(find.textContaining(_walking.name), findsOneWidget);
+    expect(find.textContaining(_shoulder.name), findsNothing);
   });
 
   testWidgets('no suggestions leaves a quiet one-line empty state', (


### PR DESCRIPTION
## Summary

* AI 개인 운동 제안 카드에서 운동 이름 - 종류 - 시간/분/회를 한 줄로 합쳐 배치했습니다.
* `추천 안 함` / `고객에게 추천` 버튼을 오른쪽으로 붙이고 크기를 줄였습니다(공용 `ActionButton` 에 `dense` 옵션 추가).
* 수정 아이콘 위치는 변경하지 않았습니다.

---

## Changes

### 🔧 Improvements

* `ActionButton` 에 `dense` 옵션을 추가해 카드처럼 여러 개가 쌓이는 자리에서 더 작은 버튼을 쓸 수 있게 했습니다.

### 🎨 UI/UX

* 제안 카드의 운동 이름·종류·시간/분/회를 한 줄로 병합했습니다(문구·값은 그대로, 배치만 변경).
* `추천 안 함`·`고객에게 추천` 버튼을 오른쪽 정렬 + dense 크기로 바꿨습니다.

---

## Commits

1. `854a5574` fix(program): AI 개인 운동 제안 카드 버튼·정보 레이아웃 정리

---

## Notes

* `추천 안 함`/`고객에게 추천` 버튼은 기존에 `OverflowBar` 로 좁은 화면에서 세로로 흘리도록 돼 있었습니다(#849). 이번 변경은 넓은 화면에서의 정렬만 `spaceBetween` → `end` 로 바꾼 것으로, 좁을 때 세로로 흐르는 동작은 그대로입니다.
* `ActionButton` 의 `dense` 옵션은 기본값이 `false`라 다른 화면의 버튼 크기에는 영향이 없습니다.

---

## Screenshots (Optional)

| Before | After |
| ------ | ----- |
|        |       |

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [ ] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 트레이너 앱 → 프로그램 탭 → 고객 선택 → `AI 개인운동 제안` 카드 확인
2. 제안 카드에서 운동 이름·종류·시간/분/회가 한 줄에 표시되는지 확인
3. `추천 안 함`·`고객에게 추천` 버튼이 오른쪽에 작게 붙어 있는지 확인

---

## Related Issues

Closes #1441

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [ ] 데모 시나리오 영향 확인