### PR TITLE
fix(infra): immutable GitHub OIDC subject 지원

### DIFF
--- a/docs/aws-frontend-deployment.md
+++ b/docs/aws-frontend-deployment.md
@@ -16,6 +16,18 @@ Flutter 회원 앱과 트레이너 웹을 하나의 private S3 버킷에 올리�
 
 AWS CloudShell에서 브랜치를 받은 뒤 템플릿을 먼저 검증합니다.
 
+템플릿은 기본적으로 GitHub의 immutable OIDC subject를 사용합니다. 저장소 설정값은 다음 명령으로
+확인합니다. 응답의 `sub_claim_prefix`에 표시된 owner ID와 repository ID가 템플릿 기본값과 다르면
+배포 시 `GitHubOwnerId`, `GitHubRepositoryId` 파라미터로 전달합니다.
+
+```bash
+gh api repos/CSE-Sudo-26/on-care/actions/oidc/customization/sub
+```
+
+2026년 7월 15일 이전에 생성되어 이름 기반 subject를 계속 사용하는 저장소에서는
+`UseImmutableGitHubOidcSubject=false`를 전달할 수 있습니다. 와일드카드로 권한 범위를 넓히지 않고,
+저장소와 `main` 브랜치가 포함된 정확한 subject를 유지합니다.
+
 ```bash
 git clone https://github.com/CSE-Sudo-26/on-care.git
 cd on-care
@@ -65,7 +77,10 @@ aws cloudformation deploy \
 >   --template-file infra/frontend-hosting.yml \
 >   --stack-name oncare-frontend \
 >   --capabilities CAPABILITY_IAM \
->   --parameter-overrides GitHubRepository=on-care \
+>   --parameter-overrides \
+>     GitHubRepository=on-care \
+>     GitHubOwnerId=265976266 \
+>     GitHubRepositoryId=1174354664 \
 >   --region ap-northeast-2
 > ```
 

--- a/infra/frontend-hosting.yml
+++ b/infra/frontend-hosting.yml
@@ -8,9 +8,26 @@ Parameters:
   GitHubRepository:
     Type: String
     Default: on-care
+  GitHubOwnerId:
+    Type: String
+    Default: '265976266'
+    AllowedPattern: '^[0-9]+$'
+    Description: Immutable numeric GitHub organization or owner ID
+  GitHubRepositoryId:
+    Type: String
+    Default: '1174354664'
+    AllowedPattern: '^[0-9]+$'
+    Description: Immutable numeric GitHub repository ID
   GitHubBranch:
     Type: String
     Default: main
+  UseImmutableGitHubOidcSubject:
+    Type: String
+    Default: 'true'
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Description: Use GitHub's owner-ID and repository-ID based OIDC subject format
   ExistingGitHubOidcProviderArn:
     Type: String
     Default: ''
@@ -18,6 +35,7 @@ Parameters:
 
 Conditions:
   CreateGitHubOidcProvider: !Equals [!Ref ExistingGitHubOidcProviderArn, '']
+  UseImmutableGitHubOidcSubjectCondition: !Equals [!Ref UseImmutableGitHubOidcSubject, 'true']
 
 Resources:
   FrontendBucket:
@@ -193,7 +211,10 @@ Resources:
             Condition:
               StringEquals:
                 token.actions.githubusercontent.com:aud: sts.amazonaws.com
-                token.actions.githubusercontent.com:sub: !Sub 'repo:${GitHubOwner}/${GitHubRepository}:ref:refs/heads/${GitHubBranch}'
+                token.actions.githubusercontent.com:sub: !If
+                  - UseImmutableGitHubOidcSubjectCondition
+                  - !Sub 'repo:${GitHubOwner}@${GitHubOwnerId}/${GitHubRepository}@${GitHubRepositoryId}:ref:refs/heads/${GitHubBranch}'
+                  - !Sub 'repo:${GitHubOwner}/${GitHubRepository}:ref:refs/heads/${GitHubBranch}'
       Policies:
         - PolicyName: deploy-frontend
           PolicyDocument:


### PR DESCRIPTION
## 변경 사항
- GitHub owner ID와 repository ID를 CloudFormation 파라미터로 추가
- 2026-07-15 이후 immutable OIDC subject를 기본 신뢰 조건으로 사용
- 기존 이름 기반 subject는 명시적 호환 옵션으로 유지
- OIDC 설정 확인 및 기존 스택 갱신 방법 문서화

## 보안
- 저장소 또는 브랜치 와일드카드를 사용하지 않음
- 저장소 ID와 refs/heads/main을 정확히 제한

## 검증
- git diff --check 통과
- AWS CloudShell에서 aws cloudformation validate-template 통과
- 실제 계정의 동일 immutable subject 수동 보정 후 Actions run 32980334321 전체 배포 성공

Fixes #1567