### PR TITLE
feat(report): 주간 운동 비교 그래프에 지표별 색상 적용

### DIFF
--- a/frontend/flutter_trainer/lib/features/reports/presentation/widgets/bar_line_chart.dart
+++ b/frontend/flutter_trainer/lib/features/reports/presentation/widgets/bar_line_chart.dart
@@ -29,6 +29,8 @@ class BarLineChart extends StatelessWidget {
     this.pendingFrom,
     this.segments,
     this.goal,
+    this.barColor,
+    this.lineColor,
     this.height = 118,
     this.maxBarWidth = 30,
     this.highlightIndex,
@@ -60,8 +62,17 @@ class BarLineChart extends StatelessWidget {
   /// 칸별 누적 조각. 준 칸은 조각 색으로 쌓고, 안 준 칸은 한 색으로 채운다.
   final List<List<BarSegment>?>? segments;
 
-  /// 넘으면 막대가 빨강이 되는 값. 없으면 늘 브랜드 색이다.
+  /// 넘으면 막대가 빨강이 되는 값. 없으면 늘 [barColor] 다.
   final double? goal;
+
+  /// 목표 이내 막대의 색. 기본은 브랜드 색이다. 보고 있는 지표가 색을 갖는
+  /// 그래프(운동 유형별 비교 등)만 자기 색을 준다 — 지표를 바꿔도 그림이 그대로면
+  /// 지금 무엇을 보고 있는지 색으로 알 수 없다(#1424).
+  final Color? barColor;
+
+  /// 꺾은선·점의 색. 기본은 [AppColors.accentDark]. 막대에 지표 색을 줄 때는
+  /// 같은 계열의 진한 색을 함께 줘 한 그림이 한 지표를 말하게 한다.
+  final Color? lineColor;
 
   /// 막대 영역 높이(값 라벨·칸 라벨 제외).
   final double height;
@@ -91,6 +102,8 @@ class BarLineChart extends StatelessWidget {
               pendingFrom: pendingFrom ?? values.length,
               segments: segments,
               goal: goal,
+              barColor: barColor ?? AppColors.primary,
+              lineColor: lineColor ?? AppColors.accentDark,
               maxBarWidth: maxBarWidth,
               highlightIndex: highlightIndex,
               textDirection: Directionality.of(context),
@@ -117,6 +130,8 @@ class _BarLinePainter extends CustomPainter {
     required this.pendingFrom,
     required this.segments,
     required this.goal,
+    required this.barColor,
+    required this.lineColor,
     required this.maxBarWidth,
     required this.highlightIndex,
     required this.textDirection,
@@ -131,6 +146,8 @@ class _BarLinePainter extends CustomPainter {
   final int pendingFrom;
   final List<List<BarSegment>?>? segments;
   final double? goal;
+  final Color barColor;
+  final Color lineColor;
   final double maxBarWidth;
   final int? highlightIndex;
   final TextDirection textDirection;
@@ -205,7 +222,7 @@ class _BarLinePainter extends CustomPainter {
           Paint()
             ..color = goal != null && value > goal!
                 ? AppColors.overTarget
-                : AppColors.primary,
+                : barColor,
         );
       }
     }
@@ -222,7 +239,7 @@ class _BarLinePainter extends CustomPainter {
         canvas.drawPath(
           path,
           Paint()
-            ..color = AppColors.accentDark
+            ..color = lineColor
             ..style = PaintingStyle.stroke
             ..strokeWidth = 2
             ..strokeCap = StrokeCap.round
@@ -249,7 +266,7 @@ class _BarLinePainter extends CustomPainter {
         point,
         4,
         Paint()
-          ..color = AppColors.accentDark
+          ..color = lineColor
           ..style = PaintingStyle.stroke
           ..strokeWidth = 2,
       );
@@ -338,6 +355,8 @@ class _BarLinePainter extends CustomPainter {
       old.ceiling != ceiling ||
       old.pendingFrom != pendingFrom ||
       old.goal != goal ||
+      old.barColor != barColor ||
+      old.lineColor != lineColor ||
       old.emptyLabel != emptyLabel ||
       old.highlightIndex != highlightIndex ||
       old.maxBarWidth != maxBarWidth ||

--- a/frontend/flutter_trainer/lib/features/reports/presentation/widgets/metric_comparison_section.dart
+++ b/frontend/flutter_trainer/lib/features/reports/presentation/widgets/metric_comparison_section.dart
@@ -9,8 +9,10 @@ import 'package:oncare_trainer/features/reports/data/repositories/report_reposit
 import 'package:oncare_trainer/features/reports/domain/weekly_report.dart';
 import 'package:oncare_trainer/features/reports/presentation/widgets/bar_line_chart.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
+import 'package:oncare_trainer/shared/exercise_burn_goals.dart';
 import 'package:oncare_trainer/shared/models/trainer_client.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
+import 'package:oncare_trainer/shared/widgets/activity_charts.dart';
 import 'package:oncare_trainer/shared/widgets/metric_pill.dart';
 
 /// 운동 상자가 견주는 값.
@@ -116,6 +118,8 @@ class _ComparisonBox extends StatelessWidget {
     required this.goal,
     required this.segments,
     required this.legend,
+    this.barColor,
+    this.lineColor,
     required this.higherIsBetter,
     required this.loading,
     required this.emptyLabel,
@@ -142,6 +146,11 @@ class _ComparisonBox extends StatelessWidget {
 
   /// 조각이 무엇인지 적는 줄.
   final Widget? legend;
+
+  /// 지금 고른 지표의 색. 주지 않으면 그래프의 기본 브랜드 색이다 — 식단
+  /// 상자는 지금까지처럼 지표와 무관하게 한 색을 쓴다(#1424).
+  final Color? barColor;
+  final Color? lineColor;
 
   final bool? higherIsBetter;
   final bool loading;
@@ -237,6 +246,8 @@ class _ComparisonBox extends StatelessWidget {
               ceiling: ceiling,
               goal: goal,
               segments: segments,
+              barColor: barColor,
+              lineColor: lineColor,
               format: format,
               emptyLabel: emptyLabel,
               highlightIndex: 1,
@@ -272,6 +283,21 @@ class _ExerciseComparisonBoxState
         ExerciseCompareMetric.strength => l.routineTypeStrength,
         ExerciseCompareMetric.stretching => l.routineTypeStretching,
       };
+
+  /// 지금 고른 지표의 색. 유형 셋은 다른 운동 그래프(주간 운동 시간·이행률
+  /// 막대)와 같은 램프를, 소모 칼로리는 그 셋이 함께 만든 결과를 뜻하는
+  /// [kBurnColor] 를 쓴다 — 같은 값이 화면마다 다른 색이면 색이 뜻을 잃는다.
+  Color get _metricColor => switch (_metric) {
+    ExerciseCompareMetric.burned => kBurnColor,
+    ExerciseCompareMetric.cardio => kindColor(ExerciseKind.cardio),
+    ExerciseCompareMetric.strength => kindColor(ExerciseKind.strength),
+    ExerciseCompareMetric.stretching => kindColor(ExerciseKind.stretching),
+  };
+
+  /// 꺾은선은 같은 색의 한 단계 진한 쪽이다. 스트레칭처럼 옅은 색은 흰 바탕
+  /// 위에서 선이 거의 보이지 않는다 — 막대와 같은 계열을 유지하면서 선만
+  /// 또렷하게 둔다.
+  Color get _metricLineColor => Color.lerp(_metricColor, Colors.black, 0.3)!;
 
   double? _value(ClientExercisePeriod? period) {
     if (period == null) return null;
@@ -328,6 +354,10 @@ class _ExerciseComparisonBoxState
       goal: null,
       segments: null,
       legend: null,
+      // 지표를 바꾸면 그래프 색도 바뀐다 — 알약만 보고 무엇을 보고 있는지
+      // 되짚지 않아도 되게(#1424).
+      barColor: _metricColor,
+      lineColor: _metricLineColor,
       // 운동은 많이 할수록 좋은 값이다.
       higherIsBetter: true,
       loading: week.isLoading || before.isLoading,

--- a/frontend/flutter_trainer/test/features/reports/metric_comparison_colors_test.dart
+++ b/frontend/flutter_trainer/test/features/reports/metric_comparison_colors_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oncare_trainer/app/router/routes.dart';
+import 'package:oncare_trainer/design_system/tokens/colors.dart';
+import 'package:oncare_trainer/features/reports/presentation/widgets/bar_line_chart.dart';
+import 'package:oncare_trainer/features/reports/presentation/widgets/metric_comparison_section.dart';
+import 'package:oncare_trainer/shared/exercise_burn_goals.dart';
+import 'package:oncare_trainer/shared/widgets/activity_charts.dart';
+
+import '../../helpers/pump_app.dart';
+
+/// `이번 주 vs 지난 주` 운동 비교 그래프의 지표별 색. (#1424)
+///
+/// 지표를 바꿔도 그림이 늘 브랜드 색이면, 지금 무엇을 보고 있는지 알약을 다시
+/// 읽어야 안다. 색 기준은 다른 운동 그래프(주간 운동 시간·이행률 막대)와 같은
+/// 램프다 — 같은 값이 화면마다 다른 색이면 색이 뜻을 잃는다.
+void main() {
+  Future<void> openReports(WidgetTester tester) async {
+    tester.view.devicePixelRatio = 1.0;
+    tester.view.physicalSize = const Size(1600, 1400);
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await pumpTrainerApp(
+      tester,
+      token: 'demo-trainer-token',
+      at: AppRoutes.reports,
+    );
+    await tester.pumpAndSettle();
+  }
+
+  /// 운동 상자의 그래프. 두 상자가 같은 위젯을 쓰므로 시맨틱 문구로 가른다.
+  BarLineChart exerciseChart(WidgetTester tester) => tester
+      .widgetList<BarLineChart>(
+        find.descendant(
+          of: find.byType(MetricComparisonSection),
+          matching: find.byType(BarLineChart),
+        ),
+      )
+      .firstWhere((chart) => chart.semanticsLabel.startsWith('운동'));
+
+  BarLineChart dietChart(WidgetTester tester) => tester
+      .widgetList<BarLineChart>(
+        find.descendant(
+          of: find.byType(MetricComparisonSection),
+          matching: find.byType(BarLineChart),
+        ),
+      )
+      .firstWhere((chart) => chart.semanticsLabel.startsWith('식단'));
+
+  Future<void> pickExercise(WidgetTester tester, String metric) async {
+    final pill = find.byKey(ValueKey<String>('compare-exercise-$metric'));
+    await tester.ensureVisible(pill);
+    await tester.pumpAndSettle();
+    await tester.tap(pill);
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('운동 지표를 바꾸면 막대와 꺾은선 색이 그 지표 색으로 바뀐다', (tester) async {
+    await openReports(tester);
+
+    // 기본은 소모 칼로리 — 유형 램프보다 한 단계 진한 결과 색이다.
+    expect(exerciseChart(tester).barColor, kBurnColor);
+
+    for (final entry in <({String metric, Color color})>[
+      (metric: 'cardio', color: AppColors.chartCardio),
+      (metric: 'strength', color: AppColors.chartStrength),
+      (metric: 'stretching', color: AppColors.chartStretching),
+      (metric: 'burned', color: kBurnColor),
+    ]) {
+      await pickExercise(tester, entry.metric);
+      final BarLineChart chart = exerciseChart(tester);
+      expect(chart.barColor, entry.color, reason: entry.metric);
+      // 꺾은선은 같은 색의 진한 쪽이다 — 한 그림이 한 지표를 말한다.
+      expect(
+        chart.lineColor,
+        Color.lerp(entry.color, Colors.black, 0.3),
+        reason: entry.metric,
+      );
+    }
+  });
+
+  testWidgets('운동 유형 색은 다른 운동 그래프와 같은 램프다', (tester) async {
+    expect(kindColor(ExerciseKind.cardio), AppColors.chartCardio);
+    expect(kindColor(ExerciseKind.strength), AppColors.chartStrength);
+    expect(kindColor(ExerciseKind.stretching), AppColors.chartStretching);
+  });
+
+  testWidgets('식단 비교 그래프의 색은 그대로다', (tester) async {
+    await openReports(tester);
+
+    // 식단 상자는 지표와 무관하게 한 색을 쓴다 — 색을 주지 않으므로 그래프의
+    // 기본값(브랜드 색)이 그대로 쓰인다.
+    final BarLineChart diet = dietChart(tester);
+    expect(diet.barColor, isNull);
+    expect(diet.lineColor, isNull);
+    // 칼로리 막대의 탄·단·지 조각도 그대로다.
+    expect(diet.segments, isNotNull);
+  });
+}


### PR DESCRIPTION
Closes #1424

## Summary

주간 리포트 `이번 주 vs 지난 주` 운동 상자는 소모 칼로리·유산소·근력·스트레칭을 알약으로 갈아 끼우는데, 그래프는 지표와 상관없이 늘 브랜드 색 하나였다. 지금 어떤 운동 유형을 보고 있는지 색으로 구분할 수 없었다.

## Changes

- `BarLineChart` 가 막대 색과 꺾은선 색을 인자로 받는다. 주지 않으면 지금까지 쓰던 값(`AppColors.primary` · `AppColors.accentDark`)이라 다른 사용처의 그림은 그대로다.
- 운동 비교 상자만 지금 고른 지표의 색을 준다.
  - 소모 칼로리: `kBurnColor` — 유형 셋이 함께 만든 결과를 뜻하는 색(운동 도넛·링과 같다).
  - 유산소·근력·스트레칭: `chartCardio` · `chartStrength` · `chartStretching` — 주간 운동 시간·이행률 막대와 같은 램프.
- 꺾은선·점은 같은 색의 한 단계 진한 쪽이다. 스트레칭처럼 옅은 색은 흰 바탕에서 선이 거의 보이지 않았다.
- 지난 주·이번 주는 같은 지표 색을 쓰고, 현재 주 강조는 기존 규칙(라벨 굵기·`highlightIndex`) 그대로다. 목표 초과 빨강도 그대로다.
- 색만으로 말하지 않는다 — 지표 알약, 값, 주 라벨, 시맨틱 문구는 건드리지 않았다.

## Verification

- 새 테스트 `test/features/reports/metric_comparison_colors_test.dart` 3건: 네 지표를 차례로 골라 막대·꺾은선 색이 그 지표 색으로 바뀐다 / 유형 색이 다른 운동 그래프와 같은 램프다 / 식단 비교 그래프는 색 인자를 받지 않아 기존 색과 탄·단·지 조각이 그대로다.
- `flutter analyze` 무경고, `flutter test` 전체 통과(로컬).
