### PR TITLE
fix(diet): 식단 추가 시트 하단 여백과 사진 아이콘 색상 통일

### DIFF
--- a/frontend/flutter/lib/features/diet/presentation/widgets/diet_flows.dart
+++ b/frontend/flutter/lib/features/diet/presentation/widgets/diet_flows.dart
@@ -294,10 +294,12 @@ class _DietAddSheetState extends ConsumerState<_DietAddSheet> {
             padding: const EdgeInsets.fromLTRB(20, 12, 20, 0),
             child: Column(
               children: <Widget>[
+                // 두 갈래 모두 브랜드 파랑의 농담이다 — 촬영이 진한 쪽(주된
+                // 경로), 갤러리가 옅은 쪽이다.
                 _SourceOption(
                   icon: Icons.image_outlined,
-                  iconBg: FigmaColors.primaryA(0.12),
-                  iconColor: FigmaColors.primary,
+                  iconBg: FigmaColors.primaryA(0.10),
+                  iconColor: FigmaColors.primaryA(0.55),
                   title: l.dietPickPhoto,
                   subtitle: l.dietPickPhotoSub,
                   onTap: () => _pickAndAnalyze(MealPhotoSource.gallery),
@@ -305,8 +307,8 @@ class _DietAddSheetState extends ConsumerState<_DietAddSheet> {
                 const SizedBox(height: 12),
                 _SourceOption(
                   icon: Icons.photo_camera_outlined,
-                  iconBg: FigmaColors.greenA(0.12),
-                  iconColor: FigmaColors.greenText,
+                  iconBg: FigmaColors.primaryA(0.12),
+                  iconColor: FigmaColors.primary,
                   title: l.dietTakePhoto,
                   subtitle: l.dietTakePhotoSub,
                   onTap: () => _pickAndAnalyze(MealPhotoSource.camera),
@@ -314,6 +316,9 @@ class _DietAddSheetState extends ConsumerState<_DietAddSheet> {
               ],
             ),
           ),
+          // 마지막 카드가 화면 끝(홈 인디케이터)에 닿아 잘려 보이던 것을
+          // 띄운다 — 시스템 인셋이 없는 기기에서도 남는 여백이다.
+          const SizedBox(height: 20),
         ],
       ),
       key: const Key('dietAddSheet'),

--- a/frontend/flutter/test/widget_test.dart
+++ b/frontend/flutter/test/widget_test.dart
@@ -260,7 +260,7 @@ void main() {
     expect(bottomSpacing, 34);
   });
 
-  testWidgets('diet add opens as a content-sized sheet without a bottom gap', (
+  testWidgets('diet add opens as a content-sized sheet with a bottom gap', (
     tester,
   ) async {
     await pumpApp(tester, locale: const Locale('ko'));
@@ -281,9 +281,11 @@ void main() {
     final logicalHeight =
         tester.view.physicalSize.height / tester.view.devicePixelRatio;
     expect(tester.getBottomRight(sheet).dy, logicalHeight);
+    // 마지막 카드가 화면 끝(홈 인디케이터)에 붙어 잘려 보이지 않도록
+    // 시트 자체가 아래 여백을 갖는다 — 시스템 인셋이 없는 기기에서도.
     expect(
       tester.getBottomRight(sheet).dy - tester.getBottomRight(options).dy,
-      0,
+      20,
     );
     expect(find.byKey(const Key('recordAddSheet')), findsNothing);
   });


### PR DESCRIPTION
## Summary

식단 추가 시트(`+` → 식단)에서 마지막 카드가 화면 끝에 붙어 잘려 보이던 것을 띄우고, 두 갈래 아이콘 색을 브랜드 파랑의 농담으로 맞춘다.

Closes #1512

## Changes

- 카드 목록 뒤에 시트가 직접 가진 아래 여백을 둔다. `SafeArea` 안이라 홈 인디케이터가 있는 기기에서는 인셋만큼 더 벌어지고, 인셋이 없는 기기에서도 카드가 화면 끝에 붙지 않는다.
- `사진 선택` 아이콘은 브랜드 파랑의 옅은 농담, `사진 찍기` 는 메인 파랑으로. 촬영이 주된 경로라 진한 쪽을 준다. 이 시트에서 초록 계열은 빠진다.
- `diet add opens as a content-sized sheet …` 가 "아래 여백 0" 을 강제하고 있어 새 의도에 맞게 갱신했다.

## Notes

- 운동·코칭 시트의 "시스템 인셋만" 규칙과 달리 이 시트만 고정 여백을 갖는다 — 마지막 요소가 카드(테두리가 보이는 면)라 화면 끝에 닿으면 잘린 것처럼 읽히기 때문이다.
- 로컬 검증: `flutter test` 전체 통과, `flutter analyze` 이슈 없음. 골든 스냅샷으로 여백·색을 눈으로 확인했다.