### PR TITLE
fix(schedule): 날짜 선택기 입력창·달력 동시 표시로 재설계

### DIFF
--- a/frontend/flutter/lib/core/utils/portrait_date_picker.dart
+++ b/frontend/flutter/lib/core/utils/portrait_date_picker.dart
@@ -13,8 +13,10 @@ import 'package:oncare/design_system/tokens/spacing.dart';
 /// 버튼을 모두 둔다 — 앱의 다른 모달과 같은 X 로도 닫히고, 하단
 /// 취소·확인은 다른 다이얼로그 액션과 같은 자리를 유지한다.
 ///
-/// Material 기본 다이얼로그처럼 연필 아이콘으로 그리드([CalendarDatePicker])
-/// ↔ 키보드 직접 입력([InputDatePickerFormField]) 을 전환할 수 있다.
+/// 날짜 값 자체가 입력창이라 따로 전환할 필요 없이 타이핑도, 바로 아래
+/// 달력([CalendarDatePicker])에서 탭으로 고르는 것도 둘 다 항상 된다.
+/// 입력창에 타이핑하면 [MaterialLocalizations.parseCompactDate] 로 즉시
+/// 해석해 달력도 같이 움직이고, 달력에서 고르면 입력창 글자도 같이 바뀐다.
 Future<DateTime?> showPortraitDatePicker({
   required BuildContext context,
   required DateTime initialDate,
@@ -50,30 +52,59 @@ class _PortraitDatePickerDialog extends StatefulWidget {
 
 class _PortraitDatePickerDialogState extends State<_PortraitDatePickerDialog> {
   late DateTime _selected = widget.initialDate;
-  final GlobalKey<FormState> _inputFormKey = GlobalKey<FormState>();
-  DatePickerEntryMode _entryMode = DatePickerEntryMode.calendar;
+  final TextEditingController _dateController = TextEditingController();
+  String? _errorText;
 
-  void _toggleEntryMode() {
+  @override
+  void dispose() {
+    _dateController.dispose();
+    super.dispose();
+  }
+
+  /// 입력창 글자가 바뀔 때마다(키 입력마다) 유효한 날짜인지 확인해 곧장
+  /// 반영한다 — 아래 달력이 입력과 같이 움직여야 한다.
+  void _handleTextChanged(MaterialLocalizations l, String text) {
+    if (text.isEmpty) {
+      setState(() => _errorText = null);
+      return;
+    }
+    final DateTime? parsed = l.parseCompactDate(text);
+    if (parsed == null) {
+      setState(() => _errorText = l.invalidDateFormatLabel);
+      return;
+    }
+    if (parsed.isBefore(widget.firstDate) || parsed.isAfter(widget.lastDate)) {
+      setState(() => _errorText = l.dateOutOfRangeLabel);
+      return;
+    }
     setState(() {
-      _entryMode = _entryMode == DatePickerEntryMode.calendar
-          ? DatePickerEntryMode.input
-          : DatePickerEntryMode.calendar;
+      _selected = parsed;
+      _errorText = null;
+    });
+  }
+
+  /// 달력 탭은 입력창의 글자도 같이 바꾼다 — 타이핑 쪽(`_handleTextChanged`)과
+  /// 달리 이쪽은 사용자가 지금 커서를 두고 타이핑 중이 아니므로 컨트롤러
+  /// 텍스트를 직접 덮어써도 된다.
+  void _handleCalendarChanged(MaterialLocalizations l, DateTime date) {
+    setState(() {
+      _selected = date;
+      _errorText = null;
+      _dateController.text = l.formatCompactDate(date);
     });
   }
 
   void _confirm() {
-    if (_entryMode == DatePickerEntryMode.input) {
-      final FormState? form = _inputFormKey.currentState;
-      if (form == null || !form.validate()) return;
-      form.save();
-    }
+    if (_errorText != null) return;
     Navigator.of(context).pop(_selected);
   }
 
   @override
   Widget build(BuildContext context) {
     final MaterialLocalizations l = MaterialLocalizations.of(context);
-    final bool isCalendar = _entryMode == DatePickerEntryMode.calendar;
+    if (_dateController.text.isEmpty) {
+      _dateController.text = l.formatCompactDate(_selected);
+    }
     return Dialog(
       key: const Key('portraitDatePicker'),
       backgroundColor: Colors.white,
@@ -86,96 +117,88 @@ class _PortraitDatePickerDialogState extends State<_PortraitDatePickerDialog> {
       ),
       child: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 400),
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(
-            AppSpacing.lg,
-            AppSpacing.md,
-            AppSpacing.md,
-            AppSpacing.lg,
-          ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: <Widget>[
-              Row(
-                children: <Widget>[
-                  Expanded(
-                    child: Text(
-                      l.datePickerHelpText,
-                      style: Theme.of(context).textTheme.titleMedium
-                          ?.copyWith(fontWeight: FontWeight.w700),
+        // 오류 문구가 뜨거나 화면이 낮으면 입력창+달력+버튼 전체 높이가
+        // 다이얼로그보다 커질 수 있다 — 넘치는 대신 스크롤하게 한다.
+        child: SingleChildScrollView(
+          child: Padding(
+            // 시간 선택 다이얼로그(`consult_time_range_picker.dart`)와 같은
+            // 여백을 써서 두 다이얼로그의 크기 차이가 두드러지지 않게 한다.
+            padding: const EdgeInsets.all(AppSpacing.xl),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                Row(
+                  children: <Widget>[
+                    Expanded(
+                      child: Text(
+                        l.datePickerHelpText,
+                        style: Theme.of(context).textTheme.titleMedium
+                            ?.copyWith(fontWeight: FontWeight.w700),
+                      ),
                     ),
-                  ),
-                  IconButton(
-                    tooltip: isCalendar
-                        ? l.inputDateModeButtonLabel
-                        : l.calendarModeButtonLabel,
-                    icon: Icon(isCalendar ? Icons.edit : Icons.calendar_today),
-                    onPressed: _toggleEntryMode,
-                  ),
-                  Material(
-                    color: AppColors.accent,
-                    shape: const CircleBorder(),
-                    child: InkWell(
-                      customBorder: const CircleBorder(),
-                      onTap: () => Navigator.of(context).pop(),
-                      child: Tooltip(
-                        message: l.closeButtonTooltip,
-                        child: const SizedBox(
-                          width: 32,
-                          height: 32,
-                          child: Icon(Icons.close, size: 18),
+                    Material(
+                      color: AppColors.accent,
+                      shape: const CircleBorder(),
+                      child: InkWell(
+                        customBorder: const CircleBorder(),
+                        onTap: () => Navigator.of(context).pop(),
+                        child: Tooltip(
+                          message: l.closeButtonTooltip,
+                          child: const SizedBox(
+                            width: 32,
+                            height: 32,
+                            child: Icon(Icons.close, size: 18),
+                          ),
                         ),
                       ),
                     ),
+                  ],
+                ),
+                // 날짜 값 자체가 입력창이다 — 따로 전환할 필요 없이 타이핑도,
+                // 아래 달력 탭도 둘 다 바로 된다. 한쪽이 바뀌면 다른 쪽도
+                // 같이 움직인다.
+                TextField(
+                  key: const Key('portraitDatePickerInput'),
+                  controller: _dateController,
+                  keyboardType: TextInputType.datetime,
+                  decoration: InputDecoration(
+                    labelText: l.dateInputLabel,
+                    errorText: _errorText,
                   ),
-                ],
-              ),
-              if (isCalendar)
+                  onChanged: (String text) => _handleTextChanged(l, text),
+                ),
+                const SizedBox(height: AppSpacing.sm),
                 CalendarDatePicker(
-                  initialDate: widget.initialDate,
+                  key: ValueKey<DateTime>(_selected),
+                  initialDate: _selected,
                   firstDate: widget.firstDate,
                   lastDate: widget.lastDate,
                   onDateChanged: (DateTime date) =>
-                      setState(() => _selected = date),
-                )
-              else
-                Padding(
-                  padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
-                  child: Form(
-                    key: _inputFormKey,
-                    child: InputDatePickerFormField(
-                      initialDate: _selected,
-                      firstDate: widget.firstDate,
-                      lastDate: widget.lastDate,
-                      onDateSubmitted: (DateTime date) =>
-                          setState(() => _selected = date),
-                      onDateSaved: (DateTime date) =>
-                          setState(() => _selected = date),
-                    ),
-                  ),
+                      _handleCalendarChanged(l, date),
                 ),
-              const SizedBox(height: AppSpacing.sm),
-              Row(
-                children: <Widget>[
-                  Expanded(
-                    child: TextButton(
-                      key: const Key('portraitDatePickerCancel'),
-                      onPressed: () => Navigator.of(context).pop(),
-                      child: Text(l.cancelButtonLabel),
+                const SizedBox(height: AppSpacing.sm),
+                Row(
+                  children: <Widget>[
+                    Expanded(
+                      child: TextButton(
+                        key: const Key('portraitDatePickerCancel'),
+                        onPressed: () => Navigator.of(context).pop(),
+                        child: Text(l.cancelButtonLabel),
+                      ),
                     ),
-                  ),
-                  const SizedBox(width: AppSpacing.sm),
-                  Expanded(
-                    child: FilledButton(
-                      key: const Key('portraitDatePickerConfirm'),
-                      onPressed: _confirm,
-                      child: Text(l.okButtonLabel),
+                    const SizedBox(width: AppSpacing.sm),
+                    Expanded(
+                      child: FilledButton(
+                        key: const Key('portraitDatePickerConfirm'),
+                        onPressed: _confirm,
+                        child: Text(l.okButtonLabel),
+                      ),
                     ),
-                  ),
-                ],
-              ),
-            ],
+                  ],
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/frontend/flutter/lib/core/utils/portrait_date_picker.dart
+++ b/frontend/flutter/lib/core/utils/portrait_date_picker.dart
@@ -12,6 +12,9 @@ import 'package:oncare/design_system/tokens/spacing.dart';
 /// 않아 별도 세로 고정 트릭이 필요 없다. 우측 상단 X 와 하단 취소·확인
 /// 버튼을 모두 둔다 — 앱의 다른 모달과 같은 X 로도 닫히고, 하단
 /// 취소·확인은 다른 다이얼로그 액션과 같은 자리를 유지한다.
+///
+/// Material 기본 다이얼로그처럼 연필 아이콘으로 그리드([CalendarDatePicker])
+/// ↔ 키보드 직접 입력([InputDatePickerFormField]) 을 전환할 수 있다.
 Future<DateTime?> showPortraitDatePicker({
   required BuildContext context,
   required DateTime initialDate,
@@ -47,10 +50,30 @@ class _PortraitDatePickerDialog extends StatefulWidget {
 
 class _PortraitDatePickerDialogState extends State<_PortraitDatePickerDialog> {
   late DateTime _selected = widget.initialDate;
+  final GlobalKey<FormState> _inputFormKey = GlobalKey<FormState>();
+  DatePickerEntryMode _entryMode = DatePickerEntryMode.calendar;
+
+  void _toggleEntryMode() {
+    setState(() {
+      _entryMode = _entryMode == DatePickerEntryMode.calendar
+          ? DatePickerEntryMode.input
+          : DatePickerEntryMode.calendar;
+    });
+  }
+
+  void _confirm() {
+    if (_entryMode == DatePickerEntryMode.input) {
+      final FormState? form = _inputFormKey.currentState;
+      if (form == null || !form.validate()) return;
+      form.save();
+    }
+    Navigator.of(context).pop(_selected);
+  }
 
   @override
   Widget build(BuildContext context) {
     final MaterialLocalizations l = MaterialLocalizations.of(context);
+    final bool isCalendar = _entryMode == DatePickerEntryMode.calendar;
     return Dialog(
       key: const Key('portraitDatePicker'),
       backgroundColor: Colors.white,
@@ -79,10 +102,16 @@ class _PortraitDatePickerDialogState extends State<_PortraitDatePickerDialog> {
                   Expanded(
                     child: Text(
                       l.datePickerHelpText,
-                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.w700,
-                      ),
+                      style: Theme.of(context).textTheme.titleMedium
+                          ?.copyWith(fontWeight: FontWeight.w700),
                     ),
+                  ),
+                  IconButton(
+                    tooltip: isCalendar
+                        ? l.inputDateModeButtonLabel
+                        : l.calendarModeButtonLabel,
+                    icon: Icon(isCalendar ? Icons.edit : Icons.calendar_today),
+                    onPressed: _toggleEntryMode,
                   ),
                   Material(
                     color: AppColors.accent,
@@ -102,13 +131,30 @@ class _PortraitDatePickerDialogState extends State<_PortraitDatePickerDialog> {
                   ),
                 ],
               ),
-              CalendarDatePicker(
-                initialDate: widget.initialDate,
-                firstDate: widget.firstDate,
-                lastDate: widget.lastDate,
-                onDateChanged: (DateTime date) =>
-                    setState(() => _selected = date),
-              ),
+              if (isCalendar)
+                CalendarDatePicker(
+                  initialDate: widget.initialDate,
+                  firstDate: widget.firstDate,
+                  lastDate: widget.lastDate,
+                  onDateChanged: (DateTime date) =>
+                      setState(() => _selected = date),
+                )
+              else
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
+                  child: Form(
+                    key: _inputFormKey,
+                    child: InputDatePickerFormField(
+                      initialDate: _selected,
+                      firstDate: widget.firstDate,
+                      lastDate: widget.lastDate,
+                      onDateSubmitted: (DateTime date) =>
+                          setState(() => _selected = date),
+                      onDateSaved: (DateTime date) =>
+                          setState(() => _selected = date),
+                    ),
+                  ),
+                ),
               const SizedBox(height: AppSpacing.sm),
               Row(
                 children: <Widget>[
@@ -123,7 +169,7 @@ class _PortraitDatePickerDialogState extends State<_PortraitDatePickerDialog> {
                   Expanded(
                     child: FilledButton(
                       key: const Key('portraitDatePickerConfirm'),
-                      onPressed: () => Navigator.of(context).pop(_selected),
+                      onPressed: _confirm,
                       child: Text(l.okButtonLabel),
                     ),
                   ),

--- a/frontend/flutter/test/core/utils/portrait_date_picker_test.dart
+++ b/frontend/flutter/test/core/utils/portrait_date_picker_test.dart
@@ -27,7 +27,7 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  testWidgets('공용 날짜 선택기는 흰 배경에 닫기 아이콘과 취소·확인 버튼을 모두 보인다', (
+  testWidgets('공용 날짜 선택기는 흰 배경에 닫기 아이콘·입력창·달력·취소·확인을 모두 보인다', (
     WidgetTester tester,
   ) async {
     await openPicker(tester);
@@ -40,42 +40,26 @@ void main() {
       find.descendant(of: dialog, matching: find.byIcon(Icons.close)),
       findsOneWidget,
     );
+    // 전환 없이 입력창과 달력이 항상 같이 보인다.
+    expect(find.byKey(const Key('portraitDatePickerInput')), findsOneWidget);
+    expect(find.byType(CalendarDatePicker), findsOneWidget);
     expect(find.byKey(const Key('portraitDatePickerCancel')), findsOneWidget);
     expect(find.byKey(const Key('portraitDatePickerConfirm')), findsOneWidget);
-
-    // 처음엔 그리드 모드다 — 연필 아이콘으로 키보드 입력으로 전환할 수 있다.
-    expect(
-      find.descendant(of: dialog, matching: find.byType(CalendarDatePicker)),
-      findsOneWidget,
-    );
-    expect(
-      find.descendant(of: dialog, matching: find.byIcon(Icons.edit)),
-      findsOneWidget,
-    );
   });
 
-  testWidgets('연필 아이콘을 누르면 키보드 입력 모드로, 다시 누르면 그리드로 돌아간다', (
-    WidgetTester tester,
-  ) async {
+  testWidgets('달력에서 날짜를 고르면 입력창 글자도 같이 바뀐다', (WidgetTester tester) async {
     await openPicker(tester);
 
-    await tester.tap(find.byIcon(Icons.edit));
+    await tester.tap(find.text('30'));
     await tester.pumpAndSettle();
 
-    expect(find.byType(CalendarDatePicker), findsNothing);
-    expect(find.byType(InputDatePickerFormField), findsOneWidget);
-    expect(find.byIcon(Icons.calendar_today), findsOneWidget);
-
-    await tester.tap(find.byIcon(Icons.calendar_today));
-    await tester.pumpAndSettle();
-
-    expect(find.byType(CalendarDatePicker), findsOneWidget);
-    expect(find.byType(InputDatePickerFormField), findsNothing);
+    final TextField field = tester.widget<TextField>(
+      find.byKey(const Key('portraitDatePickerInput')),
+    );
+    expect(field.controller!.text, contains('30'));
   });
 
-  testWidgets('키보드 입력 모드에서 날짜를 타이핑하고 확인하면 그 날짜를 돌려준다', (
-    WidgetTester tester,
-  ) async {
+  testWidgets('입력창에 유효한 날짜를 타이핑하면 달력도 그 날짜로 움직인다', (WidgetTester tester) async {
     DateTime? result;
     await tester.pumpWidget(
       MaterialApp(
@@ -97,14 +81,42 @@ void main() {
 
     await tester.tap(find.text('달력 열기'));
     await tester.pumpAndSettle();
-    await tester.tap(find.byIcon(Icons.edit));
+
+    await tester.enterText(
+      find.byKey(const Key('portraitDatePickerInput')),
+      '8/30/2026',
+    );
     await tester.pumpAndSettle();
 
-    await tester.enterText(find.byType(TextFormField), '08/30/2026');
+    // 달력이 8월 30일을 이미 고른 상태로 넘어와 있다 — 30 이 선택 표시로
+    // 유일하게 보인다.
     await tester.tap(find.byKey(const Key('portraitDatePickerConfirm')));
     await tester.pumpAndSettle();
 
     expect(result, DateTime(2026, 8, 30));
+  });
+
+  testWidgets('입력창에 범위 밖 날짜를 타이핑하면 오류를 보여주고 확인을 막는다', (
+    WidgetTester tester,
+  ) async {
+    await openPicker(tester);
+
+    await tester.enterText(
+      find.byKey(const Key('portraitDatePickerInput')),
+      '1/1/2020',
+    );
+    await tester.pumpAndSettle();
+
+    final MaterialLocalizations l = MaterialLocalizations.of(
+      tester.element(find.byKey(const Key('portraitDatePicker'))),
+    );
+    expect(find.text(l.dateOutOfRangeLabel), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('portraitDatePickerConfirm')));
+    await tester.pumpAndSettle();
+
+    // 다이얼로그가 열려 있어야 한다 — 확인이 막혔다.
+    expect(find.byKey(const Key('portraitDatePicker')), findsOneWidget);
   });
 
   testWidgets('우측 상단 X 를 누르면 아무 값 없이 닫힌다', (WidgetTester tester) async {

--- a/frontend/flutter_trainer/lib/core/utils/portrait_date_picker.dart
+++ b/frontend/flutter_trainer/lib/core/utils/portrait_date_picker.dart
@@ -12,8 +12,10 @@ import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 /// 모양을 바꾸지 않아 별도 세로 고정 트릭이 필요 없다. 앱의 시간
 /// 선택기와 같은 우측 상단 X 와, 하단 취소·확인 버튼을 모두 둔다.
 ///
-/// Material 기본 다이얼로그처럼 연필 아이콘으로 그리드([CalendarDatePicker])
-/// ↔ 키보드 직접 입력([InputDatePickerFormField]) 을 전환할 수 있다.
+/// 날짜 값 자체가 입력창이라 따로 전환할 필요 없이 타이핑도, 바로 아래
+/// 달력([CalendarDatePicker])에서 탭으로 고르는 것도 둘 다 항상 된다.
+/// 입력창에 타이핑하면 [MaterialLocalizations.parseCompactDate] 로 즉시
+/// 해석해 달력도 같이 움직이고, 달력에서 고르면 입력창 글자도 같이 바뀐다.
 Future<DateTime?> showPortraitDatePicker({
   required BuildContext context,
   required DateTime initialDate,
@@ -49,30 +51,59 @@ class _PortraitDatePickerDialog extends StatefulWidget {
 
 class _PortraitDatePickerDialogState extends State<_PortraitDatePickerDialog> {
   late DateTime _selected = widget.initialDate;
-  final GlobalKey<FormState> _inputFormKey = GlobalKey<FormState>();
-  DatePickerEntryMode _entryMode = DatePickerEntryMode.calendar;
+  final TextEditingController _dateController = TextEditingController();
+  String? _errorText;
 
-  void _toggleEntryMode() {
+  @override
+  void dispose() {
+    _dateController.dispose();
+    super.dispose();
+  }
+
+  /// 입력창 글자가 바뀔 때마다(키 입력마다) 유효한 날짜인지 확인해 곧장
+  /// 반영한다 — 아래 달력이 입력과 같이 움직여야 한다.
+  void _handleTextChanged(MaterialLocalizations l, String text) {
+    if (text.isEmpty) {
+      setState(() => _errorText = null);
+      return;
+    }
+    final DateTime? parsed = l.parseCompactDate(text);
+    if (parsed == null) {
+      setState(() => _errorText = l.invalidDateFormatLabel);
+      return;
+    }
+    if (parsed.isBefore(widget.firstDate) || parsed.isAfter(widget.lastDate)) {
+      setState(() => _errorText = l.dateOutOfRangeLabel);
+      return;
+    }
     setState(() {
-      _entryMode = _entryMode == DatePickerEntryMode.calendar
-          ? DatePickerEntryMode.input
-          : DatePickerEntryMode.calendar;
+      _selected = parsed;
+      _errorText = null;
+    });
+  }
+
+  /// 달력 탭은 입력창의 글자도 같이 바꾼다 — 타이핑 쪽(`_handleTextChanged`)과
+  /// 달리 이쪽은 사용자가 지금 커서를 두고 타이핑 중이 아니므로 컨트롤러
+  /// 텍스트를 직접 덮어써도 된다.
+  void _handleCalendarChanged(MaterialLocalizations l, DateTime date) {
+    setState(() {
+      _selected = date;
+      _errorText = null;
+      _dateController.text = l.formatCompactDate(date);
     });
   }
 
   void _confirm() {
-    if (_entryMode == DatePickerEntryMode.input) {
-      final FormState? form = _inputFormKey.currentState;
-      if (form == null || !form.validate()) return;
-      form.save();
-    }
+    if (_errorText != null) return;
     Navigator.of(context).pop(_selected);
   }
 
   @override
   Widget build(BuildContext context) {
     final MaterialLocalizations l = MaterialLocalizations.of(context);
-    final bool isCalendar = _entryMode == DatePickerEntryMode.calendar;
+    if (_dateController.text.isEmpty) {
+      _dateController.text = l.formatCompactDate(_selected);
+    }
     return Dialog(
       key: const Key('portraitDatePicker'),
       backgroundColor: AppColors.card,
@@ -85,88 +116,80 @@ class _PortraitDatePickerDialogState extends State<_PortraitDatePickerDialog> {
       ),
       child: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 400),
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(
-            AppSpacing.lg,
-            AppSpacing.md,
-            AppSpacing.md,
-            AppSpacing.lg,
-          ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: <Widget>[
-              Row(
-                children: <Widget>[
-                  Expanded(
-                    child: Text(
-                      l.datePickerHelpText,
-                      style: const TextStyle(
-                        fontSize: 16,
-                        fontWeight: FontWeight.w800,
-                        color: AppColors.foreground,
+        // 오류 문구가 뜨거나 화면이 낮으면 입력창+달력+버튼 전체 높이가
+        // 다이얼로그보다 커질 수 있다 — 넘치는 대신 스크롤하게 한다.
+        child: SingleChildScrollView(
+          child: Padding(
+            // 시간 선택 다이얼로그(`_TimeRangePickerDialog`)와 같은 여백을
+            // 써서 두 다이얼로그의 크기 차이가 두드러지지 않게 한다.
+            padding: const EdgeInsets.all(AppSpacing.xl),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                Row(
+                  children: <Widget>[
+                    Expanded(
+                      child: Text(
+                        l.datePickerHelpText,
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w800,
+                          color: AppColors.foreground,
+                        ),
                       ),
                     ),
+                    IconButton(
+                      tooltip: l.closeButtonTooltip,
+                      onPressed: () => Navigator.of(context).pop(),
+                      icon: const Icon(Icons.close),
+                    ),
+                  ],
+                ),
+                // 날짜 값 자체가 입력창이다 — 따로 전환할 필요 없이 타이핑도,
+                // 아래 달력 탭도 둘 다 바로 된다. 한쪽이 바뀌면 다른 쪽도
+                // 같이 움직인다.
+                TextField(
+                  key: const Key('portraitDatePickerInput'),
+                  controller: _dateController,
+                  keyboardType: TextInputType.datetime,
+                  decoration: InputDecoration(
+                    labelText: l.dateInputLabel,
+                    errorText: _errorText,
                   ),
-                  IconButton(
-                    tooltip: isCalendar
-                        ? l.inputDateModeButtonLabel
-                        : l.calendarModeButtonLabel,
-                    onPressed: _toggleEntryMode,
-                    icon: Icon(isCalendar ? Icons.edit : Icons.calendar_today),
-                  ),
-                  IconButton(
-                    tooltip: l.closeButtonTooltip,
-                    onPressed: () => Navigator.of(context).pop(),
-                    icon: const Icon(Icons.close),
-                  ),
-                ],
-              ),
-              if (isCalendar)
+                  onChanged: (String text) => _handleTextChanged(l, text),
+                ),
+                const SizedBox(height: AppSpacing.sm),
                 CalendarDatePicker(
-                  initialDate: widget.initialDate,
+                  key: ValueKey<DateTime>(_selected),
+                  initialDate: _selected,
                   firstDate: widget.firstDate,
                   lastDate: widget.lastDate,
                   onDateChanged: (DateTime date) =>
-                      setState(() => _selected = date),
-                )
-              else
-                Padding(
-                  padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
-                  child: Form(
-                    key: _inputFormKey,
-                    child: InputDatePickerFormField(
-                      initialDate: _selected,
-                      firstDate: widget.firstDate,
-                      lastDate: widget.lastDate,
-                      onDateSubmitted: (DateTime date) =>
-                          setState(() => _selected = date),
-                      onDateSaved: (DateTime date) =>
-                          setState(() => _selected = date),
-                    ),
-                  ),
+                      _handleCalendarChanged(l, date),
                 ),
-              const SizedBox(height: AppSpacing.sm),
-              Row(
-                children: <Widget>[
-                  Expanded(
-                    child: TextButton(
-                      key: const Key('portraitDatePickerCancel'),
-                      onPressed: () => Navigator.of(context).pop(),
-                      child: Text(l.cancelButtonLabel),
+                const SizedBox(height: AppSpacing.sm),
+                Row(
+                  children: <Widget>[
+                    Expanded(
+                      child: TextButton(
+                        key: const Key('portraitDatePickerCancel'),
+                        onPressed: () => Navigator.of(context).pop(),
+                        child: Text(l.cancelButtonLabel),
+                      ),
                     ),
-                  ),
-                  const SizedBox(width: AppSpacing.sm),
-                  Expanded(
-                    child: FilledButton(
-                      key: const Key('portraitDatePickerConfirm'),
-                      onPressed: _confirm,
-                      child: Text(l.okButtonLabel),
+                    const SizedBox(width: AppSpacing.sm),
+                    Expanded(
+                      child: FilledButton(
+                        key: const Key('portraitDatePickerConfirm'),
+                        onPressed: _confirm,
+                        child: Text(l.okButtonLabel),
+                      ),
                     ),
-                  ),
-                ],
-              ),
-            ],
+                  ],
+                ),
+              ],
+            ),
           ),
         ),
       ),
@@ -175,28 +198,424 @@ class _PortraitDatePickerDialogState extends State<_PortraitDatePickerDialog> {
 }
 
 /// 반복 일정의 시작·종료 날짜를 한 번의 달력에서 고른다 — 위
-/// [showPortraitDatePicker] 와 같은 자리에서 쓰이지만, Flutter 에는 그
-/// 자체 커스텀 다이얼로그에 대응하는 공용 범위 선택 위젯이 없어 여기서는
-/// Material 기본 [showDateRangePicker] 를 세로 배치로 강제해 쓴다.
+/// [showPortraitDatePicker] 와 같은 자리에서 쓰인다.
+///
+/// Material 기본 [showDateRangePicker] 는 전체화면에 월 단위로 끝없이
+/// 스크롤되는 목록이라 이 앱의 다른 모달과 스타일이 완전히 달랐다. 이
+/// 화면은 그 대신 한 번에 한 달만 보여주고 좌우 화살표로 달을 넘기는
+/// 고정 그리드([_MonthGrid])를 직접 그린다 — 시작·종료일 사이는 이어진
+/// 색 띠로, 시작·종료일 자체는 원으로 표시해 기본 다이얼로그의 범위
+/// 표시 느낌은 그대로 두면서 화면만 넘치지 않게 한다.
+///
+/// 시작·종료일 값 자체가 입력창이라 따로 전환할 필요 없이 타이핑도,
+/// 바로 아래 달력에서 탭으로 고르는 것도 둘 다 항상 된다.
 Future<DateTimeRange?> showPortraitDateRangePicker({
   required BuildContext context,
   required DateTimeRange initialDateRange,
   required DateTime firstDate,
   required DateTime lastDate,
 }) {
-  return showDateRangePicker(
+  return showDialog<DateTimeRange>(
     context: context,
-    initialDateRange: initialDateRange,
-    firstDate: firstDate,
-    lastDate: lastDate,
-    builder: (context, child) {
-      final Widget themed = child!;
-      final MediaQueryData query = MediaQuery.of(context);
-      if (query.size.width <= query.size.height) return themed;
-      return MediaQuery(
-        data: query.copyWith(size: Size(query.size.height, query.size.width)),
-        child: themed,
-      );
-    },
+    barrierColor: Colors.black54,
+    builder: (BuildContext ctx) => _PortraitDateRangePickerDialog(
+      initialDateRange: initialDateRange,
+      firstDate: firstDate,
+      lastDate: lastDate,
+    ),
   );
+}
+
+DateTime _dateOnly(DateTime value) =>
+    DateTime(value.year, value.month, value.day);
+
+bool _isSameDay(DateTime a, DateTime b) =>
+    a.year == b.year && a.month == b.month && a.day == b.day;
+
+class _PortraitDateRangePickerDialog extends StatefulWidget {
+  const _PortraitDateRangePickerDialog({
+    required this.initialDateRange,
+    required this.firstDate,
+    required this.lastDate,
+  });
+
+  final DateTimeRange initialDateRange;
+  final DateTime firstDate;
+  final DateTime lastDate;
+
+  @override
+  State<_PortraitDateRangePickerDialog> createState() =>
+      _PortraitDateRangePickerDialogState();
+}
+
+class _PortraitDateRangePickerDialogState
+    extends State<_PortraitDateRangePickerDialog> {
+  late DateTime? _start = _dateOnly(widget.initialDateRange.start);
+  late DateTime? _end = _dateOnly(widget.initialDateRange.end);
+  late DateTime _displayedMonth = DateTime(_start!.year, _start!.month);
+  final TextEditingController _startController = TextEditingController();
+  final TextEditingController _endController = TextEditingController();
+  String? _startErrorText;
+  String? _endErrorText;
+
+  @override
+  void dispose() {
+    _startController.dispose();
+    _endController.dispose();
+    super.dispose();
+  }
+
+  /// 시작일 입력창에 타이핑할 때마다 곧장 해석해 달력·종료일에 반영한다.
+  /// 새 시작일이 종료일보다 뒤라면 범위가 깨지므로 종료일은 다시 고르게
+  /// 비운다.
+  void _handleStartTextChanged(MaterialLocalizations l, String text) {
+    if (text.isEmpty) {
+      setState(() => _startErrorText = null);
+      return;
+    }
+    final DateTime? parsed = l.parseCompactDate(text);
+    if (parsed == null) {
+      setState(() => _startErrorText = l.invalidDateFormatLabel);
+      return;
+    }
+    if (parsed.isBefore(widget.firstDate) || parsed.isAfter(widget.lastDate)) {
+      setState(() => _startErrorText = l.dateOutOfRangeLabel);
+      return;
+    }
+    setState(() {
+      _start = parsed;
+      _startErrorText = null;
+      _displayedMonth = DateTime(parsed.year, parsed.month);
+      if (_end != null && _end!.isBefore(parsed)) {
+        _end = null;
+        _endController.clear();
+      }
+    });
+  }
+
+  /// 종료일 입력창 쪽도 마찬가지다 — 시작일보다 앞선 날짜는 범위 밖으로
+  /// 취급한다.
+  void _handleEndTextChanged(MaterialLocalizations l, String text) {
+    if (text.isEmpty) {
+      setState(() => _endErrorText = null);
+      return;
+    }
+    final DateTime? parsed = l.parseCompactDate(text);
+    if (parsed == null) {
+      setState(() => _endErrorText = l.invalidDateFormatLabel);
+      return;
+    }
+    final DateTime lower = _start ?? widget.firstDate;
+    if (parsed.isBefore(lower) || parsed.isAfter(widget.lastDate)) {
+      setState(() => _endErrorText = l.dateOutOfRangeLabel);
+      return;
+    }
+    setState(() {
+      _end = parsed;
+      _endErrorText = null;
+      _displayedMonth = DateTime(parsed.year, parsed.month);
+    });
+  }
+
+  /// 달력 탭은 입력창 글자도 같이 바꾼다 — 타이핑 쪽과 달리 사용자가 지금
+  /// 커서를 두고 타이핑 중이 아니므로 컨트롤러 텍스트를 직접 덮어써도
+  /// 된다.
+  void _handleCalendarTap(MaterialLocalizations l, DateTime day) {
+    setState(() {
+      if (_start == null || _end != null) {
+        _start = day;
+        _end = null;
+        _startController.text = l.formatCompactDate(day);
+        _endController.clear();
+      } else if (day.isBefore(_start!)) {
+        _start = day;
+        _startController.text = l.formatCompactDate(day);
+      } else {
+        _end = day;
+        _endController.text = l.formatCompactDate(day);
+      }
+      _startErrorText = null;
+      _endErrorText = null;
+    });
+  }
+
+  void _confirm() {
+    if (_start == null || _end == null) return;
+    if (_startErrorText != null || _endErrorText != null) return;
+    Navigator.of(context).pop(DateTimeRange(start: _start!, end: _end!));
+  }
+
+  bool get _canGoPrevious => DateTime(
+    _displayedMonth.year,
+    _displayedMonth.month - 1,
+  ).isAfter(DateTime(widget.firstDate.year, widget.firstDate.month - 1));
+
+  bool get _canGoNext => DateTime(
+    _displayedMonth.year,
+    _displayedMonth.month + 1,
+  ).isBefore(DateTime(widget.lastDate.year, widget.lastDate.month + 1));
+
+  void _goToMonth(int delta) {
+    setState(() {
+      _displayedMonth = DateTime(
+        _displayedMonth.year,
+        _displayedMonth.month + delta,
+      );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final MaterialLocalizations l = MaterialLocalizations.of(context);
+    if (_startController.text.isEmpty) {
+      _startController.text = l.formatCompactDate(_start!);
+    }
+    if (_endController.text.isEmpty && _end != null) {
+      _endController.text = l.formatCompactDate(_end!);
+    }
+    return Dialog(
+      key: const Key('portraitDateRangePicker'),
+      backgroundColor: AppColors.card,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.all(AppRadius.card),
+      ),
+      insetPadding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.lg,
+        vertical: AppSpacing.xl,
+      ),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 400),
+        // 오류 문구가 뜨거나 화면이 낮으면 입력창+달력+버튼 전체 높이가
+        // 다이얼로그보다 커질 수 있다 — 넘치는 대신 스크롤하게 한다.
+        child: SingleChildScrollView(
+          child: Padding(
+            // 시간 선택 다이얼로그(`_TimeRangePickerDialog`)와 같은 여백을
+            // 써서 두 다이얼로그의 크기 차이가 두드러지지 않게 한다.
+            padding: const EdgeInsets.all(AppSpacing.xl),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                Row(
+                  children: <Widget>[
+                    Expanded(
+                      child: Text(
+                        l.dateRangePickerHelpText,
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w800,
+                          color: AppColors.foreground,
+                        ),
+                      ),
+                    ),
+                    IconButton(
+                      tooltip: l.closeButtonTooltip,
+                      onPressed: () => Navigator.of(context).pop(),
+                      icon: const Icon(Icons.close),
+                    ),
+                  ],
+                ),
+                // 시작·종료일 값 자체가 입력창이다 — 따로 전환할 필요 없이
+                // 타이핑도, 바로 아래 달력 탭도 둘 다 항상 된다.
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Expanded(
+                      child: TextField(
+                        key: const Key('portraitDateRangePickerStartInput'),
+                        controller: _startController,
+                        keyboardType: TextInputType.datetime,
+                        decoration: InputDecoration(
+                          labelText: l.dateRangeStartLabel,
+                          errorText: _startErrorText,
+                        ),
+                        onChanged: (String text) =>
+                            _handleStartTextChanged(l, text),
+                      ),
+                    ),
+                    const SizedBox(width: AppSpacing.sm),
+                    Expanded(
+                      child: TextField(
+                        key: const Key('portraitDateRangePickerEndInput'),
+                        controller: _endController,
+                        keyboardType: TextInputType.datetime,
+                        decoration: InputDecoration(
+                          labelText: l.dateRangeEndLabel,
+                          errorText: _endErrorText,
+                        ),
+                        onChanged: (String text) =>
+                            _handleEndTextChanged(l, text),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                Row(
+                  children: <Widget>[
+                    IconButton(
+                      tooltip: '이전 달',
+                      onPressed: _canGoPrevious ? () => _goToMonth(-1) : null,
+                      icon: const Icon(Icons.chevron_left),
+                    ),
+                    Expanded(
+                      child: Text(
+                        '${_displayedMonth.year}년 ${_displayedMonth.month}월',
+                        textAlign: TextAlign.center,
+                        style: const TextStyle(fontWeight: FontWeight.w700),
+                      ),
+                    ),
+                    IconButton(
+                      tooltip: '다음 달',
+                      onPressed: _canGoNext ? () => _goToMonth(1) : null,
+                      icon: const Icon(Icons.chevron_right),
+                    ),
+                  ],
+                ),
+                _MonthGrid(
+                  month: _displayedMonth,
+                  firstDate: widget.firstDate,
+                  lastDate: widget.lastDate,
+                  start: _start,
+                  end: _end,
+                  onDayTap: (DateTime day) => _handleCalendarTap(l, day),
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                Row(
+                  children: <Widget>[
+                    Expanded(
+                      child: TextButton(
+                        key: const Key('portraitDateRangePickerCancel'),
+                        onPressed: () => Navigator.of(context).pop(),
+                        child: Text(l.cancelButtonLabel),
+                      ),
+                    ),
+                    const SizedBox(width: AppSpacing.sm),
+                    Expanded(
+                      child: FilledButton(
+                        key: const Key('portraitDateRangePickerConfirm'),
+                        onPressed: _confirm,
+                        child: Text(l.okButtonLabel),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// 한 달을 고정 그리드로 그린다 — [start]·[end] 사이는 이어진 띠로,
+/// 시작·종료일 자체는 원으로 강조한다. [firstDate]~[lastDate] 밖의
+/// 날짜는 흐리게 표시하고 탭을 막는다.
+class _MonthGrid extends StatelessWidget {
+  const _MonthGrid({
+    required this.month,
+    required this.firstDate,
+    required this.lastDate,
+    required this.start,
+    required this.end,
+    required this.onDayTap,
+  });
+
+  final DateTime month;
+  final DateTime firstDate;
+  final DateTime lastDate;
+  final DateTime? start;
+  final DateTime? end;
+  final ValueChanged<DateTime> onDayTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final MaterialLocalizations l = MaterialLocalizations.of(context);
+    final int daysInMonth = DateUtils.getDaysInMonth(month.year, month.month);
+    final int firstOffset = DateUtils.firstDayOffset(
+      month.year,
+      month.month,
+      l,
+    );
+    final int cellCount = ((firstOffset + daysInMonth) / 7).ceil() * 7;
+
+    return Column(
+      children: <Widget>[
+        Row(
+          children: <Widget>[
+            for (final String weekday in l.narrowWeekdays)
+              Expanded(
+                child: Center(
+                  child: Text(
+                    weekday,
+                    style: const TextStyle(
+                      fontSize: 12,
+                      color: AppColors.mutedForeground,
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        ),
+        GridView.count(
+          crossAxisCount: 7,
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          childAspectRatio: 1.2,
+          children: <Widget>[
+            for (int i = 0; i < cellCount; i++)
+              _dayCell(i - firstOffset + 1, daysInMonth),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _dayCell(int dayOfMonth, int daysInMonth) {
+    if (dayOfMonth < 1 || dayOfMonth > daysInMonth) return const SizedBox();
+    final DateTime day = DateTime(month.year, month.month, dayOfMonth);
+    final bool disabled = day.isBefore(firstDate) || day.isAfter(lastDate);
+    final bool isStart = start != null && _isSameDay(day, start!);
+    final bool isEnd = end != null && _isSameDay(day, end!);
+    final bool isCap = isStart || isEnd;
+    // 시작·종료일 자체도 띠에 포함해(양 끝 포함) 원과 이어진 것처럼 보이게
+    // 한다. 알약(스타디움) 모양을 내려고 시작일의 바깥쪽(왼쪽)·종료일의
+    // 바깥쪽(오른쪽) 모서리만 크게 둥글리고 — 주가 바뀌며 줄이 꺾이는
+    // 자리를 포함한 나머지는 각지게 둬 옆 칸과 색이 그대로 이어지게 한다.
+    final bool inBand =
+        start != null &&
+        end != null &&
+        !day.isBefore(start!) &&
+        !day.isAfter(end!);
+    const Radius capRadius = Radius.circular(999);
+    final BorderRadius bandRadius = BorderRadius.horizontal(
+      left: isStart ? capRadius : Radius.zero,
+      right: isEnd ? capRadius : Radius.zero,
+    );
+
+    return GestureDetector(
+      onTap: disabled ? null : () => onDayTap(day),
+      child: Container(
+        decoration: BoxDecoration(
+          // 띠와 시작·종료일 원을 같은 진한 색으로 둬, 두 원이 띠 하나로
+          // 이어진 것처럼 보이게 한다 — 옅은 배경색을 따로 쓰지 않는다.
+          color: inBand ? AppColors.primary : Colors.transparent,
+          borderRadius: bandRadius,
+        ),
+        child: Center(
+          child: Text(
+            '$dayOfMonth',
+            style: TextStyle(
+              color: inBand
+                  ? Colors.white
+                  : disabled
+                  ? AppColors.mutedForeground
+                  : AppColors.foreground,
+              fontWeight: isCap ? FontWeight.w700 : FontWeight.w400,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
 }

--- a/frontend/flutter_trainer/lib/core/utils/portrait_date_picker.dart
+++ b/frontend/flutter_trainer/lib/core/utils/portrait_date_picker.dart
@@ -11,6 +11,9 @@ import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 /// 늘 세로 배치로 그린다 — CalendarDatePicker 자체는 orientation 에 따라
 /// 모양을 바꾸지 않아 별도 세로 고정 트릭이 필요 없다. 앱의 시간
 /// 선택기와 같은 우측 상단 X 와, 하단 취소·확인 버튼을 모두 둔다.
+///
+/// Material 기본 다이얼로그처럼 연필 아이콘으로 그리드([CalendarDatePicker])
+/// ↔ 키보드 직접 입력([InputDatePickerFormField]) 을 전환할 수 있다.
 Future<DateTime?> showPortraitDatePicker({
   required BuildContext context,
   required DateTime initialDate,
@@ -46,10 +49,30 @@ class _PortraitDatePickerDialog extends StatefulWidget {
 
 class _PortraitDatePickerDialogState extends State<_PortraitDatePickerDialog> {
   late DateTime _selected = widget.initialDate;
+  final GlobalKey<FormState> _inputFormKey = GlobalKey<FormState>();
+  DatePickerEntryMode _entryMode = DatePickerEntryMode.calendar;
+
+  void _toggleEntryMode() {
+    setState(() {
+      _entryMode = _entryMode == DatePickerEntryMode.calendar
+          ? DatePickerEntryMode.input
+          : DatePickerEntryMode.calendar;
+    });
+  }
+
+  void _confirm() {
+    if (_entryMode == DatePickerEntryMode.input) {
+      final FormState? form = _inputFormKey.currentState;
+      if (form == null || !form.validate()) return;
+      form.save();
+    }
+    Navigator.of(context).pop(_selected);
+  }
 
   @override
   Widget build(BuildContext context) {
     final MaterialLocalizations l = MaterialLocalizations.of(context);
+    final bool isCalendar = _entryMode == DatePickerEntryMode.calendar;
     return Dialog(
       key: const Key('portraitDatePicker'),
       backgroundColor: AppColors.card,
@@ -86,19 +109,43 @@ class _PortraitDatePickerDialogState extends State<_PortraitDatePickerDialog> {
                     ),
                   ),
                   IconButton(
+                    tooltip: isCalendar
+                        ? l.inputDateModeButtonLabel
+                        : l.calendarModeButtonLabel,
+                    onPressed: _toggleEntryMode,
+                    icon: Icon(isCalendar ? Icons.edit : Icons.calendar_today),
+                  ),
+                  IconButton(
                     tooltip: l.closeButtonTooltip,
                     onPressed: () => Navigator.of(context).pop(),
                     icon: const Icon(Icons.close),
                   ),
                 ],
               ),
-              CalendarDatePicker(
-                initialDate: widget.initialDate,
-                firstDate: widget.firstDate,
-                lastDate: widget.lastDate,
-                onDateChanged: (DateTime date) =>
-                    setState(() => _selected = date),
-              ),
+              if (isCalendar)
+                CalendarDatePicker(
+                  initialDate: widget.initialDate,
+                  firstDate: widget.firstDate,
+                  lastDate: widget.lastDate,
+                  onDateChanged: (DateTime date) =>
+                      setState(() => _selected = date),
+                )
+              else
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
+                  child: Form(
+                    key: _inputFormKey,
+                    child: InputDatePickerFormField(
+                      initialDate: _selected,
+                      firstDate: widget.firstDate,
+                      lastDate: widget.lastDate,
+                      onDateSubmitted: (DateTime date) =>
+                          setState(() => _selected = date),
+                      onDateSaved: (DateTime date) =>
+                          setState(() => _selected = date),
+                    ),
+                  ),
+                ),
               const SizedBox(height: AppSpacing.sm),
               Row(
                 children: <Widget>[
@@ -113,7 +160,7 @@ class _PortraitDatePickerDialogState extends State<_PortraitDatePickerDialog> {
                   Expanded(
                     child: FilledButton(
                       key: const Key('portraitDatePickerConfirm'),
-                      onPressed: () => Navigator.of(context).pop(_selected),
+                      onPressed: _confirm,
                       child: Text(l.okButtonLabel),
                     ),
                   ),

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/session_sheet.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/session_sheet.dart
@@ -444,64 +444,56 @@ class _SessionSheetState extends ConsumerState<SessionSheet> {
               const SizedBox(height: AppSpacing.lg),
               // 고객·유형은 같은 층위의 선택이라 한 줄에 묶는다 — 세로로
               // 나란한 두 드롭다운이 각자 한 줄을 다 쓸 이유가 없다(#1090).
-              //
-              // 값 길이에 맞춰 폭을 잡는다(`IntrinsicWidth`) — 예전에는 둘 다
-              // `Expanded` 로 줄 절반씩을 강제로 채워, "김민수" 같은 짧은
-              // 값에도 상자가 크게 남았다.
+              // 날짜·시간 필드 쌍과 같이 절반씩 나눈다(`Expanded`) — 값
+              // 길이에 맞춘 `IntrinsicWidth` 는 좁은 값일 때 상자 폭이 너무
+              // 좁아 보였다.
               Row(
                 children: <Widget>[
-                  IntrinsicWidth(
-                    child: ConstrainedBox(
-                      constraints: const BoxConstraints(minWidth: 96),
-                      child: _pillField(
-                        label: l.schedFieldClient,
-                        // 등록된 고객이 아니면(상담 신청자 등) 고를 수 없게
-                        // 값만 보여준다 — 드롭다운은 실제로 옮길 수 있는
-                        // 고객 목록만 옵션으로 내놓는다(#1396).
-                        child: _clientLocked
-                            ? Text(_client, style: _fieldValueStyle)
-                            : DropdownButton<String>(
-                                value: _client,
-                                underline: const SizedBox.shrink(),
-                                items: <DropdownMenuItem<String>>[
-                                  for (final name in _clientOptions)
-                                    DropdownMenuItem<String>(
-                                      value: name,
-                                      child: Text(
-                                        name,
-                                        style: _fieldValueStyle,
-                                      ),
-                                    ),
-                                ],
-                                onChanged: (v) =>
-                                    setState(() => _client = v ?? _client),
-                              ),
-                      ),
+                  Expanded(
+                    child: _pillField(
+                      label: l.schedFieldClient,
+                      // 등록된 고객이 아니면(상담 신청자 등) 고를 수 없게
+                      // 값만 보여준다 — 드롭다운은 실제로 옮길 수 있는
+                      // 고객 목록만 옵션으로 내놓는다(#1396).
+                      child: _clientLocked
+                          ? Text(_client, style: _fieldValueStyle)
+                          : DropdownButton<String>(
+                              value: _client,
+                              isExpanded: true,
+                              underline: const SizedBox.shrink(),
+                              items: <DropdownMenuItem<String>>[
+                                for (final name in _clientOptions)
+                                  DropdownMenuItem<String>(
+                                    value: name,
+                                    child: Text(name, style: _fieldValueStyle),
+                                  ),
+                              ],
+                              onChanged: (v) =>
+                                  setState(() => _client = v ?? _client),
+                            ),
                     ),
                   ),
                   const SizedBox(width: AppSpacing.sm),
-                  IntrinsicWidth(
-                    child: ConstrainedBox(
-                      constraints: const BoxConstraints(minWidth: 96),
-                      child: _pillField(
-                        label: l.schedFieldType,
-                        child: DropdownButton<String>(
-                          value: _type,
-                          underline: const SizedBox.shrink(),
-                          items: <DropdownMenuItem<String>>[
-                            for (final t in _typeOptions)
-                              // 값은 계약값 그대로, 보이는 문구만 로케일에서
-                              // 가져온다.
-                              DropdownMenuItem<String>(
-                                value: t,
-                                child: Text(
-                                  sessionTypeLabel(l, t),
-                                  style: _fieldValueStyle,
-                                ),
+                  Expanded(
+                    child: _pillField(
+                      label: l.schedFieldType,
+                      child: DropdownButton<String>(
+                        value: _type,
+                        isExpanded: true,
+                        underline: const SizedBox.shrink(),
+                        items: <DropdownMenuItem<String>>[
+                          for (final t in _typeOptions)
+                            // 값은 계약값 그대로, 보이는 문구만 로케일에서
+                            // 가져온다.
+                            DropdownMenuItem<String>(
+                              value: t,
+                              child: Text(
+                                sessionTypeLabel(l, t),
+                                style: _fieldValueStyle,
                               ),
-                          ],
-                          onChanged: (v) => setState(() => _type = v ?? _type),
-                        ),
+                            ),
+                        ],
+                        onChanged: (v) => setState(() => _type = v ?? _type),
                       ),
                     ),
                   ),
@@ -713,21 +705,15 @@ class _SessionSheetState extends ConsumerState<SessionSheet> {
           children: <Widget>[
             Expanded(
               child: Text(
+                // 프로그램 등록 날짜 칩(`program-register-date`)과 같이
+                // 연도까지 보이는 `ymd` 표기로 맞춘다 — 월·일만 있으면 해가
+                // 바뀌는 반복(예: 12월 시작 다음 해 1월 종료)에서 헷갈린다.
                 repeating
                     ? l.schedTimeRange(
-                        l.dateMonthDay(_date.month, _date.day),
-                        _repeatUntil == null
-                            ? '-'
-                            : l.dateMonthDay(
-                                _repeatUntil!.month,
-                                _repeatUntil!.day,
-                              ),
+                        ymd(_date),
+                        _repeatUntil == null ? '-' : ymd(_repeatUntil!),
                       )
-                    : l.dateMonthDayWeekday(
-                        _date.month,
-                        _date.day,
-                        weekdayNames(l)[_date.weekday - 1],
-                      ),
+                    : ymd(_date),
                 overflow: TextOverflow.ellipsis,
                 style: _fieldValueStyle,
               ),

--- a/frontend/flutter_trainer/test/core/utils/portrait_date_picker_test.dart
+++ b/frontend/flutter_trainer/test/core/utils/portrait_date_picker_test.dart
@@ -27,7 +27,7 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  testWidgets('공용 날짜 선택기는 닫기 아이콘과 취소·확인 버튼, 그리드 모드를 모두 보인다', (
+  testWidgets('공용 날짜 선택기는 닫기 아이콘·입력창·달력·취소·확인을 모두 보인다', (
     WidgetTester tester,
   ) async {
     await openPicker(tester);
@@ -39,40 +39,26 @@ void main() {
       find.descendant(of: dialog, matching: find.byIcon(Icons.close)),
       findsOneWidget,
     );
+    // 전환 없이 입력창과 달력이 항상 같이 보인다.
+    expect(find.byKey(const Key('portraitDatePickerInput')), findsOneWidget);
+    expect(find.byType(CalendarDatePicker), findsOneWidget);
     expect(find.byKey(const Key('portraitDatePickerCancel')), findsOneWidget);
     expect(find.byKey(const Key('portraitDatePickerConfirm')), findsOneWidget);
-    expect(
-      find.descendant(of: dialog, matching: find.byType(CalendarDatePicker)),
-      findsOneWidget,
-    );
-    expect(
-      find.descendant(of: dialog, matching: find.byIcon(Icons.edit)),
-      findsOneWidget,
-    );
   });
 
-  testWidgets('연필 아이콘을 누르면 키보드 입력 모드로, 다시 누르면 그리드로 돌아간다', (
-    WidgetTester tester,
-  ) async {
+  testWidgets('달력에서 날짜를 고르면 입력창 글자도 같이 바뀐다', (WidgetTester tester) async {
     await openPicker(tester);
 
-    await tester.tap(find.byIcon(Icons.edit));
+    await tester.tap(find.text('30'));
     await tester.pumpAndSettle();
 
-    expect(find.byType(CalendarDatePicker), findsNothing);
-    expect(find.byType(InputDatePickerFormField), findsOneWidget);
-    expect(find.byIcon(Icons.calendar_today), findsOneWidget);
-
-    await tester.tap(find.byIcon(Icons.calendar_today));
-    await tester.pumpAndSettle();
-
-    expect(find.byType(CalendarDatePicker), findsOneWidget);
-    expect(find.byType(InputDatePickerFormField), findsNothing);
+    final TextField field = tester.widget<TextField>(
+      find.byKey(const Key('portraitDatePickerInput')),
+    );
+    expect(field.controller!.text, contains('30'));
   });
 
-  testWidgets('키보드 입력 모드에서 날짜를 타이핑하고 확인하면 그 날짜를 돌려준다', (
-    WidgetTester tester,
-  ) async {
+  testWidgets('입력창에 유효한 날짜를 타이핑하면 달력도 그 날짜로 움직인다', (WidgetTester tester) async {
     DateTime? result;
     await tester.pumpWidget(
       MaterialApp(
@@ -94,14 +80,40 @@ void main() {
 
     await tester.tap(find.text('달력 열기'));
     await tester.pumpAndSettle();
-    await tester.tap(find.byIcon(Icons.edit));
+
+    await tester.enterText(
+      find.byKey(const Key('portraitDatePickerInput')),
+      '8/30/2026',
+    );
     await tester.pumpAndSettle();
 
-    await tester.enterText(find.byType(TextFormField), '08/30/2026');
     await tester.tap(find.byKey(const Key('portraitDatePickerConfirm')));
     await tester.pumpAndSettle();
 
     expect(result, DateTime(2026, 8, 30));
+  });
+
+  testWidgets('입력창에 범위 밖 날짜를 타이핑하면 오류를 보여주고 확인을 막는다', (
+    WidgetTester tester,
+  ) async {
+    await openPicker(tester);
+
+    await tester.enterText(
+      find.byKey(const Key('portraitDatePickerInput')),
+      '1/1/2020',
+    );
+    await tester.pumpAndSettle();
+
+    final MaterialLocalizations l = MaterialLocalizations.of(
+      tester.element(find.byKey(const Key('portraitDatePicker'))),
+    );
+    expect(find.text(l.dateOutOfRangeLabel), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('portraitDatePickerConfirm')));
+    await tester.pumpAndSettle();
+
+    // 다이얼로그가 열려 있어야 한다 — 확인이 막혔다.
+    expect(find.byKey(const Key('portraitDatePicker')), findsOneWidget);
   });
 
   testWidgets('우측 상단 X 를 누르면 아무 값 없이 닫힌다', (WidgetTester tester) async {

--- a/frontend/flutter_trainer/test/core/utils/portrait_date_picker_test.dart
+++ b/frontend/flutter_trainer/test/core/utils/portrait_date_picker_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:oncare/core/utils/portrait_date_picker.dart';
+import 'package:oncare_trainer/core/utils/portrait_date_picker.dart';
 
 void main() {
   Future<void> openPicker(WidgetTester tester) async {
@@ -27,14 +27,13 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  testWidgets('공용 날짜 선택기는 흰 배경에 닫기 아이콘과 취소·확인 버튼을 모두 보인다', (
+  testWidgets('공용 날짜 선택기는 닫기 아이콘과 취소·확인 버튼, 그리드 모드를 모두 보인다', (
     WidgetTester tester,
   ) async {
     await openPicker(tester);
 
     final Finder dialog = find.byKey(const Key('portraitDatePicker'));
     expect(dialog, findsOneWidget);
-    expect(tester.widget<Dialog>(dialog).backgroundColor, Colors.white);
 
     expect(
       find.descendant(of: dialog, matching: find.byIcon(Icons.close)),
@@ -42,8 +41,6 @@ void main() {
     );
     expect(find.byKey(const Key('portraitDatePickerCancel')), findsOneWidget);
     expect(find.byKey(const Key('portraitDatePickerConfirm')), findsOneWidget);
-
-    // 처음엔 그리드 모드다 — 연필 아이콘으로 키보드 입력으로 전환할 수 있다.
     expect(
       find.descendant(of: dialog, matching: find.byType(CalendarDatePicker)),
       findsOneWidget,


### PR DESCRIPTION
## Summary

* PR #1461 이후 사라졌던 날짜 선택기의 키보드 직접 입력 기능을 복원한다
* 나아가 토글 없이 입력창과 달력이 항상 같이 보이는 방식으로 재설계한다 — 타이핑↔달력 탭이 실시간으로 서로 동기화된다
* 반복 일정의 범위(기간) 선택기도 같은 설계로 통일하고, Material 기본 스크롤 목록 대신 고정 그리드 + 알약 모양 연결 띠로 다시 그린다
* 곁가지로 "새 일정" 시트의 고객·유형 필드 폭, 날짜 표시 형식, 다이얼로그 여백도 다른 화면과 맞춘다

---

## Changes

### ✨ Features

*

### 🔧 Improvements

* 날짜 선택기(`showPortraitDatePicker`)를 입력창+달력 동시 표시로 재설계 — 연필 아이콘 토글 제거, `MaterialLocalizations.parseCompactDate`로 타이핑 즉시 해석
* 범위 선택기(`showPortraitDateRangePicker`)도 동일하게 시작·종료 입력창 + 고정 월 그리드로 재설계, 알약(스타디움) 모양 연결 띠 적용
* "새 일정" 시트 고객·유형 드롭다운을 50/50 폭으로 정렬 (`IntrinsicWidth` → `Expanded`)
* 날짜 표시를 연도 포함 `ymd` 형식으로 통일 (프로그램 등록 칩과 동일)
* 날짜 다이얼로그 내부 여백을 시간 다이얼로그와 동일하게 맞춤

### 🎨 UI/UX

* 날짜·범위 선택 다이얼로그 스타일 통일 (X, 취소/확인, 흰 배경)

### 📝 Docs

*

### 🐛 Fixes

* 세로형 날짜 선택기 키보드 입력 모드 복원 (#1525)

---

## Commits

1. `d636f58e` fix(schedule): 세로형 날짜 선택기에 키보드 입력 모드 복원
2. `a241ae18` fix(schedule): 날짜 선택기를 입력창+달력 동시 표시로 재설계

---

## Notes

* 트레이너 앱의 `showPortraitDateRangePicker`는 "새 일정" 반복(`매주`) 흐름에서만 쓰인다 — 다른 화면에는 영향 없음
* 사용자 앱은 범위 선택기가 없어 단일 날짜 선택기만 대상

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인 (범위 밖 날짜 타이핑 시 오류 문구)
* [x] UI 확인 (로컬 미리보기로 직접 확인)
* [x] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 트레이너 앱에서 스케줄 탭 → 새 일정 → 날짜 필드 클릭 → 입력창에 타이핑하면 달력이 같이 움직이는지 확인
2. 반복(매주) 켜고 날짜 필드 클릭 → 시작·종료 입력창과 달력이 같이 움직이는지, 알약 모양 띠가 이어지는지 확인
3. 사용자 앱에서 상담 신청 등 날짜 선택 화면에서 동일하게 확인

---

## Screenshots (Optional)

| Before | After |
| ------ | ----- |
|        |       |

---

## Related Issues

Closes #1525

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인
