### PR TITLE
fix(coaching): 프로그램 등록 시 근력 운동 횟수 누락 수정

### DIFF
--- a/frontend/flutter_trainer/lib/features/coaching/presentation/pages/coaching_page.dart
+++ b/frontend/flutter_trainer/lib/features/coaching/presentation/pages/coaching_page.dart
@@ -384,6 +384,7 @@ class _CoachingPageState extends ConsumerState<CoachingPage> {
             // 회원 기록이 같은 규칙을 쓴다 (#1276).
             duration: exercise.isStrength ? null : exercise.minutes,
             sets: exercise.isStrength ? exercise.sets : null,
+            reps: exercise.isStrength ? exercise.reps : null,
             weight: exercise.isStrength ? exercise.weight : null,
             intensity: exercise.intensity,
             session: multi ? capSessionName(session.name) : '',


### PR DESCRIPTION
## Summary

* 코칭 탭에서 짠 프로그램을 고객 일정에 등록할 때(`_draftProgram`, `coaching_page.dart`) 근력 운동의 `reps`(횟수)가 `ProgramItem`에 담기지 않아 항상 비어 있던 문제 수정
* `sets`·`weight`와 같은 규칙으로 `reps`도 함께 담도록 한 줄 추가
* 스케줄 탭 프로그램 편집기·AI 루틴 제안·프로그램 템플릿 등 다른 등록 경로는 이미 `reps`를 정상적으로 담고 있어, 코칭 탭 경로만 이번에 맞춤

---

## Changes

### ✨ Features

*

### 🔧 Improvements

*

### 🎨 UI/UX

*

### 📝 Docs

*

### 🐛 Fixes

* 코칭 탭에서 등록한 근력 운동의 횟수(reps)가 스케줄 요약에 표시되지 않던 문제 수정

---

## Commits

1. `e6277c48` fix(coaching): 프로그램 등록 시 근력 운동 횟수 누락 수정

---

## Notes

* 편집기(`프로그램 수정`)를 열면 값이 없을 때 기본값(횟수 10회·중량 20kg)을 채워 보여 주므로, 값이 비어 있어도 편집기에서는 채워진 것처럼 보인다 — 실제로는 스케줄 요약(`session_program_section.dart`)에서 값이 빠진 것으로 확인해야 한다.

---

## Test Plan

* [x] 기능 정상 동작 확인
* [ ] 예외 케이스 확인
* [ ] UI 확인
* [x] 빌드 성공
* [ ] 관련 테스트 통과

### Manual Test Steps

1. 코칭 탭에서 근력 운동을 추가하고 횟수를 지정한 뒤 고객 일정에 등록
2. 스케줄 탭에서 해당 세션을 펼쳐 프로그램 확인
3. 세트·횟수·중량이 모두 표시되는지 확인

---

## Related Issues

Closes #1537

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [ ] Merge 충돌 없음
* [ ] 데모 시나리오 영향 확인
