### PR TITLE
fix(chat): 리포트 PDF 한글 두부와 넘치는 두 번째 쪽

### DIFF
--- a/frontend/flutter/lib/features/member_coach/services/member_report_pdf_generator.dart
+++ b/frontend/flutter/lib/features/member_coach/services/member_report_pdf_generator.dart
@@ -1,6 +1,6 @@
-import 'dart:typed_data';
 import 'dart:ui' as ui;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:oncare/features/member_coach/domain/entities/member_weekly_report.dart';
@@ -11,6 +11,17 @@ import 'package:pdf/widgets.dart' as pw;
 /// 값에 단위를 붙이는 arb 패턴. `l.coachReportPdfValueMg` 처럼 tear-off 로 넘긴다
 /// — `1890mg` 와 `2 days` 처럼 단위가 붙는 자리와 띄어쓰기가 언어마다 다르다.
 typedef _Unit = String Function(String value);
+
+/// 문서에 쓰는 서체. 앱이 번들에 담고 있는 것을 **명시해서** 쓴다. (#1621)
+///
+/// 지정하지 않으면 `TextPainter` 가 플랫폼 기본 서체로 그리는데, 그 서체가 덮지
+/// 못하는 한글 음절이 네모(두부)로 나왔다 — `뒀`·`숄` 이 그랬다. 화면 쪽은 예전에
+/// 같은 증상을 CSS 로 고쳤지만(`web/index.html`), 문서는 캔버스에 직접 그리는
+/// 경로라 그 수정이 닿지 않는다.
+///
+/// 덤으로 지면 계산이 어디서나 같아진다. 대체 서체는 글자 높이가 달라, 테스트에서
+/// 한 장에 들어간 문서가 실기기에서는 한 줄 밀려 두 장이 됐다.
+const String _kFont = 'Pretendard';
 
 /// [MemberWeeklyReport] 를 A4 문서로 만든다. (#1600)
 ///
@@ -74,6 +85,30 @@ class MemberReportPdfGenerator {
     return document.save();
   }
 
