### PR TITLE
fix(ui): 프로그램·리포트 고객 목록 아바타 크기 통일

### DIFF
--- a/frontend/flutter_trainer/lib/features/coaching/presentation/pages/coaching_page.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/pages/coaching_page.dart
@@ -1049,7 +1049,12 @@ class _MemberProgramListState extends State<_MemberProgramList> {
                       child: Row(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: <Widget>[
-                          ClientAvatar(label: client.avatar, size: 32),
+                          // 아바타 크기는 리포트 탭 고객 목록과 같은
+                          // 기준을 쓴다(#1423).
+                          ClientAvatar(
+                            label: client.avatar,
+                            size: clientListAvatarSize,
+                          ),
                           const SizedBox(width: AppSpacing.sm),
                           Expanded(
                             child: Column(
@@ -1121,23 +1126,23 @@ class _WeekCompletionBars extends StatelessWidget {
       child: week.length != weekdayCount
           ? EmptyHint(message: l.reportsNoWorkoutsThisWeek)
           : BarSeriesChart(
-            key: const ValueKey<String>('program-week-completion-chart'),
-            title: l.reportsCompletionByDay,
-            values: week,
-            labels: weekdayLabels(l),
-            maxValue: 100,
-            height: 72,
-            showValues: true,
-            valueSuffix: '%',
-            // 로스터의 계열은 늘 이번 주다 — 아직 오지 않은 요일을 0% 로
-            // 그리면 `0% 수행` 이라는 다른 뜻이 된다.
-            pendingFromIndex: elapsedWeekdays(nowKst()),
-            // 지난 날인데 기록이 없는 요일도 0% 가 아니다.
-            missingIndices: <int>{
-              for (var i = 0; i < elapsedWeekdays(nowKst()); i++)
-                if (i < week.length && week[i] == 0) i,
-            },
-          ),
+              key: const ValueKey<String>('program-week-completion-chart'),
+              title: l.reportsCompletionByDay,
+              values: week,
+              labels: weekdayLabels(l),
+              maxValue: 100,
+              height: 72,
+              showValues: true,
+              valueSuffix: '%',
+              // 로스터의 계열은 늘 이번 주다 — 아직 오지 않은 요일을 0% 로
+              // 그리면 `0% 수행` 이라는 다른 뜻이 된다.
+              pendingFromIndex: elapsedWeekdays(nowKst()),
+              // 지난 날인데 기록이 없는 요일도 0% 가 아니다.
+              missingIndices: <int>{
+                for (var i = 0; i < elapsedWeekdays(nowKst()); i++)
+                  if (i < week.length && week[i] == 0) i,
+              },
+            ),
     );
   }
 }

--- a/frontend/flutter_trainer/lib/features/reports/presentation/widgets/report_client_picker.dart
+++ b/frontend/flutter_trainer/lib/features/reports/presentation/widgets/report_client_picker.dart
@@ -89,7 +89,12 @@ class _ReportClientPickerState extends State<ReportClientPicker> {
                       ),
                       child: Row(
                         children: <Widget>[
-                          ClientAvatar(label: client.avatar, size: 38),
+                          // 아바타 크기는 프로그램 탭 고객 목록과 같은
+                          // 기준을 쓴다(#1423).
+                          ClientAvatar(
+                            label: client.avatar,
+                            size: clientListAvatarSize,
+                          ),
                           const SizedBox(width: AppSpacing.md),
                           Expanded(
                             child: Column(

--- a/frontend/flutter_trainer/lib/shared/widgets/client_identity.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/client_identity.dart
@@ -75,6 +75,14 @@ TextStyle clientListNameStyle({required bool selected}) => TextStyle(
 /// 이름에서 잘리기 쉬웠고, 13.5 는 리포트 탭에서 목표 줄과 위계가 붙었다.
 const double clientListNameFontSize = 14;
 
+/// 고객 목록 아바타 지름. (#1423)
+///
+/// 이름 글씨는 14 로 맞췄지만 아바타는 프로그램 탭 32·리포트 탭 38 로
+/// 남아 있었다 — 탭을 오갈 때 같은 목록의 원 크기가 달라 보였다. 프로그램
+/// 탭 열이 세 열 중 가장 좁아, 이름 크기를 고를 때와 같은 이유로 더 작은
+/// 쪽에 맞춘다.
+const double clientListAvatarSize = 32;
+
 /// 이름 아래 목표 한 줄의 글씨 크기. 이름보다 한 단계 작다 — 두 탭이 같은
 /// 위계를 쓰도록 [ClientGoalLabel] 의 기본값 대신 이 값을 함께 준다.
 const double clientListGoalFontSize = 11;

--- a/frontend/flutter_trainer/test/shared/client_list_typography_test.dart
+++ b/frontend/flutter_trainer/test/shared/client_list_typography_test.dart
@@ -4,16 +4,17 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:oncare_trainer/app/router/routes.dart';
 import 'package:oncare_trainer/shared/models/trainer_client.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
+import 'package:oncare_trainer/shared/widgets/client_avatar.dart';
 import 'package:oncare_trainer/shared/widgets/client_identity.dart';
 
 import '../helpers/client_factory.dart';
 import '../helpers/pump_app.dart';
 
-/// 프로그램 탭과 리포트 탭의 고객 목록은 같은 타이포를 쓴다. (#1423)
+/// 프로그램 탭과 리포트 탭의 고객 목록은 같은 타이포·아바타 크기를 쓴다. (#1423)
 ///
 /// 두 탭은 같은 구조(왼쪽 고객 목록 → 오른쪽 작업 영역)에 카드 제목·아이콘도
-/// 같은데, 이름 글씨만 13.5 와 15 로 갈려 있었다. 탭을 오갈 때 같은 목록이
-/// 다른 밀도로 보인다.
+/// 같은데, 이름 글씨는 13.5 와 15, 아바타는 32 와 38 로 갈려 있었다. 탭을
+/// 오갈 때 같은 목록이 다른 밀도로 보인다.
 void main() {
   const String goal = '혈압 관리 · 체중 감량';
 
@@ -58,6 +59,16 @@ void main() {
         .fontSize!;
   }
 
+  /// [rowKey] 행 안 [ClientAvatar] 의 지름.
+  double avatarSizeIn(WidgetTester tester, String rowKey) {
+    final Finder row = find.byKey(ValueKey<String>(rowKey));
+    return tester
+        .widget<ClientAvatar>(
+          find.descendant(of: row, matching: find.byType(ClientAvatar)),
+        )
+        .size;
+  }
+
   testWidgets('프로그램 탭 고객명은 공용 크기·굵기를 쓴다', (tester) async {
     await openTab(tester, AppRoutes.coaching);
 
@@ -78,6 +89,7 @@ void main() {
     expect(selected.fontWeight, FontWeight.w800);
     expect(unselected.fontWeight, FontWeight.w600);
     expect(goalSizeIn(tester, 'program-client-type-a'), clientListGoalFontSize);
+    expect(avatarSizeIn(tester, 'program-client-type-a'), clientListAvatarSize);
   });
 
   testWidgets('리포트 탭 고객명이 프로그램 탭과 같은 크기·굵기다', (tester) async {
@@ -99,6 +111,7 @@ void main() {
     expect(selected.fontWeight, FontWeight.w800);
     expect(unselected.fontWeight, FontWeight.w600);
     expect(goalSizeIn(tester, 'report-client-type-a'), clientListGoalFontSize);
+    expect(avatarSizeIn(tester, 'report-client-type-a'), clientListAvatarSize);
   });
 
   testWidgets('긴 이름과 큰 배율에서도 행이 넘치지 않는다', (tester) async {


### PR DESCRIPTION
## Summary

* #1423 에서 고객명 글자 크기는 통일했지만 아바타 지름은 프로그램 탭 32·리포트 탭 38 로 그대로 남아 있었다
* 이름 크기를 고를 때와 같은 이유(세 열 중 가장 좁은 프로그램 탭 열 기준)로 32 에 맞춰 통일했다
* 공용 상수 `clientListAvatarSize` 로 빼 이후 한쪽만 다시 달라지지 않게 했다

---

## Changes

### 🎨 UI/UX

* 리포트 탭 고객 목록 아바타를 38 → 32 로 조정해 프로그램 탭과 통일

### 🔧 Improvements

* `client_identity.dart` 에 `clientListAvatarSize` 공용 상수 추가, 두 탭 모두 참조하도록 변경

---

## Notes

* 두 탭의 행 높이는 이미 64 로 동일해 아바타 지름을 줄여도 레이아웃 여유는 그대로다
* `_ClientChip` (운동 추가 화면의 고객 칩)의 32px 아바타는 이 목록과 무관한 다른 컴포넌트라 손대지 않았다

---

## Test Plan

* [x] 기존 `client_list_typography_test.dart` 에 아바타 크기 검증 추가, 통과 확인
* [x] `flutter test test/shared/client_list_typography_test.dart` 통과

### Manual Test Steps

1. 트레이너 앱 프로그램 탭에서 고객 목록 확인
2. 리포트 탭에서 고객 목록 확인 후 아바타 크기가 프로그램 탭과 같은지 비교

---

## Related Issues

Closes #1423

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [ ] 데모 시나리오 영향 확인