### PR TITLE
fix(trainer-clients): 미등록 고객 재등록을 신규 고객 등록과 같은 절차로 통일

### DIFF
--- a/frontend/flutter_trainer/lib/features/clients/data/repositories/client_invite_repository.dart
+++ b/frontend/flutter_trainer/lib/features/clients/data/repositories/client_invite_repository.dart
@@ -9,6 +9,8 @@ import 'package:oncare_trainer/core/storage/app_database.dart';
 import 'package:oncare_trainer/core/storage/demo_member_directory.dart';
 import 'package:oncare_trainer/core/utils/clock.dart';
 import 'package:oncare_trainer/features/clients/domain/entities/client_invite.dart';
+import 'package:oncare_trainer/shared/services/client_repository.dart'
+    show readDemoUnregisteredClientIds, writeDemoUnregisteredClientIds;
 
 /// 트레이너가 회원 ID로 회원을 찾아 담당으로 연결하는 흐름. (#919)
 ///
@@ -74,23 +76,37 @@ class DemoClientInviteRepository implements ClientInviteRepository {
     if (normalized.isEmpty) throw const NotFoundError();
     final DateTime now = nowKst();
 
-    if (normalized == demoAlreadyLinkedMemberId) {
-      final row =
-          await (_db.select(_db.trainerClients)
-                ..where((t) => t.id.equals(demoAlreadyLinkedClientId)))
-              .getSingleOrNull();
-      if (row != null) return _linkedLookup(normalized, row.name);
+    // demoAlreadyLinkedMemberId 는 seed-client-1(김민수)의 실 계정 id를
+    // 흉내낸 값이라 그 행의 기본 키(demoAlreadyLinkedClientId)와 다르다 —
+    // 여기서만 매핑한다. 다른 고객은 행의 id 자체가 곧 찾는 회원 ID다.
+    final String rowId = normalized == demoAlreadyLinkedMemberId
+        ? demoAlreadyLinkedClientId
+        : normalized;
+
+    final existing = await (_db.select(
+      _db.trainerClients,
+    )..where((t) => t.id.equals(rowId))).getSingleOrNull();
+    if (existing != null) {
+      final unregistered = await readDemoUnregisteredClientIds(_db);
+      if (!unregistered.contains(existing.id)) {
+        return _linkedLookup(normalized, existing.name);
+      }
+      // 담당이 해제된 기존 고객이다 — 트레이너가 신상 정보를 새로 입력하는
+      // 것이 아니라, 그때 등록됐던 값 그대로 다시 등록 후보로 보여준다.
+      return MemberLookup(
+        memberId: normalized,
+        name: existing.name,
+        hasTrainer: false,
+        coachedByMe: false,
+        invitePending: false,
+        gender: existing.gender ?? '',
+        age: existing.age,
+        goal: existing.goal,
+      );
     }
 
     final prospect = findDemoProspectiveMemberById(normalized);
     if (prospect == null) throw const NotFoundError();
-
-    // 이번 데모 세션에서 이미 연결한 적이 있으면(같은 회원 ID를 다시 찾는
-    // 경우) "이미 연결됨" 으로 답한다 — 중복 연결을 여기서부터 막는다.
-    final existing = await (_db.select(
-      _db.trainerClients,
-    )..where((t) => t.id.equals(prospect.id))).getSingleOrNull();
-    if (existing != null) return _linkedLookup(existing.id, existing.name);
 
     return MemberLookup(
       memberId: prospect.id,
@@ -116,7 +132,32 @@ class DemoClientInviteRepository implements ClientInviteRepository {
 
   @override
   Future<ClientInvite> invite(String memberId, {String? message}) async {
-    final prospect = findDemoProspectiveMemberById(memberId);
+    final String normalized = memberId.trim().toLowerCase();
+    final String rowId = normalized == demoAlreadyLinkedMemberId
+        ? demoAlreadyLinkedClientId
+        : normalized;
+    final existing = await (_db.select(
+      _db.trainerClients,
+    )..where((t) => t.id.equals(rowId))).getSingleOrNull();
+    if (existing != null) {
+      // 미등록으로 남아 있던 기존 고객이다 — 새 행을 넣으면 같은 id로
+      // 기본 키가 충돌하고, 지난 루틴·채팅 이력도 새 행과 갈라진다. [lookup]
+      // 이 먼저 "이미 등록됨"을 걸러내므로 여기 오는 것은 항상 미등록
+      // 상태다 — 그 상태만 되돌린다.
+      final unregistered = (await readDemoUnregisteredClientIds(_db))
+        ..remove(existing.id);
+      await writeDemoUnregisteredClientIds(_db, unregistered);
+      return ClientInvite(
+        id: 'demo-link-${existing.id}',
+        memberId: normalized,
+        memberName: existing.name,
+        memberEmail: '',
+        status: ClientInviteStatus.accepted,
+        createdAt: nowKst(),
+      );
+    }
+
+    final prospect = findDemoProspectiveMemberById(normalized);
     if (prospect == null) throw const NotFoundError();
 
     final DateTime now = nowKst();

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_connect_dialog.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_connect_dialog.dart
@@ -10,6 +10,7 @@ import 'package:oncare_trainer/design_system/tokens/toast.dart';
 import 'package:oncare_trainer/features/clients/data/repositories/client_invite_repository.dart';
 import 'package:oncare_trainer/features/clients/domain/entities/client_invite.dart';
 import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
+import 'package:oncare_trainer/shared/services/client_repository.dart';
 import 'package:oncare_trainer/shared/widgets/action_button.dart';
 import 'package:oncare_trainer/shared/widgets/app_toast.dart';
 import 'package:oncare_trainer/shared/widgets/client_avatar.dart';
@@ -36,7 +37,15 @@ import 'package:oncare_trainer/shared/widgets/client_avatar.dart';
 /// 같은 형식을 쓴다. 바닥에서 올라오는 시트로 두면 같은 성격의 두 진입점이
 /// 서로 다른 화면처럼 읽힌다.
 class ClientConnectDialog extends ConsumerStatefulWidget {
-  const ClientConnectDialog({super.key});
+  const ClientConnectDialog({super.key, this.initialMemberId});
+
+  /// Pre-fills the 회원 ID field and runs the lookup immediately — used
+  /// when 고객 관리 reopens this same "새 회원 등록" flow for a client whose
+  /// 담당 관계 was removed. 미등록 고객을 되살리는 지름길 버튼을 따로 두지
+  /// 않는 것은 의도다: 다시 등록도 회원 ID를 확인하고 눌러야 하는 신규
+  /// 등록과 같은 절차를 거쳐야, 다른 사람의 계정을 잘못 연결하는 사고를
+  /// 신규 등록과 똑같이 막을 수 있다.
+  final String? initialMemberId;
 
   @override
   ConsumerState<ClientConnectDialog> createState() =>
@@ -50,6 +59,18 @@ class _ClientConnectDialogState extends ConsumerState<ClientConnectDialog> {
   MemberLookup? _found;
   String? _error;
   bool _busy = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final initial = widget.initialMemberId;
+    if (initial != null && initial.isNotEmpty) {
+      _memberId.text = initial;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _lookup();
+      });
+    }
+  }
 
   @override
   void dispose() {
@@ -108,6 +129,10 @@ class _ClientConnectDialogState extends ConsumerState<ClientConnectDialog> {
     try {
       await repository.invite(found.memberId, message: _message.text);
       ref.invalidate(pendingClientInvitesProvider);
+      // 데모(즉시 연결)와 미등록 고객을 되살리는 경로 모두, 고객 탭과
+      // 고객 관리가 같은 목록을 보므로 두 provider 를 함께 새로고침한다.
+      ref.invalidate(clientsProvider);
+      ref.invalidate(managedClientsProvider);
       if (!mounted) return;
       navigator.pop();
       showAppToast(

--- a/frontend/flutter_trainer/lib/features/my/presentation/pages/my_page.dart
+++ b/frontend/flutter_trainer/lib/features/my/presentation/pages/my_page.dart
@@ -16,6 +16,8 @@ import 'package:oncare_trainer/design_system/tokens/radius.dart';
 import 'package:oncare_trainer/design_system/tokens/spacing.dart';
 import 'package:oncare_trainer/design_system/tokens/toast.dart';
 import 'package:oncare_trainer/features/auth/presentation/controllers/session_controller.dart';
+import 'package:oncare_trainer/features/clients/presentation/widgets/client_card.dart';
+import 'package:oncare_trainer/features/clients/presentation/widgets/client_connect_dialog.dart';
 import 'package:oncare_trainer/features/my/data/trainer_account_repository.dart';
 import 'package:oncare_trainer/features/my/data/trainer_profile_repository.dart';
 import 'package:oncare_trainer/features/my/data/trainer_settings.dart';
@@ -275,21 +277,16 @@ class _MyPageState extends ConsumerState<MyPage> {
     }
   }
 
-  Future<void> _restoreClient(TrainerClient client) async {
-    final l = AppLocalizations.of(context);
-    setState(() => _removingClients.add(client.id));
-    try {
-      await ref.read(clientRepositoryProvider).restoreClient(client.id);
-      ref.invalidate(clientsProvider);
-      ref.invalidate(managedClientsProvider);
-      if (!mounted) return;
-      showAppToast(context, l.myClientRestoreSuccess);
-    } catch (_) {
-      if (!mounted) return;
-      showAppToast(context, l.myClientRestoreFailed, kind: AppToastKind.error);
-    } finally {
-      if (mounted) setState(() => _removingClients.remove(client.id));
-    }
+  /// 미등록 고객을 되살리는 전용 API 대신, 고객 탭의 "새 회원 등록" 창을
+  /// 그 고객의 회원 ID로 미리 채워 그대로 연다. 한 번의 탭으로 조용히
+  /// 복원하던 이전 방식은 회원 ID 확인 절차를 건너뛰어, 신규 등록과
+  /// 다른 특별 취급처럼 보였다(#1591 피드백). 같은 창을 쓰면 다시 등록도
+  /// 새 회원을 등록하는 것과 완전히 같은 화면·절차로 보인다.
+  Future<void> _openReRegisterDialog(TrainerClient client) {
+    return showDialog<void>(
+      context: context,
+      builder: (_) => ClientConnectDialog(initialMemberId: client.id),
+    );
   }
 
   /// 계정 탈퇴. 이름 확인을 받은 뒤에만 나가고, 성공하면 로그아웃과 같은 경로로
@@ -471,7 +468,7 @@ class _MyPageState extends ConsumerState<MyPage> {
     clients: ref.watch(managedClientsProvider),
     removing: _removingClients,
     onRemove: _removeClient,
-    onRestore: _restoreClient,
+    onRestore: _openReRegisterDialog,
   );
 
   /// Applies a settings change and tells the trainer if it didn't stick.
@@ -1263,56 +1260,101 @@ class _ClientManagementCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l = AppLocalizations.of(context);
-    return SectionCard(
-      title: l.myStatClients,
-      icon: Icons.manage_accounts_outlined,
-      child: clients.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (_, _) => Text(l.clientsLoadFailed),
-        data: (allItems) {
-          final items = allItems;
-          if (items.isEmpty) return Text(l.myClientManagementEmpty);
-          return Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: <Widget>[
-              for (var i = 0; i < items.length; i++) ...<Widget>[
-                if (i > 0)
-                  const Divider(height: 1, color: AppColors.borderStrong),
-                ListTile(
-                  contentPadding: EdgeInsets.zero,
-                  leading: CircleAvatar(child: Text(items[i].avatar)),
-                  title: Text(items[i].name),
-                  subtitle: Text(
-                    '${items[i].registered ? l.myClientRegistered : l.myClientUnregistered} · ${items[i].goal}',
-                  ),
-                  trailing: Tooltip(
-                    message: items[i].registered
-                        ? l.myClientRemove
-                        : l.myClientRestore,
-                    child: TextButton(
-                      onPressed: removing.contains(items[i].id)
-                          ? null
-                          : () => items[i].registered
-                                ? onRemove(items[i])
-                                : onRestore(items[i]),
-                      child: removing.contains(items[i].id)
-                          ? const SizedBox.square(
-                              dimension: 18,
-                              child: CircularProgressIndicator(strokeWidth: 2),
-                            )
-                          : Text(
-                              items[i].registered
-                                  ? l.myClientRemove
-                                  : l.myClientRestore,
-                            ),
-                    ),
-                  ),
-                ),
-              ],
-            ],
+    return clients.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (_, _) => Text(l.clientsLoadFailed),
+      data: (items) {
+        if (items.isEmpty) {
+          return EmptyHint(
+            message: l.myClientManagementEmpty,
+            icon: Icons.people_outline,
           );
-        },
-      ),
+        }
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            for (final client in items) ...<Widget>[
+              _ManagedClientRow(
+                client: client,
+                busy: removing.contains(client.id),
+                onRemove: () => onRemove(client),
+                onRestore: () => onRestore(client),
+              ),
+              const SizedBox(height: AppSpacing.md),
+            ],
+          ],
+        );
+      },
+    );
+  }
+}
+
+/// 고객 관리의 한 줄 — 고객 탭 로스터와 같은 [ClientCard] 위에 등록 상태와
+/// 삭제/재등록 동작만 덧붙인다. 목록 UI가 갈리면 같은 회원이 탭마다 다른
+/// 사람처럼 보이므로, 두 화면이 카드를 공유한다.
+class _ManagedClientRow extends StatelessWidget {
+  const _ManagedClientRow({
+    required this.client,
+    required this.busy,
+    required this.onRemove,
+    required this.onRestore,
+  });
+
+  final TrainerClient client;
+  final bool busy;
+  final VoidCallback onRemove;
+  final VoidCallback onRestore;
+
+  @override
+  Widget build(BuildContext context) {
+    final l = AppLocalizations.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        ClientCard(
+          key: ValueKey<String>('managed-client-${client.id}'),
+          client: client,
+          compact: true,
+          // 미등록 고객은 일반 고객 상세에서 제외되므로(요구사항) 탭해도
+          // 열 화면이 없다 — 등록 고객만 상세로 보낸다.
+          onTap: client.registered
+              ? () => context.go(AppRoutes.clientDetail(client.id))
+              : () {},
+        ),
+        const SizedBox(height: AppSpacing.xs),
+        Row(
+          children: <Widget>[
+            StatusDotLabel(
+              label: client.registered
+                  ? l.myClientRegistered
+                  : l.myClientUnregistered,
+              color: client.registered
+                  ? AppColors.success
+                  : AppColors.mutedForeground,
+              filled: client.registered,
+            ),
+            const Spacer(),
+            Tooltip(
+              message: client.registered ? l.myClientRemove : l.myClientRestore,
+              child: TextButton(
+                onPressed: busy
+                    ? null
+                    : (client.registered ? onRemove : onRestore),
+                child: busy
+                    ? const SizedBox.square(
+                        dimension: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : Text(
+                        client.registered
+                            ? l.myClientRemove
+                            : l.myClientRestore,
+                      ),
+              ),
+            ),
+          ],
+        ),
+      ],
     );
   }
 }

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
@@ -3662,18 +3662,6 @@ abstract class AppLocalizations {
   /// **'Register again'**
   String get myClientRestore;
 
-  /// No description provided for @myClientRestoreSuccess.
-  ///
-  /// In en, this message translates to:
-  /// **'Client registered again'**
-  String get myClientRestoreSuccess;
-
-  /// No description provided for @myClientRestoreFailed.
-  ///
-  /// In en, this message translates to:
-  /// **'Couldn\'t register the client again. Please try again'**
-  String get myClientRestoreFailed;
-
   /// No description provided for @myStatSessionsDone.
   ///
   /// In en, this message translates to:

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
@@ -1,6 +1,5 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
-
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -2062,13 +2061,6 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get myClientRestore => 'Register again';
-
-  @override
-  String get myClientRestoreSuccess => 'Client registered again';
-
-  @override
-  String get myClientRestoreFailed =>
-      'Couldn\'t register the client again. Please try again';
 
   @override
   String get myStatSessionsDone => 'Sessions done';

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
@@ -1,6 +1,5 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
-
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -1976,12 +1975,6 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get myClientRestore => '다시 등록';
-
-  @override
-  String get myClientRestoreSuccess => '고객을 다시 등록했어요';
-
-  @override
-  String get myClientRestoreFailed => '고객을 다시 등록하지 못했어요. 잠시 후 다시 시도해 주세요';
 
   @override
   String get myStatSessionsDone => '완료 세션';

--- a/frontend/flutter_trainer/lib/l10n/app_en.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_en.arb
@@ -1034,8 +1034,6 @@
   "myClientRegistered": "Registered",
   "myClientUnregistered": "Unregistered",
   "myClientRestore": "Register again",
-  "myClientRestoreSuccess": "Client registered again",
-  "myClientRestoreFailed": "Couldn't register the client again. Please try again",
   "myStatSessionsDone": "Sessions done",
   "myStatRoutinesSent": "Programs sent",
   "myGymName": "Gym name",

--- a/frontend/flutter_trainer/lib/l10n/app_ko.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_ko.arb
@@ -637,8 +637,6 @@
   "myClientRegistered": "등록",
   "myClientUnregistered": "미등록",
   "myClientRestore": "다시 등록",
-  "myClientRestoreSuccess": "고객을 다시 등록했어요",
-  "myClientRestoreFailed": "고객을 다시 등록하지 못했어요. 잠시 후 다시 시도해 주세요",
   "myStatSessionsDone": "완료 세션",
   "myStatRoutinesSent": "프로그램 전송",
   "myGymName": "헬스장 이름",

--- a/frontend/flutter_trainer/lib/shared/services/client_repository.dart
+++ b/frontend/flutter_trainer/lib/shared/services/client_repository.dart
@@ -117,6 +117,27 @@ abstract interface class ClientRepository {
   Future<void> restoreClient(String id);
 }
 
+/// 데모(drift)에서 미등록 상태를 나타내는 키. 트레이너-고객 행 자체는 지우지
+/// 않고 이 id 목록에만 올려 둔다 — 원본 기록을 지우지 않는다는 정책과, 다시
+/// 등록할 때 새 행이 아니라 같은 행을 되살려야 한다는 요구가 같이 걸려 있다.
+///
+/// [DriftClientRepository] 뿐 아니라 [DemoClientInviteRepository]도 이
+/// 목록을 본다 — 고객 탭의 "새 회원 등록" 창으로 미등록 고객을 다시 연결할
+/// 때, 이미 있는 행을 무시하고 새로 넣으면 기본 키 충돌로 "이미 연결됨"
+/// 이라는 잘못된 안내가 뜬다.
+const String demoUnregisteredClientsKey = 'trainer_unregistered_clients';
+
+/// [demoUnregisteredClientsKey] 에 저장된 미등록 고객 id 목록을 읽는다.
+Future<Set<String>> readDemoUnregisteredClientIds(AppDatabase db) async {
+  final raw = await db.readValue(demoUnregisteredClientsKey);
+  if (raw == null || raw.isEmpty) return <String>{};
+  return (jsonDecode(raw) as List<Object?>).whereType<String>().toSet();
+}
+
+/// [ids] 를 [demoUnregisteredClientsKey] 에 저장한다.
+Future<void> writeDemoUnregisteredClientIds(AppDatabase db, Set<String> ids) =>
+    db.putValue(demoUnregisteredClientsKey, jsonEncode(ids.toList()..sort()));
+
 /// Reads client + schedule data from the local drift DB for the
 /// 고객 관리 tab. Returns reactive streams so the UI updates if the
 /// underlying rows change (e.g. a routine sent from another tab).
@@ -125,7 +146,6 @@ class DriftClientRepository implements ClientRepository {
   const DriftClientRepository(this._db);
 
   final AppDatabase _db;
-  static const String _unregisteredKey = 'trainer_unregistered_clients';
 
   @override
   Future<RoutineHistoryEntry> updateHistoryFeedback(
@@ -155,21 +175,12 @@ class DriftClientRepository implements ClientRepository {
           (t) => OrderingTerm(expression: t.sortOrder),
         ]);
       final rows = await query.get();
-      final removed = await _unregisteredIds();
+      final removed = await readDemoUnregisteredClientIds(_db);
       return rows
           .map((row) => _toEntity(row, registered: !removed.contains(row.id)))
           .toList();
     });
   }
-
-  Future<Set<String>> _unregisteredIds() async {
-    final raw = await _db.readValue(_unregisteredKey);
-    if (raw == null || raw.isEmpty) return <String>{};
-    return (jsonDecode(raw) as List<Object?>).whereType<String>().toSet();
-  }
-
-  Future<void> _saveUnregisteredIds(Set<String> ids) =>
-      _db.putValue(_unregisteredKey, jsonEncode(ids.toList()..sort()));
 
   /// Most recent message time per client.
   ///
@@ -302,15 +313,15 @@ class DriftClientRepository implements ClientRepository {
       await (_db.delete(
         _db.reportFeedbackDrafts,
       )..where((t) => t.clientId.equals(id))).go();
-      final removed = (await _unregisteredIds())..add(id);
-      await _saveUnregisteredIds(removed);
+      final removed = (await readDemoUnregisteredClientIds(_db))..add(id);
+      await writeDemoUnregisteredClientIds(_db, removed);
     });
   }
 
   @override
   Future<void> restoreClient(String id) async {
-    final removed = (await _unregisteredIds())..remove(id);
-    await _saveUnregisteredIds(removed);
+    final removed = (await readDemoUnregisteredClientIds(_db))..remove(id);
+    await writeDemoUnregisteredClientIds(_db, removed);
   }
 
   @override