+  /// 이 문서가 몇 장이 되는가. 그리지 않고 배치만 돌려 센다.
+  ///
+  /// 한 장에 담기로 한 문서다(#1619). 넘치면 마지막 한 줄만 든 빈 종이가 한 장
+  /// 더 생기는데, 실제로 그랬다 — 지면을 늘리거나 서체를 바꿀 때 이 값을 지킨다.
+  @visibleForTesting
+  int pageCount({
+    required AppLocalizations l,
+    required MemberWeeklyReport report,
+    String trainerNote = '',
+  }) {
+    const double contentWidth = _pageWidth - (_margin * 2);
+    int pages = 1;
+    double y = _headerHeight;
+    for (final _Block block in _blocks(l, report, trainerNote)) {
+      final double height = block.height(contentWidth);
+      if (y + height + block.after > _pageHeight - _margin) {
+        pages++;
+        y = _headerHeight;
+      }
+      y += height + block.after;
+    }
+    return pages;
+  }
+
   /// 문서에 적히는 문구. 렌더러와 테스트가 같은 소스를 쓴다.
   List<String> textContent({
     required AppLocalizations l,
@@ -94,9 +129,10 @@ class MemberReportPdfGenerator {
       text: TextSpan(
         text: title,
         style: const TextStyle(
+          fontFamily: _kFont,
           color: Color(0xff10384a),
           fontSize: 38,
-          fontWeight: FontWeight.w800,
+          fontWeight: FontWeight.w700,
         ),
       ),
       textDirection: TextDirection.ltr,
@@ -106,8 +142,11 @@ class MemberReportPdfGenerator {
       const Rect.fromLTWH(_margin, 132, _pageWidth - _margin * 2, 4),
       Paint()..color = const Color(0xff3eafdf),
     );
-    return 166;
+    return _headerHeight;
   }
+
+  /// 제목과 밑줄이 차지하는 높이. 그리는 쪽과 세는 쪽이 같은 값을 봐야 한다.
+  static const double _headerHeight = 166;
 
   Future<Uint8List> _finishPage(ui.PictureRecorder recorder) async {
     final ui.Picture picture = recorder.endRecording();
@@ -400,8 +439,8 @@ class MemberReportPdfGenerator {
       ),
 
       if (report.sodiumTarget case final int target when loggedDays > 0)
-        _TextBlock.body(l.coachReportPdfSodiumTargetNote('$target')),
-      _TextBlock.body(l.coachReportPdfPreviewNote, after: 8),
+        _TextBlock.note(l.coachReportPdfSodiumTargetNote('$target')),
+      _TextBlock.note(l.coachReportPdfPreviewNote),
     ];
   }
 
@@ -559,17 +598,36 @@ class _TextBlock extends _Block {
   factory _TextBlock.section(String text) => _TextBlock(
     text,
     const TextStyle(
+      fontFamily: _kFont,
       color: Color(0xff10384a),
       fontSize: 25,
-      fontWeight: FontWeight.w800,
+      fontWeight: FontWeight.w700,
       height: 1.35,
     ),
     16,
   );
 
+  /// 문서 맨 아래의 단서. 본문보다 작게 적는다 — 값을 읽고 난 뒤 무엇을 기준으로
+  /// 셌는지 확인하는 줄이라, 본문과 같은 크기로 두면 지면을 두 줄만큼 먹는다.
+  factory _TextBlock.note(String text) => _TextBlock(
+    text,
+    const TextStyle(
+      fontFamily: _kFont,
+      color: Color(0xff5b6b76),
+      fontSize: 17,
+      height: 1.4,
+    ),
+    6,
+  );
+
   factory _TextBlock.body(String text, {double after = 9}) => _TextBlock(
     text,
-    const TextStyle(color: Color(0xff26333a), fontSize: 20, height: 1.5),
+    const TextStyle(
+      fontFamily: _kFont,
+      color: Color(0xff26333a),
+      fontSize: 20,
+      height: 1.5,
+    ),
     after,
   );
 
@@ -683,14 +741,17 @@ class _BandBlock extends _Block {
       )..layout(maxWidth: room);
 
   static const TextStyle _bandTitle = TextStyle(
+    fontFamily: _kFont,
     color: Color(0xff5b6b76),
     fontSize: 17,
   );
   static const TextStyle _bandDelta = TextStyle(
+    fontFamily: _kFont,
     color: Color(0xff5b6b76),
     fontSize: 16,
   );
   static const TextStyle _bandValue = TextStyle(
+    fontFamily: _kFont,
     color: Color(0xff10384a),
     fontSize: 24,
     fontWeight: FontWeight.w700,
@@ -711,7 +772,7 @@ class _TableBlock extends _Block {
     this.alignRightFrom = 1,
   }) : super(20);
 
-  static const double _rowHeight = 32;
+  static const double _rowHeight = 30;
   static const double _pad = 12;
 
   @override
@@ -792,11 +853,13 @@ class _TableBlock extends _Block {
   }
 
   static const TextStyle _headerStyle = TextStyle(
+    fontFamily: _kFont,
     color: Color(0xff10384a),
     fontSize: 18,
     fontWeight: FontWeight.w700,
   );
   static const TextStyle _cellStyle = TextStyle(
+    fontFamily: _kFont,
     color: Color(0xff26333a),
     fontSize: 18,
   );
@@ -871,15 +934,18 @@ class _TileRowBlock extends _Block {
   }
 
   static const TextStyle _tileTitle = TextStyle(
+    fontFamily: _kFont,
     color: Color(0xff5b6b76),
     fontSize: 17,
   );
   static const TextStyle _tileValue = TextStyle(
+    fontFamily: _kFont,
     color: Color(0xff10384a),
     fontSize: 28,
     fontWeight: FontWeight.w700,
   );
   static const TextStyle _tileDelta = TextStyle(
+    fontFamily: _kFont,
     color: Color(0xff5b6b76),
     fontSize: 16,
   );
@@ -903,7 +969,7 @@ class _ChartBlock extends _Block {
     this.asLine = false,
   }) : super(18);
 
-  static const double _barsHeight = 190;
+  static const double _barsHeight = 172;
   static const double _titleHeight = 30;
   static const double _labelHeight = 30;
 
@@ -1140,29 +1206,35 @@ class _ChartBlock extends _Block {
   )..layout();
 
   static const TextStyle _titleStyle = TextStyle(
+    fontFamily: _kFont,
     color: Color(0xff26333a),
     fontSize: 20,
     fontWeight: FontWeight.w700,
   );
   static const TextStyle _labelStyle = TextStyle(
+    fontFamily: _kFont,
     color: Color(0xff5b6b76),
     fontSize: 18,
   );
   static const TextStyle _insideValueStyle = TextStyle(
+    fontFamily: _kFont,
     color: Color(0xffffffff),
     fontSize: 17,
     fontWeight: FontWeight.w700,
   );
   static const TextStyle _valueStyle = TextStyle(
+    fontFamily: _kFont,
     color: Color(0xff26333a),
     fontSize: 17,
   );
   static const TextStyle _overValueStyle = TextStyle(
+    fontFamily: _kFont,
     color: Color(0xffb3261e),
     fontSize: 17,
     fontWeight: FontWeight.w700,
   );
   static const TextStyle _targetStyle = TextStyle(
+    fontFamily: _kFont,
     color: Color(0xff5b6b76),
     fontSize: 17,
   );

--- a/frontend/flutter/test/features/member_coach/member_report_demo_test.dart
+++ b/frontend/flutter/test/features/member_coach/member_report_demo_test.dart
@@ -11,8 +11,11 @@
 /// 만드는 규칙은 맞았고 들어오는 값만 비어 있었다.
 library;
 
+import 'dart:io';
+
 import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:logger/logger.dart';
@@ -39,8 +42,29 @@ const AppConfig _config = AppConfig(
 
 const List<String> _weekdays = <String>['월', '화', '수', '목', '금', '토', '일'];
 
+/// 문서가 실제로 쓰는 서체를 테스트에도 올린다. (#1621)
+///
+/// 올리지 않으면 대체 서체로 재게 되는데, 그 글자 높이가 실기기와 달라 한 장에
+/// 들어가는지를 여기서 잘못 판정한다 — 실제로 테스트는 한 장, 기기는 두 장이었다.
+Future<void> _loadReportFont() async {
+  for (final String weight in <String>[
+    'Regular',
+    'Medium',
+    'SemiBold',
+    'Bold',
+  ]) {
+    final File file = File('assets/fonts/Pretendard-$weight.otf');
+    if (!file.existsSync()) continue;
+    await (FontLoader('Pretendard')..addFont(
+          Future<ByteData>.value(ByteData.sublistView(file.readAsBytesSync())),
+        ))
+        .load();
+  }
+}
+
 void main() {
   testWidgets('데모 리포트는 운동한 날마다 그날 한 운동을 적는다', (WidgetTester tester) async {
+    await _loadReportFont();
     SharedPreferences.setMockInitialValues(<String, Object>{});
     final SharedPreferences prefs = await SharedPreferences.getInstance();
     final AppDatabase db = AppDatabase.forTesting(NativeDatabase.memory());
@@ -129,5 +153,17 @@ void main() {
       }
     }
     expect(checkedAny, isTrue, reason: '운동한 날이 하나도 없으면 이 테스트가 아무것도 못 지킨다');
+
+    // 한 장에 담기로 한 문서다(#1619). 넘치면 마지막 한 줄만 든 빈 종이가 한 장
+    // 더 생긴다 — 실기기에서 실제로 그랬다(#1621).
+    expect(
+      const MemberReportPdfGenerator().pageCount(
+        l: l,
+        report: report,
+        trainerNote: notice.body,
+      ),
+      1,
+      reason: '리포트 문서는 한 장이어야 한다',
+    );
   });
 }

--- a/frontend/flutter_trainer/lib/features/reports/services/report_pdf_generator.dart
+++ b/frontend/flutter_trainer/lib/features/reports/services/report_pdf_generator.dart
@@ -20,6 +20,13 @@ typedef _Unit = String Function(String value);
 /// 리포트 데이터로 문서 레이아웃을 새로 그린다.
 ///
 /// 문구는 전부 [AppLocalizations] 에서 온다. 이 PDF 는 회원이 실제로 받아 보는
+/// 문서에 쓰는 서체. 앱이 번들에 담고 있는 것을 **명시해서** 쓴다. (#1621)
+///
+/// 지정하지 않으면 `TextPainter` 가 플랫폼 기본 서체로 그리는데, 그 서체가 덮지
+/// 못하는 한글 음절이 네모(두부)로 나온다. 회원 앱의 같은 문서에서 `뒀`·`숄` 이
+/// 그랬다. 이 파일은 회원에게 보내는 파일을 만드는 자리라 같은 규칙을 지킨다.
+const String _kFont = 'Pretendard';
+
 /// 산출물이라, 화면은 영어인데 문서만 한국어로 나가면 안 된다(#964).
 class ReportPdfGenerator {
   const ReportPdfGenerator();
@@ -99,9 +106,10 @@ class ReportPdfGenerator {
       text: TextSpan(
         text: title,
         style: const TextStyle(
+          fontFamily: _kFont,
           color: Color(0xff173b36),
           fontSize: 38,
-          fontWeight: FontWeight.w800,
+          fontWeight: FontWeight.w700,
         ),
       ),
       textDirection: TextDirection.ltr,
@@ -315,9 +323,10 @@ class _PdfBlock {
   factory _PdfBlock.section(String text) => _PdfBlock(
     text,
     const TextStyle(
+      fontFamily: _kFont,
       color: Color(0xff173b36),
       fontSize: 25,
-      fontWeight: FontWeight.w800,
+      fontWeight: FontWeight.w700,
       height: 1.35,
     ),
     16,
@@ -325,7 +334,12 @@ class _PdfBlock {
 
   factory _PdfBlock.body(String text, {double after = 9}) => _PdfBlock(
     text,
-    const TextStyle(color: Color(0xff263331), fontSize: 20, height: 1.5),
+    const TextStyle(
+      fontFamily: _kFont,
+      color: Color(0xff263331),
+      fontSize: 20,
+      height: 1.5,
+    ),
     after,
   );
 


### PR DESCRIPTION
Closes #1621

## Summary

실기기에서 리포트 PDF 의 한글 일부가 네모로 나오고, 한 장에 담기로 한 문서가 두 장이 되던 문제를 고칩니다. 두 증상의 원인이 같습니다 — 문서가 **번들 서체를 쓰지 않고** 플랫폼 기본 서체로 그리고 있었습니다.

## Changes

**한글 두부.** 문서 전체가 아니라 특정 음절만 네모였습니다(`뒀`, `숄`). 문서는 페이지를 캔버스에 그려 이미지로 넣는데, `TextPainter` 에 서체를 지정하지 않아 플랫폼 기본 서체로 그렸고 그 서체가 덮지 못하는 음절이 네모가 됐습니다. 앱은 이미 Pretendard 를 번들에 담고 있습니다(#995) — 문서의 모든 글자에 그 서체를 명시합니다. 화면 쪽은 예전에 같은 증상을 CSS 로 고쳤지만, 문서는 캔버스에 직접 그리는 경로라 그 수정이 닿지 않았습니다.

번들이 700 까지라 800 을 쓰던 자리도 700 으로 내립니다. 없는 굵기를 부르면 엔진이 대신 굵게 만들면서 글자 크기가 달라집니다.

**넘치던 두 번째 쪽.** 같은 이유였습니다. 지면 계산은 맞았지만 그것이 테스트 환경의 **대체 서체 기준**이었습니다. 서체를 고정하니 두 곳이 같은 값을 보고, 재어 보니 1672/1662 로 열 픽셀이 넘쳤습니다. 그래프 높이(190→172)와 각주 크기를 줄여 1585 로 맞춥니다.

**지키는 자리.** 문서가 몇 장인지 세는 `pageCount` 를 두고 테스트가 확인합니다. 테스트도 번들 서체를 올려서 잽니다 — 대체 서체로 재면 이 판정이 다시 어긋납니다.

**트레이너 앱.** 리포트 PDF 를 같은 방식으로 그리고 같은 서체를 번들에 담고 있어 같이 고쳤습니다. 회원에게 실제로 보내는 파일입니다.

## Commits

- `fix(chat): 리포트 PDF 한글 두부와 넘치는 두 번째 쪽`

## Notes

- 번들 서체를 올린 상태로 문서를 그려 눈으로 확인했습니다 — 두부 없이 전부 읽히고 한 장으로 끝납니다.
- 새 테스트가 실제로 회귀를 잡는지, 지면을 일부러 넘치게 해서 실패하는 것까지 확인했습니다.
- `flutter analyze` 통과. 회원 앱 `test/features/member_coach` 118개, 트레이너 웹 `test/features/reports` 95개 통과했습니다.
