### PR TITLE
fix(member-app): 식단·운동 AI 맞춤 조언의 기간별 갱신과 운동 탭 카드 순서 정리

### DIFF
--- a/backend/app/api/v1/exercise.py
+++ b/backend/app/api/v1/exercise.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import date, datetime
-from typing import Annotated
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
@@ -19,9 +19,10 @@ from app.core import clock
 from app.db.session import get_db
 from app.models.models import ExerciseSession, HealthProfile
 from app.schemas.exercise_api import (
-    ExerciseSessionCreate, ExerciseSessionOut, ExerciseWeekResponse,
+    ExerciseAdviceResponse, ExerciseSessionCreate, ExerciseSessionOut,
+    ExerciseWeekResponse,
 )
-from app.services import exercise_activity, exercise_types
+from app.services import exercise_activity, exercise_service, exercise_types
 from app.services.coach import personal_ingest
 from app.services.exercise_service import (
     weekly_goals,
@@ -95,6 +96,36 @@ def current_week(
         weekly_goal_minutes=goal_minutes,
         weekly_goal_calories=goal_calories,
         **data,
+    )
+
+
+@router.get("/exercise/advice", response_model=ExerciseAdviceResponse)
+def exercise_advice(
+    current_user: CurrentUser,
+    db: Annotated[Session, Depends(get_db)],
+    period: Annotated[
+        Literal["today", "week", "all"],
+        Query(description="조언이 다룰 구간 — 화면의 기간 토글과 같은 이름"),
+    ] = "today",
+) -> ExerciseAdviceResponse:
+    """기간에 맞는 운동 조언. (#1574)
+
+    식단 조언(`/diet/advice`, #1017)과 같은 규칙이다 — 두 카드가 같은 자리에서
+    같은 토글을 따라가므로, 한쪽만 오늘 이야기로 남으면 회원은 `이번 주` 를 보며
+    "오늘은 유산소를 했네요" 를 읽게 된다.
+
+    조언 문장은 트레이너웹이 보는 것과 **같다**(#1025) — 회원과 코치가 같은
+    회원의 같은 기간을 두고 다른 이야기를 들고 앉으면 안 된다.
+
+    경계도 앱이 아니라 서버가 정한다.
+    """
+    start, end, days = exercise_service.period_days(db, current_user.id, period)
+    return ExerciseAdviceResponse(
+        period=period,
+        from_date=start,
+        to_date=end,
+        days_logged=len(days),
+        message=exercise_service.period_coach_message(days, period),
     )
 
 

--- a/backend/app/api/v1/trainer.py
+++ b/backend/app/api/v1/trainer.py
@@ -82,9 +82,7 @@ from app.schemas.trainer_api import (
 )
 from app.services import (
     diet_service,
-    exercise_activity,
     exercise_service,
-    period_window,
     chat_image_storage,
     consultation_service,
     trainer_client_invite_service,
@@ -594,34 +592,15 @@ def trainer_client_exercise_advice(
     주를 모두 읽어 온 뒤 실제 날짜로 되돌려 거른다.
     """
     _require_client(db, trainer.id, member_id)
-    start, end = period_window.period_bounds(period)
-    weeks = _week_starts_between(start, end)
-    rows = db.scalars(
-        select(ExerciseSession).where(
-            ExerciseSession.user_id == member_id,
-            ExerciseSession.week_start.in_(weeks),
-        )
-    ).all()
-    days = exercise_service.daily_totals(list(rows), start, end)
+    # 조회·집계는 회원 앱과 **같은 함수**다(#1574) — 규칙이 갈리면 같은 회원의
+    # 같은 기간을 두 화면이 다른 날부터 세게 된다.
+    start, end, days = exercise_service.period_days(db, member_id, period)
     return ExerciseAdviceResponse(
         period=period,
         from_date=start,
         to_date=end,
         days_logged=len(days),
         message=exercise_service.period_coach_message(days, period),
-    )
-
-
-def _week_starts_between(start: str, end: str) -> list[str]:
-    """[start, end] 를 덮는 모든 주의 월요일.
-
-    구간의 첫날이 주 가운데면 그 주 월요일부터 담는다 — 월요일이 구간 밖이어도
-    그 주의 기록은 구간 안에 있을 수 있다. 계산은 논리 운동일 모듈 하나에
-    맡긴다(#1264): 조회 구간을 넓히는 규칙이 갈리면 AI 와 이 화면이 서로 다른
-    주를 읽는다.
-    """
-    return exercise_activity.week_starts_covering(
-        _date.fromisoformat(start), _date.fromisoformat(end)
     )
 
 

--- a/backend/app/services/diet_service.py
+++ b/backend/app/services/diet_service.py
@@ -113,15 +113,18 @@ def _avg(values: list[int]) -> float:
 
 
 def period_coach_message(days: list[DietDayTotals], period: str) -> str:
-    """기간에 맞는 식단 조언. (#1017)
+    """기간에 맞는 식단 조언. (#1017, #1574)
 
     기간을 바꾸는 것은 "무엇을 볼지" 를 바꾸는 일이다. 그래프만 갈아 끼우고
     조언이 오늘 이야기로 남으면, 이번 주를 보고 있는데 "오늘 점심이 짰어요" 를
     읽게 되어 조언이 지금 화면과 무관한 말이 된다.
-    
+
     기간마다 **재료가 다르다.** 오늘은 오늘 먹은 것, 이번 주는 요일별 편차와
     초과한 날 수, 전체는 주 단위 추세다. 말투도 다르다 — 오늘은 다음 끼니를
     제안하고, 이번 주·전체는 되짚어 준다.
+
+    **한 문장 반을 넘기지 않는다.** 좁은 카드 안에서 길어질수록 정작 짚어야 할
+    수치가 묻힌다 — 근거 하나와 다음 행동 하나면 충분하다. (#1574)
     """
     if not days:
         # 없는 기록으로 조언을 지어내지 않는다.
@@ -129,28 +132,19 @@ def period_coach_message(days: list[DietDayTotals], period: str) -> str:
             return "이번 주 식단 기록이 아직 없어요. 한 끼만 남겨도 흐름이 보여요."
         if period == PERIOD_ALL:
             return "기록이 쌓이면 나트륨·칼로리 흐름을 짚어 드릴게요."
-        return "아직 오늘 식단 기록이 없어요. 첫 끼니를 기록해 볼까요?"
+        return "오늘 식단 기록이 아직 없어요. 첫 끼니를 기록해 볼까요?"
 
     over = [d for d in days if d.over_sodium]
 
     if period == PERIOD_WEEK:
         if len(over) >= 3:
-            return (
-                f"이번 주 {len(over)}일이나 나트륨 권장량을 넘었어요. "
-                "국물은 건더기 위주로 먹고 남은 며칠은 담백하게 가요."
-            )
+            return f"이번 주 {len(over)}일이나 나트륨을 넘겼어요. 국물은 건더기 위주로 드세요."
         weekday, weekend = _weekday_split(days)
         if weekend and weekday and _avg(weekend) > _avg(weekday) * 1.3:
-            return (
-                "주중에는 잘 지키다가 주말에 나트륨이 확 올라요. "
-                "주말 외식은 한 끼만 정해 두면 흐름이 유지돼요."
-            )
+            return "주중엔 잘 지키다 주말에 나트륨이 올라요. 주말 외식은 한 끼만 정해요."
         if over:
-            return (
-                f"이번 주 {len(over)}일만 권장량을 넘었어요. "
-                "나머지 날의 균형은 좋았으니 이 흐름을 이어가요."
-            )
-        return "이번 주 내내 나트륨을 권장량 안에서 지켰어요. 아주 좋아요!"
+            return f"이번 주 {len(over)}일만 권장량을 넘었어요. 나머지 날의 균형은 좋았어요."
+        return f"이번 주 {len(days)}일 모두 나트륨을 권장량 안에서 지켰어요!"
 
     if period == PERIOD_ALL:
         # 최근 4주와 그 이전을 견준다 — 나아지는 중인지가 이 화면의 질문이다.
@@ -159,31 +153,22 @@ def period_coach_message(days: list[DietDayTotals], period: str) -> str:
         earlier = [d.sodium_mg for d in days if d.date < recent_from]
         if earlier and recent:
             if _avg(recent) < _avg(earlier) * 0.9:
-                return (
-                    "최근 4주 나트륨이 그 전보다 눈에 띄게 낮아졌어요. "
-                    "지금 방식이 회원님께 맞는 것 같아요."
-                )
+                return "최근 4주 나트륨이 그 전보다 낮아졌어요. 지금 방식이 잘 맞아요."
             if _avg(recent) > _avg(earlier) * 1.1:
-                return (
-                    "최근 4주 들어 나트륨이 다시 올라가고 있어요. "
-                    "무엇이 달라졌는지 한 주만 되짚어 볼까요?"
-                )
+                return "최근 4주 나트륨이 다시 올라가고 있어요. 한 주만 되짚어 볼까요?"
         weekday, weekend = _weekday_split(days)
         if weekend and weekday and _avg(weekend) > _avg(weekday) * 1.3:
-            return (
-                "기록을 통틀어 보면 주말마다 나트륨이 오르는 흐름이에요. "
-                "주말 한 끼만 담백하게 바꿔도 평균이 내려가요."
-            )
+            return "기록을 통틀어 주말마다 나트륨이 올라요. 주말 한 끼만 담백하게 바꿔요."
         ratio = round(len(over) * 100 / len(days))
         if ratio >= 40:
-            return (
-                f"기록한 날의 {ratio}%가 나트륨 권장량을 넘었어요. "
-                "국·찌개 국물을 남기는 것부터 시작해 봐요."
-            )
-        return "기록을 통틀어 나트륨이 대체로 권장량 안이에요. 지금 흐름이 좋아요."
+            return f"기록한 날의 {ratio}%가 나트륨 권장량을 넘었어요. 국물부터 남겨 봐요."
+        return f"기록한 {len(days)}일 대부분이 권장량 안이에요. 지금 흐름이 좋아요."
 
-    # 오늘 — 지금까지와 같은 규칙이다.
-    return coach_message(days[-1].sodium_mg, True)
+    # 오늘 — 그날 합계 하나로 말한다.
+    today = days[-1]
+    if today.over_sodium:
+        return f"오늘 나트륨 {today.sodium_mg}mg 로 권장량을 넘겼어요. 남은 끼니는 담백하게."
+    return f"오늘 나트륨 {today.sodium_mg}mg 로 권장량 안이에요. 이대로 마무리해요."
 
 
 def build_day(db: Session, user_id: str, date: str) -> DietTodayResponse:

--- a/backend/app/services/exercise_service.py
+++ b/backend/app/services/exercise_service.py
@@ -17,7 +17,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date, timedelta
 
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
 from app.core import clock
+from app.models.models import ExerciseSession
 from app.services import exercise_activity, exercise_types, period_window
 
 #: 요일 라벨(월=0 … 일=6). 순서를 두 벌 두지 않으려고 논리 운동일 모듈의 정의를
@@ -330,25 +334,29 @@ def _avg(values: list[int]) -> float:
 
 
 def period_coach_message(days: list[ExerciseDayTotals], period: str) -> str:
-    """기간에 맞는 운동 조언. (#1025)
+    """기간에 맞는 운동 조언. (#1025, #1574)
 
     기간마다 **재료가 다르다.** 오늘은 오늘 한 운동, 이번 주는 며칠 움직였고
     무엇에 치우쳤는지, 전체는 최근 4주와 그 이전의 추세다. 말투도 다르다 —
     오늘은 다음 한 걸음을 제안하고, 이번 주·전체는 되짚어 준다.
+
+    **한 문장 반을 넘기지 않는다.** 카드가 회원 앱·트레이너웹 양쪽에서 좁은 폭에
+    들어가고, 길어질수록 정작 숫자가 묻힌다 — 짚어 주는 수치 하나와 다음 행동
+    하나면 충분하다. (#1574)
     """
     if not days:
         if period == period_window.PERIOD_WEEK:
-            return "이번 주 운동 기록이 아직 없어요. 가벼운 산책 한 번도 흐름이 됩니다."
+            return "이번 주 운동 기록이 아직 없어요. 10분 걷기부터 시작해 볼까요?"
         if period == period_window.PERIOD_ALL:
             return "기록이 쌓이면 운동량과 유형의 흐름을 짚어 드릴게요."
-        return "아직 오늘 운동 기록이 없어요. 10분 걷기부터 시작해 볼까요?"
+        return "오늘 운동 기록이 아직 없어요. 10분 걷기부터 시작해 볼까요?"
 
     if period == period_window.PERIOD_TODAY:
         today = days[-1]
         label = exercise_types.label_for(today.main_type)
         return (
-            f"오늘 {label} 위주로 {today.minutes}분, {today.calories}kcal 를 썼어요. "
-            "마무리로 가볍게 스트레칭하면 회복이 빨라져요."
+            f"오늘 {label} 위주로 {today.minutes}분, {today.calories}kcal 썼어요. "
+            "스트레칭으로 마무리해요."
         )
 
     total_minutes = sum(d.minutes for d in days)
@@ -356,10 +364,7 @@ def period_coach_message(days: list[ExerciseDayTotals], period: str) -> str:
 
     if period == period_window.PERIOD_WEEK:
         if active_days <= 1:
-            return (
-                f"이번 주는 {active_days}일 움직였어요. "
-                "한 번 더 나가면 흐름이 끊기지 않아요."
-            )
+            return f"이번 주는 {total_minutes}분 하루뿐이에요. 한 번 더 나가면 흐름이 이어져요."
         # 한 유형에 쏠렸는지 — 코칭에서 가장 먼저 짚는 지점이다.
         by_type: dict[str, int] = {}
         for d in days:
@@ -373,14 +378,11 @@ def period_coach_message(days: list[ExerciseDayTotals], period: str) -> str:
                 else exercise_types.CARDIO
             )
             return (
-                f"이번 주 {active_days}일 {total_minutes}분을 채웠는데 "
-                f"{exercise_types.label_for(top)} 에 몰려 있어요. "
-                f"{exercise_types.label_for(missing)} 를 한 번 섞어 볼까요?"
+                f"이번 주 {active_days}일 {total_minutes}분이 "
+                f"{exercise_types.label_for(top)}에 몰렸어요. "
+                f"{exercise_types.label_for(missing)}도 섞어 볼까요?"
             )
-        return (
-            f"이번 주 {active_days}일 동안 {total_minutes}분 운동했어요. "
-            "유형도 고르게 섞였네요. 이 흐름을 이어가요."
-        )
+        return f"이번 주 {active_days}일 {total_minutes}분, 유형도 고르게 섞였어요."
 
     # 전체 — 최근 4주와 그 이전을 견준다. "나아지는 중인가" 가 이 화면의 질문이다.
     recent_from = days[-1].date - timedelta(days=27)
@@ -388,16 +390,31 @@ def period_coach_message(days: list[ExerciseDayTotals], period: str) -> str:
     earlier = [d.minutes for d in days if d.date < recent_from]
     if earlier and recent:
         if _avg(recent) > _avg(earlier) * 1.1:
-            return (
-                "최근 4주 운동량이 그 전보다 늘었어요. "
-                "지금 방식이 회원님께 맞는 것 같아요."
-            )
+            return "최근 4주 운동량이 그 전보다 늘었어요. 지금 방식이 잘 맞아요."
         if _avg(recent) < _avg(earlier) * 0.9:
-            return (
-                "최근 4주 들어 운동량이 줄고 있어요. "
-                "무엇이 달라졌는지 한 주만 되짚어 볼까요?"
-            )
-    return (
-        f"기록을 통틀어 {active_days}일 {total_minutes}분을 움직였어요. "
-        "큰 기복 없이 이어가고 있어요."
+            return "최근 4주 운동량이 줄고 있어요. 짧게라도 주 3일을 지켜 봐요."
+    weeks = round(period_window.ALL_PERIOD_DAYS / 7)
+    return f"{weeks}주 동안 {active_days}일 {total_minutes}분, 기복 없이 이어가고 있어요."
+
+
+def period_days(
+    db: Session, user_id: str, period: str
+) -> tuple[str, str, list[ExerciseDayTotals]]:
+    """기간 이름 → (시작, 끝, 그 구간의 하루별 합계). (#1574)
+
+    운동 기록은 날짜가 아니라 (그 주 월요일, 요일) 로 저장되므로, 구간이 걸치는
+    주를 모두 읽어 온 뒤 실제 날짜로 되돌려 거른다. 회원 앱과 트레이너웹이 이
+    함수 하나를 함께 쓴다 — 조회 규칙이 갈리면 같은 회원의 `이번 주` 를 두 화면이
+    다른 날부터 세게 된다.
+    """
+    start, end = period_window.period_bounds(period)
+    weeks = exercise_activity.week_starts_covering(
+        date.fromisoformat(start), date.fromisoformat(end)
     )
+    rows = db.scalars(
+        select(ExerciseSession).where(
+            ExerciseSession.user_id == user_id,
+            ExerciseSession.week_start.in_(weeks),
+        )
+    ).all()
+    return start, end, daily_totals(list(rows), start, end)

--- a/backend/tests/test_exercise.py
+++ b/backend/tests/test_exercise.py
@@ -528,3 +528,70 @@ def test_editing_without_a_date_keeps_the_record_where_it_was(client):
     assert client.get(
         "/v1/exercise/weeks/current", headers=h
     ).json()["total_minutes"] == 0
+
+
+def test_exercise_advice_changes_with_the_period(client):
+    """회원 앱의 `오늘 / 이번 주 / 전체` 가 각각 다른 조언을 받는다. (#1574)
+
+    식단 조언(#1017)과 같은 규칙이다 — 그래프만 갈아 끼우고 조언이 오늘 이야기로
+    남으면, 이번 주를 보면서 "오늘은 유산소를 했네요" 를 읽게 된다.
+    """
+    h = _login(client)
+    today = clock.today()
+    monday = today - timedelta(days=today.weekday())
+
+    # 이번 주 월요일부터 오늘까지 유산소만 채운다 — 하루 조언과 주간 조언이
+    # 서로 다른 재료를 보는지 확인할 수 있는 가장 단순한 모양이다.
+    for back in range(today.weekday() + 1):
+        day = monday + timedelta(days=back)
+        created = client.post(
+            "/v1/exercise/sessions",
+            json={
+                "type": "cardio",
+                "minutes": 30,
+                "calories": 270,
+                "date": day.isoformat(),
+            },
+            headers=h,
+        )
+        assert created.status_code == 201, created.text
+
+    week = client.get("/v1/exercise/advice?period=week", headers=h)
+    assert week.status_code == 200, week.text
+    body = week.json()
+    assert body["period"] == "week"
+    assert body["from_date"] == monday.isoformat()
+    assert body["to_date"] == today.isoformat()
+    assert body["days_logged"] == today.weekday() + 1
+    assert "이번 주" in body["message"]
+
+    day_view = client.get("/v1/exercise/advice?period=today", headers=h).json()
+    assert day_view["from_date"] == today.isoformat()
+    assert day_view["days_logged"] == 1
+    assert "오늘" in day_view["message"]
+    assert day_view["message"] != body["message"]
+
+    every = client.get("/v1/exercise/advice?period=all", headers=h).json()
+    # 전체는 12주를 거슬러 본다 — 이번 주와 시작일이 다르다.
+    assert every["from_date"] < body["from_date"]
+    assert every["to_date"] == today.isoformat()
+
+
+def test_exercise_advice_says_nothing_when_there_is_nothing(client):
+    """없는 기록으로 조언을 지어내지 않는다. 기간별 안내는 남는다. (#1574)"""
+    h = _login(client)
+    messages = set()
+    for period in ("today", "week", "all"):
+        response = client.get(f"/v1/exercise/advice?period={period}", headers=h)
+        assert response.status_code == 200, response.text
+        assert response.json()["days_logged"] == 0
+        assert response.json()["message"]
+        messages.add(response.json()["message"])
+    # 세 기간이 같은 문장을 쓰면 토글이 아무 일도 하지 않는 것처럼 보인다.
+    assert len(messages) == 3
+
+
+def test_exercise_advice_rejects_an_unknown_period(client):
+    """기간 이름이 아니면 422 다 — 조용히 오늘로 흘려보내지 않는다. (#1574)"""
+    h = _login(client)
+    assert client.get("/v1/exercise/advice?period=month", headers=h).status_code == 422

--- a/backend/tests/test_period_advice_copy.py
+++ b/backend/tests/test_period_advice_copy.py
@@ -1,0 +1,116 @@
+"""기간별 조언 문장의 규칙. (#1574)
+
+확인하는 것은 세 가지다.
+
+- 기간마다 **다른 재료를 보고 다른 말**을 하는가 (그래프만 갈리고 조언이 오늘
+  이야기로 남으면 안 된다),
+- 없는 기록으로 조언을 지어내지 않는가,
+- **짧은가.** 카드는 회원 앱·트레이너웹 양쪽에서 좁은 폭에 들어간다 — 길어질수록
+  정작 짚어 주는 수치가 묻힌다.
+
+문장은 회원 앱의 데모 재현본(`core/demo/period_advice.dart`)과 같아야 한다. 한쪽만
+고치면 데모로 본 화면과 실 연동으로 본 화면이 다른 말을 하게 된다.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+
+from app.services import diet_service, exercise_service, period_window
+from app.services.diet_service import DietDayTotals
+from app.services.exercise_service import ExerciseDayTotals
+
+#: 한 문장 반. 이보다 길어지면 카드가 두 줄을 넘겨 화면이 밀린다.
+MAX_LEN = 45
+
+PERIODS = (period_window.PERIOD_TODAY, period_window.PERIOD_WEEK, period_window.PERIOD_ALL)
+
+
+def _diet_day(day: date, sodium: int) -> DietDayTotals:
+    return DietDayTotals(date=day, calories=700, sodium_mg=sodium, sugar_g=8.0)
+
+
+def _exercise_day(day: date, minutes: int = 30, kind: str = "cardio") -> ExerciseDayTotals:
+    return ExerciseDayTotals(
+        date=day,
+        minutes=minutes,
+        calories=minutes * 9,
+        by_type={kind: minutes},
+    )
+
+
+@pytest.mark.parametrize("period", PERIODS)
+def test_empty_records_get_their_own_message(period):
+    """기록이 없으면 없다고 말한다. 기간별로 다른 안내다."""
+    assert diet_service.period_coach_message([], period)
+    assert exercise_service.period_coach_message([], period)
+
+
+def test_empty_messages_differ_between_periods():
+    """셋이 같은 문장이면 토글이 아무 일도 하지 않는 것처럼 보인다."""
+    assert len({diet_service.period_coach_message([], p) for p in PERIODS}) == 3
+    assert len({exercise_service.period_coach_message([], p) for p in PERIODS}) == 3
+
+
+def test_diet_periods_look_at_different_material():
+    today = date(2026, 8, 27)  # 목요일
+    monday = today - timedelta(days=today.weekday())
+    days = [_diet_day(monday + timedelta(days=i), 2600) for i in range(3)]
+    days.append(_diet_day(today, 1200))
+
+    day_view = diet_service.period_coach_message(days, period_window.PERIOD_TODAY)
+    week = diet_service.period_coach_message(days, period_window.PERIOD_WEEK)
+
+    # 오늘은 오늘 합계를, 이번 주는 초과한 날 수를 말한다.
+    assert "1200mg" in day_view
+    assert "이번 주 3일" in week
+    assert day_view != week
+
+
+def test_exercise_periods_look_at_different_material():
+    today = date(2026, 8, 27)
+    monday = today - timedelta(days=today.weekday())
+    days = [_exercise_day(monday + timedelta(days=i)) for i in range(4)]
+
+    day_view = exercise_service.period_coach_message(days, period_window.PERIOD_TODAY)
+    week = exercise_service.period_coach_message(days, period_window.PERIOD_WEEK)
+
+    assert "오늘" in day_view
+    # 유산소만 한 주 — 쏠림을 먼저 짚고 다른 유형을 권한다.
+    assert "유산소" in week and "근력" in week
+    assert day_view != week
+
+
+@pytest.mark.parametrize(
+    "days",
+    [
+        [],
+        [_diet_day(date(2026, 8, 27), 3400)],
+        [_diet_day(date(2026, 8, 27), 1200)],
+        [_diet_day(date(2026, 8, 24) + timedelta(days=i), 2600) for i in range(4)],
+    ],
+)
+@pytest.mark.parametrize("period", PERIODS)
+def test_diet_messages_stay_short(days, period):
+    message = diet_service.period_coach_message(days, period)
+    assert len(message) <= MAX_LEN, message
+
+
+@pytest.mark.parametrize(
+    "days",
+    [
+        [],
+        [_exercise_day(date(2026, 8, 27), minutes=45)],
+        [_exercise_day(date(2026, 8, 24) + timedelta(days=i)) for i in range(4)],
+        [
+            _exercise_day(date(2026, 8, 24), kind="cardio"),
+            _exercise_day(date(2026, 8, 25), kind="strength"),
+            _exercise_day(date(2026, 8, 26), kind="stretching"),
+        ],
+    ],
+)
+@pytest.mark.parametrize("period", PERIODS)
+def test_exercise_messages_stay_short(days, period):
+    message = exercise_service.period_coach_message(days, period)
+    assert len(message) <= MAX_LEN, message

--- a/frontend/flutter/lib/core/demo/period_advice.dart
+++ b/frontend/flutter/lib/core/demo/period_advice.dart
@@ -1,0 +1,209 @@
+/// 데모 모드의 기간별 AI 맞춤 조언. (#1574)
+///
+/// 실 서버는 `GET /diet/advice`·`GET /exercise/advice` 가 이 말을 한다
+/// (`diet_service.period_coach_message`, `exercise_service.period_coach_message`).
+/// 데모에는 그 서버가 없으므로 **같은 규칙을 같은 문장으로** 여기서 재현한다 —
+/// 데모로 본 화면과 실 연동으로 본 화면이 다른 말을 하면, 시연에서 확인한 것이
+/// 무엇이었는지 알 수 없게 된다.
+///
+/// 규칙도 문장도 서버 쪽이 원본이다. 한쪽을 고치면 다른 쪽도 함께 고친다.
+library;
+
+/// 하루치 식단 합계. **기록이 있는 날만** 들어온다 — 안 먹은 날과 기록하지 않은
+/// 날은 다른 말이고, 평균이 그 차이를 삼키면 조언이 사실과 어긋난다.
+typedef DietDayTotals = ({DateTime date, int sodiumMg});
+
+/// 하루치 운동 합계. 식단과 같은 규칙으로 **기록이 있는 날만** 들어온다.
+typedef ExerciseDayTotals = ({
+  DateTime date,
+  int minutes,
+  int calories,
+  Map<String, int> byType,
+});
+
+/// DASH 권고 상한. 서버의 `diet_service.DASH_SODIUM_LIMIT_MG` 와 같은 값이다.
+const int kDashSodiumLimitMg = 2000;
+
+/// 기간 이름 — 화면의 기간 토글, 서버의 `period` 쿼리와 같은 말이다.
+const String kPeriodToday = 'today';
+const String kPeriodWeek = 'week';
+const String kPeriodAll = 'all';
+
+double _avg(List<int> values) => values.isEmpty
+    ? 0
+    : values.fold<int>(0, (int a, int b) => a + b) / values.length;
+
+/// 주중(월~금)·주말(토·일) 나트륨을 갈라 담는다.
+({List<int> weekday, List<int> weekend}) _weekdaySplit(
+  List<DietDayTotals> days,
+) => (
+  weekday: <int>[
+    for (final DietDayTotals d in days)
+      if (d.date.weekday < DateTime.saturday) d.sodiumMg,
+  ],
+  weekend: <int>[
+    for (final DietDayTotals d in days)
+      if (d.date.weekday >= DateTime.saturday) d.sodiumMg,
+  ],
+);
+
+/// 기간에 맞는 식단 조언. [days] 는 날짜순이고 기록이 있는 날만 든다.
+String dietPeriodAdvice(List<DietDayTotals> days, String period) {
+  if (days.isEmpty) {
+    // 없는 기록으로 조언을 지어내지 않는다.
+    if (period == kPeriodWeek) return '이번 주 식단 기록이 아직 없어요. 한 끼만 남겨도 흐름이 보여요.';
+    if (period == kPeriodAll) return '기록이 쌓이면 나트륨·칼로리 흐름을 짚어 드릴게요.';
+    return '오늘 식단 기록이 아직 없어요. 첫 끼니를 기록해 볼까요?';
+  }
+
+  final List<DietDayTotals> over = <DietDayTotals>[
+    for (final DietDayTotals d in days)
+      if (d.sodiumMg > kDashSodiumLimitMg) d,
+  ];
+
+  if (period == kPeriodWeek) {
+    if (over.length >= 3) {
+      return '이번 주 ${over.length}일이나 나트륨을 넘겼어요. 국물은 건더기 위주로 드세요.';
+    }
+    final ({List<int> weekday, List<int> weekend}) split = _weekdaySplit(days);
+    if (split.weekend.isNotEmpty &&
+        split.weekday.isNotEmpty &&
+        _avg(split.weekend) > _avg(split.weekday) * 1.3) {
+      return '주중엔 잘 지키다 주말에 나트륨이 올라요. 주말 외식은 한 끼만 정해요.';
+    }
+    if (over.isNotEmpty) {
+      return '이번 주 ${over.length}일만 권장량을 넘었어요. 나머지 날의 균형은 좋았어요.';
+    }
+    return '이번 주 ${days.length}일 모두 나트륨을 권장량 안에서 지켰어요!';
+  }
+
+  if (period == kPeriodAll) {
+    // 최근 4주와 그 이전을 견준다 — 나아지는 중인지가 이 화면의 질문이다.
+    final DateTime last = days.last.date;
+    final DateTime recentFrom = DateTime(last.year, last.month, last.day - 27);
+    final List<int> recent = <int>[
+      for (final DietDayTotals d in days)
+        if (!d.date.isBefore(recentFrom)) d.sodiumMg,
+    ];
+    final List<int> earlier = <int>[
+      for (final DietDayTotals d in days)
+        if (d.date.isBefore(recentFrom)) d.sodiumMg,
+    ];
+    if (earlier.isNotEmpty && recent.isNotEmpty) {
+      if (_avg(recent) < _avg(earlier) * 0.9) {
+        return '최근 4주 나트륨이 그 전보다 낮아졌어요. 지금 방식이 잘 맞아요.';
+      }
+      if (_avg(recent) > _avg(earlier) * 1.1) {
+        return '최근 4주 나트륨이 다시 올라가고 있어요. 한 주만 되짚어 볼까요?';
+      }
+    }
+    final ({List<int> weekday, List<int> weekend}) split = _weekdaySplit(days);
+    if (split.weekend.isNotEmpty &&
+        split.weekday.isNotEmpty &&
+        _avg(split.weekend) > _avg(split.weekday) * 1.3) {
+      return '기록을 통틀어 주말마다 나트륨이 올라요. 주말 한 끼만 담백하게 바꿔요.';
+    }
+    final int ratio = (over.length * 100 / days.length).round();
+    if (ratio >= 40) return '기록한 날의 $ratio%가 나트륨 권장량을 넘었어요. 국물부터 남겨 봐요.';
+    return '기록한 ${days.length}일 대부분이 권장량 안이에요. 지금 흐름이 좋아요.';
+  }
+
+  // 오늘 — 그날 합계 하나로 말한다.
+  final DietDayTotals today = days.last;
+  if (today.sodiumMg > kDashSodiumLimitMg) {
+    return '오늘 나트륨 ${today.sodiumMg}mg 로 권장량을 넘겼어요. 남은 끼니는 담백하게.';
+  }
+  return '오늘 나트륨 ${today.sodiumMg}mg 로 권장량 안이에요. 이대로 마무리해요.';
+}
+
+/// 운동 유형 코드 → 사람이 읽는 라벨. 서버 `exercise_types.label_for` 와 같다.
+String exerciseTypeLabel(String code) => switch (code) {
+  'cardio' || 'walking' => '유산소',
+  'strength' => '근력',
+  'flexibility' || 'stretching' || 'yoga' => '스트레칭',
+  _ => '기타',
+};
+
+/// 그날 가장 오래 한 유형. 같으면 유산소 → 근력 → 스트레칭 → 기타 순이다.
+String _mainType(Map<String, int> byType) {
+  const List<String> order = <String>['cardio', 'strength', 'stretching', 'other'];
+  String best = order.first;
+  int bestMinutes = -1;
+  for (final String kind in order) {
+    final int minutes = byType[kind] ?? 0;
+    if (minutes > bestMinutes) {
+      best = kind;
+      bestMinutes = minutes;
+    }
+  }
+  return best;
+}
+
+/// `전체` 가 거슬러 올라가는 주 수. 서버의 `ALL_PERIOD_DAYS`(84일)와 같다.
+const int kAllPeriodWeeks = 12;
+
+/// 기간에 맞는 운동 조언. [days] 는 날짜순이고 기록이 있는 날만 든다.
+String exercisePeriodAdvice(List<ExerciseDayTotals> days, String period) {
+  if (days.isEmpty) {
+    if (period == kPeriodWeek) return '이번 주 운동 기록이 아직 없어요. 10분 걷기부터 시작해 볼까요?';
+    if (period == kPeriodAll) return '기록이 쌓이면 운동량과 유형의 흐름을 짚어 드릴게요.';
+    return '오늘 운동 기록이 아직 없어요. 10분 걷기부터 시작해 볼까요?';
+  }
+
+  if (period == kPeriodToday) {
+    final ExerciseDayTotals today = days.last;
+    final String label = exerciseTypeLabel(_mainType(today.byType));
+    return '오늘 $label 위주로 ${today.minutes}분, ${today.calories}kcal 썼어요. 스트레칭으로 마무리해요.';
+  }
+
+  final int totalMinutes = days.fold<int>(
+    0,
+    (int sum, ExerciseDayTotals d) => sum + d.minutes,
+  );
+  final int activeDays = days.length;
+
+  if (period == kPeriodWeek) {
+    if (activeDays <= 1) {
+      return '이번 주는 $totalMinutes분 하루뿐이에요. 한 번 더 나가면 흐름이 이어져요.';
+    }
+    // 한 유형에 쏠렸는지 — 코칭에서 가장 먼저 짚는 지점이다.
+    final Map<String, int> byType = <String, int>{};
+    for (final ExerciseDayTotals d in days) {
+      d.byType.forEach((String kind, int minutes) {
+        byType[kind] = (byType[kind] ?? 0) + minutes;
+      });
+    }
+    if (byType.isNotEmpty && totalMinutes > 0) {
+      final String top = byType.keys.reduce(
+        (String a, String b) => byType[a]! >= byType[b]! ? a : b,
+      );
+      if (byType[top]! / totalMinutes >= 0.8) {
+        final String missing = top == 'cardio' ? 'strength' : 'cardio';
+        return '이번 주 $activeDays일 $totalMinutes분이 ${exerciseTypeLabel(top)}에 몰렸어요. '
+            '${exerciseTypeLabel(missing)}도 섞어 볼까요?';
+      }
+    }
+    return '이번 주 $activeDays일 $totalMinutes분, 유형도 고르게 섞였어요.';
+  }
+
+  // 전체 — 최근 4주와 그 이전을 견준다.
+  final DateTime last = days.last.date;
+  final DateTime recentFrom = DateTime(last.year, last.month, last.day - 27);
+  final List<int> recent = <int>[
+    for (final ExerciseDayTotals d in days)
+      if (!d.date.isBefore(recentFrom)) d.minutes,
+  ];
+  final List<int> earlier = <int>[
+    for (final ExerciseDayTotals d in days)
+      if (d.date.isBefore(recentFrom)) d.minutes,
+  ];
+  if (earlier.isNotEmpty && recent.isNotEmpty) {
+    if (_avg(recent) > _avg(earlier) * 1.1) {
+      return '최근 4주 운동량이 그 전보다 늘었어요. 지금 방식이 잘 맞아요.';
+    }
+    if (_avg(recent) < _avg(earlier) * 0.9) {
+      return '최근 4주 운동량이 줄고 있어요. 짧게라도 주 3일을 지켜 봐요.';
+    }
+  }
+  return '$kAllPeriodWeeks주 동안 $activeDays일 $totalMinutes분, 기복 없이 이어가고 있어요.';
+}

--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -14,6 +14,7 @@ import 'package:drift/drift.dart'
         Value;
 import 'package:logger/logger.dart';
 import 'package:oncare/core/demo/demo_ai_advice.dart';
+import 'package:oncare/core/demo/period_advice.dart';
 import 'package:oncare/core/storage/app_database.dart';
 import 'package:oncare/core/storage/seed_data.dart' show kDietDayMessagesKey;
 import 'package:oncare/core/utils/clock.dart';
@@ -56,9 +57,11 @@ class LocalApiInterceptor extends Interceptor {
     'GET /version': _version,
     'GET /dashboard/summary': _dashboardSummary,
     'GET /diet/days/today': _dietToday,
+    'GET /diet/advice': _dietAdvice,
     'GET /diet/recommendations': _dietRecommendations,
     'POST /diet/analyze': _dietAnalyze,
     'GET /exercise/weeks/current': _exerciseCurrentWeek,
+    'GET /exercise/advice': _exerciseAdvice,
     'POST /exercise/sessions': _exerciseAddSession,
     'GET /schedule/events': _scheduleEvents,
     'POST /schedule/events': _scheduleCreate,
@@ -679,6 +682,81 @@ class LocalApiInterceptor extends Interceptor {
     });
   }
 
+  /// GET /diet/advice — 기간에 맞는 식단 조언. (#1574)
+  ///
+  /// 실 서버(`/diet/advice`)와 **같은 규칙, 같은 문장**이다. 데모에 이 경로가
+  /// 없던 동안에는 요청이 그대로 네트워크로 흘러 실패했고, 화면은 어쩔 수 없이
+  /// 오늘 조언을 대신 그렸다 — `이번 주` 를 보면서 오늘 이야기를 읽게 되는
+  /// 원인이 여기였다.
+  Future<Response<Object?>> _dietAdvice(RequestOptions options) async {
+    final String? period = _advicePeriod(options);
+    if (period == null) {
+      return _unprocessable(options, 'period must be today, week or all');
+    }
+    final (String start, String end) = _periodBounds(period);
+    final rows =
+        await (_db.select(_db.dietEntries)..where(
+              (t) =>
+                  t.date.isBiggerOrEqualValue(start) &
+                  t.date.isSmallerOrEqualValue(end),
+            ))
+            .get();
+
+    // 기록이 없는 날은 만들지 않는다 — 안 먹은 날과 적지 않은 날은 다른 말이고,
+    // 0 으로 채우면 평균과 초과 일수가 사실과 어긋난다(서버와 같은 규칙).
+    final Map<String, int> sodiumByDate = <String, int>{};
+    for (final r in rows) {
+      sodiumByDate[r.date] = (sodiumByDate[r.date] ?? 0) + r.sodiumMg;
+    }
+    final List<String> dates = sodiumByDate.keys.toList()..sort();
+    final List<DietDayTotals> days = <DietDayTotals>[
+      for (final String date in dates)
+        if (DateTime.tryParse(date) case final DateTime parsed)
+          (date: parsed, sodiumMg: sodiumByDate[date]!),
+    ];
+
+    return _ok(options, <String, Object?>{
+      'period': period,
+      'from_date': start,
+      'to_date': end,
+      'days_logged': days.length,
+      'message': dietPeriodAdvice(days, period),
+    });
+  }
+
+  /// 조언 요청의 `period`. 기간 이름이 아니면 null 이다 — 서버가 422 로
+  /// 답하므로 목업이 조용히 오늘로 흘려보내면 두 구현이 갈린다.
+  String? _advicePeriod(RequestOptions options) {
+    final Object? raw = options.queryParameters['period'];
+    final String period = raw is String && raw.isNotEmpty ? raw : kPeriodToday;
+    const Set<String> known = <String>{kPeriodToday, kPeriodWeek, kPeriodAll};
+    return known.contains(period) ? period : null;
+  }
+
+  /// 기간 이름 → [시작, 끝] (양끝 포함). 서버 `period_window.period_bounds` 와
+  /// 같은 규칙이다 — `이번 주` 는 월요일부터 오늘까지, `전체` 는 12주다.
+  (String, String) _periodBounds(String period) {
+    final DateTime now = nowKst();
+    final DateTime today = DateTime(now.year, now.month, now.day);
+    if (period == kPeriodToday) {
+      return (_dateString(today), _dateString(today));
+    }
+    if (period == kPeriodWeek) {
+      final DateTime monday = DateTime(
+        today.year,
+        today.month,
+        today.day - (today.weekday - DateTime.monday),
+      );
+      return (_dateString(monday), _dateString(today));
+    }
+    final DateTime from = DateTime(
+      today.year,
+      today.month,
+      today.day - (kAllPeriodWeeks * 7 - 1),
+    );
+    return (_dateString(from), _dateString(today));
+  }
+
   /// GET /diet/recommendations — 홈 "AI 추천 식단".
   ///
   /// 데모에는 개인화 근거가 없다(로그인하지 않은 둘러보기). 그래서 서버가 고르는
@@ -918,6 +996,87 @@ class LocalApiInterceptor extends Interceptor {
   /// `week_start` 없이 부르면 이번 주다(예전 동작 그대로). 운동 탭이 주를 뒤로
   /// 넘길 때 그 주의 월요일을 실어 보낸다(#671) — 그 전에는 조회 경로가 이번
   /// 주 하나뿐이라 지난주를 받아올 방법이 없었다.
+  /// GET /exercise/advice — 기간에 맞는 운동 조언. (#1574)
+  ///
+  /// 식단 조언과 같은 규칙이다. 운동 기록은 날짜가 아니라 (그 주 월요일, 요일)
+  /// 로 저장돼 있어, 구간이 걸치는 주를 모두 읽어 실제 날짜로 되돌린 뒤 거른다
+  /// — 서버(`exercise_service.period_days`)가 하는 일과 같다.
+  Future<Response<Object?>> _exerciseAdvice(RequestOptions options) async {
+    final String? period = _advicePeriod(options);
+    if (period == null) {
+      return _unprocessable(options, 'period must be today, week or all');
+    }
+    final (String start, String end) = _periodBounds(period);
+    final List<String> weeks = _weekStartsCovering(start, end);
+    final rows =
+        await (_db.select(
+          _db.exerciseSessions,
+        )..where((t) => t.weekStart.isIn(weeks))).get();
+
+    final Map<String, ({int minutes, int calories, Map<String, int> byType})>
+    perDate = <String, ({int minutes, int calories, Map<String, int> byType})>{};
+    for (final r in rows) {
+      final int index = _weekdayLabels.indexOf(r.dayLabel);
+      if (index < 0) continue;
+      final DateTime monday = DateTime.parse(r.weekStart);
+      final String date = _dateString(
+        DateTime(monday.year, monday.month, monday.day + index),
+      );
+      if (date.compareTo(start) < 0 || date.compareTo(end) > 0) continue;
+      final ({int minutes, int calories, Map<String, int> byType}) day =
+          perDate[date] ??
+          (minutes: 0, calories: 0, byType: <String, int>{});
+      final String kind = switch (r.type) {
+        'cardio' || 'walking' => 'cardio',
+        'strength' => 'strength',
+        'yoga' || 'stretching' || 'flexibility' => 'stretching',
+        _ => 'other',
+      };
+      day.byType[kind] = (day.byType[kind] ?? 0) + r.minutes;
+      perDate[date] = (
+        minutes: day.minutes + r.minutes,
+        calories: day.calories + r.calories,
+        byType: day.byType,
+      );
+    }
+
+    final List<String> dates = perDate.keys.toList()..sort();
+    final List<ExerciseDayTotals> days = <ExerciseDayTotals>[
+      for (final String date in dates)
+        (
+          date: DateTime.parse(date),
+          minutes: perDate[date]!.minutes,
+          calories: perDate[date]!.calories,
+          byType: perDate[date]!.byType,
+        ),
+    ];
+
+    return _ok(options, <String, Object?>{
+      'period': period,
+      'from_date': start,
+      'to_date': end,
+      'days_logged': days.length,
+      'message': exercisePeriodAdvice(days, period),
+    });
+  }
+
+  /// [start, end] 를 덮는 모든 주의 월요일. 구간의 첫날이 주 가운데면 그 주
+  /// 월요일부터 담는다 — 월요일이 구간 밖이어도 그 주의 기록은 구간 안에 있을
+  /// 수 있다.
+  List<String> _weekStartsCovering(String start, String end) {
+    final DateTime from = DateTime.parse(_mondayOfString(start));
+    final DateTime to = DateTime.parse(end);
+    final List<String> weeks = <String>[];
+    for (
+      DateTime week = from;
+      !week.isAfter(to);
+      week = DateTime(week.year, week.month, week.day + 7)
+    ) {
+      weeks.add(_dateString(week));
+    }
+    return weeks;
+  }
+
   Future<Response<Object?>> _exerciseCurrentWeek(RequestOptions options) async {
     // 파라미터가 **있으면** 그 값을 그대로 검사한다. 빈 문자열도 "잘못된 값"이다
     // — 서버(FastAPI)가 그렇게 답하므로 여기서 조용히 이번 주로 흘려보내면 두

--- a/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
+++ b/frontend/flutter/lib/features/diet/presentation/pages/diet_record_page.dart
@@ -318,17 +318,26 @@ class _DietRecordPageState extends ConsumerState<DietRecordPage> {
                             // 기간 토글을 따라 조언도 바뀐다 (#1017). 지난
                             // 날짜를 고른 동안에는 그날의 조언이다 — 기간
                             // 토글이 숨겨져 있어 화면이 하루를 말하고 있다.
+                            //
+                            // 오늘 조언으로 **되돌아가지 않는다**(#1574).
+                            // 주간·전체 조언을 기다리는 동안 오늘 조언을 대신
+                            // 그리면, 이번 주를 보고 있는데 "오늘 점심이 짰어요"
+                            // 를 읽게 되고 요청이 실패하면 그 말이 그대로 남는다.
                             _AiFeedback(
-                              message: atToday
-                                  ? ref
-                                            .watch(
-                                              dietAdviceProvider(
-                                                _advicePeriod(selectedPeriod),
-                                              ),
-                                            )
-                                            .valueOrNull ??
-                                        day.aiCoachMessage
-                                  : day.aiCoachMessage,
+                              advice: atToday
+                                  ? ref.watch(
+                                      dietAdviceProvider(
+                                        _advicePeriod(selectedPeriod),
+                                      ),
+                                    )
+                                  : AsyncValue<String>.data(
+                                      day.aiCoachMessage,
+                                    ),
+                              onRetry: () => ref.invalidate(
+                                dietAdviceProvider(
+                                  _advicePeriod(selectedPeriod),
+                                ),
+                              ),
                             ),
                             const SizedBox(height: 20),
                             _MealLog(
@@ -1340,17 +1349,22 @@ class _NutritionProgressBar extends StatelessWidget {
 // ─────────────────────────────────────────────────────── AI feedback ──
 
 class _AiFeedback extends StatelessWidget {
-  const _AiFeedback({required this.message});
+  const _AiFeedback({required this.advice, required this.onRetry});
 
-  final String message;
+  /// 지금 고른 기간의 조언. 로딩·실패도 이 값이 들고 있다 — 카드가 다른 기간의
+  /// 말을 대신 하지 않도록. (#1574)
+  final AsyncValue<String> advice;
+
+  final VoidCallback onRetry;
 
   @override
   Widget build(BuildContext context) => Padding(
     padding: const EdgeInsets.symmetric(horizontal: 24),
     // 운동 탭도 같은 카드를 쓴다 — 그림은 공용 위젯에 있다. (#1021)
-    child: AiAdviceCard(
+    child: PeriodAiAdviceCard(
       title: AppLocalizations.of(context).dietAiFeedback,
-      message: message,
+      advice: advice,
+      onRetry: onRetry,
     ),
   );
 }

--- a/frontend/flutter/lib/features/exercise/data/repositories/dio_exercise_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/dio_exercise_repository.dart
@@ -24,6 +24,15 @@ class DioExerciseRepository implements ExerciseRepository {
     return ExerciseWeek.fromJson(res.data!);
   }
 
+  @override
+  Future<String> fetchAdvice(String period) async {
+    final res = await _dio.get<Map<String, Object?>>(
+      '/exercise/advice',
+      queryParameters: <String, Object?>{'period': period},
+    );
+    return (res.data?['message'] as String?) ?? '';
+  }
+
   static String _dateString(DateTime d) =>
       '${d.year.toString().padLeft(4, '0')}-'
       '${d.month.toString().padLeft(2, '0')}-'

--- a/frontend/flutter/lib/features/exercise/data/repositories/mock_exercise_repository.dart
+++ b/frontend/flutter/lib/features/exercise/data/repositories/mock_exercise_repository.dart
@@ -1,4 +1,5 @@
 import 'package:demo_fixture/demo_fixture.dart';
+import 'package:oncare/core/demo/period_advice.dart';
 import 'package:oncare/core/utils/clock.dart';
 import 'package:oncare/features/exercise/domain/entities/exercise_load.dart';
 import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
@@ -156,6 +157,70 @@ class MockExerciseRepository implements ExerciseRepository {
     // 이번 주(또는 미래)는 CRUD 가 반영된 살아 있는 주다.
     if (weeksAgo <= 0) return _buildWeek();
     return _pastWeek(weeksAgo);
+  }
+
+  @override
+  Future<String> fetchAdvice(String period) async {
+    await Future<void>.delayed(const Duration(milliseconds: 120));
+    // 문장 규칙은 서버(`exercise_service.period_coach_message`)의 것을 그대로
+    // 쓴다 — 데모로 본 화면과 실 연동으로 본 화면이 다른 말을 하면 안 된다.
+    return exercisePeriodAdvice(_dayTotals(period), period);
+  }
+
+  /// 기간이 덮는 날들의 하루 합계. **기록이 있는 날만** 만든다 — 쉰 날과 적지
+  /// 않은 날은 다른 말이라, 0 으로 채우면 조언의 "며칠 움직였다" 가 어긋난다.
+  ///
+  /// 이번 주는 [_sessions](CRUD 가 반영된 살아 있는 주)에서, 지난 주들은
+  /// 픽스처에서 읽는다 — 주간 요약이 읽는 것과 같은 출처다.
+  List<ExerciseDayTotals> _dayTotals(String period) {
+    final int weeksBack = switch (period) {
+      kPeriodAll => kAllPeriodWeeks - 1,
+      _ => 0,
+    };
+    final DateTime thisMonday = _addDays(_today, -_todayIdx);
+    final Map<DateTime, ({int minutes, int calories, Map<String, int> byType})>
+    perDay =
+        <DateTime, ({int minutes, int calories, Map<String, int> byType})>{};
+
+    for (int weeksAgo = weeksBack; weeksAgo >= 0; weeksAgo--) {
+      final DateTime monday = _addDays(thisMonday, -7 * weeksAgo);
+      final List<ExerciseSession> sessions = weeksAgo == 0
+          ? _sessions
+          : _sessionsForWeek(weeksAgo);
+      for (final ExerciseSession s in sessions) {
+        final int index = _dayLabels.indexOf(s.dayLabel);
+        if (index < 0) continue;
+        final DateTime date = _addDays(monday, index);
+        // 오늘 이후는 담지 않는다. `오늘` 은 오늘 하루만 본다.
+        if (date.isAfter(_today)) continue;
+        if (period == kPeriodToday && date != _today) continue;
+        final ({int minutes, int calories, Map<String, int> byType}) day =
+            perDay[date] ?? (minutes: 0, calories: 0, byType: <String, int>{});
+        final String kind = switch (s.type) {
+          ExerciseType.cardio || ExerciseType.walking => 'cardio',
+          ExerciseType.strength => 'strength',
+          ExerciseType.stretching || ExerciseType.yoga => 'stretching',
+          ExerciseType.other => 'other',
+        };
+        day.byType[kind] = (day.byType[kind] ?? 0) + s.minutes;
+        perDay[date] = (
+          minutes: day.minutes + s.minutes,
+          calories: day.calories + s.calories,
+          byType: day.byType,
+        );
+      }
+    }
+
+    final List<DateTime> dates = perDay.keys.toList()..sort();
+    return <ExerciseDayTotals>[
+      for (final DateTime date in dates)
+        (
+          date: date,
+          minutes: perDay[date]!.minutes,
+          calories: perDay[date]!.calories,
+          byType: perDay[date]!.byType,
+        ),
+    ];
   }
 
   /// [weekStart] 가 이번 주에서 몇 주 전인지. 이번 주면 0.

--- a/frontend/flutter/lib/features/exercise/domain/repositories/exercise_repository.dart
+++ b/frontend/flutter/lib/features/exercise/domain/repositories/exercise_repository.dart
@@ -9,6 +9,13 @@ abstract class ExerciseRepository {
   /// 없었다(#671). 이번 주를 넘겨 부르면 [fetchThisWeek] 과 같은 결과다.
   Future<ExerciseWeek> fetchWeek(DateTime weekStart);
 
+  /// 기간에 맞는 운동 조언 — GET /exercise/advice. (#1574)
+  ///
+  /// [period] 는 화면의 기간 토글과 같은 말이다(`today`·`week`·`all`). 구간
+  /// 경계는 서버가 정한다 — 앱이 따로 계산해 넘기면 같은 회원의 `이번 주` 가
+  /// 화면마다 다른 날부터 시작한다.
+  Future<String> fetchAdvice(String period);
+
   /// Persist a new workout session (POST /exercise/sessions) and return
   /// the created session as the server materialised it.
   ///

--- a/frontend/flutter/lib/features/exercise/presentation/controllers/exercise_controller.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/controllers/exercise_controller.dart
@@ -35,6 +35,23 @@ final exerciseWeekProvider = FutureProvider<ExerciseWeek>((ref) {
   return ref.watch(exerciseRepositoryProvider).fetchThisWeek();
 }, name: 'exerciseWeek');
 
+/// 기간에 맞는 운동 조언 — GET /exercise/advice. (#1574)
+///
+/// 식단 탭이 하는 것(#1017)과 같다. 기간을 바꾸는 것은 "무엇을 볼지" 를 바꾸는
+/// 일이라, 그래프만 갈아 끼우고 조언이 오늘 이야기로 남으면 `이번 주` 를 보면서
+/// "오늘은 유산소를 했네요" 를 읽게 된다.
+///
+/// 기간마다 provider 가 따로 서므로, 토글을 빠르게 옮겨도 이전 기간의 응답이
+/// 지금 보고 있는 기간의 카드를 덮어쓰지 않는다.
+///
+/// 구간 경계는 서버가 정한다 — 앱이 따로 계산해 넘기지 않는다.
+final exerciseAdviceProvider = FutureProvider.family<String, String>((
+  ref,
+  String period,
+) async {
+  return ref.watch(exerciseRepositoryProvider).fetchAdvice(period);
+}, name: 'exerciseAdvice');
+
 /// 그 주의 월요일. 주 단위 조회의 키다.
 DateTime mondayOfWeek(DateTime date) {
   final DateTime d = DateTime(date.year, date.month, date.day);

--- a/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/pages/exercise_page.dart
@@ -313,22 +313,27 @@ class _RecordTabState extends ConsumerState<_RecordTab> {
               child: ExerciseActivityStatus(week: week),
             ),
             const SizedBox(height: 20),
-            // 1-1) 직접 기록한 운동 — 하단 `+` 로 적었든 아래 `운동 추가` 로
-            // 적었든, 방금 적은 기록이 이 자리에 남는다. 오늘도 예외가 아니다
-            // (#1428). PT 일지·추천 개인운동과 섞이지 않도록 제목과 카드를
-            // 따로 둔다.
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 24),
-              child: OwnExerciseRecords(week: week, date: today),
-            ),
-            const SizedBox(height: 20),
             // 2) AI 맞춤 조언 — "얼마나 했나" 다음은 "그래서 오늘 뭘 할까" 다.
             //    식단 탭과 같은 카드를 쓴다. (#1021)
+            //
+            // 바로 위 `운동 현황` 의 기간 토글을 그대로 따라간다 (#1574).
+            // 그래프만 갈아 끼우고 조언이 오늘 이야기로 남으면, 이번 주를
+            // 보면서 "오늘은 유산소를 했네요" 를 읽게 된다. 오늘 조언으로
+            // 되돌아가지도 않는다 — 못 받았으면 못 받았다고 말한다.
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 24),
-              child: AiAdviceCard(
-                title: l.dietAiFeedback,
-                message: week.aiCoachMessage,
+              child: Consumer(
+                builder: (BuildContext context, WidgetRef ref, Widget? _) {
+                  final String period = exerciseAdvicePeriod(
+                    ref.watch(exerciseActivityPeriodProvider),
+                  );
+                  return PeriodAiAdviceCard(
+                    title: l.dietAiFeedback,
+                    advice: ref.watch(exerciseAdviceProvider(period)),
+                    onRetry: () =>
+                        ref.invalidate(exerciseAdviceProvider(period)),
+                  );
+                },
               ),
             ),
             const SizedBox(height: 20),
@@ -347,6 +352,19 @@ class _RecordTabState extends ConsumerState<_RecordTab> {
             const Padding(
               padding: EdgeInsets.symmetric(horizontal: 24),
               child: AiCoachingCard(),
+            ),
+            const SizedBox(height: 20),
+            // 4-1) 직접 기록한 운동 — 하단 `+` 로 적었든 아래 `운동 추가` 로
+            // 적었든, 방금 적은 기록이 이 자리에 남는다. 오늘도 예외가 아니다
+            // (#1428). PT 일지·추천 개인운동과 섞이지 않도록 제목과 카드를
+            // 따로 둔다.
+            //
+            // 코칭이 말하는 것(조언 → PT 일지 → 추천 개인운동)을 먼저 읽고 나서
+            // 내가 스스로 적은 기록을 본다 — 화면 위쪽은 "무엇을 해야 하나",
+            // 아래쪽은 "내가 무엇을 했나" 다. (#1574)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: OwnExerciseRecords(week: week, date: today),
             ),
             const SizedBox(height: 20),
             // 5) 받은 담당 요청. 담당 트레이너 카드는 뺐다 — 이 화면은 기록을

--- a/frontend/flutter/lib/features/exercise/presentation/widgets/exercise_activity_status.dart
+++ b/frontend/flutter/lib/features/exercise/presentation/widgets/exercise_activity_status.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart' show DateFormat, NumberFormat;
+import 'package:oncare/core/demo/period_advice.dart';
 import 'package:oncare/core/utils/clock.dart';
 import 'package:oncare/design_system/charts/chart_reveal.dart';
 import 'package:oncare/design_system/charts/goal_line.dart';
@@ -26,6 +27,15 @@ final exerciseActivityPeriodProvider = StateProvider<int>(
   (ref) => kExerciseActivityPeriodDefault,
   name: 'exerciseActivityPeriod',
 );
+
+/// 기간 토글의 칸(0·1·2) → 서버가 아는 기간 이름. 식단 탭과 같은 말을 쓴다
+/// (`today`·`week`·`all`). 토글이 정수인 것은 화면 사정이고, 서버·조언이 아는
+/// 것은 이름이다 — 그 사이를 여기 한 곳에서만 옮긴다. (#1574)
+String exerciseAdvicePeriod(int tab) => switch (tab) {
+  1 => kPeriodWeek,
+  2 => kPeriodAll,
+  _ => kPeriodToday,
+};
 
 /// 세 기간 카드의 **공통 높이**. 토글을 눌러도 카드가 커졌다 작아졌다 하지
 /// 않도록 셋을 같은 높이로 고정한다.

--- a/frontend/flutter/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations.dart
@@ -578,6 +578,18 @@ abstract class AppLocalizations {
   /// **'AI advice'**
   String get dietAiFeedback;
 
+  /// Shown in the AI advice card while the selected period's advice loads (#1574)
+  ///
+  /// In en, this message translates to:
+  /// **'Looking at this period…'**
+  String get aiAdviceLoading;
+
+  /// Shown in the AI advice card when the selected period's advice fails (#1574)
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t load the advice.'**
+  String get aiAdviceError;
+
   /// No description provided for @dietMealLog.
   ///
   /// In en, this message translates to:

--- a/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
@@ -1,6 +1,5 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
-
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -269,6 +268,12 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get dietAiFeedback => 'AI advice';
+
+  @override
+  String get aiAdviceLoading => 'Looking at this period…';
+
+  @override
+  String get aiAdviceError => 'Couldn\'t load the advice.';
 
   @override
   String get dietMealLog => 'Meal Log';

--- a/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
@@ -1,6 +1,5 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
-
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -267,6 +266,12 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get dietAiFeedback => 'AI 맞춤 조언';
+
+  @override
+  String get aiAdviceLoading => '이 기간의 조언을 살펴보는 중이에요…';
+
+  @override
+  String get aiAdviceError => '조언을 불러오지 못했어요.';
 
   @override
   String get dietMealLog => '식단 기록';

--- a/frontend/flutter/lib/l10n/app_en.arb
+++ b/frontend/flutter/lib/l10n/app_en.arb
@@ -129,6 +129,14 @@
   "dietUnitMg": "mg",
   "dietUnitG": "g",
   "dietAiFeedback": "AI advice",
+  "aiAdviceLoading": "Looking at this period…",
+  "@aiAdviceLoading": {
+    "description": "Shown in the AI advice card while the selected period's advice loads (#1574)"
+  },
+  "aiAdviceError": "Couldn't load the advice.",
+  "@aiAdviceError": {
+    "description": "Shown in the AI advice card when the selected period's advice fails (#1574)"
+  },
   "dietMealLog": "Meal Log",
   "dietAddMeal": "Add Meal",
   "dietEmptyLog": "No meals logged.\nAdd a meal with a photo!",

--- a/frontend/flutter/lib/l10n/app_ko.arb
+++ b/frontend/flutter/lib/l10n/app_ko.arb
@@ -90,6 +90,14 @@
   "dietUnitMg": "mg",
   "dietUnitG": "g",
   "dietAiFeedback": "AI 맞춤 조언",
+  "aiAdviceLoading": "이 기간의 조언을 살펴보는 중이에요…",
+  "@aiAdviceLoading": {
+    "description": "기간별 AI 조언을 불러오는 동안 카드에 남는 문구 (#1574)"
+  },
+  "aiAdviceError": "조언을 불러오지 못했어요.",
+  "@aiAdviceError": {
+    "description": "기간별 AI 조언 요청이 실패했을 때 카드에 남는 문구 (#1574)"
+  },
   "dietMealLog": "식단 기록",
   "dietAddMeal": "식단 추가",
   "dietEmptyLog": "기록된 식단이 없어요.\n사진으로 끼니를 추가해 보세요!",

--- a/frontend/flutter/lib/shared/widgets/ai_advice_card.dart
+++ b/frontend/flutter/lib/shared/widgets/ai_advice_card.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:oncare/design_system/figma/figma_kit.dart';
+import 'package:oncare/design_system/tokens/colors.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
 
 /// AI 가 건네는 한 문단짜리 조언 카드. (#1021)
 ///
@@ -25,6 +28,32 @@ class AiAdviceCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (message.trim().isEmpty) return const SizedBox.shrink();
+    return AiAdviceShell(
+      title: title,
+      child: Text(
+        message,
+        style: const TextStyle(
+          fontSize: 13.5,
+          height: 1.5,
+          fontWeight: FontWeight.w500,
+          color: FigmaColors.ink,
+        ),
+      ),
+    );
+  }
+}
+
+/// 조언 카드의 그릇 — 아바타·머리 한 줄·본문. 본문만 갈아 끼우면 로딩·실패도
+/// 같은 카드 안에서 말할 수 있다. 상태마다 다른 그림을 그리면 기간을 옮길 때
+/// 화면이 통째로 들썩인다. (#1574)
+class AiAdviceShell extends StatelessWidget {
+  const AiAdviceShell({super.key, required this.title, required this.child});
+
+  final String title;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
     return Container(
       padding: const EdgeInsets.all(14),
       decoration: BoxDecoration(
@@ -50,19 +79,91 @@ class AiAdviceCard extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(height: 2),
-                Text(
-                  message,
-                  style: const TextStyle(
-                    fontSize: 13.5,
-                    height: 1.5,
-                    fontWeight: FontWeight.w500,
-                    color: FigmaColors.ink,
-                  ),
-                ),
+                child,
               ],
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+/// 기간을 따라가는 조언 카드. (#1574)
+///
+/// 기간 토글이 바뀌면 카드도 **그 기간의 상태**가 된다. 예전에는 주간·전체
+/// 조언을 기다리는 동안 오늘 조언을 대신 그렸는데, 그러면 이번 주를 보고 있는데
+/// "오늘 점심이 짰어요" 를 읽게 되고, 요청이 실패하면 그 말이 그대로 남았다.
+///
+/// 그래서 **폴백이 없다.** 아직 못 받았으면 못 받았다고, 실패했으면 실패했다고
+/// 말하고 다시 시도할 길을 준다 — 다른 기간의 조언을 이 기간의 조언인 것처럼
+/// 보여 주는 것보다 낫다.
+class PeriodAiAdviceCard extends ConsumerWidget {
+  const PeriodAiAdviceCard({
+    super.key,
+    required this.title,
+    required this.advice,
+    required this.onRetry,
+  });
+
+  final String title;
+
+  /// 지금 고른 기간의 조언. 기간마다 provider 가 따로 서므로, 토글을 빠르게
+  /// 옮겨도 이전 기간의 응답이 이 카드에 들어오지 않는다.
+  final AsyncValue<String> advice;
+
+  /// 실패한 기간을 다시 부른다.
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AppLocalizations l = AppLocalizations.of(context);
+    return advice.when(
+      data: (String message) => AiAdviceCard(title: title, message: message),
+      loading: () => AiAdviceShell(
+        key: const ValueKey<String>('ai-advice-loading'),
+        title: title,
+        child: Text(
+          l.aiAdviceLoading,
+          style: const TextStyle(
+            fontSize: 13.5,
+            height: 1.5,
+            fontWeight: FontWeight.w500,
+            color: AppColors.mutedForeground,
+          ),
+        ),
+      ),
+      error: (Object error, StackTrace _) => AiAdviceShell(
+        key: const ValueKey<String>('ai-advice-error'),
+        title: title,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              l.aiAdviceError,
+              style: const TextStyle(
+                fontSize: 13.5,
+                height: 1.5,
+                fontWeight: FontWeight.w500,
+                color: AppColors.mutedForeground,
+              ),
+            ),
+            const SizedBox(height: 6),
+            // 카드 안에 두는 이유: 실패한 것은 이 카드 하나다. 화면 전체를
+            // 다시 부르면 방금 보던 그래프까지 깜빡인다.
+            TextButton(
+              key: const ValueKey<String>('ai-advice-retry'),
+              onPressed: onRetry,
+              style: TextButton.styleFrom(
+                padding: const EdgeInsets.symmetric(horizontal: 10),
+                minimumSize: const Size(0, 32),
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                foregroundColor: FigmaColors.primary,
+              ),
+              child: Text(l.actionRetry),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/frontend/flutter/test/app/record_add_navigation_test.dart
+++ b/frontend/flutter/test/app/record_add_navigation_test.dart
@@ -45,6 +45,9 @@ class _SavingRepository implements ExerciseRepository {
   bool saved = false;
 
   @override
+  Future<String> fetchAdvice(String period) async => '조언';
+
+  @override
   Future<ExerciseWeek> fetchThisWeek() async => _emptyWeek();
 
   @override

--- a/frontend/flutter/test/core/demo/period_advice_test.dart
+++ b/frontend/flutter/test/core/demo/period_advice_test.dart
@@ -1,0 +1,169 @@
+/// 기간별 조언 문장 규칙. (#1574)
+///
+/// 서버(`diet_service.period_coach_message`·`exercise_service.period_coach_message`)
+/// 가 원본이고 데모가 같은 규칙을 재현한다. 여기서 확인하는 것은 두 가지다 —
+/// 기간마다 **다른 재료를 보고 다른 말을 하는가**, 그리고 없는 기록으로 조언을
+/// 지어내지 않는가.
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/core/demo/period_advice.dart';
+
+DietDayTotals _diet(String date, int sodium) =>
+    (date: DateTime.parse(date), sodiumMg: sodium);
+
+ExerciseDayTotals _exercise(
+  String date, {
+  int minutes = 30,
+  int calories = 270,
+  Map<String, int> byType = const <String, int>{'cardio': 30},
+}) => (
+  date: DateTime.parse(date),
+  minutes: minutes,
+  calories: calories,
+  byType: Map<String, int>.of(byType),
+);
+
+void main() {
+  group('식단', () {
+    test('기록이 없으면 기간마다 다른 안내를 남긴다', () {
+      final Set<String> messages = <String>{
+        for (final String period in <String>[kPeriodToday, kPeriodWeek, kPeriodAll])
+          dietPeriodAdvice(const <DietDayTotals>[], period),
+      };
+      // 셋이 같은 문장이면 토글이 아무 일도 하지 않는 것처럼 보인다.
+      expect(messages.length, 3);
+    });
+
+    test('오늘은 그날 나트륨 합계를 짚는다', () {
+      expect(
+        dietPeriodAdvice(<DietDayTotals>[_diet('2026-08-27', 3400)], kPeriodToday),
+        contains('3400mg'),
+      );
+      expect(
+        dietPeriodAdvice(<DietDayTotals>[_diet('2026-08-27', 1200)], kPeriodToday),
+        contains('권장량 안'),
+      );
+    });
+
+    test('이번 주는 초과한 날 수를 센다 — 오늘 조언과 다른 말이다', () {
+      final List<DietDayTotals> days = <DietDayTotals>[
+        _diet('2026-08-24', 2600),
+        _diet('2026-08-25', 2600),
+        _diet('2026-08-26', 2600),
+        _diet('2026-08-27', 1200),
+      ];
+      final String week = dietPeriodAdvice(days, kPeriodWeek);
+      expect(week, contains('이번 주 3일'));
+      expect(week, isNot(dietPeriodAdvice(days, kPeriodToday)));
+    });
+
+    test('전체는 최근 4주와 그 이전을 견준다', () {
+      final List<DietDayTotals> days = <DietDayTotals>[
+        for (int i = 0; i < 20; i++)
+          _diet(
+            DateTime(2026, 6, 1 + i).toIso8601String().split('T').first,
+            3000,
+          ),
+        for (int i = 0; i < 20; i++)
+          _diet(
+            DateTime(2026, 8, 1 + i).toIso8601String().split('T').first,
+            1200,
+          ),
+      ];
+      expect(dietPeriodAdvice(days, kPeriodAll), contains('최근 4주'));
+    });
+
+    test('조언은 짧다 — 카드 한 줄 반을 넘기지 않는다', () {
+      final List<String> messages = <String>[
+        dietPeriodAdvice(<DietDayTotals>[_diet('2026-08-27', 3400)], kPeriodToday),
+        dietPeriodAdvice(<DietDayTotals>[
+          _diet('2026-08-24', 2600),
+          _diet('2026-08-25', 2600),
+          _diet('2026-08-26', 2600),
+        ], kPeriodWeek),
+        dietPeriodAdvice(const <DietDayTotals>[], kPeriodAll),
+      ];
+      for (final String message in messages) {
+        expect(message.length, lessThanOrEqualTo(45), reason: message);
+      }
+    });
+  });
+
+  group('운동', () {
+    test('기록이 없으면 기간마다 다른 안내를 남긴다', () {
+      final Set<String> messages = <String>{
+        for (final String period in <String>[kPeriodToday, kPeriodWeek, kPeriodAll])
+          exercisePeriodAdvice(const <ExerciseDayTotals>[], period),
+      };
+      expect(messages.length, 3);
+    });
+
+    test('오늘은 그날 한 운동과 소모 칼로리를 말한다', () {
+      final String today = exercisePeriodAdvice(<ExerciseDayTotals>[
+        _exercise('2026-08-27', minutes: 45, calories: 400),
+      ], kPeriodToday);
+      expect(today, contains('45분'));
+      expect(today, contains('400kcal'));
+      expect(today, contains('유산소'));
+    });
+
+    test('이번 주는 한 유형에 쏠렸는지를 먼저 짚는다', () {
+      final List<ExerciseDayTotals> cardioOnly = <ExerciseDayTotals>[
+        _exercise('2026-08-24'),
+        _exercise('2026-08-25'),
+        _exercise('2026-08-26'),
+      ];
+      final String week = exercisePeriodAdvice(cardioOnly, kPeriodWeek);
+      expect(week, contains('유산소'));
+      expect(week, contains('근력'));
+      expect(week, isNot(exercisePeriodAdvice(cardioOnly, kPeriodToday)));
+
+      final String mixed = exercisePeriodAdvice(<ExerciseDayTotals>[
+        _exercise('2026-08-24'),
+        _exercise(
+          '2026-08-25',
+          byType: <String, int>{'strength': 30},
+        ),
+        _exercise(
+          '2026-08-26',
+          byType: <String, int>{'stretching': 30},
+        ),
+      ], kPeriodWeek);
+      expect(mixed, contains('고르게'));
+    });
+
+    test('전체는 최근 4주 추세를 본다', () {
+      final List<ExerciseDayTotals> days = <ExerciseDayTotals>[
+        for (int i = 0; i < 20; i++)
+          _exercise(
+            DateTime(2026, 6, 1 + i).toIso8601String().split('T').first,
+            minutes: 10,
+          ),
+        for (int i = 0; i < 20; i++)
+          _exercise(
+            DateTime(2026, 8, 1 + i).toIso8601String().split('T').first,
+            minutes: 60,
+          ),
+      ];
+      expect(exercisePeriodAdvice(days, kPeriodAll), contains('최근 4주'));
+    });
+
+    test('조언은 짧다 — 카드 한 줄 반을 넘기지 않는다', () {
+      final List<String> messages = <String>[
+        exercisePeriodAdvice(<ExerciseDayTotals>[
+          _exercise('2026-08-27', minutes: 45, calories: 400),
+        ], kPeriodToday),
+        exercisePeriodAdvice(<ExerciseDayTotals>[
+          _exercise('2026-08-24'),
+          _exercise('2026-08-25'),
+        ], kPeriodWeek),
+        exercisePeriodAdvice(const <ExerciseDayTotals>[], kPeriodWeek),
+      ];
+      for (final String message in messages) {
+        expect(message.length, lessThanOrEqualTo(45), reason: message);
+      }
+    });
+  });
+}

--- a/frontend/flutter/test/core/network/local_api_interceptor_advice_test.dart
+++ b/frontend/flutter/test/core/network/local_api_interceptor_advice_test.dart
@@ -1,0 +1,202 @@
+/// 데모의 기간별 AI 맞춤 조언. (#1574)
+///
+/// 예전에는 `GET /diet/advice` 를 데모가 아예 처리하지 않아 요청이 네트워크로
+/// 흘러 실패했고, 화면은 어쩔 수 없이 오늘 조언을 대신 그렸다 — `이번 주` 를
+/// 보면서 오늘 이야기를 읽게 되는 원인이 여기였다.
+///
+/// 여기서 확인하는 것: 세 기간이 **각자 자기 구간의 기록만** 보고, 서로 다른
+/// 말을 하는가.
+library;
+
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
+
+import 'package:oncare/core/network/interceptors/local_api_interceptor.dart';
+import 'package:oncare/core/storage/app_database.dart';
+import 'package:oncare/core/utils/clock.dart';
+
+String _ymd(DateTime d) =>
+    '${d.year.toString().padLeft(4, '0')}-'
+    '${d.month.toString().padLeft(2, '0')}-'
+    '${d.day.toString().padLeft(2, '0')}';
+
+DateTime _today() {
+  final DateTime now = nowKst();
+  return DateTime(now.year, now.month, now.day);
+}
+
+DateTime _thisMonday() {
+  final DateTime today = _today();
+  return DateTime(today.year, today.month, today.day - (today.weekday - 1));
+}
+
+const List<String> _dayLabels = <String>['월', '화', '수', '목', '금', '토', '일'];
+
+void main() {
+  late AppDatabase db;
+  late Dio dio;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    dio = Dio(BaseOptions(baseUrl: 'https://example.test'));
+    dio.interceptors.add(LocalApiInterceptor(db, Logger(level: Level.off)));
+  });
+
+  tearDown(() async {
+    await db.close();
+    dio.close();
+  });
+
+  Future<void> addMeal(DateTime date, {required int sodium}) async {
+    await db
+        .into(db.dietEntries)
+        .insert(
+          DietEntriesCompanion.insert(
+            id: 'diet-${_ymd(date)}',
+            date: _ymd(date),
+            mealType: 'lunch',
+            timeLabel: '12:00',
+            foodsJson: jsonEncode(<Map<String, Object?>>[
+              <String, Object?>{'name': '점심', 'calories': 700},
+            ]),
+            totalCalories: 700,
+            sodiumMg: Value(sodium),
+          ),
+        );
+  }
+
+  Future<void> addWorkout(
+    DateTime date, {
+    String type = 'cardio',
+    int minutes = 30,
+  }) async {
+    final DateTime monday = DateTime(
+      date.year,
+      date.month,
+      date.day - (date.weekday - 1),
+    );
+    await db
+        .into(db.exerciseSessions)
+        .insert(
+          ExerciseSessionsCompanion.insert(
+            id: 'ex-${_ymd(date)}-$type',
+            weekStart: _ymd(monday),
+            dayLabel: _dayLabels[date.weekday - 1],
+            type: type,
+            minutes: minutes,
+            calories: minutes * 9,
+          ),
+        );
+  }
+
+  test('GET /diet/advice 는 기간마다 다른 말을 한다', () async {
+    final DateTime today = _today();
+    final DateTime monday = _thisMonday();
+    // 이번 주 월요일부터 어제까지는 짜게, 오늘은 싱겁게 먹은 주.
+    for (
+      DateTime day = monday;
+      day.isBefore(today);
+      day = DateTime(day.year, day.month, day.day + 1)
+    ) {
+      await addMeal(day, sodium: 2600);
+    }
+    await addMeal(today, sodium: 900);
+
+    final Response<Map<String, Object?>> todayView = await dio
+        .get<Map<String, Object?>>(
+          '/diet/advice',
+          queryParameters: <String, Object?>{'period': 'today'},
+        );
+    expect(todayView.data!['from_date'], _ymd(today));
+    expect(todayView.data!['days_logged'], 1);
+    expect(todayView.data!['message'], contains('900mg'));
+
+    final Response<Map<String, Object?>> week = await dio
+        .get<Map<String, Object?>>(
+          '/diet/advice',
+          queryParameters: <String, Object?>{'period': 'week'},
+        );
+    expect(week.data!['from_date'], _ymd(monday));
+    expect(week.data!['message'], isNot(todayView.data!['message']));
+
+    final Response<Map<String, Object?>> all = await dio
+        .get<Map<String, Object?>>(
+          '/diet/advice',
+          queryParameters: <String, Object?>{'period': 'all'},
+        );
+    // 전체는 12주를 거슬러 본다 — 이번 주와 시작일이 다르다.
+    expect(
+      (all.data!['from_date']! as String).compareTo(_ymd(monday)),
+      lessThan(0),
+    );
+  });
+
+  test('GET /diet/advice 는 기록이 없어도 그 기간의 안내를 남긴다', () async {
+    for (final String period in <String>['today', 'week', 'all']) {
+      final Response<Map<String, Object?>> res = await dio
+          .get<Map<String, Object?>>(
+            '/diet/advice',
+            queryParameters: <String, Object?>{'period': period},
+          );
+      expect(res.data!['days_logged'], 0);
+      expect(res.data!['message'], isNotEmpty);
+    }
+  });
+
+  test('GET /exercise/advice 는 구간에 걸친 주를 모두 읽고 날짜로 거른다', () async {
+    final DateTime today = _today();
+    final DateTime monday = _thisMonday();
+    // 지난 주 하루 — `이번 주` 에는 들어오지 않고 `전체` 에만 잡힌다.
+    await addWorkout(
+      DateTime(monday.year, monday.month, monday.day - 3),
+      minutes: 50,
+    );
+    for (
+      DateTime day = monday;
+      !day.isAfter(today);
+      day = DateTime(day.year, day.month, day.day + 1)
+    ) {
+      await addWorkout(day);
+    }
+
+    final Response<Map<String, Object?>> week = await dio
+        .get<Map<String, Object?>>(
+          '/exercise/advice',
+          queryParameters: <String, Object?>{'period': 'week'},
+        );
+    expect(week.data!['from_date'], _ymd(monday));
+    expect(week.data!['days_logged'], today.weekday);
+
+    final Response<Map<String, Object?>> all = await dio
+        .get<Map<String, Object?>>(
+          '/exercise/advice',
+          queryParameters: <String, Object?>{'period': 'all'},
+        );
+    expect(all.data!['days_logged'], today.weekday + 1);
+
+    final Response<Map<String, Object?>> todayView = await dio
+        .get<Map<String, Object?>>(
+          '/exercise/advice',
+          queryParameters: <String, Object?>{'period': 'today'},
+        );
+    expect(todayView.data!['days_logged'], 1);
+    expect(todayView.data!['message'], contains('오늘'));
+    expect(todayView.data!['message'], isNot(week.data!['message']));
+  });
+
+  test('기간 이름이 아니면 422 다 — 조용히 오늘로 흘려보내지 않는다', () async {
+    for (final String path in <String>['/diet/advice', '/exercise/advice']) {
+      final Response<Object?> res = await dio.get<Object?>(
+        path,
+        queryParameters: <String, Object?>{'period': 'month'},
+        options: Options(validateStatus: (int? _) => true),
+      );
+      expect(res.statusCode, 422, reason: path);
+    }
+  });
+}

--- a/frontend/flutter/test/features/diet/diet_period_advice_test.dart
+++ b/frontend/flutter/test/features/diet/diet_period_advice_test.dart
@@ -5,21 +5,49 @@
 /// 말이 되어 신뢰를 잃는다.
 library;
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:oncare/features/account/data/repositories/mock_account_repository.dart';
 import 'package:oncare/features/account/presentation/controllers/account_controller.dart';
+import 'package:oncare/features/diet/domain/repositories/diet_repository.dart';
 import 'package:oncare/features/diet/presentation/controllers/diet_controller.dart';
 import 'package:oncare/features/diet/presentation/pages/diet_record_page.dart';
 import 'package:oncare/gen/l10n/app_localizations.dart';
+import 'package:oncare/shared/widgets/ai_advice_card.dart';
 
 import '../../helpers/fake_diet_repository.dart';
 
-Widget _app() => ProviderScope(
+/// 기간 조언을 붙잡아 두거나 실패시키는 대역. 나머지 동작은 그대로 쓴다.
+class _AdviceRepository extends FakeDietRepository {
+  _AdviceRepository({
+    this.pending = const <String>{},
+    this.failing = const <String>{},
+  });
+
+  final Set<String> pending;
+  final Set<String> failing;
+
+  /// 기간별 요청 횟수 — 다시 시도가 정말 그 기간을 다시 부르는지 본다.
+  final Map<String, int> calls = <String, int>{};
+
+  @override
+  Future<String> fetchAdvice(String period) {
+    calls[period] = (calls[period] ?? 0) + 1;
+    if (pending.contains(period)) return Completer<String>().future;
+    if (failing.contains(period)) {
+      return Future<String>.error(StateError('advice unavailable'));
+    }
+    return super.fetchAdvice(period);
+  }
+}
+
+Widget _app([DietRepository? repo]) => ProviderScope(
   overrides: <Override>[
-    dietRepositoryProvider.overrideWithValue(FakeDietRepository()),
+    dietRepositoryProvider.overrideWithValue(repo ?? FakeDietRepository()),
     accountRepositoryProvider.overrideWithValue(MockAccountRepository()),
   ],
   child: const MaterialApp(
@@ -61,7 +89,64 @@ void main() {
     final String all = advice();
     expect(all, isNot(week), reason: '전체인데 이번 주 조언이 그대로다');
   });
+
+  testWidgets('이번 주 조언을 기다리는 동안 오늘 조언으로 되돌아가지 않는다 (#1574)', (
+    WidgetTester tester,
+  ) async {
+    tester.view.physicalSize = const Size(420, 1800);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    final _AdviceRepository repo = _AdviceRepository(pending: <String>{'week'});
+    await tester.pumpWidget(_app(repo));
+    await tester.pumpAndSettle();
+
+    final String todayAdvice = _shellText(tester);
+    expect(todayAdvice, isNotEmpty);
+
+    await tester.tap(find.byKey(const Key('diet-period-tab-week')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey<String>('ai-advice-loading')), findsOne);
+    // 오늘 조언도, 하루 응답이 들고 온 문장도 이 자리를 대신 채우지 않는다.
+    expect(_shellText(tester), isNot(contains(todayAdvice)));
+  });
+
+  testWidgets('실패한 기간은 실패했다고 말하고 다시 시도할 길을 준다 (#1574)', (
+    WidgetTester tester,
+  ) async {
+    tester.view.physicalSize = const Size(420, 1800);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    final _AdviceRepository repo = _AdviceRepository(failing: <String>{'all'});
+    await tester.pumpWidget(_app(repo));
+    await tester.pumpAndSettle();
+    final String todayAdvice = _shellText(tester);
+
+    await tester.tap(find.byKey(const Key('diet-period-tab-month')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey<String>('ai-advice-error')), findsOne);
+    expect(_shellText(tester), isNot(contains(todayAdvice)));
+
+    final int before = repo.calls['all']!;
+    await tester.tap(find.byKey(const ValueKey<String>('ai-advice-retry')));
+    await tester.pumpAndSettle();
+    expect(repo.calls['all'], before + 1);
+  });
 }
+
+/// 조언 카드가 지금 보여 주는 글자 전부 — 로딩·실패 상태도 이 그릇 안에 있다.
+String _shellText(WidgetTester tester) => tester
+    .widgetList<Text>(
+      find.descendant(
+        of: find.byType(AiAdviceShell),
+        matching: find.byType(Text),
+      ),
+    )
+    .map((Text t) => t.data ?? '')
+    .join(' ');
 
 /// AI 조언 카드의 타입 — 위젯이 private 이라 화면에서 찾아 쓴다.
 Type _adviceCardType(WidgetTester tester) => tester

--- a/frontend/flutter/test/features/exercise/exercise_name_hint_test.dart
+++ b/frontend/flutter/test/features/exercise/exercise_name_hint_test.dart
@@ -32,6 +32,9 @@ const ExerciseWeek _emptyWeek = ExerciseWeek(
 
 class _StubRepository implements ExerciseRepository {
   @override
+  Future<String> fetchAdvice(String period) async => '조언';
+
+  @override
   Future<ExerciseWeek> fetchThisWeek() async => _emptyWeek;
 
   @override

--- a/frontend/flutter/test/features/exercise/exercise_period_advice_test.dart
+++ b/frontend/flutter/test/features/exercise/exercise_period_advice_test.dart
@@ -1,0 +1,221 @@
+/// 운동 탭의 AI 맞춤 조언도 기간 토글을 따라간다. (#1574)
+///
+/// 식단 탭이 먼저 한 것(#1017)과 같은 규칙이다. 예전에는 조언이 주간 요약에
+/// 실려 온 문장 하나뿐이라, `오늘` 을 보든 `전체` 를 보든 같은 말이 남았다 —
+/// 그래프만 갈아 끼우면 조언이 지금 화면과 무관한 말이 된다.
+///
+/// 화면 순서도 여기서 함께 못 박는다. `직접 추가한 운동` 은 코칭이 말하는 것
+/// (조언 → PT 일지 → 추천 개인운동) 아래에 선다.
+library;
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/features/account/data/repositories/mock_account_repository.dart';
+import 'package:oncare/features/account/presentation/controllers/account_controller.dart';
+import 'package:oncare/features/exercise/domain/entities/exercise_week.dart';
+import 'package:oncare/features/exercise/domain/repositories/exercise_repository.dart';
+import 'package:oncare/features/exercise/presentation/controllers/exercise_controller.dart';
+import 'package:oncare/features/exercise/presentation/pages/exercise_page.dart';
+import 'package:oncare/features/exercise/presentation/widgets/own_exercise_records.dart';
+import 'package:oncare/features/member_coach/data/repositories/mock_member_coach_repository.dart';
+import 'package:oncare/features/member_coach/domain/repositories/member_coach_repository.dart';
+import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
+import 'package:oncare/features/member_coach/presentation/widgets/coach_card.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+import 'package:oncare/shared/widgets/ai_advice_card.dart';
+
+const List<String> _dayLabels = <String>['월', '화', '수', '목', '금', '토', '일'];
+
+ExerciseWeek _week() {
+  final List<double> daily = List<double>.filled(7, 40);
+  return ExerciseWeek(
+    sessions: const <ExerciseSession>[],
+    dailyMinutes: daily,
+    dailyCalories: List<double>.filled(7, 280),
+    cardioMinutes: daily,
+    strengthMinutes: List<double>.filled(7, 0),
+    stretchingMinutes: List<double>.filled(7, 0),
+    dayLabels: _dayLabels,
+    totalMinutes: 280,
+    totalCalories: 1960,
+    streakDays: 1,
+    // 주간 요약이 들고 오는 옛 문장. 기간 조언이 이 값으로 되돌아가면 안 된다.
+    aiCoachMessage: '주간 요약이 들고 온 옛 조언',
+  );
+}
+
+/// 기간마다 다른 문장을 주는 대역. [pending] 에 든 기간은 응답을 붙잡아 두고,
+/// [failing] 에 든 기간은 실패한다.
+class _AdviceRepository implements ExerciseRepository {
+  _AdviceRepository({
+    this.pending = const <String>{},
+    this.failing = const <String>{},
+  });
+
+  final Set<String> pending;
+  final Set<String> failing;
+
+  /// 기간별 요청 횟수 — 다시 시도가 정말 그 기간을 다시 부르는지 본다.
+  final Map<String, int> calls = <String, int>{};
+
+  @override
+  Future<String> fetchAdvice(String period) {
+    calls[period] = (calls[period] ?? 0) + 1;
+    if (pending.contains(period)) return Completer<String>().future;
+    if (failing.contains(period)) {
+      return Future<String>.error(StateError('advice unavailable'));
+    }
+    return Future<String>.value('$period 기간 조언');
+  }
+
+  @override
+  Future<ExerciseWeek> fetchThisWeek() async => _week();
+
+  @override
+  Future<ExerciseWeek> fetchWeek(DateTime weekStart) async => _week();
+
+  @override
+  Future<ExerciseSession> addSession({
+    required ExerciseType type,
+    required int minutes,
+    required int calories,
+    required DateTime date,
+    String name = '',
+    ExerciseIntensity intensity = ExerciseIntensity.moderate,
+    int? sets,
+    int? reps,
+    double? weight,
+  }) async => throw UnimplementedError();
+
+  @override
+  Future<void> deleteSession(String id) async => throw UnimplementedError();
+
+  @override
+  Future<ExerciseSession> updateSession({
+    required String id,
+    required ExerciseType type,
+    required int minutes,
+    required int calories,
+    required DateTime date,
+    String name = '',
+    ExerciseIntensity intensity = ExerciseIntensity.moderate,
+    int? sets,
+    int? reps,
+    double? weight,
+  }) async => throw UnimplementedError();
+}
+
+Widget _app(ExerciseRepository repo) => ProviderScope(
+  overrides: <Override>[
+    appConfigProvider.overrideWithValue(
+      const AppConfig(
+        environment: Environment.dev,
+        apiBaseUrl: 'https://example.test',
+        useMockApi: true,
+      ),
+    ),
+    exerciseRepositoryProvider.overrideWithValue(repo),
+    accountRepositoryProvider.overrideWithValue(MockAccountRepository()),
+    memberCoachRepositoryProvider.overrideWithValue(
+      MockMemberCoachRepository() as MemberCoachRepository,
+    ),
+  ],
+  child: const MaterialApp(
+    locale: Locale('ko'),
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: ExercisePage(),
+  ),
+);
+
+/// 조언 카드가 지금 보여 주는 글자 전부.
+String _adviceText(WidgetTester tester) => tester
+    .widgetList<Text>(
+      find.descendant(
+        of: find.byType(AiAdviceShell),
+        matching: find.byType(Text),
+      ),
+    )
+    .map((Text t) => t.data ?? '')
+    .join(' ');
+
+Future<void> _pump(WidgetTester tester, ExerciseRepository repo) async {
+  tester.view.physicalSize = const Size(500, 2600);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.reset);
+  await tester.pumpWidget(_app(repo));
+  await tester.pumpAndSettle();
+}
+
+/// 기간 토글의 칸을 누른다. 0 = 오늘, 1 = 이번 주, 2 = 전체.
+Future<void> _tapPeriod(WidgetTester tester, int index) async {
+  final AppLocalizations l = AppLocalizations.of(
+    tester.element(find.byType(ExercisePage)),
+  );
+  final String label = <String>[l.exToday, l.exThisWeek, l.exPeriodAll][index];
+  await tester.tap(find.text(label));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('오늘 / 이번 주 / 전체가 각각 다른 조언을 보여 준다', (WidgetTester tester) async {
+    final _AdviceRepository repo = _AdviceRepository();
+    await _pump(tester, repo);
+
+    expect(_adviceText(tester), contains('today 기간 조언'));
+
+    await _tapPeriod(tester, 1);
+    expect(_adviceText(tester), contains('week 기간 조언'));
+
+    await _tapPeriod(tester, 2);
+    expect(_adviceText(tester), contains('all 기간 조언'));
+  });
+
+  testWidgets('주간 조언을 기다리는 동안 오늘 조언으로 되돌아가지 않는다', (WidgetTester tester) async {
+    final _AdviceRepository repo = _AdviceRepository(
+      pending: <String>{'week'},
+    );
+    await _pump(tester, repo);
+    final String todayAdvice = _adviceText(tester);
+
+    await _tapPeriod(tester, 1);
+
+    expect(find.byKey(const ValueKey<String>('ai-advice-loading')), findsOne);
+    expect(_adviceText(tester), isNot(contains(todayAdvice)));
+    // 주간 요약이 들고 온 옛 문장으로도 내려앉지 않는다.
+    expect(_adviceText(tester), isNot(contains('주간 요약이 들고 온 옛 조언')));
+  });
+
+  testWidgets('실패한 기간은 실패했다고 말하고 다시 시도할 길을 준다', (WidgetTester tester) async {
+    final _AdviceRepository repo = _AdviceRepository(failing: <String>{'all'});
+    await _pump(tester, repo);
+
+    await _tapPeriod(tester, 2);
+
+    expect(find.byKey(const ValueKey<String>('ai-advice-error')), findsOne);
+    expect(_adviceText(tester), isNot(contains('today 기간 조언')));
+
+    final int before = repo.calls['all']!;
+    await tester.tap(find.byKey(const ValueKey<String>('ai-advice-retry')));
+    await tester.pumpAndSettle();
+    expect(repo.calls['all'], before + 1);
+  });
+
+  testWidgets('직접 추가한 운동은 추천 개인운동 아래에 선다', (WidgetTester tester) async {
+    await _pump(tester, _AdviceRepository());
+
+    final double coaching = tester
+        .getTopLeft(find.byType(AiCoachingCard, skipOffstage: false))
+        .dy;
+    final double ownRecords = tester
+        .getTopLeft(find.byType(OwnExerciseRecords, skipOffstage: false))
+        .dy;
+    // 위쪽은 "무엇을 해야 하나", 아래쪽은 "내가 무엇을 했나" 다.
+    expect(ownRecords, greaterThan(coaching));
+  });
+}

--- a/frontend/flutter/test/features/exercise/exercise_selected_day_test.dart
+++ b/frontend/flutter/test/features/exercise/exercise_selected_day_test.dart
@@ -51,6 +51,9 @@ class _FixedWeekRepository implements ExerciseRepository {
   final double minutes;
 
   @override
+  Future<String> fetchAdvice(String period) async => '조언';
+
+  @override
   Future<ExerciseWeek> fetchThisWeek() async => _week(minutes);
 
   @override

--- a/frontend/flutter/test/features/exercise/exercise_sets_input_test.dart
+++ b/frontend/flutter/test/features/exercise/exercise_sets_input_test.dart
@@ -26,6 +26,9 @@ class _CapturingRepository implements ExerciseRepository {
   String? updatedId;
 
   @override
+  Future<String> fetchAdvice(String period) async => '조언';
+
+  @override
   Future<ExerciseWeek> fetchThisWeek() async => _emptyWeek;
 
   @override

--- a/frontend/flutter/test/features/exercise/mock_exercise_repository_test.dart
+++ b/frontend/flutter/test/features/exercise/mock_exercise_repository_test.dart
@@ -367,4 +367,53 @@ void main() {
       expect(week.dailyMinutes, everyElement(0.0));
     });
   });
+
+  group('기간별 조언은 그 기간의 기록만 본다 (#1574)', () {
+    test('오늘 / 이번 주 / 전체가 서로 다른 말을 한다', () async {
+      final MockExerciseRepository r = _repo();
+      final String today = await r.fetchAdvice('today');
+      final String week = await r.fetchAdvice('week');
+      final String all = await r.fetchAdvice('all');
+
+      expect(<String>{today, week, all}.length, 3);
+      // 오늘은 그날 한 것을, 이번 주는 며칠 움직였는지를 말한다.
+      expect(today, contains('오늘'));
+      expect(week, contains('이번 주'));
+    });
+
+    test('오늘 조언은 오늘 기록만 센다', () async {
+      final MockExerciseRepository r = _repo();
+      final List<FixtureDay> days = _weekDays(_friday);
+      final FixtureDay? todayFixture = days
+          .where((FixtureDay d) => d.date == _ymd(_friday))
+          .firstOrNull;
+      final int minutes =
+          todayFixture?.doneExercises.fold<int>(
+            0,
+            (int sum, FixtureExercise e) => sum + e.minutes,
+          ) ??
+          0;
+
+      final String advice = await r.fetchAdvice('today');
+      if (minutes == 0) {
+        // 없는 기록으로 조언을 지어내지 않는다.
+        expect(advice, contains('기록이 아직 없어요'));
+      } else {
+        expect(advice, contains('$minutes분'));
+      }
+    });
+
+    test('직접 적은 기록이 그날 조언에 바로 반영된다', () async {
+      final MockExerciseRepository r = _repo();
+      final String before = await r.fetchAdvice('today');
+      await r.addSession(
+        type: ExerciseType.cardio,
+        minutes: 25,
+        calories: 220,
+        date: _friday,
+        name: '저녁 걷기',
+      );
+      expect(await r.fetchAdvice('today'), isNot(before));
+    });
+  });
 }

--- a/frontend/flutter/test/features/exercise/own_exercise_records_test.dart
+++ b/frontend/flutter/test/features/exercise/own_exercise_records_test.dart
@@ -78,6 +78,9 @@ class _RecordingRepository implements ExerciseRepository {
   String? deletedId;
 
   @override
+  Future<String> fetchAdvice(String period) async => '조언';
+
+  @override
   Future<ExerciseWeek> fetchThisWeek() async => _week(sessions: _sessions);
 
   @override

--- a/frontend/flutter_trainer/lib/shared/services/client_repository.dart
+++ b/frontend/flutter_trainer/lib/shared/services/client_repository.dart
@@ -595,28 +595,24 @@ class DriftClientRepository implements ClientRepository {
     final bool weekendHeavy = _weekendRuns(logged);
     if (period == ClientPeriod.week) {
       if (over >= 3) {
-        return '이번 주 $over일이나 나트륨 권장량을 넘었어요. '
-            '국물은 건더기 위주로 먹고 남은 며칠은 담백하게 가요.';
+        return '이번 주 $over일이나 나트륨을 넘겼어요. 국물은 건더기 위주로 드세요.';
       }
       if (weekendHeavy) {
-        return '주중에는 잘 지키다가 주말에 나트륨이 확 올라요. '
-            '주말 외식은 한 끼만 정해 두면 흐름이 유지돼요.';
+        return '주중엔 잘 지키다 주말에 나트륨이 올라요. 주말 외식은 한 끼만 정해요.';
       }
       if (over > 0) {
-        return '이번 주 $over일만 권장량을 넘었어요. '
-            '나머지 날의 균형은 좋았으니 이 흐름을 이어가요.';
+        return '이번 주 $over일만 권장량을 넘었어요. 나머지 날의 균형은 좋았어요.';
       }
-      return '이번 주 내내 나트륨을 권장량 안에서 지켰어요. 아주 좋아요!';
+      return '이번 주 ${logged.length}일 모두 나트륨을 권장량 안에서 지켰어요!';
     }
     if (weekendHeavy) {
-      return '기록을 통틀어 보면 주말마다 나트륨이 오르는 흐름이에요. '
-          '주말 한 끼만 담백하게 바꿔도 평균이 내려가요.';
+      return '기록을 통틀어 주말마다 나트륨이 올라요. 주말 한 끼만 담백하게 바꿔요.';
     }
     if (over * 10 >= logged.length * 4) {
       return '기록한 날의 ${(over * 100 / logged.length).round()}%가 나트륨 권장량을 넘었어요. '
-          '국·찌개 국물을 남기는 것부터 시작해 봐요.';
+          '국물부터 남겨 봐요.';
     }
-    return '기록을 통틀어 나트륨이 대체로 권장량 안이에요. 지금 흐름이 좋아요.';
+    return '기록한 ${logged.length}일 대부분이 권장량 안이에요. 지금 흐름이 좋아요.';
   }
 
   @override
@@ -635,16 +631,16 @@ class DriftClientRepository implements ClientRepository {
         .toList();
     if (logged.isEmpty) {
       return switch (period) {
-        ClientPeriod.week => '이번 주 운동 기록이 아직 없어요. 가벼운 산책 한 번도 흐름이 됩니다.',
+        ClientPeriod.week => '이번 주 운동 기록이 아직 없어요. 10분 걷기부터 시작해 볼까요?',
         ClientPeriod.month => '기록이 쌓이면 운동량과 유형의 흐름을 짚어 드릴게요.',
-        ClientPeriod.today => '아직 오늘 운동 기록이 없어요. 10분 걷기부터 시작해 볼까요?',
+        ClientPeriod.today => '오늘 운동 기록이 아직 없어요. 10분 걷기부터 시작해 볼까요?',
       };
     }
 
     if (period == ClientPeriod.today) {
       final ClientExerciseDay day = logged.last;
       return '오늘 ${_mainTypeLabel(day)} 위주로 ${day.minutes}분, '
-          '${day.calories}kcal 를 썼어요. 마무리로 가볍게 스트레칭하면 회복이 빨라져요.';
+          '${day.calories}kcal 썼어요. 스트레칭으로 마무리해요.';
     }
 
     final int totalMinutes = logged.fold<int>(
@@ -653,7 +649,7 @@ class DriftClientRepository implements ClientRepository {
     );
     if (period == ClientPeriod.week) {
       if (logged.length <= 1) {
-        return '이번 주는 ${logged.length}일 움직였어요. 한 번 더 나가면 흐름이 끊기지 않아요.';
+        return '이번 주는 $totalMinutes분 하루뿐이에요. 한 번 더 나가면 흐름이 이어져요.';
       }
       final int cardio = logged.fold<int>(
         0,
@@ -665,15 +661,14 @@ class DriftClientRepository implements ClientRepository {
       );
       // 서버와 같은 8할 기준 — 한 유형에 쏠렸는지가 코칭의 첫 질문이다.
       if (totalMinutes > 0 && cardio * 10 >= totalMinutes * 8) {
-        return '이번 주 ${logged.length}일 $totalMinutes분을 채웠는데 유산소에 몰려 있어요. '
-            '근력을 한 번 섞어 볼까요?';
+        return '이번 주 ${logged.length}일 $totalMinutes분이 유산소에 몰렸어요. '
+            '근력도 섞어 볼까요?';
       }
       if (totalMinutes > 0 && strength * 10 >= totalMinutes * 8) {
-        return '이번 주 ${logged.length}일 $totalMinutes분을 채웠는데 근력에 몰려 있어요. '
-            '유산소를 한 번 섞어 볼까요?';
+        return '이번 주 ${logged.length}일 $totalMinutes분이 근력에 몰렸어요. '
+            '유산소도 섞어 볼까요?';
       }
-      return '이번 주 ${logged.length}일 동안 $totalMinutes분 운동했어요. '
-          '유형도 고르게 섞였네요. 이 흐름을 이어가요.';
+      return '이번 주 ${logged.length}일 $totalMinutes분, 유형도 고르게 섞였어요.';
     }
 
     // 전체 — 최근 4주와 그 이전을 견준다.
@@ -692,14 +687,13 @@ class DriftClientRepository implements ClientRepository {
         xs.isEmpty ? 0 : xs.fold<int>(0, (int a, int b) => a + b) / xs.length;
     if (recent.isNotEmpty && earlier.isNotEmpty) {
       if (mean(recent) > mean(earlier) * 1.1) {
-        return '최근 4주 운동량이 그 전보다 늘었어요. 지금 방식이 회원님께 맞는 것 같아요.';
+        return '최근 4주 운동량이 그 전보다 늘었어요. 지금 방식이 잘 맞아요.';
       }
       if (mean(recent) < mean(earlier) * 0.9) {
-        return '최근 4주 들어 운동량이 줄고 있어요. 무엇이 달라졌는지 한 주만 되짚어 볼까요?';
+        return '최근 4주 운동량이 줄고 있어요. 짧게라도 주 3일을 지켜 봐요.';
       }
     }
-    return '기록을 통틀어 ${logged.length}일 $totalMinutes분을 움직였어요. '
-        '큰 기복 없이 이어가고 있어요.';
+    return '12주 동안 ${logged.length}일 $totalMinutes분, 기복 없이 이어가고 있어요.';
   }
 
   /// [period] 가 덮는 구간의 일별 운동 집계.

--- a/frontend/flutter_trainer/test/features/clients/client_detail_diet_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_detail_diet_test.dart
@@ -481,10 +481,10 @@ void main() {
           .firstWhere((c) => c.id == 'seed-client-1');
       final over = minsu.sodiumOverDays;
       final expectedText = over >= 3
-          ? '이번 주 $over일이나 나트륨 권장량을 넘었어요'
+          ? '이번 주 $over일이나 나트륨을 넘겼어요'
           : over > 0
           ? '이번 주 $over일만 권장량을 넘었어요'
-          : '이번 주 내내 나트륨을 권장량 안에서 지켰어요';
+          : '나트륨을 권장량 안에서 지켰어요';
 
       // 오늘 문장은 사라지고, 그 자리에 이번 주를 읽은 문장이 온다.
       expect(find.textContaining('나트륨이 목표치를'), findsNothing);


### PR DESCRIPTION
Closes #1574

## Summary

`AI 맞춤 조언` 카드가 **식단 탭과 운동 탭 모두** 바로 위 기간 토글(`오늘 / 이번 주 / 전체`)을 따라간다. 기간마다 그 구간의 기록만 보고 서로 다른 말을 하며, 아직 못 받았거나 실패했을 때 **다른 기간의 조언으로 되돌아가지 않는다.**

조언 문구는 기간·실제 수치에 맞게 전부 다시 쓰고 한 문장 반 이내로 줄였다. 운동 탭에서는 `직접 기록한 운동` 을 `추천 개인운동` 아래(가장 마지막)로 옮겼다.

## Changes

**백엔드**

- `GET /exercise/advice?period=today|week|all` (회원) 추가. 트레이너웹의 `#1025` 경로와 **같은 함수·같은 문장**을 쓴다.
- 조회·집계를 `exercise_service.period_days` 하나로 모으고, 트레이너 라우터도 그것을 부른다 — 구간 규칙이 갈리면 같은 회원의 `이번 주` 를 두 화면이 다른 날부터 센다.
- 식단·운동 기간 조언 문구를 데이터에 맞게 다시 쓰고 축약. 오늘은 그날 수치를, 이번 주는 초과 일수·쏠린 유형을, 전체는 최근 4주 추세를 짚는다.

**사용자 앱**

- 조언 카드가 `AsyncValue` 를 그대로 받는다. 로딩 중에는 그 기간의 로딩 상태를, 실패하면 실패 문구와 카드 안 재시도 버튼을 보여 준다(폴백 제거).
- 운동 탭: `exerciseAdviceProvider(period)` 를 기간 토글에 물렸다. 기간마다 provider 가 따로 서므로 토글을 빠르게 옮겨도 이전 기간의 응답이 지금 카드를 덮어쓰지 않는다.
- 운동 탭 순서: 운동 현황 → AI 맞춤 조언 → 오늘 완료한 PT → 추천 개인운동 → **직접 기록한 운동**.
- 데모(목업): `/diet/advice`·`/exercise/advice` 를 로컬 인터셉터와 목업 운동 저장소에 서버와 같은 규칙·같은 문장으로 재현했다. 예전에는 이 경로가 없어 요청이 늘 실패했고, 그래서 데모에서는 기간을 바꿔도 조언이 한 번도 바뀌지 않았다.
- l10n: 조언 카드의 로딩·실패 문구(ko/en).

**트레이너웹**

- UI 변경 없음. 데모가 들고 있던 같은 규칙의 문장을 서버 문구에 맞춰 옮겼다 — 실 연동과 데모가 같은 말을 해야 한다.

## Verification

- 백엔드: 전체 pytest 통과. 새 테스트 — 회원 `/exercise/advice` 의 기간별 응답·빈 기록·잘못된 기간(422), 두 서비스 조언 문구의 기간별 구분과 길이 상한.
- 사용자 앱: `flutter analyze` 무경고, 전체 `flutter test` 통과. 새 테스트 — 두 탭의 기간별 조언 전환, 로딩 중 오늘 조언 미노출, 실패 시 재시도가 그 기간을 다시 부르는지, 운동 탭 카드 순서, 데모 경로 응답, 조언 규칙 단위 테스트.
- 트레이너웹: 전체 `flutter test` 통과.
- 데모 픽스처 기준 실제 문장(오늘 목요일): 식단 `오늘 나트륨 3428mg 로 권장량을 넘겼어요. 남은 끼니는 담백하게.` / `이번 주 2일만 권장량을 넘었어요. 나머지 날의 균형은 좋았어요.` / `기록한 84일 대부분이 권장량 안이에요. 지금 흐름이 좋아요.`, 운동 `오늘 근력 위주로 40분, 240kcal 썼어요. 스트레칭으로 마무리해요.` / `이번 주 4일 188분, 유형도 고르게 섞였어요.` / `12주 동안 67일 3229분, 기복 없이 이어가고 있어요.`

## Notes

- `전체` 조언이 보는 구간은 서버가 정한 12주(84일)다. 식단 탭 그래프와 같은 구간이고, 운동 탭 그래프는 더 뒤(35주)까지 밀어 볼 수 있어 문장에 `12주` 를 밝혀 두었다. 두 탭의 `전체` 정의를 하나로 맞추는 것은 이 PR 범위 밖이라 따로 뗀다.
- 오늘 식단 카드에는 이제 데모 시드의 큐레이션 문장 대신 그날 수치로 만든 문장이 선다. 지난 날짜를 고르면 예전처럼 그날의 문장이 그대로 나온다.
