### PR TITLE
fix(chat): 리포트 PDF 요일별 상세의 빈 운동 내역

### DIFF
--- a/frontend/flutter/lib/features/member_coach/domain/entities/member_weekly_report.dart
+++ b/frontend/flutter/lib/features/member_coach/domain/entities/member_weekly_report.dart
@@ -126,6 +126,12 @@ class MemberWeeklyReport {
   ///
   /// 세션은 요일 표시(`dayLabel`)를 들고 있다 — 날짜가 비어 있는 경로(데모)도
   /// 있어서, 날짜가 있으면 날짜로 판정하고 없으면 표시를 쓴다.
+  ///
+  /// 이름은 [ExerciseSession.items] 를 먼저 본다. 두 경로가 이름을 담는 자리가
+  /// 다르기 때문이다 — 실 API·drift 는 그날 그 종류의 운동을 `name` 한 줄로 이어
+  /// 붙이고 `items` 에도 그 한 줄을 담지만, 데모 경로는 `items` 에 운동을 하나씩
+  /// 담고 `name` 을 비워 둔다. `name` 만 읽으면 데모에서 이름이 전부 걸러져,
+  /// 5일을 운동한 주의 요일별 상세가 이레 내내 `기록 없음` 이 됐다(#1617).
   List<String> exercisesOn(int weekdayIndex, List<String> weekdayLabels) {
     final DateTime day = DateTime(
       weekStart.year,
@@ -146,8 +152,12 @@ class MemberWeeklyReport {
           }
           return label.isNotEmpty && s.dayLabel == label;
         })
-        .map((ExerciseSession s) => s.name)
-        .where((String name) => name.trim().isNotEmpty)
+        .expand(
+          (ExerciseSession s) =>
+              s.items.isNotEmpty ? s.items : <String>[s.name],
+        )
+        .map((String name) => name.trim())
+        .where((String name) => name.isNotEmpty)
         .toList(growable: false);
   }
 }

--- a/frontend/flutter/lib/features/member_coach/presentation/controllers/member_report_providers.dart
+++ b/frontend/flutter/lib/features/member_coach/presentation/controllers/member_report_providers.dart
@@ -108,6 +108,9 @@ final _memberWeekProvider = FutureProvider.family<MemberWeeklyReport, DateTime>(
                 .length
           : inWeek.where((CoachSession s) => s.isDone).length,
       sodiumTarget: (await profile).effectiveDailySodiumMg,
+      // 세운 날. 그 주에서 아직 오지 않은 요일을 가리는 데 쓴다(#1613) — 넘기지
+      // 않으면 오지 않은 날이 다시 `기록 없음` 으로 적힌다.
+      asOf: today,
     );
   },
   name: 'memberWeek',

--- a/frontend/flutter/test/features/member_coach/coach_report_preview_test.dart
+++ b/frontend/flutter/test/features/member_coach/coach_report_preview_test.dart
@@ -242,6 +242,32 @@ void main() {
       expect(lines.last, contains('회원님 기록으로 정리한 미리보기'));
     });
 
