### PR TITLE
fix(program): 직접 만들기 날짜·시간 선택 UI 통일

### DIFF
--- a/frontend/flutter_trainer/lib/features/coaching/presentation/widgets/program_editor_workspace.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/widgets/program_editor_workspace.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:oncare_trainer/core/utils/clock.dart';
 import 'package:oncare_trainer/core/utils/date_format.dart';
+import 'package:oncare_trainer/core/utils/portrait_date_picker.dart';
 import 'package:oncare_trainer/design_system/tokens/colors.dart';
 import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
@@ -11,6 +12,7 @@ import 'package:oncare_trainer/features/coaching/domain/exercise_estimate.dart';
 import 'package:oncare_trainer/features/coaching/domain/program_editor_state.dart';
 import 'package:oncare_trainer/features/coaching/domain/program_template.dart';
 import 'package:oncare_trainer/features/coaching/presentation/widgets/routine_form_fields.dart';
+import 'package:oncare_trainer/features/schedule/presentation/widgets/time_range_picker_dialog.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 import 'package:oncare_trainer/shared/widgets/action_button.dart';
 import 'package:oncare_trainer/shared/widgets/section_card.dart';
@@ -554,11 +556,13 @@ class _ProgramEditorWorkspaceState extends State<ProgramEditorWorkspace> {
   /// 등록할 날짜를 고른다 — 기본값은 오늘, 과거 날짜는 고를 수 없다.
   Future<void> _pickRegisterDate(BuildContext context) async {
     final today = _todayDate();
-    final picked = await showDatePicker(
+    // 다른 탭의 날짜 입력과 같은 세로형 달력이다(#1425) — 트레이너 웹은 늘
+    // 넓은 창이라 기본 `showDatePicker` 는 좌우로 퍼진 달력을 띄운다.
+    final picked = await showPortraitDatePicker(
       context: context,
       // 자정을 넘긴 채로 다이얼로그가 열려 있으면 `registerDate`(연 상태)가
-      // `today`(지금 다시 계산한 값)보다 이전일 수 있다 — `showDatePicker`
-      // 는 initialDate가 firstDate보다 빠르면 assertion으로 죽는다.
+      // `today`(지금 다시 계산한 값)보다 이전일 수 있다 — 달력은 initialDate
+      // 가 firstDate 보다 빠르면 assertion 으로 죽는다.
       initialDate: widget.registerDate.isBefore(today)
           ? today
           : widget.registerDate,
@@ -569,9 +573,12 @@ class _ProgramEditorWorkspaceState extends State<ProgramEditorWorkspace> {
     widget.onRegisterDateChanged(DateTime(picked.year, picked.month, picked.day));
   }
 
-  /// 등록할 시각을 고른다.
+  /// 등록할 시각을 고른다 — 스케줄 탭과 같은 시각 선택 모달이다(#1425).
+  ///
+  /// 프로그램은 시작 시각 하나만 필요하므로 시작·종료 범위 모달 대신 같은
+  /// 필드·시계 다이얼을 쓰는 단일 시각용을 부른다.
   Future<void> _pickRegisterTime(BuildContext context) async {
-    final picked = await showTimePicker(
+    final picked = await showScheduleTimePicker(
       context: context,
       initialTime: widget.registerTime,
     );

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/time_range_picker_dialog.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/time_range_picker_dialog.dart
@@ -17,6 +17,289 @@ Future<TimeRangeValue?> showScheduleTimeRangePicker({
   builder: (_) => _TimeRangePickerDialog(start: start, end: end),
 );
 
+/// 시각 **하나**를 같은 시계로 고르는 선택기 (#1425).
+///
+/// 프로그램 직접 만들기의 PT 등록 시각처럼 시작 시각만 필요한 자리가 쓴다.
+/// 범위 선택기와 같은 값 상자·오전/오후·시계 얼굴을 그대로 쓰고 단계만
+/// 시 → 분 둘이다 — 같은 앱에서 시각을 고르는 방법이 화면마다 달라지지 않게.
+Future<TimeOfDay?> showScheduleTimePicker({
+  required BuildContext context,
+  required TimeOfDay initialTime,
+}) => showDialog<TimeOfDay>(
+  context: context,
+  builder: (_) => _TimePickerDialog(initialTime: initialTime),
+);
+
+class _TimePickerDialog extends StatefulWidget {
+  const _TimePickerDialog({required this.initialTime});
+
+  final TimeOfDay initialTime;
+
+  @override
+  State<_TimePickerDialog> createState() => _TimePickerDialogState();
+}
+
+class _TimePickerDialogState extends State<_TimePickerDialog> {
+  late TimeOfDay _time = widget.initialTime;
+  late final TextEditingController _controller = TextEditingController(
+    text: _clock(_time),
+  );
+
+  /// 0 = 시, 1 = 분. 범위 선택기의 네 단계 중 앞의 둘만 쓴다.
+  int _step = 0;
+
+  bool get _isHour => _step == 0;
+
+  String _clock(TimeOfDay value) =>
+      '${value.hour.toString().padLeft(2, '0')}:'
+      '${value.minute.toString().padLeft(2, '0')}';
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _readField(String text) {
+    final match = RegExp(r'^(\d{1,2}):(\d{1,2})$').firstMatch(text.trim());
+    if (match == null) return;
+    final hour = int.tryParse(match.group(1)!);
+    final minute = int.tryParse(match.group(2)!);
+    if (hour == null || minute == null || hour > 23 || minute > 59) return;
+    setState(() {
+      _time = TimeOfDay(hour: hour, minute: minute);
+      _step = 0;
+    });
+  }
+
+  void _setValue(int value, {required bool advance}) {
+    setState(() {
+      _time = _isHour
+          ? TimeOfDay(hour: value, minute: _time.minute)
+          : TimeOfDay(hour: _time.hour, minute: value);
+      if (advance && _step == 0) _step = 1;
+      _controller.text = _clock(_time);
+    });
+  }
+
+  void _setPeriod(bool pm) {
+    setState(() {
+      _time = TimeOfDay(hour: _time.hour % 12 + (pm ? 12 : 0), minute: _time.minute);
+      _controller.text = _clock(_time);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      insetPadding: const EdgeInsets.fromLTRB(
+        AppSpacing.lg,
+        AppToastStyle.dialogTopClearance,
+        AppSpacing.lg,
+        AppSpacing.lg,
+      ),
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.all(AppRadius.lg),
+      ),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 480),
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.all(AppSpacing.xl),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                Row(
+                  children: <Widget>[
+                    const Expanded(
+                      child: Text(
+                        '시간 선택',
+                        style: TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.w800,
+                        ),
+                      ),
+                    ),
+                    IconButton(
+                      onPressed: () => Navigator.pop(context),
+                      icon: const Icon(Icons.close),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: AppSpacing.md),
+                _timeValueBox(
+                  label: '시각',
+                  controller: _controller,
+                  active: true,
+                  fieldKey: const ValueKey<String>('session-time-input'),
+                  onTap: () => setState(() => _step = 0),
+                  onSubmitted: _readField,
+                ),
+                const SizedBox(height: AppSpacing.lg),
+                SizedBox(
+                  height: 48,
+                  child: Row(
+                    children: <Widget>[
+                      Expanded(
+                        child: Text(
+                          _isHour ? '시' : '분',
+                          style: const TextStyle(
+                            color: AppColors.mutedForeground,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ),
+                      IconButton(
+                        key: const ValueKey<String>('session-time-back'),
+                        tooltip: '이전 단계',
+                        onPressed: _step > 0
+                            ? () => setState(() => _step = 0)
+                            : null,
+                        icon: const Icon(Icons.chevron_left),
+                      ),
+                      IconButton(
+                        key: const ValueKey<String>('session-time-next'),
+                        tooltip: '다음 단계',
+                        onPressed: _step == 0
+                            ? () => setState(() => _step = 1)
+                            : null,
+                        icon: const Icon(Icons.chevron_right),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                SizedBox(
+                  height: 52,
+                  child: Center(
+                    child: Visibility(
+                      visible: _isHour,
+                      maintainAnimation: true,
+                      maintainSize: true,
+                      maintainState: true,
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: <Widget>[
+                          _timePeriodButton('오전', pm: false, time: _time, onTap: _setPeriod),
+                          const SizedBox(width: AppSpacing.sm),
+                          _timePeriodButton('오후', pm: true, time: _time, onTap: _setPeriod),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                _ClockFace(
+                  key: ValueKey<String>('session-time-step-$_step'),
+                  isHour: _isHour,
+                  selected: _isHour ? _time.hour : _time.minute,
+                  onChanged: (value) => _setValue(value, advance: false),
+                  onSelected: (value) => _setValue(value, advance: true),
+                ),
+                const SizedBox(height: AppSpacing.lg),
+                Row(
+                  children: <Widget>[
+                    Expanded(
+                      child: TextButton(
+                        key: const ValueKey<String>('session-time-cancel'),
+                        onPressed: () => Navigator.pop(context),
+                        child: const Text('취소'),
+                      ),
+                    ),
+                    const SizedBox(width: AppSpacing.sm),
+                    Expanded(
+                      child: FilledButton(
+                        key: const ValueKey<String>('session-time-confirm'),
+                        onPressed: () => Navigator.pop(context, _time),
+                        child: const Text('확인'),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// 범위 선택기의 값 상자와 같은 모양 — 두 선택기가 같은 필드를 쓴다.
+Widget _timeValueBox({
+  required String label,
+  required TextEditingController controller,
+  required bool active,
+  required Key fieldKey,
+  required VoidCallback onTap,
+  required ValueChanged<String> onSubmitted,
+}) => Container(
+  padding: const EdgeInsets.symmetric(
+    horizontal: AppSpacing.md,
+    vertical: AppSpacing.sm,
+  ),
+  decoration: BoxDecoration(
+    color: active ? AppColors.accentSurface : AppColors.inputBackground,
+    borderRadius: const BorderRadius.all(AppRadius.md),
+  ),
+  child: Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: <Widget>[
+      Text(label, style: const TextStyle(color: AppColors.mutedForeground)),
+      TextField(
+        key: fieldKey,
+        controller: controller,
+        onTap: onTap,
+        onChanged: onSubmitted,
+        onSubmitted: onSubmitted,
+        onEditingComplete: () => onSubmitted(controller.text),
+        keyboardType: TextInputType.datetime,
+        textAlign: TextAlign.center,
+        decoration: const InputDecoration(
+          isDense: true,
+          border: InputBorder.none,
+          contentPadding: EdgeInsets.zero,
+        ),
+        style: TextStyle(
+          fontSize: 24,
+          fontWeight: FontWeight.w700,
+          color: active ? AppColors.primary : AppColors.foreground,
+        ),
+      ),
+    ],
+  ),
+);
+
+/// 범위 선택기의 오전·오후 버튼과 같은 모양.
+Widget _timePeriodButton(
+  String label, {
+  required bool pm,
+  required TimeOfDay time,
+  required ValueChanged<bool> onTap,
+}) {
+  final active = (time.hour >= 12) == pm;
+  return Material(
+    color: active ? AppColors.accentSurface : AppColors.inputBackground,
+    borderRadius: const BorderRadius.all(AppRadius.sm),
+    child: InkWell(
+      key: ValueKey<String>('session-time-period-${pm ? 'pm' : 'am'}'),
+      onTap: () => onTap(pm),
+      borderRadius: const BorderRadius.all(AppRadius.sm),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 22, vertical: 10),
+        child: Text(
+          label,
+          style: TextStyle(
+            color: active ? AppColors.primary : AppColors.mutedForeground,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
 /// 시 → 분 → 종료 시 → 종료 분을 한 시계에서 고르는 범위 선택기.
 /// 기본 Material 시간 선택기의 검은 윤곽선을 쓰지 않고 스케줄 화면의 옅은
 /// 채움과 브랜드 남색만 사용한다.

--- a/frontend/flutter_trainer/test/features/coaching/program_register_pickers_test.dart
+++ b/frontend/flutter_trainer/test/features/coaching/program_register_pickers_test.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oncare_trainer/core/utils/clock.dart';
+import 'package:oncare_trainer/core/utils/date_format.dart';
+import 'package:oncare_trainer/features/coaching/domain/entities/ai_routine_item.dart';
+import 'package:oncare_trainer/features/coaching/presentation/widgets/program_editor_workspace.dart';
+import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
+
+/// 프로그램 직접 만들기의 PT 등록 날짜·시각 선택 UI. (#1425)
+///
+/// 이 흐름만 기본 Material `showDatePicker`·`showTimePicker` 를 썼다. 앱의 다른
+/// 입력 화면은 세로형 달력(`showPortraitDatePicker`)과 스케줄 탭의 시계
+/// 선택기를 쓴다 — 같은 앱에서 날짜·시각을 고르는 방법이 탭마다 다르면 공통
+/// 검증·접근성 개선도 함께 가지 않는다.
+void main() {
+  DateTime today() {
+    final now = nowKst();
+    return DateTime(now.year, now.month, now.day);
+  }
+
+  /// 워크스페이스만 띄운다 — 등록 날짜·시각은 이 위젯이 쥔다.
+  Future<({DateTime date, TimeOfDay time}) Function()> pumpWorkspace(
+    WidgetTester tester, {
+    Size size = const Size(1400, 1000),
+  }) async {
+    tester.view.devicePixelRatio = 1.0;
+    tester.view.physicalSize = size;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    DateTime date = today();
+    TimeOfDay time = const TimeOfDay(hour: 10, minute: 0);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('ko'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: StatefulBuilder(
+            builder: (context, setState) => SingleChildScrollView(
+              child: ProgramEditorWorkspace(
+                clientGoal: '체지방 감량',
+                aiSuggestions: const <AiRoutineItem>[],
+                registerDate: date,
+                registerTime: time,
+                onRegisterDateChanged: (value) => setState(() => date = value),
+                onRegisterTimeChanged: (value) => setState(() => time = value),
+                onSend: (_) {},
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return () => (date: date, time: time);
+  }
+
+  Future<void> tapChip(WidgetTester tester, String key) async {
+    final chip = find.byKey(ValueKey<String>(key));
+    await tester.scrollUntilVisible(
+      chip,
+      150,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.ensureVisible(chip);
+    await tester.pumpAndSettle();
+    await tester.tap(chip);
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('기본값은 오늘·오전 10시이고 칩에 그대로 보인다', (tester) async {
+    final read = await pumpWorkspace(tester);
+
+    expect(read().date, today());
+    expect(read().time, const TimeOfDay(hour: 10, minute: 0));
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey<String>('program-register-date')),
+        matching: find.text(ymd(today())),
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('날짜 선택은 넓은 창에서도 세로형 달력이다', (tester) async {
+    await pumpWorkspace(tester);
+    await tapChip(tester, 'program-register-date');
+
+    expect(find.byType(DatePickerDialog), findsOneWidget);
+    // 달력은 자기 화면이 가로로 넓으면 헤더와 그리드를 좌우로 나눈다.
+    // `showPortraitDatePicker` 는 이 다이얼로그에게만 세로 화면을 넘겨 늘
+    // 위아래로 선 달력이 되게 한다 — 트레이너 웹은 늘 넓은 창이다.
+    final BuildContext dialogContext = tester.element(
+      find.byType(DatePickerDialog),
+    );
+    expect(MediaQuery.of(dialogContext).orientation, Orientation.portrait);
+  });
+
+  testWidgets('과거 날짜는 고를 수 없고 한 해 앞까지 고른다', (tester) async {
+    await pumpWorkspace(tester);
+    await tapChip(tester, 'program-register-date');
+
+    final DatePickerDialog dialog = tester.widget<DatePickerDialog>(
+      find.byType(DatePickerDialog),
+    );
+    expect(dialog.firstDate, today());
+    expect(dialog.lastDate, today().add(const Duration(days: 365)));
+    expect(dialog.initialDate, today());
+  });
+
+  testWidgets('시각 선택은 스케줄 탭과 같은 시계 선택기다', (tester) async {
+    final read = await pumpWorkspace(tester);
+    await tapChip(tester, 'program-register-time');
+
+    // Material 기본 시간 선택기가 아니라 스케줄 탭의 시계다.
+    expect(find.byType(TimePickerDialog), findsNothing);
+    expect(
+      find.byKey(const ValueKey<String>('session-time-input')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey<String>('session-time-confirm')),
+      findsOneWidget,
+    );
+
+    // 오후 → 2시 → 30분 순으로 고르고 확인한다.
+    await tester.tap(
+      find.byKey(const ValueKey<String>('session-time-period-pm')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey<String>('clock-value-2')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey<String>('clock-value-30')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const ValueKey<String>('session-time-confirm')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(read().time, const TimeOfDay(hour: 14, minute: 30));
+  });
+
+  testWidgets('시각 선택을 닫으면 값이 그대로다', (tester) async {
+    final read = await pumpWorkspace(tester);
+    await tapChip(tester, 'program-register-time');
+
+    await tester.tap(find.byKey(const ValueKey<String>('session-time-cancel')));
+    await tester.pumpAndSettle();
+
+    expect(read().time, const TimeOfDay(hour: 10, minute: 0));
+  });
+}


### PR DESCRIPTION
Closes #1425

## Summary

프로그램 탭에서 프로그램을 직접 구성한 뒤 PT 등록 날짜·시각을 고르는 UI만 기본 Material `showDatePicker`·`showTimePicker` 였다. 앱의 다른 입력 화면은 세로형 달력과 스케줄 탭의 시계 선택기를 쓰므로, 같은 앱 안에서 날짜·시각을 고르는 방법과 생김새가 이 탭에서만 달랐다.

## Changes

- 날짜: `showPortraitDatePicker` 로 바꾼다. 트레이너 웹은 늘 넓은 창이라 기본 달력이 헤더·그리드를 좌우로 나눠 띄웠다 — 이제 다른 탭(스케줄 세션 시트·운동 날짜 필드·후속 관리)과 같은 세로형이다.
- 시각: 스케줄 탭이 실제로 쓰는 시간 범위 선택기(`time_range_picker_dialog.dart`)와 같은 값 상자·오전/오후 버튼·시계 얼굴을 쓰는 **단일 시각용** `showScheduleTimePicker` 를 같은 파일에 두고 부른다. 프로그램은 시작 시각 하나만 필요하다는 기존 계약 그대로다.
- 기본값(오늘·오전 10시), 과거 날짜 제한(`firstDate = 오늘`), 한 해 앞까지의 범위, 자정 경계 처리, 등록 payload 는 모두 그대로다.

## Verification

- 새 테스트 `test/features/coaching/program_register_pickers_test.dart` 5건: 기본값이 오늘·오전 10시로 칩에 보인다 / 넓은 창에서도 달력이 세로형으로 뜬다 / `firstDate`·`lastDate`·`initialDate` 가 그대로다 / 시각 선택이 Material 기본 선택기가 아니라 스케줄 탭 시계이며 오후 2시 30분을 고르면 그 값이 반영된다 / 닫으면 값이 그대로다.
- 기존 `coaching_page_test.dart` 의 날짜·시각 등록 회귀 테스트(고른 날짜·시각으로 PT 가 등록되는지) 통과.
- `flutter analyze` 무경고, `flutter test` 전체 통과(로컬).
