### PR TITLE
fix: 상담 요청 선택 팝업 X 버튼 스타일 통일

### DIFF
--- a/frontend/flutter/lib/core/utils/portrait_date_picker.dart
+++ b/frontend/flutter/lib/core/utils/portrait_date_picker.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:oncare/design_system/tokens/colors.dart';
 import 'package:oncare/design_system/tokens/radius.dart';
 import 'package:oncare/design_system/tokens/spacing.dart';
 
@@ -137,21 +136,15 @@ class _PortraitDatePickerDialogState extends State<_PortraitDatePickerDialog> {
                             ?.copyWith(fontWeight: FontWeight.w700),
                       ),
                     ),
-                    Material(
-                      color: AppColors.accent,
-                      shape: const CircleBorder(),
-                      child: InkWell(
-                        customBorder: const CircleBorder(),
-                        onTap: () => Navigator.of(context).pop(),
-                        child: Tooltip(
-                          message: l.closeButtonTooltip,
-                          child: const SizedBox(
-                            width: 32,
-                            height: 32,
-                            child: Icon(Icons.close, size: 18),
-                          ),
-                        ),
+                    IconButton(
+                      tooltip: l.closeButtonTooltip,
+                      onPressed: () => Navigator.of(context).pop(),
+                      style: IconButton.styleFrom(
+                        backgroundColor: Colors.transparent,
+                        hoverColor: Colors.transparent,
+                        highlightColor: Colors.transparent,
                       ),
+                      icon: const Icon(Icons.close),
                     ),
                   ],
                 ),

--- a/frontend/flutter/lib/features/exercise/presentation/pages/consultation_request_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/consultation_request_page.dart
@@ -78,6 +78,17 @@ class _ConsultationRequestPageState
       initialDate: _preferredDate ?? today,
       firstDate: today,
       lastDate: DateTime(today.year + 100),
+      // 바로 아래 희망 시간대 선택 팝업의 X 버튼과 같은 모습으로 맞춘다.
+      builder: (BuildContext context, Widget child) => IconButtonTheme(
+        data: IconButtonThemeData(
+          style: IconButton.styleFrom(
+            backgroundColor: Colors.transparent,
+            hoverColor: Colors.transparent,
+            highlightColor: Colors.transparent,
+          ),
+        ),
+        child: child,
+      ),
     );
     if (selected != null && mounted) {
       setState(() => _preferredDate = selected);

--- a/frontend/flutter/lib/features/exercise/presentation/pages/consultation_request_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/consultation_request_page.dart
@@ -78,17 +78,6 @@ class _ConsultationRequestPageState
       initialDate: _preferredDate ?? today,
       firstDate: today,
       lastDate: DateTime(today.year + 100),
-      // 바로 아래 희망 시간대 선택 팝업의 X 버튼과 같은 모습으로 맞춘다.
-      builder: (BuildContext context, Widget? child) => IconButtonTheme(
-        data: IconButtonThemeData(
-          style: IconButton.styleFrom(
-            backgroundColor: Colors.transparent,
-            hoverColor: Colors.transparent,
-            highlightColor: Colors.transparent,
-          ),
-        ),
-        child: child!,
-      ),
     );
     if (selected != null && mounted) {
       setState(() => _preferredDate = selected);

--- a/frontend/flutter/lib/features/exercise/presentation/pages/consultation_request_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/consultation_request_page.dart
@@ -79,7 +79,7 @@ class _ConsultationRequestPageState
       firstDate: today,
       lastDate: DateTime(today.year + 100),
       // 바로 아래 희망 시간대 선택 팝업의 X 버튼과 같은 모습으로 맞춘다.
-      builder: (BuildContext context, Widget child) => IconButtonTheme(
+      builder: (BuildContext context, Widget? child) => IconButtonTheme(
         data: IconButtonThemeData(
           style: IconButton.styleFrom(
             backgroundColor: Colors.transparent,
@@ -87,7 +87,7 @@ class _ConsultationRequestPageState
             highlightColor: Colors.transparent,
           ),
         ),
-        child: child,
+        child: child!,
       ),
     );
     if (selected != null && mounted) {

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/consult_time_range_picker.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/consult_time_range_picker.dart
@@ -157,6 +157,11 @@ class _TimeRangePickerDialogState extends State<_TimeRangePickerDialog> {
                     IconButton(
                       tooltip: l.actionClose,
                       onPressed: () => Navigator.pop(context),
+                      style: IconButton.styleFrom(
+                        backgroundColor: Colors.transparent,
+                        hoverColor: Colors.transparent,
+                        highlightColor: Colors.transparent,
+                      ),
                       icon: const Icon(Icons.close),
                     ),
                   ],


### PR DESCRIPTION
## 변경 사항

- 사용자 상담 요청의 희망 날짜 선택 팝업에서 X 버튼 배경을 제거했습니다.
- hover/pressed 상태에서도 배경이 나타나지 않도록 처리했습니다.
- 희망 시간대 선택 팝업의 X 버튼에도 동일한 투명 배경 스타일을 적용했습니다.

## 확인 사항

- 날짜 선택 팝업과 희망 시간대 선택 팝업의 X 버튼 스타일이 동일함
- X 버튼의 기본, hover, pressed 배경이 투명함
- `git diff --check` 통과

Closes #1533 