--- a/frontend/flutter_trainer/test/features/clients/clients_page_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/clients_page_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:oncare_trainer/app/router/routes.dart';
 import 'package:oncare_trainer/core/errors/app_error.dart';
 import 'package:oncare_trainer/core/storage/app_database.dart';
+import 'package:oncare_trainer/core/storage/demo_member_directory.dart';
 import 'package:oncare_trainer/core/storage/seed_data.dart';
 import 'package:oncare_trainer/features/clients/data/repositories/client_invite_repository.dart';
 import 'package:oncare_trainer/features/clients/domain/entities/client_invite.dart';
@@ -221,6 +222,44 @@ void main() {
         );
       },
     );
+
+    test('미등록 고객은 새 회원 등록과 같은 lookup·invite 로 같은 행을 되살린다', () async {
+      final repo = DriftClientRepository(db);
+      final invites = DemoClientInviteRepository(db);
+      await repo.removeClient('seed-client-1');
+
+      // 실 계정 id(demoAlreadyLinkedMemberId)로 찾아야 한다 — 회원 관리
+      // 화면의 행 id(seed-client-1)를 그대로 입력하는 것이 아니다.
+      final found = await invites.lookup(demoAlreadyLinkedMemberId);
+      expect(found.name, '김민수');
+      expect(found.canInvite, isTrue); // 미등록이라 다시 연결할 수 있다
+
+      await invites.invite(demoAlreadyLinkedMemberId);
+
+      final clients = await repo.watchClients().first;
+      final revived = clients.firstWhere((c) => c.id == 'seed-client-1');
+      expect(revived.registered, isTrue);
+      expect(revived.name, '김민수'); // 새 프로필이 아니라 같은 행이 되살아났다
+      expect(clients.length, 15); // 새 행이 추가되지 않았다
+    });
+
+    test('실 계정 id 매핑이 없는 고객도 행 id 자체로 다시 등록할 수 있다', () async {
+      final repo = DriftClientRepository(db);
+      final invites = DemoClientInviteRepository(db);
+      await repo.removeClient('seed-client-3');
+
+      final found = await invites.lookup('seed-client-3');
+      expect(found.canInvite, isTrue);
+
+      await invites.invite('seed-client-3');
+
+      final clients = await repo.watchClients().first;
+      expect(
+        clients.firstWhere((c) => c.id == 'seed-client-3').registered,
+        isTrue,
+      );
+      expect(clients.length, 15);
+    });
 
     // 예약 수는 이제 로스터가 아니라 오늘 스케줄에서 파생된다(#387).
     // 배지 계산은 todayReservationCountProvider 테스트가 덮고, 날짜 필터링은

