### PR TITLE
fix(trainer-program): 세부사항 입력 라벨을 테두리로 옮기고 AI 루틴 2단계에도 compact 입력 적용

### DIFF
--- a/frontend/flutter_trainer/lib/features/coaching/presentation/pages/ai_routine_options_flow.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/pages/ai_routine_options_flow.dart
@@ -305,9 +305,7 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
                 fontSize: 12,
                 fontWeight: FontWeight.w700,
               ),
-              padding: const EdgeInsets.symmetric(
-                horizontal: AppSpacing.xs,
-              ),
+              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
               visualDensity: VisualDensity.compact,
             ),
             icon: const Icon(Icons.edit_note_outlined, size: 14),
@@ -833,41 +831,58 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
             decoration: _inputDecoration(hintText: l.progExerciseName),
           ),
           const SizedBox(height: AppSpacing.sm),
-          // 근력은 세트·횟수·중량으로, 그 외 유형은 시간으로 잰다
-          // (#1029, #1310). 다른 편집 화면과 같은 스테퍼를 쓴다 — 같은 운동을
-          // 화면마다 다른 칸으로 받으면 나가는 값도 화면마다 달라진다.
-          if (exercise.type == '근력') ...<Widget>[
-            RoutineSetsField(
-              key: ValueKey<String>('routine-sets-$_selectedKey-$index'),
-              keyPrefix: 'routine-sets-$_selectedKey-$index',
-              sets: exercise.sets > 0 ? exercise.sets : 3,
-              onChanged: (sets) => setState(() {
-                _edited[index] = _edited[index].copyWith(sets: sets);
-              }),
-            ),
-            const SizedBox(height: AppSpacing.sm),
-            RoutineRepsField(
-              key: ValueKey<String>('routine-reps-$_selectedKey-$index'),
-              keyPrefix: 'routine-reps-$_selectedKey-$index',
-              reps: exercise.reps > 0 ? exercise.reps : 10,
-              onChanged: (reps) => setState(() {
-                _edited[index] = _edited[index].copyWith(reps: reps);
-              }),
-            ),
-            const SizedBox(height: AppSpacing.sm),
-            RoutineWeightField(
-              key: ValueKey<String>('routine-weight-$_selectedKey-$index'),
-              keyPrefix: 'routine-weight-$_selectedKey-$index',
-              weight: exercise.weight,
-              onChanged: (weight) => setState(() {
-                _edited[index] = _edited[index].copyWith(weight: weight);
-              }),
-            ),
-          ] else
+          // 근력은 세트·횟수·중량을 한 줄에, 그 외 유형은 시간 한 칸으로
+          // 잰다(#1029, #1310, #1489). 다른 편집 화면과 같은 compact 입력을
+          // 쓴다 — 같은 운동을 화면마다 다른 칸으로 받으면 나가는 값도
+          // 화면마다 달라진다.
+          if (exercise.type == '근력')
+            Row(
+              children: <Widget>[
+                Expanded(
+                  child: RoutineSetsField(
+                    key: ValueKey<String>('routine-sets-$_selectedKey-$index'),
+                    keyPrefix: 'routine-sets-$_selectedKey-$index',
+                    sets: exercise.sets > 0 ? exercise.sets : 3,
+                    compact: true,
+                    onChanged: (sets) => setState(() {
+                      _edited[index] = _edited[index].copyWith(sets: sets);
+                    }),
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.sm),
+                Expanded(
+                  child: RoutineRepsField(
+                    key: ValueKey<String>('routine-reps-$_selectedKey-$index'),
+                    keyPrefix: 'routine-reps-$_selectedKey-$index',
+                    reps: exercise.reps > 0 ? exercise.reps : 10,
+                    compact: true,
+                    onChanged: (reps) => setState(() {
+                      _edited[index] = _edited[index].copyWith(reps: reps);
+                    }),
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.sm),
+                Expanded(
+                  child: RoutineWeightField(
+                    key: ValueKey<String>(
+                      'routine-weight-$_selectedKey-$index',
+                    ),
+                    keyPrefix: 'routine-weight-$_selectedKey-$index',
+                    weight: exercise.weight,
+                    compact: true,
+                    onChanged: (weight) => setState(() {
+                      _edited[index] = _edited[index].copyWith(weight: weight);
+                    }),
+                  ),
+                ),
+              ],
+            )
+          else
             RoutineMinutesField(
               key: ValueKey<String>('routine-minutes-$index'),
               keyPrefix: 'routine-minutes-$index',
               minutes: exercise.minutes,
+              compact: true,
               onChanged: (minutes) => setState(() {
                 _edited[index] = _edited[index].copyWith(minutes: minutes);
               }),
@@ -901,34 +916,50 @@ class _AiRoutineOptionsFlowState extends ConsumerState<AiRoutineOptionsFlow> {
             onChanged: (type) => setState(() => _newExerciseType = type),
           ),
           const SizedBox(height: AppSpacing.sm),
-          // 근력은 세트·횟수·중량으로, 그 외 유형은 시간으로 잰다
-          // (#1029, #1310).
-          if (_newExerciseType == '근력') ...<Widget>[
-            RoutineSetsField(
-              key: const ValueKey<String>('new-exercise-sets'),
-              keyPrefix: 'new-exercise-sets',
-              sets: _newExerciseSets,
-              onChanged: (sets) => setState(() => _newExerciseSets = sets),
-            ),
-            const SizedBox(height: AppSpacing.sm),
-            RoutineRepsField(
-              key: const ValueKey<String>('new-exercise-reps'),
-              keyPrefix: 'new-exercise-reps',
-              reps: _newExerciseReps,
-              onChanged: (reps) => setState(() => _newExerciseReps = reps),
-            ),
-            const SizedBox(height: AppSpacing.sm),
-            RoutineWeightField(
-              key: const ValueKey<String>('new-exercise-weight'),
-              keyPrefix: 'new-exercise-weight',
-              weight: _newExerciseWeight,
-              onChanged: (weight) =>
-                  setState(() => _newExerciseWeight = weight),
-            ),
-          ] else
+          // 근력은 세트·횟수·중량을 한 줄에, 그 외 유형은 시간 한 칸으로
+          // 잰다(#1029, #1310, #1489).
+          if (_newExerciseType == '근력')
+            Row(
+              children: <Widget>[
+                Expanded(
+                  child: RoutineSetsField(
+                    key: const ValueKey<String>('new-exercise-sets'),
+                    keyPrefix: 'new-exercise-sets',
+                    sets: _newExerciseSets,
+                    compact: true,
+                    onChanged: (sets) =>
+                        setState(() => _newExerciseSets = sets),
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.sm),
+                Expanded(
+                  child: RoutineRepsField(
+                    key: const ValueKey<String>('new-exercise-reps'),
+                    keyPrefix: 'new-exercise-reps',
+                    reps: _newExerciseReps,
+                    compact: true,
+                    onChanged: (reps) =>
+                        setState(() => _newExerciseReps = reps),
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.sm),
+                Expanded(
+                  child: RoutineWeightField(
+                    key: const ValueKey<String>('new-exercise-weight'),
+                    keyPrefix: 'new-exercise-weight',
+                    weight: _newExerciseWeight,
+                    compact: true,
+                    onChanged: (weight) =>
+                        setState(() => _newExerciseWeight = weight),
+                  ),
+                ),
+              ],
+            )
+          else
             RoutineMinutesField(
               key: const ValueKey<String>('new-exercise-minutes'),
               minutes: _newExerciseMinutes,
+              compact: true,
               onChanged: (minutes) => setState(() {
                 _newExerciseMinutes = minutes;
               }),

--- a/frontend/flutter_trainer/lib/features/coaching/presentation/widgets/program_editor_workspace.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/widgets/program_editor_workspace.dart
@@ -988,28 +988,45 @@ class _SessionEditorState extends State<_SessionEditor> {
                     onSubmitted: (_) => widget.onConfirmAdd(),
                   ),
                   const SizedBox(height: AppSpacing.sm),
-                  if (widget.exerciseType == '근력') ...<Widget>[
-                    RoutineSetsField(
-                      keyPrefix: 'custom-exercise-sets',
-                      sets: widget.exerciseSets,
-                      onChanged: widget.onExerciseSetsChanged,
-                    ),
-                    const SizedBox(height: AppSpacing.sm),
-                    RoutineRepsField(
-                      keyPrefix: 'custom-exercise-reps',
-                      reps: widget.exerciseReps,
-                      onChanged: widget.onExerciseRepsChanged,
-                    ),
-                    const SizedBox(height: AppSpacing.sm),
-                    RoutineWeightField(
-                      keyPrefix: 'custom-exercise-weight',
-                      weight: widget.exerciseWeight,
-                      onChanged: widget.onExerciseWeightChanged,
-                    ),
-                  ] else
+                  // 근력은 세트·횟수·중량을 한 줄에, 그 외 유형은 시간
+                  // 한 칸으로 잰다(#1029, #1310, #1489) — 스케줄 탭·AI
+                  // 루틴 2단계와 같은 compact 입력이다.
+                  if (widget.exerciseType == '근력')
+                    Row(
+                      children: <Widget>[
+                        Expanded(
+                          child: RoutineSetsField(
+                            keyPrefix: 'custom-exercise-sets',
+                            sets: widget.exerciseSets,
+                            compact: true,
+                            onChanged: widget.onExerciseSetsChanged,
+                          ),
+                        ),
+                        const SizedBox(width: AppSpacing.sm),
+                        Expanded(
+                          child: RoutineRepsField(
+                            keyPrefix: 'custom-exercise-reps',
+                            reps: widget.exerciseReps,
+                            compact: true,
+                            onChanged: widget.onExerciseRepsChanged,
+                          ),
+                        ),
+                        const SizedBox(width: AppSpacing.sm),
+                        Expanded(
+                          child: RoutineWeightField(
+                            keyPrefix: 'custom-exercise-weight',
+                            weight: widget.exerciseWeight,
+                            compact: true,
+                            onChanged: widget.onExerciseWeightChanged,
+                          ),
+                        ),
+                      ],
+                    )
+                  else
                     RoutineMinutesField(
                       keyPrefix: 'custom-exercise-duration',
                       minutes: widget.exerciseMinutes,
+                      compact: true,
                       onChanged: widget.onExerciseMinutesChanged,
                     ),
                   const SizedBox(height: AppSpacing.sm),
@@ -1306,31 +1323,48 @@ class _ExerciseEditorState extends State<_ExerciseEditor> {
                         widget.onChanged(exercise.copyWith(type: value)),
                   ),
                   const SizedBox(height: AppSpacing.sm),
-                  if (exercise.isStrength) ...<Widget>[
-                    RoutineSetsField(
-                      keyPrefix: '${exercise.id}-sets',
-                      sets: exercise.sets,
-                      onChanged: (value) =>
-                          widget.onChanged(exercise.copyWith(sets: value)),
-                    ),
-                    const SizedBox(height: AppSpacing.sm),
-                    RoutineRepsField(
-                      keyPrefix: '${exercise.id}-reps',
-                      reps: exercise.reps,
-                      onChanged: (value) =>
-                          widget.onChanged(exercise.copyWith(reps: value)),
-                    ),
-                    const SizedBox(height: AppSpacing.sm),
-                    RoutineWeightField(
-                      keyPrefix: '${exercise.id}-weight',
-                      weight: exercise.weight,
-                      onChanged: (value) =>
-                          widget.onChanged(exercise.copyWith(weight: value)),
-                    ),
-                  ] else
+                  if (exercise.isStrength)
+                    Row(
+                      children: <Widget>[
+                        Expanded(
+                          child: RoutineSetsField(
+                            keyPrefix: '${exercise.id}-sets',
+                            sets: exercise.sets,
+                            compact: true,
+                            onChanged: (value) => widget.onChanged(
+                              exercise.copyWith(sets: value),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: AppSpacing.sm),
+                        Expanded(
+                          child: RoutineRepsField(
+                            keyPrefix: '${exercise.id}-reps',
+                            reps: exercise.reps,
+                            compact: true,
+                            onChanged: (value) => widget.onChanged(
+                              exercise.copyWith(reps: value),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: AppSpacing.sm),
+                        Expanded(
+                          child: RoutineWeightField(
+                            keyPrefix: '${exercise.id}-weight',
+                            weight: exercise.weight,
+                            compact: true,
+                            onChanged: (value) => widget.onChanged(
+                              exercise.copyWith(weight: value),
+                            ),
+                          ),
+                        ),
+                      ],
+                    )
+                  else
                     RoutineMinutesField(
                       keyPrefix: '${exercise.id}-duration',
                       minutes: exercise.minutes,
+                      compact: true,
                       onChanged: (value) =>
                           widget.onChanged(exercise.copyWith(minutes: value)),
                     ),

--- a/frontend/flutter_trainer/lib/features/coaching/presentation/widgets/program_editor_workspace.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/widgets/program_editor_workspace.dart
@@ -517,28 +517,34 @@ class _ProgramEditorWorkspaceState extends State<ProgramEditorWorkspace> {
             const SizedBox(height: AppSpacing.sm),
           ],
           // 박스 하단 — PT 등록 날짜·시간 범위·일정 추가를 순서대로
-          // 같은 Wrap에 둔다. 넓으면 한 줄, 좁거나 글자가 커지면 왼쪽
-          // 기준과 순서를 유지한 채 줄바꿈된다. `일정 추가`(예전 `보내기`)가
-          // 확인창을 거쳐 실제로 배정+PT 등록까지 한다. 실제 전송·등록
-          // API 호출은 전부 호출부(`onSend`)가 한다 — 여기는 트리거와
-          // 등록일·시각 값만 쥔다.
+          // 오른쪽 정렬로 둔다. 날짜·시간은 예약 슬롯(`reservation_slots_
+          // sheet.dart`)과 같은 라벨+테두리 박스 UI다 — 트레이너 웹의 날짜·
+          // 시간 선택 자리가 화면마다 다른 모양이면 안 된다. 넓으면 한 줄,
+          // 좁거나 글자가 커지면 오른쪽 기준을 유지한 채 줄바꿈된다.
+          // `일정 추가`(예전 `보내기`)가 확인창을 거쳐 실제로 배정+PT
+          // 등록까지 한다. 실제 전송·등록 API 호출은 전부 호출부(`onSend`)
+          // 가 한다 — 여기는 트리거와 등록일·시각 값만 쥔다.
           Wrap(
+            alignment: WrapAlignment.end,
+            crossAxisAlignment: WrapCrossAlignment.end,
             spacing: AppSpacing.sm,
             runSpacing: AppSpacing.xs,
             children: <Widget>[
-              ActionButton(
+              _RegisterFieldBox(
                 key: const ValueKey<String>('program-register-date'),
-                label: ymd(widget.registerDate),
+                label: l.schedFieldDate,
                 icon: Icons.calendar_today_outlined,
-                onPressed: () => unawaited(_pickRegisterDate(context)),
+                value: ymd(widget.registerDate),
+                onTap: () => unawaited(_pickRegisterDate(context)),
               ),
-              ActionButton(
+              _RegisterFieldBox(
                 key: const ValueKey<String>('program-register-time'),
-                label:
+                label: l.schedFieldTime,
+                icon: Icons.schedule_outlined,
+                value:
                     '${widget.registerStartTime.format(context)} – '
                     '${widget.registerEndTime.format(context)}',
-                icon: Icons.schedule_outlined,
-                onPressed: () => unawaited(_pickRegisterTimeRange(context)),
+                onTap: () => unawaited(_pickRegisterTimeRange(context)),
               ),
               Tooltip(
                 message: !_draft.supportsAssignment
@@ -1410,6 +1416,84 @@ class _ExerciseEditorState extends State<_ExerciseEditor> {
         widget.onDelete();
         return;
     }
+  }
+}
+
+/// 라벨 + 테두리 박스(아이콘·값·펼침 화살표) 한 벌 — 날짜·시간처럼 눌러서
+/// 다이얼로그를 여는 자리에 쓴다. 예약 슬롯 시트(`reservation_slots_sheet.
+/// dart`의 `_tappableFieldColumn`/`_fieldBox`)와 같은 모양이다 — 트레이너
+/// 웹의 날짜·시간 선택 UI가 화면마다 다르면 안 된다.
+class _RegisterFieldBox extends StatelessWidget {
+  const _RegisterFieldBox({
+    required this.label,
+    required this.icon,
+    required this.value,
+    required this.onTap,
+    super.key,
+  });
+
+  final String label;
+  final IconData icon;
+  final String value;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        Text(
+          label,
+          style: const TextStyle(
+            fontSize: 12,
+            fontWeight: FontWeight.w600,
+            color: AppColors.subtleForeground,
+          ),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        Material(
+          color: Colors.transparent,
+          borderRadius: const BorderRadius.all(AppRadius.md),
+          child: InkWell(
+            onTap: onTap,
+            borderRadius: const BorderRadius.all(AppRadius.md),
+            child: Container(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSpacing.md,
+                vertical: AppSpacing.sm + 2,
+              ),
+              decoration: BoxDecoration(
+                color: AppColors.card,
+                borderRadius: const BorderRadius.all(AppRadius.md),
+                border: Border.all(color: AppColors.borderStrong),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  Icon(icon, size: 15, color: AppColors.accent),
+                  const SizedBox(width: AppSpacing.sm),
+                  Text(
+                    value,
+                    style: const TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w700,
+                      color: AppColors.foreground,
+                    ),
+                  ),
+                  const SizedBox(width: AppSpacing.sm),
+                  const Icon(
+                    Icons.keyboard_arrow_down,
+                    size: 18,
+                    color: AppColors.subtleForeground,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
   }
 }
 

--- a/frontend/flutter_trainer/lib/features/coaching/presentation/widgets/routine_form_fields.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/widgets/routine_form_fields.dart
@@ -102,8 +102,7 @@ class RoutineMinutesField extends StatelessWidget {
         value: minutes.toDouble(),
         min: 1,
         max: 600,
-        placeholder:
-            '${label ?? l.routineFieldMinutes}(${l.routineUnitMinutes})',
+        label: label ?? l.routineFieldMinutes,
         suffix: l.routineUnitMinutes,
         keyPrefix: keyPrefix ?? 'routine-minutes',
         onChanged: (double v) => onChanged(v.round()),
@@ -146,7 +145,7 @@ class RoutineSetsField extends StatelessWidget {
         value: sets.toDouble(),
         min: 1,
         max: 99,
-        placeholder: '${l.routineFieldSets}(${l.routineUnitSets})',
+        label: l.routineFieldSets,
         suffix: l.routineUnitSets,
         keyPrefix: keyPrefix ?? 'routine-sets',
         onChanged: (double v) => onChanged(v.round()),
@@ -192,7 +191,7 @@ class RoutineRepsField extends StatelessWidget {
         value: reps.toDouble(),
         min: 1,
         max: 999,
-        placeholder: '${l.routineFieldReps}(${l.routineUnitReps})',
+        label: l.routineFieldReps,
         suffix: l.routineUnitReps,
         keyPrefix: keyPrefix ?? 'routine-reps',
         onChanged: (double v) => onChanged(v.round()),
@@ -236,7 +235,7 @@ class RoutineWeightField extends StatelessWidget {
         min: 0,
         max: 1000,
         decimals: 1,
-        placeholder: '${l.routineFieldWeight}(${l.routineUnitKg})',
+        label: l.routineFieldWeight,
         suffix: l.routineUnitKg,
         keyPrefix: keyPrefix ?? 'routine-weight',
         onChanged: onChanged,
@@ -499,9 +498,10 @@ class _LabeledStepper extends StatelessWidget {
   }
 }
 
-/// 숫자 한 칸 — 스테퍼 없이 키보드로 직접 입력한다. 라벨은 얹지 않고
-/// placeholder 로 대신한다. 근력의 세트·횟수·중량을 한 줄에 나란히 둘 때
-/// 쓴다 — 셋 다 라벨+스테퍼 박스를 쌓으면 세로 폭이 다른 필드보다 훨씬
+/// 숫자 한 칸 — 스테퍼 없이 키보드로 직접 입력한다. 라벨은 위에 따로 얹지
+/// 않고 테두리에 걸치는 Material outline label 로 대신한다. 근력의
+/// 세트·횟수·중량을 한 줄에 나란히 둘 때 쓴다 — 셋 다 라벨+스테퍼 박스를
+/// 쌓으면 세로 폭이 다른 필드보다 훨씬
 /// 길어진다. (#1489)
 class _CompactNumberField extends StatefulWidget {
   const _CompactNumberField({
@@ -509,7 +509,7 @@ class _CompactNumberField extends StatefulWidget {
     required this.onChanged,
     required this.min,
     required this.max,
-    required this.placeholder,
+    required this.label,
     required this.suffix,
     this.decimals = 0,
     this.keyPrefix,
@@ -519,11 +519,14 @@ class _CompactNumberField extends StatefulWidget {
   final ValueChanged<double> onChanged;
   final double min;
   final double max;
-  final String placeholder;
 
-  /// 값 오른쪽에 붙는 단위("세트"·"회"·"kg"·"분"). 칸이 항상 기본값으로
-  /// 채워져 있어 placeholder(빈 칸 문구)는 사실상 보이지 않는다 — 입력된
-  /// 숫자가 무엇을 재는 값인지는 이 단위로 구분한다. (#1489 후속)
+  /// 테두리에 얹히는 라벨("세트 수"·"횟수"·"중량"·"운동 시간"). 칸이 항상
+  /// 기본값으로 채워져 있어 hint(빈 칸 문구)는 사실상 보이지 않는다 —
+  /// Material 의 outline label 은 값이 있어도 계속 보이므로 이걸 쓴다.
+  /// (#1489 후속)
+  final String label;
+
+  /// 값 오른쪽에 붙는 단위("세트"·"회"·"kg"·"분").
   final String suffix;
   final int decimals;
   final String? keyPrefix;
@@ -613,11 +616,16 @@ class _CompactNumberFieldState extends State<_CompactNumberField> {
       ),
       decoration: InputDecoration(
         isDense: true,
-        hintText: widget.placeholder,
-        hintStyle: const TextStyle(
+        labelText: widget.label,
+        labelStyle: const TextStyle(
           fontSize: 11,
           fontWeight: FontWeight.w600,
           color: AppColors.subtleForeground,
+        ),
+        floatingLabelStyle: const TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w700,
+          color: AppColors.accent,
         ),
         suffixText: widget.suffix,
         suffixStyle: const TextStyle(

--- a/frontend/flutter_trainer/lib/features/coaching/presentation/widgets/routine_form_fields.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/widgets/routine_form_fields.dart
@@ -104,6 +104,7 @@ class RoutineMinutesField extends StatelessWidget {
         max: 600,
         placeholder:
             '${label ?? l.routineFieldMinutes}(${l.routineUnitMinutes})',
+        suffix: l.routineUnitMinutes,
         keyPrefix: keyPrefix ?? 'routine-minutes',
         onChanged: (double v) => onChanged(v.round()),
       );
@@ -146,6 +147,7 @@ class RoutineSetsField extends StatelessWidget {
         min: 1,
         max: 99,
         placeholder: '${l.routineFieldSets}(${l.routineUnitSets})',
+        suffix: l.routineUnitSets,
         keyPrefix: keyPrefix ?? 'routine-sets',
         onChanged: (double v) => onChanged(v.round()),
       );
@@ -191,6 +193,7 @@ class RoutineRepsField extends StatelessWidget {
         min: 1,
         max: 999,
         placeholder: '${l.routineFieldReps}(${l.routineUnitReps})',
+        suffix: l.routineUnitReps,
         keyPrefix: keyPrefix ?? 'routine-reps',
         onChanged: (double v) => onChanged(v.round()),
       );
@@ -234,6 +237,7 @@ class RoutineWeightField extends StatelessWidget {
         max: 1000,
         decimals: 1,
         placeholder: '${l.routineFieldWeight}(${l.routineUnitKg})',
+        suffix: l.routineUnitKg,
         keyPrefix: keyPrefix ?? 'routine-weight',
         onChanged: onChanged,
       );
@@ -506,6 +510,7 @@ class _CompactNumberField extends StatefulWidget {
     required this.min,
     required this.max,
     required this.placeholder,
+    required this.suffix,
     this.decimals = 0,
     this.keyPrefix,
   });
@@ -515,6 +520,11 @@ class _CompactNumberField extends StatefulWidget {
   final double min;
   final double max;
   final String placeholder;
+
+  /// 값 오른쪽에 붙는 단위("세트"·"회"·"kg"·"분"). 칸이 항상 기본값으로
+  /// 채워져 있어 placeholder(빈 칸 문구)는 사실상 보이지 않는다 — 입력된
+  /// 숫자가 무엇을 재는 값인지는 이 단위로 구분한다. (#1489 후속)
+  final String suffix;
   final int decimals;
   final String? keyPrefix;
 
@@ -605,6 +615,12 @@ class _CompactNumberFieldState extends State<_CompactNumberField> {
         isDense: true,
         hintText: widget.placeholder,
         hintStyle: const TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+          color: AppColors.subtleForeground,
+        ),
+        suffixText: widget.suffix,
+        suffixStyle: const TextStyle(
           fontSize: 11,
           fontWeight: FontWeight.w600,
           color: AppColors.subtleForeground,

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/models/program_draft.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/models/program_draft.dart
@@ -34,11 +34,15 @@ class ProgramDraft {
     intensity: normaliseRoutineIntensity(item.intensity),
   );
 
-  /// 새 운동 행의 기본값 — 오늘, 근력 3세트 10회 20kg, 보통 강도.
-  factory ProgramDraft.empty() => ProgramDraft(
+  /// 새 운동 행의 기본값 — 근력 3세트 10회 20kg, 보통 강도.
+  ///
+  /// [date] 는 이 운동이 속한 세션의 날짜를 그대로 받는다(#1489 후속) — 운동
+  /// 행마다 날짜를 따로 고르게 하면 세션 날짜와 어긋날 수 있는 두 번째
+  /// 입력이 생긴다. 넘기지 않으면 오늘로 떨어진다.
+  factory ProgramDraft.empty({DateTime? date}) => ProgramDraft(
     name: '',
     type: '근력',
-    date: _today(),
+    date: date ?? _today(),
     minutes: 30,
     sets: 3,
     reps: 10,

--- a/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/session_program_editor.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/presentation/widgets/session_program_editor.dart
@@ -58,7 +58,11 @@ class _SessionProgramEditorState extends ConsumerState<SessionProgramEditor> {
   }
 
   void _addItem() {
-    setState(() => _items.add(ProgramDraft.empty()));
+    setState(
+      () => _items.add(
+        ProgramDraft.empty(date: DateTime.parse(widget.session.date)),
+      ),
+    );
   }
 
   void _removeItem(int index) {
@@ -236,17 +240,20 @@ class _ProgramDraftFields extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
-          // 회원 앱의 운동 추가 시트와 같은 순서다 (#1276) — 날짜 → 종류 →
-          // 이름 → 시간(또는 세트·중량) → 강도 → 예상 칼로리.
+          // 회원 앱의 운동 추가 시트와 같은 순서다 (#1276) — 종류 → 이름 →
+          // 시간(또는 세트·중량) → 강도 → 예상 칼로리. 날짜는 없다(#1489
+          // 후속) — 이 운동은 세션 날짜(위 카드의 실제 일정)에 속해 있고,
+          // 여기서 따로 고르게 하면 세션 날짜와 어긋나는 두 번째 입력이
+          // 생긴다.
           Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
               Expanded(
-                child: RoutineDateField(
-                  keyPrefix: 'program-date-$index',
-                  date: draft.date,
-                  onChanged: (DateTime value) {
-                    draft.date = value;
+                child: RoutineCategoryChips(
+                  keyPrefix: 'program-type-$index',
+                  value: normaliseRoutineType(draft.type),
+                  onChanged: (String value) {
+                    draft.type = value;
                     onChanged();
                   },
                 ),
@@ -263,15 +270,6 @@ class _ProgramDraftFields extends StatelessWidget {
             ],
           ),
           const SizedBox(height: AppSpacing.sm),
-          RoutineCategoryChips(
-            keyPrefix: 'program-type-$index',
-            value: normaliseRoutineType(draft.type),
-            onChanged: (String value) {
-              draft.type = value;
-              onChanged();
-            },
-          ),
-          const SizedBox(height: AppSpacing.sm),
           RoutineNameField(
             keyPrefix: 'program-name-$index',
             controller: draft.name,
@@ -279,8 +277,8 @@ class _ProgramDraftFields extends StatelessWidget {
           ),
           const SizedBox(height: AppSpacing.sm),
           // 근력은 세트·횟수·중량을 한 줄에, 나머지는 시간 한 칸으로 묻는다.
-          // 라벨 대신 placeholder 를 쓰는 compact 입력이라 세 칸이 나란히
-          // 들어가도 세로 폭이 늘어나지 않는다. (#1489)
+          // 라벨이 테두리에 얹히는 compact 입력이라 세 칸이 나란히 들어가도
+          // 세로 폭이 늘어나지 않는다. (#1489)
           if (draft.isStrength)
             Row(
               children: <Widget>[

--- a/frontend/flutter_trainer/test/features/coaching/program_editor_workspace_test.dart
+++ b/frontend/flutter_trainer/test/features/coaching/program_editor_workspace_test.dart
@@ -572,40 +572,23 @@ void main() {
       expect(added.weight, 20);
     });
 
-    testWidgets('−/+ 버튼은 값을 한 칸씩 옮긴다', (tester) async {
+    testWidgets('세트 칸은 스테퍼 없이 키보드로 직접 값을 고친다 (#1489)', (tester) async {
       await pumpEditor(tester);
       await openAddForm(tester);
 
-      await tester.tap(
-        find.byKey(const ValueKey<String>('custom-exercise-sets-plus')),
-      );
-      await tester.pump();
-      expect(
-        tester
-            .widget<TextField>(
-              find.byKey(const ValueKey<String>('custom-exercise-sets-field')),
-            )
-            .controller!
-            .text,
-        '4',
-      );
+      // 근력 세트·횟수·중량은 compact 입력이라 −/+ 스테퍼 버튼이 없다 —
+      // 키보드로 직접 값을 바꾼다.
+      expect(find.byIcon(Icons.remove), findsNothing);
 
-      await tester.tap(
-        find.byKey(const ValueKey<String>('custom-exercise-sets-minus')),
+      final setsField = find.byKey(
+        const ValueKey<String>('custom-exercise-sets-field'),
       );
+      await tester.enterText(setsField, '4');
       await tester.pump();
-      expect(
-        tester
-            .widget<TextField>(
-              find.byKey(const ValueKey<String>('custom-exercise-sets-field')),
-            )
-            .controller!
-            .text,
-        '3',
-      );
+      expect(tester.widget<TextField>(setsField).controller!.text, '4');
     });
 
-    testWidgets('운동 수정 모드도 같은 스테퍼로 값을 고친다', (tester) async {
+    testWidgets('운동 수정 모드도 같은 compact 입력으로 값을 고친다', (tester) async {
       await pumpEditor(tester);
       await mergeSuggestions(tester);
 

--- a/frontend/flutter_trainer/test/features/coaching/program_editor_workspace_test.dart
+++ b/frontend/flutter_trainer/test/features/coaching/program_editor_workspace_test.dart
@@ -143,7 +143,7 @@ void main() {
   });
 
   group('일정 추가', () {
-    testWidgets('넓은 화면에서 날짜 → 시간 범위 → 추가가 같은 높이의 한 줄이다', (tester) async {
+    testWidgets('넓은 화면에서 날짜 → 시간 범위 → 추가가 오른쪽 정렬로 한 줄이다', (tester) async {
       await pumpEditor(tester);
       final date = find.byKey(const ValueKey<String>('program-register-date'));
       final time = find.byKey(const ValueKey<String>('program-register-time'));
@@ -154,14 +154,13 @@ void main() {
       final dateRect = tester.getRect(date);
       final timeRect = tester.getRect(time);
       final sendRect = tester.getRect(send);
-      expect(dateRect.top, timeRect.top);
-      expect(timeRect.top, sendRect.top);
+      // 날짜·시간은 예약 슬롯과 같은 라벨+박스 UI라 `일정 추가` 버튼보다
+      // 키가 크다 — 아래(bottom) 기준으로 같은 줄에 나란히 선다.
+      expect(dateRect.bottom, timeRect.bottom);
+      expect(timeRect.bottom, sendRect.bottom);
       expect(dateRect.left, lessThan(timeRect.left));
       expect(timeRect.left, lessThan(sendRect.left));
-      expect(
-        <double>[dateRect.height, timeRect.height, sendRect.height],
-        <double>[36, 36, 36],
-      );
+      expect(dateRect.height, timeRect.height);
       expect(
         find.descendant(
           of: date,
@@ -171,7 +170,7 @@ void main() {
       );
     });
 
-    testWidgets('좁은 화면·글자 확대에서 순서와 왼쪽 기준을 유지해 줄바꿈한다', (tester) async {
+    testWidgets('좁은 화면·글자 확대에서 순서와 오른쪽 기준을 유지해 줄바꿈한다', (tester) async {
       tester.view.devicePixelRatio = 1;
       tester.view.physicalSize = const Size(600, 1000);
       addTearDown(tester.view.resetPhysicalSize);
@@ -213,14 +212,27 @@ void main() {
       await tester.ensureVisible(controls.first);
       await tester.pump();
       final rects = controls.map(tester.getRect).toList();
+      // 같은 줄에서는 순서(왼→오)를 유지하고, 다음 줄로 넘어가면 아래로
+      // 내려간다.
       for (var i = 1; i < rects.length; i++) {
         final followsInSameRun =
             rects[i].top == rects[i - 1].top &&
             rects[i].left > rects[i - 1].left;
-        final startsLaterRun =
-            rects[i].top > rects[i - 1].top &&
-            rects[i].left == rects.first.left;
+        final startsLaterRun = rects[i].top > rects[i - 1].top;
         expect(followsInSameRun || startsLaterRun, isTrue);
+      }
+      // 오른쪽 정렬이라, 각 줄의 마지막 칸은 모두 같은 오른쪽 기준선에
+      // 붙는다.
+      final rightEdge = rects.fold<double>(
+        0,
+        (max, r) => r.right > max ? r.right : max,
+      );
+      for (var i = 0; i < rects.length; i++) {
+        final isLastInRow =
+            i == rects.length - 1 || rects[i + 1].top != rects[i].top;
+        if (isLastInRow) {
+          expect(rects[i].right, closeTo(rightEdge, 1));
+        }
       }
       expect(tester.takeException(), isNull);
     });

--- a/frontend/flutter_trainer/test/features/coaching/routine_form_fields_compact_test.dart
+++ b/frontend/flutter_trainer/test/features/coaching/routine_form_fields_compact_test.dart
@@ -4,8 +4,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:oncare_trainer/features/coaching/presentation/widgets/routine_form_fields.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 
-// 스테퍼(-/+) 대신 라벨 없는 키보드 입력 칸으로 바뀐 근력 세트·횟수·중량 및
-// 시간 입력을 검증한다. (#1489)
+// 스테퍼(-/+) 대신 테두리 라벨 + 오른쪽 단위로 바뀐 근력 세트·횟수·중량 및
+// 시간 입력을 검증한다. (#1489, #1489 후속)
 void main() {
   Widget buildApp(Widget child) => MaterialApp(
     locale: const Locale('ko'),
@@ -14,7 +14,7 @@ void main() {
     home: Scaffold(body: child),
   );
 
-  testWidgets('compact 세트 입력은 스테퍼 버튼 없이 placeholder 만 보인다', (tester) async {
+  testWidgets('compact 세트 입력은 스테퍼 버튼 없이 테두리 라벨과 단위를 보여준다', (tester) async {
     int? changed;
     await tester.pumpWidget(
       buildApp(
@@ -25,7 +25,8 @@ void main() {
     expect(find.byIcon(Icons.remove), findsNothing);
     expect(find.byIcon(Icons.add), findsNothing);
     final field = tester.widget<TextField>(find.byType(TextField));
-    expect(field.decoration?.hintText, '세트 수(세트)');
+    expect(field.decoration?.labelText, '세트 수');
+    expect(field.decoration?.suffixText, '세트');
 
     await tester.enterText(find.byType(TextField), '5');
     await tester.testTextInput.receiveAction(TextInputAction.done);
@@ -33,7 +34,7 @@ void main() {
     expect(changed, 5);
   });
 
-  testWidgets('compact 중량 입력은 placeholder 로 중량(kg) 를 보여준다', (tester) async {
+  testWidgets('compact 중량 입력은 테두리 라벨 중량과 단위 kg 를 보여준다', (tester) async {
     await tester.pumpWidget(
       buildApp(
         RoutineWeightField(weight: 40, compact: true, onChanged: (_) {}),
@@ -41,10 +42,11 @@ void main() {
     );
 
     final field = tester.widget<TextField>(find.byType(TextField));
-    expect(field.decoration?.hintText, '중량(kg)');
+    expect(field.decoration?.labelText, '중량');
+    expect(field.decoration?.suffixText, 'kg');
   });
 
-  testWidgets('compact 시간 입력은 placeholder 로 운동 시간(분) 을 보여준다', (tester) async {
+  testWidgets('compact 시간 입력은 테두리 라벨 운동 시간과 단위 분 을 보여준다', (tester) async {
     await tester.pumpWidget(
       buildApp(
         RoutineMinutesField(minutes: 30, compact: true, onChanged: (_) {}),
@@ -52,7 +54,8 @@ void main() {
     );
 
     final field = tester.widget<TextField>(find.byType(TextField));
-    expect(field.decoration?.hintText, '운동 시간(분)');
+    expect(field.decoration?.labelText, '운동 시간');
+    expect(field.decoration?.suffixText, '분');
   });
 
   testWidgets('근력 세트·횟수·중량 세 칸이 한 줄 Row 에 나란히 들어간다', (tester) async {

--- a/frontend/flutter_trainer/test/features/coaching/routine_options_provider_and_flow_test.dart
+++ b/frontend/flutter_trainer/test/features/coaching/routine_options_provider_and_flow_test.dart
@@ -209,39 +209,33 @@ void main() {
       }
     });
 
-    test(
-      '#776 — demo member has no real history, so the mock reports '
-      'template (never claims to be personalized)',
-      () async {
-        const repo = MockTrainerRoutineOptionsRepository();
-        final options = await repo.generate(
-          'm1',
-          availableMinutes: 40,
-          intensityPreference: 'moderate',
-          trainerNote: '',
-        );
-        expect(
-          options.analysis.recommendationStatus,
-          RecommendationStatus.template,
-        );
-        expect(options.analysis.frequentExercises, isEmpty);
-      },
-    );
+    test('#776 — demo member has no real history, so the mock reports '
+        'template (never claims to be personalized)', () async {
+      const repo = MockTrainerRoutineOptionsRepository();
+      final options = await repo.generate(
+        'm1',
+        availableMinutes: 40,
+        intensityPreference: 'moderate',
+        trainerNote: '',
+      );
+      expect(
+        options.analysis.recommendationStatus,
+        RecommendationStatus.template,
+      );
+      expect(options.analysis.frequentExercises, isEmpty);
+    });
 
-    test(
-      '#776 — null conditions fall back to the same default as the backend '
-      '(30 minutes / moderate)',
-      () async {
-        const repo = MockTrainerRoutineOptionsRepository();
-        final options = await repo.generate(
-          'm1',
-          availableMinutes: null,
-          intensityPreference: null,
-          trainerNote: '',
-        );
-        expect(options.planB.totalMinutes, 30);
-      },
-    );
+    test('#776 — null conditions fall back to the same default as the backend '
+        '(30 minutes / moderate)', () async {
+      const repo = MockTrainerRoutineOptionsRepository();
+      final options = await repo.generate(
+        'm1',
+        availableMinutes: null,
+        intensityPreference: null,
+        trainerNote: '',
+      );
+      expect(options.planB.totalMinutes, 30);
+    });
   });
 
   group('#1028 단계 이름 · 자연어 요청 · 데모', () {
@@ -337,14 +331,8 @@ void main() {
       expect(find.text('맞춤 루틴 후보 생성'), findsOneWidget);
     });
 
-    testWidgets('실 API 모드에서는 기록이 적은 회원에게 그 사실을 그대로 말한다', (
-      tester,
-    ) async {
-      await pumpFlow(
-        tester,
-        config: realConfig,
-        response: _templateOptions(),
-      );
+    testWidgets('실 API 모드에서는 기록이 적은 회원에게 그 사실을 그대로 말한다', (tester) async {
+      await pumpFlow(tester, config: realConfig, response: _templateOptions());
       await generate(tester);
 
       expect(find.text('목표 기반 기본 추천'), findsOneWidget);
@@ -403,9 +391,7 @@ void main() {
         expect(
           tester
               .widget<TextField>(
-                find.byKey(
-                  const ValueKey<String>('generation-minutes-field'),
-                ),
+                find.byKey(const ValueKey<String>('generation-minutes-field')),
               )
               .controller!
               .text,
@@ -508,249 +494,21 @@ void main() {
 
   testWidgets(
     'inline flow: analyse → horizontal options → edit/apply to template',
-    (
-    tester,
-  ) async {
-    // Tall viewport so every step's content fits (buttons sit at the bottom
-    // of a scrolling list otherwise, and taps miss off-screen).
-    tester.view.physicalSize = const Size(1000, 2400);
-    tester.view.devicePixelRatio = 1.0;
-    addTearDown(tester.view.resetPhysicalSize);
-    addTearDown(tester.view.resetDevicePixelRatio);
-
-    final assigned = _CapturingRoutineRepository();
-    List<RoutineExercise>? reviewed;
-    await tester.pumpWidget(
-      ProviderScope(
-        overrides: <Override>[
-          appConfigProvider.overrideWithValue(_mockConfig),
-          trainerRoutineRepositoryProvider.overrideWithValue(assigned),
-        ],
-        child: MaterialApp(
-          locale: const Locale('ko'),
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
-          home: AiRoutineOptionsFlow(
-            client: _client,
-            recommendedExercises: const <RoutineExercise>[
-              RoutineExercise(name: '실내 자전거', minutes: 20, type: '유산소'),
-            ],
-            recommendedReason: '기존 고객 데이터 기반 추천',
-            onReviewCompleted: (exercises) => reviewed = exercises,
-          ),
-        ),
-      ),
-    );
-
-    // 조건 설정 단계에는 자연어 요청 칸이 있고(#1028), 예시 문구는 입력 전
-    // 참고용이라 흐린 placeholder 로 남는다.
-    expect(
-      find.text('운동 목표와 최근 활동, 오늘의 식단 정보를 확인했어요'),
-      findsOneWidget,
-    );
-    // 분석 제목과 생성 버튼의 AI 아이콘은 유지하되 요청 제목 아이콘만 뺀다.
-    expect(find.byIcon(Icons.auto_awesome), findsNWidgets(2));
-    expect(find.text('요청 내용'), findsOneWidget);
-    final promptBlurb = tester.widget<Text>(
-      find.textContaining('요청은 고객 데이터와 함께 AI에 전달돼요'),
-    );
-    expect(promptBlurb.maxLines, 1);
-    expect(promptBlurb.overflow, TextOverflow.ellipsis);
-    final promptField = find.byKey(
-      const ValueKey<String>('ai-natural-language-prompt'),
-    );
-    final initialPrompt = tester.widget<TextField>(promptField);
-    expect(initialPrompt.decoration?.hintStyle?.color, AppColors.mutedForeground);
-    expect(initialPrompt.decoration?.fillColor, AppColors.card);
-    expect(
-      (initialPrompt.decoration?.enabledBorder! as OutlineInputBorder)
-          .borderSide
-          .color,
-      AppColors.borderStrong,
-    );
-    expect(initialPrompt.buildCounter, isNotNull);
-    expect(
-      find.byKey(const ValueKey<String>('ai-prompt-counter')),
-      findsOneWidget,
-    );
-    // 서버 상한(`trainer_note`, 500자)을 화면에서 먼저 막는다.
-    expect(initialPrompt.maxLength, 500);
-    expect(
-      initialPrompt.decoration?.hintText,
-      '예: 하체 부담 적고 유산소 비중 높은 40분 프로그램 만들어줘',
-    );
-    final generationMinutes = find.byKey(
-      const ValueKey<String>('generation-minutes'),
-    );
-    expect(
-      find.descendant(of: generationMinutes, matching: find.text('총 운동시간')),
-      findsOneWidget,
-    );
-    expect(
-      find.descendant(of: generationMinutes, matching: find.text('운동 시간')),
-      findsNothing,
-    );
-    await tester.enterText(promptField, '무릎 부담 적게, 유산소 위주로 만들어줘');
-
-    await tester.ensureVisible(
-      find.byKey(const ValueKey<String>('generate-routine-options')),
-    );
-    await tester.tap(
-      find.byKey(const ValueKey<String>('generate-routine-options')),
-    );
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 700));
-    await tester.pumpAndSettle();
-
-    // A/B + the existing recommendation are shown together. The layout
-    // adapts — side by side when the column is wide enough, stacked
-    // vertically when it isn't — so this asserts the three options
-    // themselves rather than which of the two layouts rendered them.
-    expect(find.textContaining('회복안 · 회복·지속 중심'), findsOneWidget);
-    expect(find.textContaining('강화안 · 강도·운동량 중심'), findsOneWidget);
-    expect(find.textContaining('기존안 · 기존 AI 추천'), findsOneWidget);
-    // 세 번째 후보의 key 는 선택 식별자다 — 화면 문구가 아니라서 로케일과
-    // 무관하게 'recommended' 로 고정돼 있다(#501).
-    final optionHeights = <String>['A', 'B', 'recommended']
-        .map(
-          (key) => tester
-              .getSize(find.byKey(ValueKey<String>('routine-option-$key')))
-              .height,
-        )
-        .toSet();
-    expect(optionHeights, hasLength(1));
-
-    // Select B and edit its first exercise in the common inline editor.
-    await tester.tap(find.byKey(const ValueKey<String>('routine-option-B')));
-    await tester.pumpAndSettle();
-    final categoryNameGap = tester.widget<SizedBox>(
-      find.byKey(const ValueKey<String>('routine-category-name-gap-0')),
-    );
-    expect(categoryNameGap.height, AppSpacing.md);
-    expect(
-      find.descendant(
-        of: find.byKey(const ValueKey<String>('routine-minutes-0')),
-        matching: find.text('운동 시간'),
-      ),
-      findsOneWidget,
-    );
-
-    final showAddExerciseForm = find.byKey(
-      const ValueKey<String>('show-add-exercise-form'),
-    );
-    await tester.ensureVisible(showAddExerciseForm);
-    await tester.tap(showAddExerciseForm);
-    await tester.pumpAndSettle();
-    // 기본 유형이 근력이라 시간 슬라이더 대신 세트·횟수 칸이 보인다(#1029).
-    expect(
-      find.byKey(const ValueKey<String>('new-exercise-sets')),
-      findsOneWidget,
-    );
-    expect(
-      find.byKey(const ValueKey<String>('new-exercise-minutes')),
-      findsNothing,
-    );
-    // 근력이 아닌 유형으로 바꾸면 시간 슬라이더로 바뀐다.
-    await tester.tap(
-      find.byKey(const ValueKey<String>('new-exercise-category-유산소')),
-    );
-    await tester.pumpAndSettle();
-    expect(
-      find.descendant(
-        of: find.byKey(const ValueKey<String>('new-exercise-minutes')),
-        matching: find.text('운동 시간'),
-      ),
-      findsOneWidget,
-    );
-    expect(
-      find.byKey(const ValueKey<String>('new-exercise-sets')),
-      findsNothing,
-    );
-    await tester.tap(
-      find.byKey(const ValueKey<String>('hide-add-exercise-form')),
-    );
-    await tester.pumpAndSettle();
-
-    await tester.enterText(find.byType(TextFormField).first, '인터벌 걷기');
-    final minutesField = find.byKey(
-      const ValueKey<String>('routine-minutes-0-field'),
-    );
-    await tester.enterText(minutesField, '20');
-    await tester.pump();
-    expect(tester.widget<TextField>(minutesField).controller!.text, '20');
-    // 유형은 네 가지다 (#996, #1276).
-    for (final category in <String>['유산소', '근력', '스트레칭', '기타']) {
-      expect(
-        find.byKey(ValueKey<String>('routine-category-B-0-$category')),
-        findsOneWidget,
-      );
-    }
-    await tester.pump();
-
-    // 고객에게 함께 보낼 메모는 AI 요청과 **다른 칸**이다 (#1028) — 여기 적은
-    // 것만 회원이 받는 루틴 사유로 나간다.
-    final clientNote = find.byKey(
-      const ValueKey<String>('final-trainer-memo'),
-    );
-    await tester.ensureVisible(clientNote);
-    await tester.enterText(clientNote, '무릎 충격 주의');
-    await tester.pump();
-
-    await tester.ensureVisible(
-      find.byKey(const ValueKey<String>('complete-routine-review')),
-    );
-    await tester.tap(
-      find.byKey(const ValueKey<String>('complete-routine-review')),
-    );
-    await tester.pumpAndSettle();
-    // 최종 검토에 들어온 것만으로는 아직 아무 데도 반영되지 않는다 (#1028
-    // 후속) — `템플릿에 반영`을 눌러야 [onReviewCompleted] 가 호출된다.
-    expect(reviewed, isNull);
-    expect(
-      find.byKey(const ValueKey<String>('reviewed-routine-list')),
-      findsOneWidget,
-    );
-    expect(assigned.memberId, isNull);
-    expect(assigned.assigned, isNull);
-    // 이 화면에는 고객에게 직접 보내는 버튼이 없다 — `템플릿에 반영` 뿐이다.
-    expect(
-      find.byKey(const ValueKey<String>('send-selected-routine')),
-      findsNothing,
-    );
-
-    await tester.ensureVisible(
-      find.byKey(const ValueKey<String>('apply-routine-to-template')),
-    );
-    await tester.tap(
-      find.byKey(const ValueKey<String>('apply-routine-to-template')),
-    );
-    await tester.pumpAndSettle();
-
-    // 템플릿(편집기)로만 반영된다 — 서버에는 여전히 아무것도 나가지 않는다.
-    expect(reviewed, isNotNull);
-    expect(reviewed!.first.name, '인터벌 걷기');
-    expect(assigned.memberId, isNull);
-    expect(assigned.assigned, isNull);
-  });
-
-  testWidgets(
-    '템플릿에 반영은 회원에게 보내는 API를 호출하지 않는다 (#1028 후속)',
     (tester) async {
-      // AI 3단계 최종 검토는 더 이상 여기서 곧바로 전송하지 않는다 — `템플릿에
-      // 반영`은 [onReviewCompleted] 로 편집기에 넘길 뿐이다. 실수로라도 회원
-      // 전송 API 가 호출되면 곧바로 던지도록 만들어 회귀를 잡는다.
+      // Tall viewport so every step's content fits (buttons sit at the bottom
+      // of a scrolling list otherwise, and taps miss off-screen).
       tester.view.physicalSize = const Size(1000, 2400);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.resetPhysicalSize);
       addTearDown(tester.view.resetDevicePixelRatio);
 
-      final repository = _ThrowingRoutineRepository(const NetworkError());
+      final assigned = _CapturingRoutineRepository();
       List<RoutineExercise>? reviewed;
       await tester.pumpWidget(
         ProviderScope(
           overrides: <Override>[
             appConfigProvider.overrideWithValue(_mockConfig),
-            trainerRoutineRepositoryProvider.overrideWithValue(repository),
+            trainerRoutineRepositoryProvider.overrideWithValue(assigned),
           ],
           child: MaterialApp(
             locale: const Locale('ko'),
@@ -768,17 +526,247 @@ void main() {
         ),
       );
 
-      await _driveToApplyReady(tester);
+      // 조건 설정 단계에는 자연어 요청 칸이 있고(#1028), 예시 문구는 입력 전
+      // 참고용이라 흐린 placeholder 로 남는다.
+      expect(find.text('운동 목표와 최근 활동, 오늘의 식단 정보를 확인했어요'), findsOneWidget);
+      // 분석 제목과 생성 버튼의 AI 아이콘은 유지하되 요청 제목 아이콘만 뺀다.
+      expect(find.byIcon(Icons.auto_awesome), findsNWidgets(2));
+      expect(find.text('요청 내용'), findsOneWidget);
+      final promptBlurb = tester.widget<Text>(
+        find.textContaining('요청은 고객 데이터와 함께 AI에 전달돼요'),
+      );
+      expect(promptBlurb.maxLines, 1);
+      expect(promptBlurb.overflow, TextOverflow.ellipsis);
+      final promptField = find.byKey(
+        const ValueKey<String>('ai-natural-language-prompt'),
+      );
+      final initialPrompt = tester.widget<TextField>(promptField);
+      expect(
+        initialPrompt.decoration?.hintStyle?.color,
+        AppColors.mutedForeground,
+      );
+      expect(initialPrompt.decoration?.fillColor, AppColors.card);
+      expect(
+        (initialPrompt.decoration?.enabledBorder! as OutlineInputBorder)
+            .borderSide
+            .color,
+        AppColors.borderStrong,
+      );
+      expect(initialPrompt.buildCounter, isNotNull);
+      expect(
+        find.byKey(const ValueKey<String>('ai-prompt-counter')),
+        findsOneWidget,
+      );
+      // 서버 상한(`trainer_note`, 500자)을 화면에서 먼저 막는다.
+      expect(initialPrompt.maxLength, 500);
+      expect(
+        initialPrompt.decoration?.hintText,
+        '예: 하체 부담 적고 유산소 비중 높은 40분 프로그램 만들어줘',
+      );
+      final generationMinutes = find.byKey(
+        const ValueKey<String>('generation-minutes'),
+      );
+      expect(
+        find.descendant(of: generationMinutes, matching: find.text('총 운동시간')),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(of: generationMinutes, matching: find.text('운동 시간')),
+        findsNothing,
+      );
+      await tester.enterText(promptField, '무릎 부담 적게, 유산소 위주로 만들어줘');
+
+      await tester.ensureVisible(
+        find.byKey(const ValueKey<String>('generate-routine-options')),
+      );
+      await tester.tap(
+        find.byKey(const ValueKey<String>('generate-routine-options')),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 700));
+      await tester.pumpAndSettle();
+
+      // A/B + the existing recommendation are shown together. The layout
+      // adapts — side by side when the column is wide enough, stacked
+      // vertically when it isn't — so this asserts the three options
+      // themselves rather than which of the two layouts rendered them.
+      expect(find.textContaining('회복안 · 회복·지속 중심'), findsOneWidget);
+      expect(find.textContaining('강화안 · 강도·운동량 중심'), findsOneWidget);
+      expect(find.textContaining('기존안 · 기존 AI 추천'), findsOneWidget);
+      // 세 번째 후보의 key 는 선택 식별자다 — 화면 문구가 아니라서 로케일과
+      // 무관하게 'recommended' 로 고정돼 있다(#501).
+      final optionHeights = <String>['A', 'B', 'recommended']
+          .map(
+            (key) => tester
+                .getSize(find.byKey(ValueKey<String>('routine-option-$key')))
+                .height,
+          )
+          .toSet();
+      expect(optionHeights, hasLength(1));
+
+      // Select B and edit its first exercise in the common inline editor.
+      await tester.tap(find.byKey(const ValueKey<String>('routine-option-B')));
+      await tester.pumpAndSettle();
+      final categoryNameGap = tester.widget<SizedBox>(
+        find.byKey(const ValueKey<String>('routine-category-name-gap-0')),
+      );
+      expect(categoryNameGap.height, AppSpacing.md);
+      // 시간 칸은 스테퍼가 아니라 라벨 없는 compact 입력이다(#1489) — 값
+      // 오른쪽의 단위(suffixText)로 무엇을 재는 칸인지 구분한다.
+      expect(
+        tester
+            .widget<TextField>(
+              find.byKey(const ValueKey<String>('routine-minutes-0-field')),
+            )
+            .decoration
+            ?.suffixText,
+        '분',
+      );
+
+      final showAddExerciseForm = find.byKey(
+        const ValueKey<String>('show-add-exercise-form'),
+      );
+      await tester.ensureVisible(showAddExerciseForm);
+      await tester.tap(showAddExerciseForm);
+      await tester.pumpAndSettle();
+      // 기본 유형이 근력이라 시간 슬라이더 대신 세트·횟수 칸이 보인다(#1029).
+      expect(
+        find.byKey(const ValueKey<String>('new-exercise-sets')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey<String>('new-exercise-minutes')),
+        findsNothing,
+      );
+      // 근력이 아닌 유형으로 바꾸면 시간 슬라이더로 바뀐다.
+      await tester.tap(
+        find.byKey(const ValueKey<String>('new-exercise-category-유산소')),
+      );
+      await tester.pumpAndSettle();
+      expect(
+        tester
+            .widget<TextField>(
+              find.byKey(const ValueKey<String>('routine-minutes-field')),
+            )
+            .decoration
+            ?.suffixText,
+        '분',
+      );
+      expect(
+        find.byKey(const ValueKey<String>('new-exercise-sets')),
+        findsNothing,
+      );
+      await tester.tap(
+        find.byKey(const ValueKey<String>('hide-add-exercise-form')),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextFormField).first, '인터벌 걷기');
+      final minutesField = find.byKey(
+        const ValueKey<String>('routine-minutes-0-field'),
+      );
+      await tester.enterText(minutesField, '20');
+      await tester.pump();
+      expect(tester.widget<TextField>(minutesField).controller!.text, '20');
+      // 유형은 네 가지다 (#996, #1276).
+      for (final category in <String>['유산소', '근력', '스트레칭', '기타']) {
+        expect(
+          find.byKey(ValueKey<String>('routine-category-B-0-$category')),
+          findsOneWidget,
+        );
+      }
+      await tester.pump();
+
+      // 고객에게 함께 보낼 메모는 AI 요청과 **다른 칸**이다 (#1028) — 여기 적은
+      // 것만 회원이 받는 루틴 사유로 나간다.
+      final clientNote = find.byKey(
+        const ValueKey<String>('final-trainer-memo'),
+      );
+      await tester.ensureVisible(clientNote);
+      await tester.enterText(clientNote, '무릎 충격 주의');
+      await tester.pump();
+
+      await tester.ensureVisible(
+        find.byKey(const ValueKey<String>('complete-routine-review')),
+      );
+      await tester.tap(
+        find.byKey(const ValueKey<String>('complete-routine-review')),
+      );
+      await tester.pumpAndSettle();
+      // 최종 검토에 들어온 것만으로는 아직 아무 데도 반영되지 않는다 (#1028
+      // 후속) — `템플릿에 반영`을 눌러야 [onReviewCompleted] 가 호출된다.
+      expect(reviewed, isNull);
+      expect(
+        find.byKey(const ValueKey<String>('reviewed-routine-list')),
+        findsOneWidget,
+      );
+      expect(assigned.memberId, isNull);
+      expect(assigned.assigned, isNull);
+      // 이 화면에는 고객에게 직접 보내는 버튼이 없다 — `템플릿에 반영` 뿐이다.
+      expect(
+        find.byKey(const ValueKey<String>('send-selected-routine')),
+        findsNothing,
+      );
+
+      await tester.ensureVisible(
+        find.byKey(const ValueKey<String>('apply-routine-to-template')),
+      );
       await tester.tap(
         find.byKey(const ValueKey<String>('apply-routine-to-template')),
       );
       await tester.pumpAndSettle();
 
+      // 템플릿(편집기)로만 반영된다 — 서버에는 여전히 아무것도 나가지 않는다.
       expect(reviewed, isNotNull);
-      expect(repository.attempts, isEmpty);
-      expect(find.text('전송에 실패했어요. 다시 시도해 주세요'), findsNothing);
+      expect(reviewed!.first.name, '인터벌 걷기');
+      expect(assigned.memberId, isNull);
+      expect(assigned.assigned, isNull);
     },
   );
+
+  testWidgets('템플릿에 반영은 회원에게 보내는 API를 호출하지 않는다 (#1028 후속)', (tester) async {
+    // AI 3단계 최종 검토는 더 이상 여기서 곧바로 전송하지 않는다 — `템플릿에
+    // 반영`은 [onReviewCompleted] 로 편집기에 넘길 뿐이다. 실수로라도 회원
+    // 전송 API 가 호출되면 곧바로 던지도록 만들어 회귀를 잡는다.
+    tester.view.physicalSize = const Size(1000, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final repository = _ThrowingRoutineRepository(const NetworkError());
+    List<RoutineExercise>? reviewed;
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          appConfigProvider.overrideWithValue(_mockConfig),
+          trainerRoutineRepositoryProvider.overrideWithValue(repository),
+        ],
+        child: MaterialApp(
+          locale: const Locale('ko'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: AiRoutineOptionsFlow(
+            client: _client,
+            recommendedExercises: const <RoutineExercise>[
+              RoutineExercise(name: '실내 자전거', minutes: 20, type: '유산소'),
+            ],
+            recommendedReason: '기존 고객 데이터 기반 추천',
+            onReviewCompleted: (exercises) => reviewed = exercises,
+          ),
+        ),
+      ),
+    );
+
+    await _driveToApplyReady(tester);
+    await tester.tap(
+      find.byKey(const ValueKey<String>('apply-routine-to-template')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(reviewed, isNotNull);
+    expect(repository.attempts, isEmpty);
+    expect(find.text('전송에 실패했어요. 다시 시도해 주세요'), findsNothing);
+  });
 }
 
 /// Records what conditions the flow actually sent, and returns a fixed
@@ -911,7 +899,10 @@ class _ThrowingOptionsRepository implements TrainerRoutineOptionsRepository {
   }
 }
 
-Future<void> _pumpFlowWithOptionsError(WidgetTester tester, Object error) async {
+Future<void> _pumpFlowWithOptionsError(
+  WidgetTester tester,
+  Object error,
+) async {
   tester.view.physicalSize = const Size(1000, 2400);
   tester.view.devicePixelRatio = 1.0;
   addTearDown(tester.view.resetPhysicalSize);

--- a/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
@@ -461,9 +461,7 @@ void main() {
         );
         await tester.ensureVisible(confirmButton);
         await tester.pump();
-        await tester.tap(
-          confirmButton,
-        );
+        await tester.tap(confirmButton);
         await settle(tester);
       }
     }
@@ -479,9 +477,9 @@ void main() {
     ) async {
       final AppDatabase db = container.read(appDatabaseProvider);
       await tester.runAsync(
-        () => (db.delete(db.trainerScheduleEntries)
-              ..where((t) => t.date.equals(ymd(day))))
-            .go(),
+        () => (db.delete(
+          db.trainerScheduleEntries,
+        )..where((t) => t.date.equals(ymd(day)))).go(),
       );
       await settle(tester);
     }
@@ -1060,6 +1058,13 @@ void main() {
       // 읽는 사람이 알 수 없다(#1011).
       expect(
         find.byKey(const ValueKey<String>('program-trainer-note')),
+        findsNothing,
+      );
+      // 운동별 날짜 선택도 없다(#1489 후속) — 이 운동은 이미 이 세션(위
+      // 실제 일정)에 속해 있고, 여기서 따로 고르면 세션 날짜와 어긋나는
+      // 두 번째 입력이 생긴다.
+      expect(
+        find.byKey(const ValueKey<String>('program-date-0')),
         findsNothing,
       );
       await tester.ensureVisible(


### PR DESCRIPTION
## Summary

* #1489/#1490에서 스테퍼(−/+)를 키보드 입력으로 바꾸면서 라벨을 hintText로 뒀는데, 칸이 늘 기본값으로 채워져 있어 라벨이 실제로는 보이지 않는 문제가 있었다 — 라벨을 **테두리에 얹는 Material outline label**로 바꿔, 값이 있어도 계속 보이게 했다. 단위(세트·회·kg·분)는 그대로 값 오른쪽(suffix)에 남는다.
* 같은 compact 입력(3칸 한 줄 배치)을 **AI 루틴 생성 2단계**(운동 편집·직접 추가, `ai_routine_options_flow.dart`)에도 적용해 스케줄 탭과 화면을 통일했다.
* 스케줄 탭 `프로그램 수정` 창에서 운동별 날짜 선택 UI를 제거했다 — 애초 #1489 계획에 있었는데 빠졌던 부분이다. 이 운동은 이미 세션(실제 일정)에 속해 있어, 여기서 따로 날짜를 고르면 세션 날짜와 어긋날 수 있는 두 번째 입력이 생긴다. 새 운동 행은 세션 날짜를 그대로 물려받는다.

---

## Changes

### 🔧 Improvements

* `_CompactNumberField`의 `placeholder`(hint) 파라미터를 `label`로 바꾸고 `labelText`/`floatingLabelStyle`을 적용했다(`_DraftField`가 이미 쓰던 패턴과 동일).
* `ProgramDraft.empty()`가 `date` 파라미터를 받도록 바꿔, 새 운동 행이 세션 날짜를 물려받게 했다.

### 🎨 UI/UX

* 세트·횟수·중량·시간 입력칸에 값이 있어도 무엇을 재는 칸인지 테두리 라벨로 항상 구분된다.
* AI 루틴 생성 2단계의 운동 편집·직접 추가 폼도 근력 세트·횟수·중량이 한 줄에 나란히 들어간다.
* 스케줄 탭 프로그램 수정 창에서 운동 카드 상단이 유형 칩 + 삭제 아이콘 한 줄로 정리됐다(날짜 칸 제거).

---

## Notes

* 새 worktree에는 Git에서 추적하지 않는 `web/sqlite3.wasm`과 `web/drift_worker.js`가 없으므로, 바로 실행하면 Chrome과 web-server 모두 WASM 요청에 404 응답을 반환하고 브라우저가 이를 `Incorrect response MIME type`으로 보고한다. 이때 drift 데모 시딩이 실패해 빈 로컬 데이터로 부팅된다.
* 로컬 검증 전에 `bash tool/fetch_drift_wasm.sh`를 실행해 두 런타임 파일을 준비한 뒤 `flutter run -d chrome`으로 실행해야 한다. Windows에서 WSL/Git Bash가 없으면 해당 `.sh`는 실행되지 않으므로 동일 버전의 파일을 `web/`에 직접 준비해야 한다. 2026-08-26 PR head `6790f6e4` worktree에는 drift 2.29.0 / sqlite3 2.9.4용 파일을 준비했다.

---

## Test Plan

* [x] 기능 정상 동작 확인 (`flutter test test/features/coaching/routine_form_fields_compact_test.dart` — 라벨·단위 검증)
* [x] 예외 케이스 확인 (`flutter test test/features/coaching/ test/features/schedule/` 330개 전체 통과)
* [x] UI 확인 (로컬 `flutter run -d chrome` 로 스케줄 탭 프로그램 수정 / AI 루틴 2단계 직접 확인)
* [x] 빌드 성공 (`flutter analyze` 통과)
* [x] 관련 테스트 통과

### Manual Test Steps

1. 스케줄 탭 → 세션 열기 → `프로그램 수정`을 연다.
2. 근력 운동 카드에서 세트·횟수·중량 칸에 테두리 라벨(세트 수/횟수/중량)과 오른쪽 단위(세트/회/kg)가 함께 보이는지 확인한다.
3. 같은 카드에 운동별 날짜 선택 UI가 없는지 확인한다.
4. 코칭 탭 → AI 루틴 생성 2단계에서 운동 편집 또는 `운동 직접 추가하기`를 열어 같은 방식으로 표시되는지 확인한다.

---

## Related Issues

Closes #1530

관련: #1489, #1490

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [ ] 데모 시나리오 영향 확인

