### PR TITLE
fix(nav): 하단 탭바 라벨 아래 고정 여백 추가

### DIFF
--- a/frontend/flutter/lib/app/router/main_shell.dart
+++ b/frontend/flutter/lib/app/router/main_shell.dart
@@ -146,7 +146,11 @@ class _MainShellState extends ConsumerState<MainShell>
     // 예전에는 라벨을 4dp 아래로 '그려서' 미는 바람에 바닥 여백이 0 인 웹에서
     // 글자 아래가 잘렸고, 그만큼을 웹에서만 따로 확보하고 있었다. 이제
     // 목적지 열이 바 높이 안에서 가운데 정렬되므로 그 보정은 필요 없다(#840).
-    final double effectiveBottomPadding = navBottomPadding;
+    //
+    // 안전영역 위에 얹는 고정 여백은 라벨이 화면 끝에 붙어 보이지 않게 한다 —
+    // 인셋을 다 따르는 기기에서도 빠듯했다.
+    final double effectiveBottomPadding =
+        navBottomPadding + AppNavMetrics.labelBottomPadding;
     // 바 본체 높이와 `+` 버튼이 솟은 높이는 [AppNavMetrics] 가 들고 있다 —
     // 바 위에 뜨는 토스트가 같은 값을 봐야 `+` 를 비킬 수 있다(#1259).
     const double barHeight = AppNavMetrics.barHeight;

--- a/frontend/flutter/lib/design_system/tokens/nav_metrics.dart
+++ b/frontend/flutter/lib/design_system/tokens/nav_metrics.dart
@@ -24,4 +24,9 @@ class AppNavMetrics {
   /// 닿아 가려 보였고, 28 로도 실기에서 빠듯했다. 지금 값은 그런 기기의
   /// 인셋을 그대로 따른다 — 즉 이 상한은 그보다 깊은 기기에서만 걸린다.
   static const double maxBottomInset = 34;
+
+  /// 안전영역 **위에** 항상 얹는 고정 여백. 인셋을 다 따라도 라벨이 화면
+  /// 끝(홈 인디케이터)에 가까워 빠듯해 보여, 그만큼을 더 띄운다. 인셋이 없는
+  /// 기기에서도 라벨 아래에 이 여백은 남는다.
+  static const double labelBottomPadding = 8;
 }


### PR DESCRIPTION
## Summary

하단 탭바 라벨(홈·식단·운동·MY) 아래에 안전영역 위로 얹는 고정 여백을 둔다. #1516 의 후속 조정이다.

Closes #1518

## Changes

- `AppNavMetrics` 에 안전영역 위에 항상 더해지는 고정 여백을 둔다. 바의 아래 여백이 인셋뿐이면 인셋이 끝나는 자리가 곧 라벨의 아래 경계라, 상한을 더 올려도 이 이상 벌어지지 않았다.
- 바 높이 계산이 이 여백을 함께 들어, 바 본체·배경·`+` 버튼 자리 관계는 그대로 유지된다.

## Notes

- 인셋이 없는 웹·안드로이드 일부 기기에서도 같은 여백이 남는다 — 라벨이 화면 끝에 붙던 자리다.
- `barHeight` 와 `addButtonLift` 는 건드리지 않아, 바 위 토스트가 `+` 를 비키는 계산에는 영향이 없다.
- 로컬 검증: `flutter test` 전체 통과, `flutter analyze` 이슈 없음.