### PR TITLE
feat(chat): 리포트 PDF 요일별 그래프

### DIFF
--- a/frontend/flutter/lib/features/member_coach/services/member_report_pdf_generator.dart
+++ b/frontend/flutter/lib/features/member_coach/services/member_report_pdf_generator.dart
@@ -41,21 +41,18 @@ class MemberReportPdfGenerator {
     double y = _beginPage(canvas, l, 1);
     int pageNumber = 1;
 
+    const double contentWidth = _pageWidth - (_margin * 2);
     for (final _Block block in blocks) {
-      final TextPainter painter = TextPainter(
-        text: TextSpan(text: block.text, style: block.style),
-        textDirection: TextDirection.ltr,
-        textScaler: TextScaler.noScaling,
-      )..layout(maxWidth: _pageWidth - (_margin * 2));
-      if (y + painter.height + block.after > _pageHeight - _margin) {
+      final double height = block.height(contentWidth);
+      if (y + height + block.after > _pageHeight - _margin) {
         pageImages.add(await _finishPage(recorder));
         recorder = ui.PictureRecorder();
         canvas = Canvas(recorder);
         pageNumber++;
         y = _beginPage(canvas, l, pageNumber);
       }
-      painter.paint(canvas, Offset(_margin, y));
-      y += painter.height + block.after;
+      block.paint(canvas, Offset(_margin, y), contentWidth);
+      y += height + block.after;
     }
     pageImages.add(await _finishPage(recorder));
 
@@ -142,18 +139,18 @@ class MemberReportPdfGenerator {
     ];
     final int loggedDays = report.diet.loggedDays;
     final List<_Block> blocks = <_Block>[
-      _Block.body(
+      _TextBlock.body(
         l.coachReportPdfPeriod(_date(report.weekStart), _date(report.weekEnd)),
       ),
       // 트레이너가 리포트와 함께 보낸 글을 맨 앞에 둔다 — 트레이너 화면도
       // 지표보다 먼저 `트레이너 피드백` 을 읽게 되어 있다(#1613).
-      _Block.section(l.coachReportPdfSectionTrainerNote),
-      _Block.body(
+      _TextBlock.section(l.coachReportPdfSectionTrainerNote),
+      _TextBlock.body(
         trainerNote.trim().isEmpty
             ? l.coachReportPdfNoTrainerNote
             : trainerNote.trim(),
       ),
-      _Block.section(l.coachReportPdfSectionMetrics),
+      _TextBlock.section(l.coachReportPdfSectionMetrics),
       _bullet(
         l,
         l.coachReportPdfLabelWorkoutDays,
@@ -228,7 +225,7 @@ class MemberReportPdfGenerator {
                 report.diet.avgSugarG.toStringAsFixed(1),
               ),
       ),
-      _Block.section(l.coachReportPdfSectionTypes),
+      _TextBlock.section(l.coachReportPdfSectionTypes),
       _bullet(
         l,
         l.coachReportPdfLabelCardio,
@@ -248,41 +245,55 @@ class MemberReportPdfGenerator {
           l.coachReportPdfValueMinutes,
         ),
       ),
-      _Block.section(l.coachReportPdfSectionMacros),
+      _TextBlock.section(l.coachReportPdfSectionMacros),
       _bullet(l, l.homeMacroCarbs, _gram(l, report.avgCarbsG)),
       _bullet(l, l.homeMacroProtein, _gram(l, report.avgProteinG)),
       _bullet(l, l.homeMacroFat, _gram(l, report.avgFatG)),
-      _Block.section(l.coachReportPdfSectionChange),
+      _TextBlock.section(l.coachReportPdfSectionChange),
       ..._changes(l, report),
-      _Block.section(l.coachReportPdfSectionTrend),
-      _bullet(
+      _TextBlock.section(l.coachReportPdfSectionTrend),
+      // 운동 시간·섭취 칼로리·나트륨은 막대로 그린다(#1615). 나머지 한 줄짜리
+      // 계열(당류)은 글로 남긴다 — 그래프를 넷까지 늘리면 한 장이 그래프로만
+      // 채워져, 무엇을 먼저 볼지가 사라진다.
+      _chart(
         l,
-        l.coachReportPdfLabelMinutesShort,
-        _series(l, report.minutesByDay, l.coachReportPdfValueMinutes),
+        report,
+        weekdays,
+        title: l.coachReportPdfLabelMinutesShort,
+        values: report.minutesByDay,
+        unit: l.coachReportPdfValueMinutes,
       ),
-      _bullet(
+      _chart(
         l,
-        l.coachReportPdfLabelCaloriesShort,
-        _series(l, report.caloriesByDay, l.coachReportPdfValueKcal),
+        report,
+        weekdays,
+        title: l.coachReportPdfLabelCaloriesShort,
+        values: report.caloriesByDay.map((int v) => v.toDouble()).toList(),
+        unit: l.coachReportPdfValueKcal,
       ),
-      _bullet(
+      _chart(
         l,
-        l.coachReportPdfLabelSodiumShort,
-        _series(l, report.sodiumByDay, l.coachReportPdfValueMg),
+        report,
+        weekdays,
+        title: l.coachReportPdfLabelSodiumShort,
+        values: report.sodiumByDay.map((int v) => v.toDouble()).toList(),
+        unit: l.coachReportPdfValueMg,
+        // 위에서 센 `나트륨 목표 초과 N일` 이 어느 날이었는지 이 선이 답한다.
+        target: report.sodiumTarget?.toDouble(),
       ),
       _bullet(
         l,
         l.coachReportPdfLabelSugarShort,
         _series(l, report.sugarByDay, l.coachReportPdfValueGram),
       ),
-      _Block.section(l.coachReportPdfSectionDaily),
+      _TextBlock.section(l.coachReportPdfSectionDaily),
     ];
 
     for (int i = 0; i < weekdays.length; i++) {
       // 아직 오지 않은 요일은 `기록 없음` 이 아니다 — 그렇게 적으면 지키지 못한
       // 날처럼 읽힌다. 이번 주 리포트는 늘 뒷날이 비어 있어 절반이 그랬다(#1613).
       if (report.isUpcoming(i)) {
-        blocks.add(_Block.body(l.coachReportPdfDayUpcoming(weekdays[i])));
+        blocks.add(_TextBlock.body(l.coachReportPdfDayUpcoming(weekdays[i])));
         continue;
       }
       final List<String> done = report.exercisesOn(i, weekdays);
@@ -290,7 +301,7 @@ class MemberReportPdfGenerator {
           ? report.caloriesByDay[i]
           : 0;
       blocks.add(
-        _Block.body(
+        _TextBlock.body(
           l.coachReportPdfDay(
             weekdays[i],
             done.isEmpty ? l.coachReportPdfNoData : done.join(', '),
@@ -304,26 +315,54 @@ class MemberReportPdfGenerator {
     // 나트륨 초과를 셌다면 어느 기준으로 셌는지 밝힌다 — 기준을 적지 않으면
     // 트레이너가 보는 초과 일수와 숫자가 달라도 왜 다른지 알 수 없다.
     if (report.sodiumTarget case final int target when loggedDays > 0) {
-      blocks.add(_Block.body(l.coachReportPdfSodiumTargetNote('$target')));
+      blocks.add(_TextBlock.body(l.coachReportPdfSodiumTargetNote('$target')));
     }
     // 이 문서가 어디서 온 값인지 마지막에 한 줄로 밝힌다 — 트레이너가 보낸
     // 파일과 같은 자리에서 열리므로, 같은 것으로 오해하지 않도록.
-    blocks.add(_Block.body(l.coachReportPdfPreviewNote, after: 12));
+    blocks.add(_TextBlock.body(l.coachReportPdfPreviewNote, after: 12));
     return blocks;
   }
 
-  static _Block _bullet(AppLocalizations l, String label, String value) =>
-      _Block.body(l.coachReportPdfBullet(label, value));
+  static _TextBlock _bullet(AppLocalizations l, String label, String value) =>
+      _TextBlock.body(l.coachReportPdfBullet(label, value));
+
+  /// 요일별 막대 하나. 글로 적던 계열([_series])을 그대로 그림으로 옮긴다 —
+  /// 문서가 말하는 값은 같아야 하므로 [_ChartBlock.text] 도 같은 줄을 든다.
+  static _ChartBlock _chart(
+    AppLocalizations l,
+    MemberWeeklyReport report,
+    List<String> weekdays, {
+    required String title,
+    required List<double> values,
+    required _Unit unit,
+    double? target,
+  }) => _ChartBlock(
+    title: title,
+    text: l.coachReportPdfBullet(title, _series(l, values, unit)),
+    values: values,
+    labels: weekdays,
+    upcoming: <bool>[
+      for (int i = 0; i < weekdays.length; i++) report.isUpcoming(i),
+    ],
+    format: (double value) => unit(_trim(value)),
+    target: target,
+    targetLabel: target == null
+        ? null
+        : l.coachReportPdfChartTarget(unit(_trim(target))),
+  );
 
   /// `지난주 대비` 줄들. 견줄 주가 없으면 그 사실을 한 줄로 적는다 — 항목만
   /// 빠지면 문서가 그 주에 아무 변화도 없었던 것처럼 읽힌다.
-  static List<_Block> _changes(AppLocalizations l, MemberWeeklyReport report) {
+  static List<_TextBlock> _changes(
+    AppLocalizations l,
+    MemberWeeklyReport report,
+  ) {
     final MemberWeeklyReport? last = report.previous;
     if (last == null ||
         (last.exercise.totalMinutes == 0 && last.loggedDays == 0)) {
-      return <_Block>[_Block.body(l.coachReportPdfNoPreviousWeek)];
+      return <_TextBlock>[_TextBlock.body(l.coachReportPdfNoPreviousWeek)];
     }
-    return <_Block>[
+    return <_TextBlock>[
       _change(
         l,
         l.coachReportPdfLabelWorkoutMinutes,
@@ -338,7 +377,7 @@ class MemberReportPdfGenerator {
         last.exercise.totalCalories,
         l.coachReportPdfValueKcal,
       ),
-      if (report.loggedDays > 0 && last.loggedDays > 0) ...<_Block>[
+      if (report.loggedDays > 0 && last.loggedDays > 0) ...<_TextBlock>[
         _change(
           l,
           l.coachReportPdfLabelCalories,
@@ -357,7 +396,7 @@ class MemberReportPdfGenerator {
     ];
   }
 
-  static _Block _change(
+  static _TextBlock _change(
     AppLocalizations l,
     String label,
     int current,
@@ -370,7 +409,7 @@ class MemberReportPdfGenerator {
         : delta > 0
         ? l.coachReportPdfDeltaUp(unit('$delta'))
         : l.coachReportPdfDeltaDown(unit('${-delta}'));
-    return _Block.body(
+    return _TextBlock.body(
       l.coachReportPdfChange(
         label,
         unit('$current'),
@@ -422,11 +461,30 @@ class MemberReportPdfGenerator {
       : value.toStringAsFixed(1);
 }
 
-/// 문서 한 줄. 화면 측정값과 무관하게 문서 레이아웃을 새로 그린다.
-class _Block {
-  const _Block(this.text, this.style, this.after);
+/// 문서의 한 덩이. 화면 측정값과 무관하게 문서 레이아웃을 새로 그린다.
+///
+/// 글줄과 그래프가 같은 것으로 취급돼야 페이지 넘김이 한 곳에서 끝난다 — 높이를
+/// 스스로 재고 스스로 그린다.
+sealed class _Block {
+  const _Block(this.after);
 
-  factory _Block.section(String text) => _Block(
+  /// 이 덩이 아래에 두는 여백.
+  final double after;
+
+  /// 문서에서 이 덩이가 하는 말. 테스트와 텍스트 추출이 읽는 값이라, 그래프도
+  /// 자기 값을 글로 옮겨 놓는다 — 그림만 남으면 무엇을 그렸는지 확인할 길이 없다.
+  String get text;
+
+  double height(double width);
+
+  void paint(Canvas canvas, Offset offset, double width);
+}
+
+/// 글줄 하나.
+class _TextBlock extends _Block {
+  const _TextBlock(this.text, this.style, super.after);
+
+  factory _TextBlock.section(String text) => _TextBlock(
     text,
     const TextStyle(
       color: Color(0xff10384a),
@@ -437,15 +495,211 @@ class _Block {
     16,
   );
 
-  factory _Block.body(String text, {double after = 9}) => _Block(
+  factory _TextBlock.body(String text, {double after = 9}) => _TextBlock(
     text,
     const TextStyle(color: Color(0xff26333a), fontSize: 20, height: 1.5),
     after,
   );
 
+  @override
   final String text;
   final TextStyle style;
-  final double after;
+
+  TextPainter _painter(double width) => TextPainter(
+    text: TextSpan(text: text, style: style),
+    textDirection: TextDirection.ltr,
+    textScaler: TextScaler.noScaling,
+  )..layout(maxWidth: width);
+
+  @override
+  double height(double width) => _painter(width).height;
+
+  @override
+  void paint(Canvas canvas, Offset offset, double width) =>
+      _painter(width).paint(canvas, offset);
+}
+
+/// 요일별 값 하나를 막대로 그린다. (#1615)
+///
+/// 일곱 칸을 `30분 / - / 45분 / …` 로 늘어놓으면 어느 날이 높고 낮은지 눈으로
+/// 훑어 견줘야 한다. 트레이너 리포트 탭은 같은 값을 막대로 보여 주므로, 같은 주를
+/// 두 사람이 다른 밀도로 읽지 않도록 문서도 막대로 그린다.
+class _ChartBlock extends _Block {
+  const _ChartBlock({
+    required this.title,
+    required this.text,
+    required this.values,
+    required this.labels,
+    required this.upcoming,
+    required this.format,
+    this.target,
+    this.targetLabel,
+  }) : super(22);
+
+  static const double _barsHeight = 190;
+  static const double _titleHeight = 30;
+  static const double _labelHeight = 30;
+
+  /// 그래프 위에 적는 이름.
+  final String title;
+
+  @override
+  final String text;
+
+  /// 월→일 일곱 칸.
+  final List<double> values;
+
+  /// 요일 표시.
+  final List<String> labels;
+
+  /// 아직 오지 않은 요일. 막대를 그리지 않는다 — 0 으로 그리면 지키지 못한 날처럼
+  /// 읽힌다(#1613 의 요일별 상세와 같은 규칙).
+  final List<bool> upcoming;
+
+  /// 막대 위에 적는 값. 단위를 붙이는 자리는 로케일이 정한다.
+  final String Function(double value) format;
+
+  /// 하루 목표. 있으면 가로선으로 얹고, 넘긴 날의 막대를 달리 칠한다.
+  final double? target;
+  final String? targetLabel;
+
+  @override
+  double height(double width) => _titleHeight + _barsHeight + _labelHeight;
+
+  @override
+  void paint(Canvas canvas, Offset offset, double width) {
+    _text(title, _titleStyle).paint(canvas, offset);
+
+    final double top = offset.dy + _titleHeight;
+    final double bottom = top + _barsHeight;
+    final Paint axis = Paint()
+      ..color = const Color(0xffd3dde3)
+      ..strokeWidth = 2;
+    canvas.drawLine(
+      Offset(offset.dx, bottom),
+      Offset(offset.dx + width, bottom),
+      axis,
+    );
+
+    // 축은 값이 있는 막대와 목표선을 모두 담을 만큼만 높인다. 0 뿐인 주에도
+    // 눈금이 무너지지 않도록 바닥값을 둔다.
+    final double peak = <double>[
+      ...values,
+      if (target case final double t) t,
+      1,
+    ].reduce((double a, double b) => a > b ? a : b);
+    final double scale = _barsHeight * 0.78 / peak;
+
+    // 목표선은 막대보다 **먼저** 긋는다. 나중에 그으면 막대 위에 적은 값 글자를
+    // 가로질러, 그 숫자가 선에 붙은 것처럼 읽힌다.
+    if (target case final double t) {
+      _dashedLine(canvas, offset.dx, offset.dx + width, bottom - t * scale);
+    }
+
+    final int count = labels.length;
+    final double slot = width / count;
+    final double barWidth = slot * 0.46;
+    for (int i = 0; i < count; i++) {
+      final double centre = offset.dx + slot * i + slot / 2;
+      _text(labels[i], _labelStyle).paint(
+        canvas,
+        Offset(centre - _text(labels[i], _labelStyle).width / 2, bottom + 6),
+      );
+      if (i < upcoming.length && upcoming[i]) continue;
+      final double value = i < values.length ? values[i] : 0;
+      if (value <= 0) continue;
+      final double barHeight = value * scale;
+      final bool over = target != null && value > target!;
+      canvas.drawRRect(
+        RRect.fromRectAndCorners(
+          Rect.fromLTWH(
+            centre - barWidth / 2,
+            bottom - barHeight,
+            barWidth,
+            barHeight,
+          ),
+          topLeft: const Radius.circular(6),
+          topRight: const Radius.circular(6),
+        ),
+        Paint()
+          ..color = over ? const Color(0xffb3261e) : const Color(0xff3eafdf),
+      );
+      // 값은 막대 **안에** 적는다. 막대 위에 적으면 목표선 바로 아래에 있는
+      // 막대의 숫자가 선 위로 올라가, 목표를 넘긴 값처럼 읽힌다.
+      final bool inside = barHeight >= 46;
+      final TextPainter valueText = _text(
+        format(value),
+        inside
+            ? _insideValueStyle
+            : over
+            ? _overValueStyle
+            : _valueStyle,
+      );
+      valueText.paint(
+        canvas,
+        Offset(
+          centre - valueText.width / 2,
+          inside ? bottom - barHeight + 8 : bottom - barHeight - 26,
+        ),
+      );
+    }
+
+    // 목표선 글자는 막대 위에 얹는다 — 선 자체는 막대 아래에 이미 깔았다.
+    if (target case final double t) {
+      final TextPainter targetText = _text(
+        targetLabel ?? format(t),
+        _targetStyle,
+      );
+      targetText.paint(
+        canvas,
+        Offset(offset.dx + width - targetText.width, bottom - t * scale - 26),
+      );
+    }
+  }
+
+  /// 목표선은 점선이다 — 실선으로 그으면 막대와 같은 무게로 읽힌다.
+  void _dashedLine(Canvas canvas, double from, double to, double y) {
+    final Paint paint = Paint()
+      ..color = const Color(0xff7d8f9b)
+      ..strokeWidth = 2;
+    for (double x = from; x < to; x += 16) {
+      canvas.drawLine(Offset(x, y), Offset(x + 9, y), paint);
+    }
+  }
+
+  static TextPainter _text(String value, TextStyle style) => TextPainter(
+    text: TextSpan(text: value, style: style),
+    textDirection: TextDirection.ltr,
+    textScaler: TextScaler.noScaling,
+  )..layout();
+
+  static const TextStyle _titleStyle = TextStyle(
+    color: Color(0xff26333a),
+    fontSize: 20,
+    fontWeight: FontWeight.w700,
+  );
+  static const TextStyle _labelStyle = TextStyle(
+    color: Color(0xff5b6b76),
+    fontSize: 18,
+  );
+  static const TextStyle _insideValueStyle = TextStyle(
+    color: Color(0xffffffff),
+    fontSize: 17,
+    fontWeight: FontWeight.w700,
+  );
+  static const TextStyle _valueStyle = TextStyle(
+    color: Color(0xff26333a),
+    fontSize: 17,
+  );
+  static const TextStyle _overValueStyle = TextStyle(
+    color: Color(0xffb3261e),
+    fontSize: 17,
+    fontWeight: FontWeight.w700,
+  );
+  static const TextStyle _targetStyle = TextStyle(
+    color: Color(0xff5b6b76),
+    fontSize: 17,
+  );
 }
 
 /// 미리보기 문서를 만드는 서비스.

--- a/frontend/flutter/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations.dart
@@ -2678,6 +2678,12 @@ abstract class AppLocalizations {
   /// **'None booked'**
   String get coachReportPdfNoSessions;
 
+  /// Label on a chart's dashed goal line.
+  ///
+  /// In en, this message translates to:
+  /// **'goal {value}'**
+  String coachReportPdfChartTarget(String value);
+
   /// Daily line for a weekday that has not happened yet.
   ///
   /// In en, this message translates to:

--- a/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_en.dart
@@ -1450,6 +1450,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get coachReportPdfNoSessions => 'None booked';
 
   @override
+  String coachReportPdfChartTarget(String value) {
+    return 'goal $value';
+  }
+
+  @override
   String coachReportPdfDayUpcoming(String weekday) {
     return '$weekday — still to come';
   }

--- a/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter/lib/gen/l10n/app_localizations_ko.dart
@@ -1423,6 +1423,11 @@ class AppLocalizationsKo extends AppLocalizations {
   String get coachReportPdfNoSessions => '잡힌 일정 없음';
 
   @override
+  String coachReportPdfChartTarget(String value) {
+    return '목표 $value';
+  }
+
+  @override
   String coachReportPdfDayUpcoming(String weekday) {
     return '$weekday요일 — 아직 지나지 않았어요';
   }

--- a/frontend/flutter/lib/l10n/app_en.arb
+++ b/frontend/flutter/lib/l10n/app_en.arb
@@ -821,6 +821,11 @@
   "@coachReportPdfNoSessions": {
     "description": "Shown for PT when nothing was booked and nothing was recorded."
   },
+  "coachReportPdfChartTarget": "goal {value}",
+  "@coachReportPdfChartTarget": {
+    "description": "Label on a chart's dashed goal line.",
+    "placeholders": {"value": {"type": "String"}}
+  },
   "coachReportPdfDayUpcoming": "{weekday} — still to come",
   "@coachReportPdfDayUpcoming": {
     "description": "Daily line for a weekday that has not happened yet.",

--- a/frontend/flutter/lib/l10n/app_ko.arb
+++ b/frontend/flutter/lib/l10n/app_ko.arb
@@ -513,6 +513,7 @@
   "coachReportPdfLabelStretching": "스트레칭",
   "coachReportPdfSectionTypes": "운동 유형별 시간",
   "coachReportPdfNoSessions": "잡힌 일정 없음",
+  "coachReportPdfChartTarget": "목표 {value}",
   "coachReportPdfDayUpcoming": "{weekday}요일 — 아직 지나지 않았어요",
   "coachReportPdfChange": "· {label}: {current} (지난주 {previous}, {delta})",
   "coachReportPdfDeltaUp": "+{value}",

--- a/frontend/flutter/test/features/member_coach/coach_report_preview_test.dart
+++ b/frontend/flutter/test/features/member_coach/coach_report_preview_test.dart
@@ -6,6 +6,8 @@
 /// 그린다. 한쪽 문구만 고치면 여기서 깨진다.
 library;
 
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -312,6 +314,44 @@ void main() {
       // `_week()` 는 기록한 여섯 날 모두 2100mg 이다.
       expect(lines, contains('· 나트륨 목표 초과: 6일'));
       expect(lines, contains(contains('하루 2000mg 기준')));
+    });
+
+    testWidgets('요일별 값은 그래프로 그려도 같은 값을 말한다', (WidgetTester tester) async {
+      final AppLocalizations l = await localizations(tester);
+      final List<String> lines = const MemberReportPdfGenerator().textContent(
+        l: l,
+        report: _report(days: _week(), asOf: DateTime(2026, 8, 23)),
+      );
+
+      // 그래프 블록도 자기 값을 글로 든다 — 그림만 남으면 문서가 무엇을 말하는지
+      // 확인할 길이 없다.
+      expect(lines, contains('· 운동 시간: 30분 / - / 45분 / - / 20분 / - / -'));
+      expect(lines, contains(startsWith('· 섭취 칼로리: ')));
+      expect(lines, contains(startsWith('· 나트륨: ')));
+    });
+
+    testWidgets('값이 없거나 목표가 있어도 문서가 만들어진다', (WidgetTester tester) async {
+      final AppLocalizations l = await localizations(tester);
+      const MemberReportPdfGenerator generator = MemberReportPdfGenerator();
+
+      // 막대 높이를 나누는 자리가 0 이 되는 주 — 눈금이 무너지면 여기서 터진다.
+      Uint8List? empty;
+      Uint8List? withTarget;
+      await tester.runAsync(() async {
+        empty = await generator.generate(
+          l: l,
+          report: _report(minutes: const <double>[0, 0, 0, 0, 0, 0, 0]),
+        );
+        withTarget = await generator.generate(
+          l: l,
+          report: _report(days: _week(), sodiumTarget: 2000),
+        );
+      });
+
+      expect(empty, isNotNull);
+      expect(empty!.length, greaterThan(0));
+      expect(withTarget, isNotNull);
+      expect(withTarget!.length, greaterThan(0));
     });
 
     testWidgets('지난주가 있으면 견주고, 없으면 없다고 적는다', (WidgetTester tester) async {


### PR DESCRIPTION
Closes #1615

## Summary

리포트 PDF 의 요일별 값을 막대 그래프로 그립니다. 운동 시간·섭취 칼로리·나트륨 셋이고, 나트륨에는 회원의 하루 목표를 점선으로 얹습니다.

## Changes

**왜 그래프인가.** 지금은 `· 운동 시간: 30분 / - / 45분 / - / 20분 / - / -` 처럼 일곱 칸을 늘어놓습니다. 눈으로 훑어 견줘야 해서 어느 날이 높고 낮은지 들어오지 않고, 트레이너 리포트 탭은 같은 값을 막대로 보여 주고 있어 같은 주를 두 사람이 다른 밀도로 읽고 있었습니다.

**어떻게.** 이 문서는 한글 폰트 때문에 페이지를 Flutter Canvas 에 그린 뒤 이미지로 PDF 에 넣습니다. 이미 캔버스에 그리고 있어서 막대·점선은 그리기 명령만 더하면 되고, 새 의존성이 없습니다.

**블록 구조.** 블록이 `글줄 하나 + 아래 여백` 이라 페이지 넘김이 글자 높이로만 돌아갔습니다. `자기 높이를 재고 스스로 그리는` 블록으로 바꿔 글줄과 그래프가 같은 페이지 넘김 로직을 씁니다. 그래프도 자기 값을 글로 들고 있어(`_Block.text`), 텍스트 추출과 기존 테스트가 보는 값은 그대로입니다.

**나트륨 목표선.** 회원의 하루 목표를 점선으로 긋고 넘긴 날의 막대를 달리 칠합니다. `나트륨 목표 초과 N일`(#1613)이 어느 날이었는지 문서 안에서 답이 납니다.

**읽기.** 값은 막대 안에 적습니다 — 막대 위에 적으면 목표선 바로 아래에 있는 막대의 숫자가 선 위로 올라가, 목표를 넘긴 값처럼 읽힙니다. 목표선은 막대보다 먼저 그어 숫자를 가로지르지 않게 합니다.

**아직 오지 않은 요일**은 막대를 그리지 않습니다(#1613 의 요일별 상세와 같은 규칙) — 0 으로 그리면 지키지 못한 날처럼 읽힙니다.

당류는 글로 남겼습니다. 그래프를 넷까지 늘리면 한 장이 그래프로만 채워져 무엇을 먼저 볼지가 사라집니다.

## Commits

- `feat(chat): 리포트 PDF 요일별 그래프`

## Notes

- 문서 페이지를 실제로 그려 눈으로 확인했습니다(막대 높이·목표선 위치·초과일 강조·오지 않은 요일 빈 칸).
- 눈금이 무너질 수 있는 자리(값이 전부 0 인 주, 목표가 있는 주)를 테스트로 막았습니다. 그래프 블록이 같은 값을 글로 든다는 것도 테스트가 지킵니다.
- `flutter analyze` 통과, 회원 앱 전체 테스트 통과했습니다.