+    testWidgets('운동 이름이 items 에만 있어도 요일별 상세에 적힌다', (WidgetTester tester) async {
+      final AppLocalizations l = await localizations(tester);
+      final List<String> lines = const MemberReportPdfGenerator().textContent(
+        l: l,
+        report: _report(
+          days: _week(),
+          sessions: <ExerciseSession>[
+            // 데모 경로가 주는 모양 — 이름은 `items` 에 하나씩, `name` 은 비어
+            // 있고 날짜도 없다. 예전에는 `name` 만 읽어 전부 걸러졌다.
+            const ExerciseSession(
+              dayLabel: '월',
+              type: ExerciseType.cardio,
+              minutes: 30,
+              calories: 210,
+              items: <String>['저강도 유산소 (걷기) 30분', '코어 강화 10분'],
+            ),
+          ],
+        ),
+      );
+
+      expect(
+        lines,
+        contains('월요일 — 운동 저강도 유산소 (걷기) 30분, 코어 강화 10분, 섭취 1800kcal'),
+      );
+    });
+
     testWidgets('아직 오지 않은 요일은 기록 없음이라고 적지 않는다', (WidgetTester tester) async {
       final AppLocalizations l = await localizations(tester);
       final List<String> lines = const MemberReportPdfGenerator().textContent(

--- a/frontend/flutter/test/features/member_coach/member_report_demo_test.dart
+++ b/frontend/flutter/test/features/member_coach/member_report_demo_test.dart
@@ -1,0 +1,133 @@
+/// 데모 데이터로 세운 리포트 문서 (#1617).
+///
+/// 다른 리포트 테스트들은 손으로 만든 [MemberWeeklyReport] 를 문서로 옮기는
+/// 부분만 본다. 여기서는 **데모가 실제로 지나는 길**을 통째로 지난다 — drift 시드
+/// → 저장소 → provider → 문서. 문서를 만드는 규칙이 아니라, 그 규칙에 들어오는
+/// 값이 비어 있어서 났던 회귀를 잡는 자리다.
+///
+/// 실제로 두 가지가 그랬다. 요일별 상세의 운동 이름이 데모 경로에서 전부 걸러져
+/// 이레 내내 `기록 없음` 이었고, 아직 오지 않은 요일을 가리는 기준 날짜가
+/// provider 에서 넘어가지 않아 같은 자리에 다시 `기록 없음` 이 적혔다. 둘 다 문서를
+/// 만드는 규칙은 맞았고 들어오는 값만 비어 있었다.
+library;
+
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
+
+import 'package:oncare/core/config/app_config.dart';
+import 'package:oncare/core/logging/app_logger.dart';
+import 'package:oncare/core/storage/app_database.dart';
+import 'package:oncare/core/storage/prefs_store.dart';
+import 'package:oncare/core/storage/seed_data.dart';
+import 'package:oncare/core/utils/clock.dart';
+import 'package:oncare/features/member_coach/domain/entities/member_coach.dart';
+import 'package:oncare/features/member_coach/domain/entities/member_weekly_report.dart';
+import 'package:oncare/features/member_coach/presentation/controllers/member_coach_providers.dart';
+import 'package:oncare/features/member_coach/presentation/controllers/member_report_providers.dart';
+import 'package:oncare/features/member_coach/services/member_report_pdf_generator.dart';
+import 'package:oncare/gen/l10n/app_localizations.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const AppConfig _config = AppConfig(
+  environment: Environment.dev,
+  apiBaseUrl: 'https://dev.api.test',
+  useMockApi: true,
+);
+
+const List<String> _weekdays = <String>['월', '화', '수', '목', '금', '토', '일'];
+
+void main() {
+  testWidgets('데모 리포트는 운동한 날마다 그날 한 운동을 적는다', (WidgetTester tester) async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    final AppDatabase db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    await seedIfEmpty(db);
+
+    late AppLocalizations l;
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('ko'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (BuildContext context) {
+            l = AppLocalizations.of(context);
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final ProviderContainer container = ProviderContainer(
+      overrides: <Override>[
+        appConfigProvider.overrideWithValue(_config),
+        appLoggerProvider.overrideWithValue(Logger(level: Level.off)),
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        appDatabaseProvider.overrideWithValue(db),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final List<CoachMessage> chat = await container
+        .read(memberCoachRepositoryProvider)
+        .fetchChat();
+    final CoachMessage notice = chat.firstWhere(
+      (CoachMessage m) => m.reportWeekStart != null,
+      orElse: () => throw StateError('데모 대화에 리포트 안내가 없다'),
+    );
+
+    late MemberWeeklyReport report;
+    await tester.runAsync(() async {
+      report = await container.read(
+        memberWeeklyReportProvider(notice.reportWeekStart!).future,
+      );
+    });
+
+    final List<String> lines = const MemberReportPdfGenerator().textContent(
+      l: l,
+      report: report,
+      trainerNote: notice.body,
+    );
+
+    // 시드는 오늘에 맞춰 미끄러지므로 요일을 고정하지 않는다 — 문서가 스스로
+    // 말하는 값(운동한 분)과 요일별 상세가 어긋나지 않는지만 본다.
+    expect(report.exercise.totalMinutes, greaterThan(0));
+    final DateTime now = nowKst();
+    final DateTime today = DateTime(now.year, now.month, now.day);
+    bool checkedAny = false;
+    for (int i = 0; i < _weekdays.length; i++) {
+      final String prefix = '${_weekdays[i]}요일 — ';
+      final String line = lines.firstWhere(
+        (String s) => s.startsWith(prefix),
+        orElse: () => throw StateError('$prefix 줄이 없다'),
+      );
+      final DateTime day = DateTime(
+        report.weekStart.year,
+        report.weekStart.month,
+        report.weekStart.day + i,
+      );
+      if (day.isAfter(today)) {
+        expect(
+          line,
+          l.coachReportPdfDayUpcoming(_weekdays[i]),
+          reason: '오지 않은 날을 기록이 없는 날로 적으면 안 된다',
+        );
+        continue;
+      }
+      if (report.minutesByDay[i] > 0) {
+        checkedAny = true;
+        expect(
+          line,
+          isNot(contains(l.coachReportPdfNoData)),
+          reason: '$prefix 그날 운동한 시간이 있는데 내역이 비어 있다',
+        );
+      }
+    }
+    expect(checkedAny, isTrue, reason: '운동한 날이 하나도 없으면 이 테스트가 아무것도 못 지킨다');
+  });
+}


### PR DESCRIPTION
Closes #1617

## Summary

리포트 PDF 의 `요일별 상세` 가 이레 내내 `운동 기록 없음` 이던 문제를 고칩니다. 같은 자리에서 죽어 있던 `아직 지나지 않았어요` 도 함께 살립니다.

데모(김민수) 문서를 그대로 뽑으면 이랬습니다.

```
· 운동한 날: 5일
· 총 운동 시간: 228분
· 운동 시간: 45분 / 40분 / 55분 / 48분 / 40분 / - / -
...
월요일 — 운동 기록 없음, 섭취 1310kcal
화요일 — 운동 기록 없음, 섭취 1510kcal
```

고친 뒤:

```
월요일 — 운동 저강도 유산소 (걷기) 30분, 코어 강화 10분, 하체 스트레칭 5분, 섭취 1310kcal
화요일 — 운동 저강도 유산소 (걷기) 40분, 섭취 1510kcal
...
토요일 — 아직 지나지 않았어요
일요일 — 아직 지나지 않았어요
```

## Changes

**빈 운동 내역.** `exercisesOn` 이 세션의 `name` 하나만 읽었습니다. 운동 기록은 두 경로로 들어오는데 이름을 담는 자리가 다릅니다 — 실 API·drift 는 그날 그 종류의 운동을 `name` 한 줄로 이어 붙이고 `items` 에도 그 한 줄을 담지만, 데모 경로(`MockExerciseRepository`)는 `items` 에 운동을 하나씩 담고 `name` 을 비워 둡니다. 그래서 데모에서는 이름이 전부 걸러졌습니다. 운동한 날 수·시간·칼로리는 다른 필드에서 오므로 멀쩡해, 문서 안에서 앞뒤가 어긋나 보였습니다. `items` 를 먼저 보고 비어 있을 때 `name` 으로 물러섭니다.

**죽어 있던 `아직 지나지 않았어요`.** #1613 에서 넣은 규칙인데, 기준 날짜를 provider 가 넘기지 않아 `asOf` 가 늘 null 이었습니다. 오지 않은 요일이 다시 `기록 없음` 으로 적히고 있었습니다. 넘깁니다.

**테스트.** 두 가지 다 문서를 만드는 규칙은 맞았고 들어오는 값만 비어 있었습니다. 손으로 만든 리포트를 문서로 옮기는 기존 테스트가 그래서 통과했습니다. 데모가 실제로 지나는 길을 통째로 지나는 테스트를 더합니다 — drift 시드에서 provider 를 거쳐 문서까지.

## Commits

- `fix(chat): 리포트 PDF 요일별 상세의 빈 운동 내역`

## Notes

- 새 테스트는 시드가 오늘에 맞춰 미끄러지는 것을 감안해 요일을 고정하지 않습니다. 문서가 스스로 말하는 값(그날 운동한 분)과 요일별 상세가 어긋나지 않는지만 봅니다.
- 고치기 전 코드로 되돌려 새 테스트가 실제로 실패하는 것까지 확인했습니다.
- `flutter analyze` 통과, 회원 앱 전체 테스트 통과했습니다.
