### PR TITLE
feat(trainer-consult): 데모 상담 인박스에 기존 고객 재상담 요청 추가

### DIFF
--- a/frontend/flutter_trainer/lib/features/consultations/data/repositories/consultation_repository.dart
+++ b/frontend/flutter_trainer/lib/features/consultations/data/repositories/consultation_repository.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:oncare_trainer/core/config/app_config.dart';
 import 'package:oncare_trainer/core/errors/app_error.dart';
 import 'package:oncare_trainer/core/network/dio_client.dart';
+import 'package:oncare_trainer/core/storage/demo_member_directory.dart';
 import 'package:oncare_trainer/core/utils/active_polling_stream.dart';
 import 'package:oncare_trainer/core/utils/clock.dart';
 import 'package:oncare_trainer/features/consultations/data/dtos/consultation_dtos.dart';
@@ -138,6 +139,19 @@ class DemoConsultationRepository implements ConsultationRepository {
                preferredTimeCode: '19:00-20:00',
                status: 'pending',
                message: '퇴근 후 가능한 시간으로 첫 상담을 받고 싶어요.',
+             ),
+             // 이미 담당 고객인 회원도 재상담을 요청할 수 있다 — 김민수
+             // (`demoAlreadyLinkedMemberId`)로 그 시나리오를 보여준다.
+             ConsultationRequest(
+               id: 'demo-consultation-2',
+               memberId: demoAlreadyLinkedMemberId,
+               memberName: '김민수',
+               goalCode: 'weight_loss',
+               purposeCode: 'chronic',
+               preferredDate: nowKst().add(const Duration(days: 3)),
+               preferredTimeCode: '12:00-13:00',
+               status: 'pending',
+               message: '혈압 관리도 같이 봐주시면 좋겠어요.',
              ),
            ];
 

--- a/frontend/flutter_trainer/test/features/consultations/dio_consultation_repository_test.dart
+++ b/frontend/flutter_trainer/test/features/consultations/dio_consultation_repository_test.dart
@@ -338,7 +338,7 @@ void main() {
       );
       addTearDown(container.dispose);
 
-      expect(await container.read(consultationPendingCountProvider.future), 1);
+      expect(await container.read(consultationPendingCountProvider.future), 2);
     });
 
     test('the pending badge keeps counting so a request that arrives while the '
@@ -409,12 +409,22 @@ void main() {
 
     test('the demo source removes decided requests from pending', () async {
       final repo = DemoConsultationRepository();
-      final request = (await repo.fetch()).single;
+      final request = (await repo.fetch()).firstWhere(
+        (r) => r.id == 'demo-consultation-1',
+      );
 
       await repo.accept(request.id);
 
-      expect(await repo.fetch(), isEmpty);
-      expect((await repo.fetch(status: 'all')).single.status, 'accepted');
+      expect(
+        (await repo.fetch()).map((r) => r.id),
+        isNot(contains(request.id)),
+      );
+      expect(
+        (await repo.fetch(status: 'all'))
+            .firstWhere((r) => r.id == request.id)
+            .status,
+        'accepted',
+      );
     });
 
     test(
@@ -437,7 +447,9 @@ void main() {
         final repo = DemoConsultationRepository(
           scheduleRepository: () => scheduleRepository,
         );
-        final request = (await repo.fetch()).single;
+        final request = (await repo.fetch()).firstWhere(
+          (r) => r.id == 'demo-consultation-1',
+        );
 
         final result = await repo.accept(
           request.id,

--- a/frontend/flutter_trainer/test/features/dashboard/dashboard_page_test.dart
+++ b/frontend/flutter_trainer/test/features/dashboard/dashboard_page_test.dart
@@ -413,7 +413,7 @@ void main() {
     await openDashboard(tester);
     await expandTaskCategory(tester, '상담');
 
-    final mission = findMissionRow('consultation');
+    final mission = findMissionRow('consultation').first;
     await tester.ensureVisible(mission);
     await tester.tap(mission);
     await settle(tester);

--- a/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/schedule_page_test.dart
@@ -657,10 +657,10 @@ void main() {
       final Badge badge = tester.widget<Badge>(
         find.descendant(of: entry, matching: find.byType(Badge)),
       );
-      expect(badge.isLabelVisible, isTrue, reason: '시드에 대기 1건');
+      expect(badge.isLabelVisible, isTrue, reason: '시드에 대기 2건');
       expect(badge.backgroundColor, AppColors.destructive);
       expect(
-        find.descendant(of: entry, matching: find.text('1')),
+        find.descendant(of: entry, matching: find.text('2')),
         findsOneWidget,
       );
     });
@@ -679,7 +679,7 @@ void main() {
         ),
       );
       final Rect label = tester.getRect(
-        find.descendant(of: entry, matching: find.text('1')),
+        find.descendant(of: entry, matching: find.text('2')),
       );
       // 배지 원(지름 16)은 라벨을 가운데 두므로, 원 전체를 아이콘 오른쪽
       // 바깥에서 재려면 라벨이 아니라 원의 왼쪽 끝을 봐야 한다.


### PR DESCRIPTION
## Summary

* 트레이너 웹 데모(`USE_MOCK_API=true`) 상담 요청 인박스에 이미 담당 고객으로 연결된 김민수(`demoAlreadyLinkedMemberId`)의 재상담 요청을 두 번째 시드로 추가
* 시드 개수 변경에 맞춰 배지 카운트·인박스 목록 테스트 갱신

---

## Changes

### ✨ Features

* 데모 상담 인박스에 기존 고객의 재상담 요청 시드 추가

### 🔧 Improvements

*

### 🎨 UI/UX

* 데모 화면의 상담 요청 배지가 대기 2건으로 표시됨

### 📝 Docs

*

### 🐛 Fixes

*

---

## Notes

* 신규 시드는 `demoAlreadyLinkedMemberId`(김민수)를 재사용해 다른 데모 화면(고객 연결 등)과 계정 id가 일관되게 유지된다.
* 기존 `DemoConsultationRepository()` 기본 시드에 의존하던 테스트 2건(`dio_consultation_repository_test.dart`)과 배지 관련 테스트 2건(`schedule_page_test.dart`)을 시드 2건 기준으로 갱신했다.

---

## Test Plan

* [x] `flutter test test/features/consultations/` 통과
* [x] `flutter test test/features/schedule/schedule_page_test.dart` 통과
* [x] `flutter analyze` 통과

### Manual Test Steps

1. 트레이너 웹을 데모 모드(`USE_MOCK_API=true`, 기본값)로 실행한다.
2. 스케줄 탭 상단의 상담 요청 아이콘을 연다.
3. 대기 배지가 2건으로 표시되고, 김하늘·김민수 요청이 모두 보이는지 확인한다.

---

## Related Issues

Closes #1597

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인