--- a/frontend/flutter_trainer/test/features/my/my_page_test.dart
+++ b/frontend/flutter_trainer/test/features/my/my_page_test.dart
@@ -140,6 +140,45 @@ void main() {
       expect(find.byTooltip('다시 등록'), findsOneWidget);
     });
 
+    testWidgets('미등록 고객의 다시 등록은 새 회원 등록과 같은 창을 연다', (tester) async {
+      await openTab(tester);
+
+      final management = find.text('고객 관리');
+      await tester.scrollUntilVisible(management, 200);
+      await tester.tap(management);
+      await tester.pumpAndSettle();
+
+      // 김민수(seed-client-1)를 삭제한다 — 실 계정 id로 조회되는 유일한
+      // 데모 고객이라 재등록 시나리오를 여기로 고정한다.
+      await tester.tap(find.byTooltip('고객 삭제').first);
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.descendant(
+          of: find.byType(AlertDialog),
+          matching: find.text('고객 삭제'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byTooltip('다시 등록'));
+      await tester.pumpAndSettle();
+
+      // 회원 ID가 이미 채워져 조회까지 자동으로 끝난 상태다 — 그래도
+      // 신규 등록과 똑같이 이름을 확인하는 카드를 거친 뒤에만 등록된다.
+      expect(find.text('신규 고객 등록'), findsOneWidget);
+      expect(find.text('김민수'), findsWidgets);
+      expect(find.text('이 고객이 맞나요?'), findsOneWidget);
+      final registerButton = find.text('고객 등록');
+      expect(registerButton, findsOneWidget);
+
+      await tester.tap(registerButton);
+      await tester.pumpAndSettle();
+
+      expect(find.text('김민수님을 고객으로 등록했어요'), findsOneWidget);
+      // 새 행이 아니라 같은 고객이 되살아나 다시 등록 상태로 돌아온다.
+      expect(find.byTooltip('다시 등록'), findsNothing);
+    });
+
     testWidgets('로그아웃 returns to the login screen', (tester) async {
       await openSettings(tester);
 


### PR DESCRIPTION
## Summary

* 고객 관리에서 담당을 종료(삭제)한 고객은 이제 트레이너 화면에서 완전히 사라진다 — 미등록 상태로 목록에 남아 한 번의 탭으로 되살리는 지름길을 없앴다
* 다시 담당하려면 고객 탭의 "신규 고객 등록"에서 회원 ID로 새로 찾아 연결해야 한다 — 신규 등록과 완전히 같은 절차(회원 ID 조회 → 이름 확인 → 등록)를 거친다
* 회원 앱 쪽 데이터(스케줄, 기록, 채팅 등)는 그대로 남는다 — 회원 본인은 계속 자기 데이터를 볼 수 있다. 바뀌는 것은 트레이너 화면에서의 노출뿐이다
* 데모(로컬) 저장소의 회원 조회·연결 로직도 고쳤다 — 미등록 상태인 기존 고객을 회원 ID로 다시 조회·연결할 수 없거나, 연결하면 같은 id로 새 행이 끼어들 수 있던 문제를 고쳐 기존 행을 되살리게 했다
* 고객 관리 목록이 고객 탭 로스터와 같은 카드(ClientCard)를 쓰도록 통일했다

---

## Changes

### 🔧 Improvements

* 고객 관리 목록이 등록 고객만 보여주는 `clientsProvider`를 쓴다 — 미등록 상태·재등록 버튼 자체가 없다
* 고객 등록 성공 시 고객 탭·고객 관리가 보는 provider를 함께 새로고침한다

### 🎨 UI/UX

* 고객 관리(내 정보 > 고객 관리) 목록의 각 행을 고객 탭과 동일한 `ClientCard`로 통일하고, 삭제 버튼만 그 아래 별도 줄로 뺐다

### 🐛 Fixes

* 데모(mock API) 모드에서 담당 종료한 고객을 회원 ID로 다시 조회·연결하면 찾지 못하거나("찾을 수 없음") 기본 키 충돌로 "이미 연결됨"이 잘못 뜨던 문제를 고쳤다 — 이제 기존 행을 되살린다

---

## Notes

* 백엔드의 `PUT /trainer/clients/{member_id}/registration`(전용 재등록 API)은 계약을 바꾸지 않고 그대로 뒀다 — 프론트 UI만 더 이상 그 경로로 지름길을 만들지 않는다
* 미등록 고객을 다시 연결할 때도 실 API와 마찬가지로 트레이너가 신상 정보를 새로 입력하지 않고, 등록돼 있던 값 그대로 다시 등록 후보로 뜬다

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 빌드 성공 (`flutter analyze`)
* [x] 관련 테스트 통과 (`flutter test test/features/clients/ test/features/my/`, 신규 테스트 포함)

### Manual Test Steps

1. 트레이너 앱 내 정보 > 고객 관리에서 고객 한 명을 삭제한다 → 목록에서 완전히 사라지는지 확인한다
2. 고객 탭 > "신규 고객 등록"에서 그 고객의 회원 ID를 입력해 조회한다 → 신규 등록과 같은 이름 확인 카드가 뜨는지 확인한다
3. "고객 등록"을 눌러 다시 연결되는지, 고객 탭·고객 관리 양쪽에 곧바로 반영되는지 확인한다(지난 스케줄·기록이 갈라지지 않고 같은 고객으로 이어지는지)

---

## Related Issues

Closes #1591

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인