### PR TITLE
fix(trainer): 이동 버튼 있는 토스트 오른쪽 정렬과 한 줄 너비

### DIFF
--- a/frontend/flutter_trainer/lib/shared/widgets/app_toast.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/app_toast.dart
@@ -31,7 +31,9 @@ void showAppToast(
   AppToastAction? action,
   Duration? duration,
 }) {
-  AppToastHost.of(context).show(message, kind: kind, action: action, duration: duration);
+  AppToastHost.of(
+    context,
+  ).show(message, kind: kind, action: action, duration: duration);
 }
 
 /// 토스트를 띄우는 손잡이. 화면이 사라진 뒤에도 쓸 수 있도록 오버레이를 미리
@@ -203,16 +205,18 @@ class _AppToastState extends State<_AppToast>
             ),
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.start,
-              // 동작 버튼이 없는 토스트는 **내용 너비**로 선다(#1466). `max`
-              // 로 두면 "추천하지 않아요" 한 줄짜리 안내도 최대 너비(560)를
-              // 거의 채워, 짧은 말이 크게 보인다. 동작 버튼이 있는 토스트는
-              // 지금처럼 자리를 다 쓴다 — 메시지 길이에 따라 버튼이 좌우로
-              // 흔들리면 누를 자리가 매번 달라진다.
-              mainAxisSize: widget.action == null
-                  ? MainAxisSize.min
-                  : MainAxisSize.max,
+              // 동작 버튼이 있어도 없어도 **내용 너비**로 선다(#1571). `max`
+              // 로 두면 "리포트를 보냈어요" 처럼 짧은 말도 최대 너비(560)를
+              // 거의 채워, 버튼이 텍스트에서 멀찍이 오른쪽 빈 자리에 걸린다.
+              // `min` 이면 줄이 길지 않은 한 버튼이 자연스레 텍스트 바로
+              // 오른쪽 끝에 붙는다.
+              mainAxisSize: MainAxisSize.min,
               children: <Widget>[
-                Icon(_icon(widget.kind), size: 20, color: _iconColor(widget.kind)),
+                Icon(
+                  _icon(widget.kind),
+                  size: 20,
+                  color: _iconColor(widget.kind),
+                ),
                 const SizedBox(width: AppSpacing.md),
                 // 긴 메시지는 최대 너비 안에서 줄바꿈한다 — `Flexible` 이라
                 // 짧은 메시지에서는 제 너비만 차지하고, 길면 남은 자리까지
@@ -224,14 +228,18 @@ class _AppToastState extends State<_AppToast>
                   ),
                 ),
                 if (widget.action case final action?) ...[
-                  const SizedBox(width: AppSpacing.md),
+                  // 버튼이 텍스트에 바짝 붙지 않게 `md` 보다 넉넉히 뗀다.
+                  const SizedBox(width: AppSpacing.lg),
                   GestureDetector(
                     key: const ValueKey<String>('app-toast-action'),
                     onTap: _runAction,
                     child: Row(
                       mainAxisSize: MainAxisSize.min,
                       children: <Widget>[
-                        Text(action.label, style: AppToastStyle.actionTextStyle),
+                        Text(
+                          action.label,
+                          style: AppToastStyle.actionTextStyle,
+                        ),
                         const Icon(
                           Icons.chevron_right,
                           size: 16,

--- a/frontend/flutter_trainer/test/shared/app_toast_width_test.dart
+++ b/frontend/flutter_trainer/test/shared/app_toast_width_test.dart
@@ -1,9 +1,9 @@
-/// 토스트 너비 규칙. (#1466)
+/// 토스트 너비 규칙. (#1466, #1571)
 ///
-/// 동작 버튼이 없는 안내는 내용만큼만 넓다 — `추천하지 않아요` 한 줄짜리 말이
-/// 최대 너비(560)를 거의 채우면 짧은 말이 크게 보인다. 동작 버튼이 있는
-/// 토스트(리포트 전송 완료의 `채팅으로 이동`)는 고정 너비를 지킨다: 메시지
-/// 길이에 따라 버튼이 좌우로 흔들리면 누를 자리가 매번 달라진다.
+/// 동작 버튼이 있든 없든 토스트는 내용만큼만 넓다 — `추천하지 않아요` 한 줄짜리
+/// 말이나 `리포트를 보냈어요` + `채팅으로 이동` 조합이나 최대 너비(560)를
+/// 고정으로 채우면 짧은 말이 크게 보이고, 버튼이 텍스트에서 멀리 떨어진
+/// 오른쪽 빈 자리에 걸린다. 버튼은 텍스트 바로 오른쪽 끝에 간격을 두고 붙는다.
 library;
 
 import 'package:flutter/material.dart';
@@ -71,14 +71,52 @@ void main() {
     expect(info, error);
   });
 
-  testWidgets('동작 버튼이 있는 토스트는 고정 너비를 지킨다', (tester) async {
+  testWidgets('동작 버튼이 있어도 내용 너비로 선다', (tester) async {
     final double withAction = await toastWidth(
       tester,
       '리포트를 보냈어요',
       action: AppToastAction(label: '채팅으로 이동', onTap: () {}),
     );
 
-    expect(withAction, AppToastStyle.maxWidth);
+    expect(withAction, lessThan(AppToastStyle.maxWidth));
+  });
+
+  testWidgets('동작 버튼은 텍스트 오른쪽 끝에 간격을 두고 붙는다', (tester) async {
+    const String message = '리포트를 보냈어요';
+    await tester.binding.setSurfaceSize(const Size(1200, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    late BuildContext ctx;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (BuildContext context) {
+            ctx = context;
+            return const Scaffold(body: SizedBox.expand());
+          },
+        ),
+      ),
+    );
+    AppToastHost.of(ctx).show(
+      message,
+      action: AppToastAction(label: '채팅으로 이동', onTap: () {}),
+    );
+    await tester.pumpAndSettle();
+
+    final Rect pill = tester.getRect(
+      find
+          .ancestor(of: find.text(message), matching: find.byType(Material))
+          .first,
+    );
+    final Rect text = tester.getRect(find.text(message));
+    final Rect action = tester.getRect(
+      find.byKey(const ValueKey<String>('app-toast-action')),
+    );
+
+    // 버튼이 알약의 오른쪽 끝(안쪽 여백만큼 안쪽)에 붙는다.
+    expect(pill.right - action.right, closeTo(16, 1));
+    // 텍스트와 버튼 사이에 눈에 띄는 간격이 있다.
+    expect(action.left - text.right, greaterThan(8));
   });
 
   testWidgets('좁은 화면에서는 좌우 여백 안으로 줄어든다', (tester) async {


### PR DESCRIPTION
## Summary

* 동작 버튼(`채팅으로 이동` 등)이 있는 토스트가 메시지 길이와 무관하게 항상 최대 너비(560)로 고정되던 문제를 수정
* 동작 버튼 유무와 상관없이 토스트가 내용 너비만큼만 서도록 통일
* 버튼은 텍스트와 간격을 두고 토스트 오른쪽 끝에 붙도록 정리

---

## Changes

### 🔧 Improvements

* 동작 버튼이 있는 토스트도 `MainAxisSize.min`으로 내용 너비에 맞춰 서게 변경 (기존 #1466에서는 버튼 위치 흔들림을 막기 위해 최대 너비로 고정했으나, 그 결과 짧은 메시지에서는 버튼이 오른쪽 빈 공간에 멀리 떨어져 보이는 문제가 있었음)
* 텍스트와 동작 버튼 사이 간격을 `AppSpacing.md(12)`에서 `AppSpacing.lg(16)`로 넓힘

### 🐛 Fixes

* `frontend/flutter_trainer/lib/shared/widgets/app_toast.dart`: 토스트 너비/정렬 로직 수정

---

## Commits

1. `8942acac` fix(trainer): 이동 버튼 있는 토스트 오른쪽 정렬과 한 줄 너비

---

## Notes

* `frontend/flutter_trainer/test/shared/app_toast_width_test.dart`의 "동작 버튼이 있는 토스트는 고정 너비를 지킨다" 테스트를 새 동작(내용 너비 + 오른쪽 정렬)에 맞게 갱신

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 빌드 성공
* [x] 관련 테스트 통과

### Manual Test Steps

1. 트레이너 앱에서 리포트를 전송해 "리포트를 보냈어요 · 채팅으로 이동" 토스트를 띄운다.
2. 토스트가 메시지+버튼 길이만큼만 좁게 뜨고, 버튼이 텍스트 오른쪽에 간격을 두고 붙어 있는지 확인한다.
3. 매우 긴 메시지에서는 최대 너비(560) 안에서 줄바꿈되는지 확인한다.

---

## Related Issues

Closes #1571

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인