### PR TITLE
fix(nav): 하단 탭바 라벨이 홈 인디케이터에 가려지는 여백 부족 해소

### DIFF
--- a/frontend/flutter/lib/design_system/tokens/nav_metrics.dart
+++ b/frontend/flutter/lib/design_system/tokens/nav_metrics.dart
@@ -19,5 +19,9 @@ class AppNavMetrics {
 
   /// 바 아래 안전영역을 이만큼까지만 따른다. 그보다 깊은 기기에서도
   /// 바가 지나치게 두꺼워지지 않는다.
-  static const double maxBottomInset = 22;
+  ///
+  /// 22 일 때 홈 인디케이터가 있는 기기(인셋 34)에서 라벨 아래가 인디케이터에
+  /// 닿아 가려 보였다. 인셋을 그대로 따르면 바가 두꺼워지므로, 라벨이 비켜설
+  /// 만큼만 올린다.
+  static const double maxBottomInset = 28;
 }


### PR DESCRIPTION
## Summary

아이폰 실기에서 하단 탭바 라벨(홈·식단·운동·MY) 아래가 홈 인디케이터에 닿아 가려 보이던 것을 띄운다.

Closes #1513

## Changes

- `AppNavMetrics.maxBottomInset` 상한을 올린다. 바는 기기 안전영역을 이 상한까지만 따르는데, 값이 22 라 인셋이 34 인 기기에서도 22 밖에 반영되지 않아 라벨 아래 여유가 인디케이터 바로 위에서 끝났다.
- 인셋을 그대로 따르면 바가 두꺼워지므로, 라벨이 비켜설 만큼만 올린다.

## Notes

- 상한 하나만 바뀐다 — 바 본체 높이(`barHeight`)와 `+` 버튼이 솟은 높이(`addButtonLift`)는 그대로라, 바 위에 뜨는 토스트가 `+` 를 비키는 계산도 영향이 없다.
- 인셋이 없는 웹·안드로이드 일부 기기는 상한에 걸리지 않아 이전과 같다.
- 로컬 검증: `flutter test` 전체 통과, `flutter analyze` 이슈 없음.