### PR TITLE
fix(trainer-clients): 데모 고객 삭제가 운동 기록·채팅·스케줄을 실제로 지우던 문제 수정

### DIFF
--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_connect_dialog.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_connect_dialog.dart
@@ -113,6 +113,8 @@ class _ClientConnectDialogState extends ConsumerState<ClientConnectDialog> {
       // 고객 관리가 같은 목록을 보므로 두 provider 를 함께 새로고침한다.
       ref.invalidate(clientsProvider);
       ref.invalidate(managedClientsProvider);
+      // 미등록 동안 걸러졌던 오늘 일정·안읽음 배지도 다시 보인다(#1623).
+      invalidateClientVisibilityDependentViews(ref);
       if (!mounted) return;
       navigator.pop();
       showAppToast(

--- a/frontend/flutter_trainer/lib/features/my/presentation/pages/my_page.dart
+++ b/frontend/flutter_trainer/lib/features/my/presentation/pages/my_page.dart
@@ -266,6 +266,7 @@ class _MyPageState extends ConsumerState<MyPage> {
       await ref.read(clientRepositoryProvider).removeClient(client.id);
       ref.invalidate(clientsProvider);
       ref.invalidate(managedClientsProvider);
+      invalidateClientVisibilityDependentViews(ref);
       if (!mounted) return;
       showAppToast(context, l.myClientRemoveSuccess);
     } catch (_) {

--- a/frontend/flutter_trainer/lib/features/schedule/data/repositories/schedule_repository.dart
+++ b/frontend/flutter_trainer/lib/features/schedule/data/repositories/schedule_repository.dart
@@ -12,6 +12,8 @@ import 'package:oncare_trainer/features/schedule/data/repositories/dio_schedule_
 import 'package:oncare_trainer/features/schedule/domain/entities/schedule_recurrence.dart';
 import 'package:oncare_trainer/features/schedule/domain/entities/schedule_session.dart';
 import 'package:oncare_trainer/features/schedule/domain/entities/schedule_status.dart';
+import 'package:oncare_trainer/shared/services/client_repository.dart'
+    show demoUnregisteredClientIdsSnapshot;
 
 /// Identifies a client for [ScheduleRepository.watchClientSessions].
 ///
@@ -182,6 +184,9 @@ class DriftScheduleRepository implements ScheduleRepository {
   Stream<List<ScheduleSession>> watchToday() => watchDate(ymd(nowKst()));
 
   /// The timeline for one calendar [date] (`YYYY-MM-DD`).
+  ///
+  /// 미등록(담당 종료) 고객의 슬롯은 원본 행을 지우지 않고 걸러낸다(#1623)
+  /// — 트레이너 화면에서만 빠지고, 다시 등록하면 그대로 돌아온다.
   @override
   Stream<List<ScheduleSession>> watchDate(String date) {
     final query = _db.select(_db.trainerScheduleEntries)
@@ -193,21 +198,32 @@ class DriftScheduleRepository implements ScheduleRepository {
         (t) => OrderingTerm(expression: t.time),
         (t) => OrderingTerm(expression: t.sortOrder),
       ]);
-    return query.watch().map((rows) => rows.map(_toEntity).toList());
+    return _watchExcludingUnregistered(
+      query,
+      (rows) => rows.map(_toEntity).toList(),
+      keyOf: (s) => s.clientId,
+    );
   }
 
   /// Dates (`YYYY-MM-DD`) that have at least one booked (non-공백)
-  /// session — drives the week strip's dot markers.
+  /// session — drives the week strip's dot markers. 미등록 고객의 슬롯만
+  /// 있는 날은 점을 찍지 않는다(#1623).
   @override
   Stream<Set<String>> watchBookedDates() {
     final t = _db.trainerScheduleEntries;
-    final query = _db.selectOnly(t, distinct: true)
-      ..addColumns(<Expression<Object>>[t.date])
+    final query = _db.selectOnly(t)
+      ..addColumns(<Expression<Object>>[t.date, t.clientId])
       ..where(t.status.equals(ScheduleStatus.gap).not());
-    return query
-        .map((row) => row.read(t.date)!)
-        .watch()
-        .map((rows) => rows.toSet());
+    return query.watch().map((rows) {
+      final unregistered = demoUnregisteredClientIdsSnapshot(_db);
+      final dates = <String>{};
+      for (final row in rows) {
+        final clientId = row.read(t.clientId);
+        if (clientId != null && unregistered.contains(clientId)) continue;
+        dates.add(row.read(t.date)!);
+      }
+      return dates;
+    });
   }
 
   /// Every slot between [fromDate] and [toDate] inclusive (`YYYY-MM-DD`),
@@ -228,7 +244,27 @@ class DriftScheduleRepository implements ScheduleRepository {
         (t) => OrderingTerm(expression: t.time),
         (t) => OrderingTerm(expression: t.sortOrder),
       ]);
-    return query.watch().map((rows) => rows.map(_toEntity).toList());
+    return _watchExcludingUnregistered(
+      query,
+      (rows) => rows.map(_toEntity).toList(),
+      keyOf: (s) => s.clientId,
+    );
+  }
+
+  /// Re-runs [query] whenever the table it reads from changes, then drops
+  /// entries whose [keyOf] id is currently unregistered. `null` ids
+  /// (공백 슬롯 등, 특정 고객에 속하지 않는 행) always pass through.
+  Stream<List<T>> _watchExcludingUnregistered<Row extends Object, T>(
+    Selectable<Row> query,
+    List<T> Function(List<Row> rows) toEntities, {
+    required String? Function(T entity) keyOf,
+  }) {
+    return query.watch().map((rows) {
+      final unregistered = demoUnregisteredClientIdsSnapshot(_db);
+      return toEntities(rows)
+          .where((e) => keyOf(e) == null || !unregistered.contains(keyOf(e)))
+          .toList();
+    });
   }
 
   /// A client's booked sessions, newest first. Drives the 고객 상세 루틴

--- a/frontend/flutter_trainer/lib/shared/services/chat_repository.dart
+++ b/frontend/flutter_trainer/lib/shared/services/chat_repository.dart
@@ -7,6 +7,8 @@ import 'package:oncare_trainer/core/utils/clock.dart';
 import 'package:oncare_trainer/core/utils/date_format.dart';
 import 'package:oncare_trainer/features/clients/data/repositories/dio_chat_repository.dart';
 import 'package:oncare_trainer/shared/models/client_chat_message.dart';
+import 'package:oncare_trainer/shared/services/client_repository.dart'
+    show demoUnregisteredClientIdsSnapshot;
 
 /// Reads and sends messages in a trainer↔member chat thread.
 ///
@@ -62,13 +64,11 @@ class DriftChatRepository implements ChatRepository {
   Future<Map<String, String>> _reportWeekStarts(
     Iterable<String> messageIds,
   ) async {
-    final keys = <String>[
-      for (final id in messageIds) '$_reportKeyPrefix$id',
-    ];
+    final keys = <String>[for (final id in messageIds) '$_reportKeyPrefix$id'];
     if (keys.isEmpty) return const <String, String>{};
-    final rows =
-        await (_db.select(_db.appKeyValues)..where((t) => t.key.isIn(keys)))
-            .get();
+    final rows = await (_db.select(
+      _db.appKeyValues,
+    )..where((t) => t.key.isIn(keys))).get();
     return <String, String>{
       for (final row in rows)
         row.key.substring(_reportKeyPrefix.length): row.value,
@@ -119,6 +119,10 @@ class DriftChatRepository implements ChatRepository {
   /// Per-client unread counts — client-sent messages after the trainer's
   /// last-read marker (an `AppKeyValues` row per client, so no schema
   /// migration). Clients with zero unread are absent.
+  ///
+  /// 담당을 종료한(미등록) 고객의 메시지는 원본을 지우지 않고 여기서만
+  /// 걸러낸다(#1623) — 지우면 사이드바 전체 안읽음 배지가 트레이너가 다시는
+  /// 열어 읽을 수 없는 수를 영영 안고 가게 된다.
   @override
   Stream<Map<String, int>> watchUnreadCounts() {
     // The marker is a monotonic `rowid`, not an epoch second: two client
@@ -138,11 +142,14 @@ class DriftChatRepository implements ChatRepository {
         _db.appKeyValues,
       },
     );
-    return query.watch().map(
-      (rows) => <String, int>{
-        for (final row in rows) row.read<String>('cid'): row.read<int>('cnt'),
-      },
-    );
+    return query.watch().map((rows) {
+      final unregistered = demoUnregisteredClientIdsSnapshot(_db);
+      return <String, int>{
+        for (final row in rows)
+          if (!unregistered.contains(row.read<String>('cid')))
+            row.read<String>('cid'): row.read<int>('cnt'),
+      };
+    });
   }
 
   /// Marks a client's thread read up to its newest client message.

--- a/frontend/flutter_trainer/lib/shared/services/client_repository.dart
+++ b/frontend/flutter_trainer/lib/shared/services/client_repository.dart
@@ -19,6 +19,7 @@ import 'package:oncare_trainer/features/clients/domain/entities/routine_history_
 import 'package:oncare_trainer/features/schedule/data/repositories/schedule_repository.dart';
 import 'package:oncare_trainer/shared/exercise_burn_goals.dart';
 import 'package:oncare_trainer/shared/models/trainer_client.dart';
+import 'package:oncare_trainer/shared/services/chat_repository.dart';
 
 /// Reads a trainer's clients + their diet/history for the 고객 관리 tab.
 ///
@@ -127,16 +128,65 @@ abstract interface class ClientRepository {
 /// 이라는 잘못된 안내가 뜬다.
 const String demoUnregisteredClientsKey = 'trainer_unregistered_clients';
 
-/// [demoUnregisteredClientsKey] 에 저장된 미등록 고객 id 목록을 읽는다.
+/// [readDemoUnregisteredClientIds] 가 채워 둔, db 인스턴스별 동기 스냅샷.
+///
+/// 오늘 일정·주간 캘린더·안읽음 배지처럼 여러 고객을 한 번에 훑는 조회는
+/// 매 emission 마다 이 목록을 다시 읽으면(비동기 라운드트립) 이미 초 단위로
+/// 고정된 pump 예산으로 검증하는 다른 위젯 테스트들의 타이밍을 밀어낸다
+/// (#1623 구현 중 `client_status_toggle_test`·`dashboard_page_test` 에서
+/// 실제로 깨졌다). 그 조회들은 이 동기 스냅샷으로 거른다.
+///
+/// db 를 연 직후, 아무 조회도 [readDemoUnregisteredClientIds] 를 부르기
+/// 전에는 비어 있다 — 실제로는 앱 부팅 직후 사이드바·대시보드가 고객
+/// 목록([DriftClientRepository.watchClients], 매 emission 마다 이 목록을
+/// 새로 읽는다)을 거의 즉시 구독하므로 그 창은 실질적으로 없다. 그 뒤로는
+/// [writeDemoUnregisteredClientIds] 가 (고객 삭제·(재)등록에서) 즉시
+/// 갱신한다.
+final Expando<Set<String>> _unregisteredSnapshots = Expando<Set<String>>();
+
+/// [db] 의 현재 미등록 고객 id 스냅샷 — DB를 읽지 않는다.
+Set<String> demoUnregisteredClientIdsSnapshot(AppDatabase db) =>
+    _unregisteredSnapshots[db] ?? const <String>{};
+
+/// [demoUnregisteredClientsKey] 에 저장된 미등록 고객 id 목록을 읽고,
+/// [demoUnregisteredClientIdsSnapshot] 도 함께 갱신한다.
 Future<Set<String>> readDemoUnregisteredClientIds(AppDatabase db) async {
   final raw = await db.readValue(demoUnregisteredClientsKey);
-  if (raw == null || raw.isEmpty) return <String>{};
-  return (jsonDecode(raw) as List<Object?>).whereType<String>().toSet();
+  final ids = raw == null || raw.isEmpty
+      ? <String>{}
+      : (jsonDecode(raw) as List<Object?>).whereType<String>().toSet();
+  _unregisteredSnapshots[db] = ids;
+  return ids;
 }
 
 /// [ids] 를 [demoUnregisteredClientsKey] 에 저장한다.
-Future<void> writeDemoUnregisteredClientIds(AppDatabase db, Set<String> ids) =>
-    db.putValue(demoUnregisteredClientsKey, jsonEncode(ids.toList()..sort()));
+Future<void> writeDemoUnregisteredClientIds(
+  AppDatabase db,
+  Set<String> ids,
+) async {
+  _unregisteredSnapshots[db] = ids;
+  await db.putValue(
+    demoUnregisteredClientsKey,
+    jsonEncode(ids.toList()..sort()),
+  );
+}
+
+/// 고객을 삭제하거나(재)등록한 뒤, 그 결과로 노출이 바뀌는 여러 고객을
+/// 한꺼번에 보여주는 조회들을 새로고침한다 — 오늘 일정, 주간 캘린더, 예약
+/// 날짜 점, 사이드바 안읽음 배지.
+///
+/// 이 provider 들의 스트림은 [demoUnregisteredClientsKey] 변화를 직접 듣지
+/// 않는다(#1623) — 앱 전체가 쓰는 키-값 테이블이라 거기 걸면 무관한 값 하나가
+/// 바뀔 때마다 다시 돈다. 대신 미등록 상태를 바꾸는 이 두 호출부
+/// (`MyPage._removeClient`, `ClientConnectDialog._send`)가 명시적으로
+/// 무효화한다.
+void invalidateClientVisibilityDependentViews(WidgetRef ref) {
+  ref.invalidate(todayScheduleProvider);
+  ref.invalidate(scheduleForDateProvider);
+  ref.invalidate(bookedDatesProvider);
+  ref.invalidate(scheduleRangeProvider);
+  ref.invalidate(unreadCountsProvider);
+}
 
 /// Reads client + schedule data from the local drift DB for the
 /// 고객 관리 tab. Returns reactive streams so the UI updates if the
@@ -295,27 +345,20 @@ class DriftClientRepository implements ClientRepository {
 
   @override
   Future<void> removeClient(String id) async {
-    await _db.transaction(() async {
-      // Demo DB에는 회원 앱 저장소가 없으므로 트레이너 화면용 투영만 정리한다.
-      // 식단·일별 지표처럼 회원이 만든 원본은 남긴다.
-      await (_db.delete(
-        _db.trainerScheduleEntries,
-      )..where((t) => t.clientId.equals(id))).go();
-      await (_db.delete(
-        _db.clientAiRoutines,
-      )..where((t) => t.clientId.equals(id))).go();
-      await (_db.delete(
-        _db.clientRoutineHistory,
-      )..where((t) => t.clientId.equals(id))).go();
-      await (_db.delete(
-        _db.clientChatMessages,
-      )..where((t) => t.clientId.equals(id))).go();
-      await (_db.delete(
-        _db.reportFeedbackDrafts,
-      )..where((t) => t.clientId.equals(id))).go();
-      final removed = (await readDemoUnregisteredClientIds(_db))..add(id);
-      await writeDemoUnregisteredClientIds(_db, removed);
-    });
+    // 삭제 확인창이 트레이너에게 하는 약속(스케줄·루틴·리포트·메시지가
+    // **트레이너 화면에서만** 사라지고, 원본은 지워지지 않는다)은 실
+    // 백엔드(`trainer_service.remove_client`)와 같아야 한다. 예전에는 여기서
+    // 스케줄·AI 루틴·운동 기록·채팅·리포트 피드백 행을 실제로 지웠는데, 그
+    // 대가가 재등록 때 드러났다 — 카드의 주간 이행률(`weekCompletionJson`)은
+    // 캐시라 손대지 않은 채 남는데 근거가 되는 `clientRoutineHistory` 는 이미
+    // 사라져, 되살린 고객의 카드와 상세 화면이 서로 다른 값을 보여줬다(#1623).
+    //
+    // 이제는 행을 지우지 않고 미등록 id 목록에만 올린다. 여러 고객을 한 번에
+    // 보여주는 조회(오늘 일정·전체 안읽음 배지)만 이 목록으로 걸러 낸다 — 특정
+    // 고객 하나를 이미 알고 여는 조회(상세 화면 등)는 애초에 등록 고객만 그
+    // 화면으로 갈 수 있어 걸러낼 필요가 없다.
+    final removed = (await readDemoUnregisteredClientIds(_db))..add(id);
+    await writeDemoUnregisteredClientIds(_db, removed);
   }
 
   @override

--- a/frontend/flutter_trainer/test/features/clients/clients_page_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/clients_page_test.dart
@@ -7,6 +7,7 @@ import 'package:oncare_trainer/core/errors/app_error.dart';
 import 'package:oncare_trainer/core/storage/app_database.dart';
 import 'package:oncare_trainer/core/storage/demo_member_directory.dart';
 import 'package:oncare_trainer/core/storage/seed_data.dart';
+import 'package:oncare_trainer/core/utils/clock.dart';
 import 'package:oncare_trainer/features/clients/data/repositories/client_invite_repository.dart';
 import 'package:oncare_trainer/features/clients/domain/entities/client_invite.dart';
 import 'package:oncare_trainer/features/clients/domain/repositories/client_data_refresher.dart';
@@ -16,6 +17,7 @@ import 'package:oncare_trainer/features/schedule/data/repositories/schedule_repo
 import 'package:oncare_trainer/features/schedule/domain/entities/schedule_session.dart';
 import 'package:oncare_trainer/features/search/presentation/widgets/client_search_bar.dart';
 import 'package:oncare_trainer/shared/models/trainer_client.dart';
+import 'package:oncare_trainer/shared/services/chat_repository.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
 
 import '../../helpers/pump_app.dart';
@@ -222,6 +224,99 @@ void main() {
         );
       },
     );
+
+    test(
+      'removeClient keeps 운동 기록·채팅·스케줄 원본 — 트레이너 화면에서만 사라진다 (#1623)',
+      () async {
+        final repo = DriftClientRepository(db);
+        final schedule = DriftScheduleRepository(db);
+        final chat = DriftChatRepository(db);
+
+        final histBefore = await (db.select(
+          db.clientRoutineHistory,
+        )..where((t) => t.clientId.equals('seed-client-1'))).get();
+        expect(histBefore, isNotEmpty); // seed fixture keeps this honest
+
+        await repo.removeClient('seed-client-1');
+
+        // 원본 행은 그대로다 — 지워지지 않는다.
+        final histAfter = await (db.select(
+          db.clientRoutineHistory,
+        )..where((t) => t.clientId.equals('seed-client-1'))).get();
+        expect(histAfter.length, histBefore.length);
+
+        // 카드의 캐시된 주간 이행률도 그 원본과 여전히 맞아떨어진다 — 지워진
+        // 기록을 근거로 한 숫자를 보여주지 않는다.
+        final client = (await repo.watchClients().first).firstWhere(
+          (c) => c.id == 'seed-client-1',
+        );
+        expect(client.weekCompletion, isNotEmpty);
+
+        // 채팅 원본도 지워지지 않지만, 안읽음 배지·오늘 일정에는 더는
+        // 잡히지 않는다 — 트레이너 화면에서만 사라진다는 약속.
+        final thread = await chat.watchThread('seed-client-1').first;
+        expect(thread, isNotEmpty);
+        final counts = await chat.watchUnreadCounts().first;
+        expect(counts.containsKey('seed-client-1'), isFalse);
+
+        final range = await schedule
+            .watchRange('2000-01-01', '2099-12-31')
+            .first;
+        expect(range.any((s) => s.clientId == 'seed-client-1'), isFalse);
+        // 원본 슬롯은 지워지지 않았다 — 걸러졌을 뿐이다.
+        final rowsAfter = await (db.select(
+          db.trainerScheduleEntries,
+        )..where((t) => t.clientId.equals('seed-client-1'))).get();
+        expect(rowsAfter, isNotEmpty);
+      },
+    );
+
+    test('재등록하면 걸러졌던 채팅·일정 노출이 그대로 돌아온다 (#1623)', () async {
+      final repo = DriftClientRepository(db);
+      final invites = DemoClientInviteRepository(db);
+      final chat = DriftChatRepository(db);
+      final schedule = DriftScheduleRepository(db);
+
+      // 미읽은 회원 메시지를 하나 만들어 둔다 — 삭제 중 사라지지 않고,
+      // 재등록 후 다시 배지에 잡히는지까지 확인한다.
+      await db
+          .into(db.clientChatMessages)
+          .insert(
+            ClientChatMessagesCompanion.insert(
+              id: 'chat-1623-check',
+              clientId: 'seed-client-1',
+              sender: 'client',
+              body: '다음 세션 언제예요?',
+              timeLabel: '09:00',
+              createdAt: nowKst(),
+            ),
+          );
+
+      await repo.removeClient('seed-client-1');
+      expect(
+        (await chat.watchUnreadCounts().first).containsKey('seed-client-1'),
+        isFalse,
+      );
+      expect(
+        (await schedule.watchRange('2000-01-01', '2099-12-31').first).any(
+          (s) => s.clientId == 'seed-client-1',
+        ),
+        isFalse,
+      );
+
+      await invites.invite(demoAlreadyLinkedMemberId);
+
+      expect(
+        (await chat.watchUnreadCounts().first)['seed-client-1'],
+        greaterThan(0),
+      );
+      expect(
+        (await schedule.watchRange('2000-01-01', '2099-12-31').first).any(
+          (s) => s.clientId == 'seed-client-1',
+        ),
+        isTrue,
+      );
+    });
 
     test('미등록 고객은 새 회원 등록과 같은 lookup·invite 로 같은 행을 되살린다', () async {
       final repo = DriftClientRepository(db);


### PR DESCRIPTION
## Summary

* 고객 삭제 확인창은 "스케줄, 프로그램·루틴, 리포트, 메시지 등이 트레이너 화면에서만 사라지고, 고객 앱의 기존 데이터는 삭제되지 않는다"고 약속하고, 실 백엔드(`trainer_service.remove_client`)도 그렇게 동작한다
* 데모(drift) 저장소의 `removeClient`만 스케줄·AI 루틴·운동 기록·채팅·리포트 피드백 행을 실제로 지우고 있었다 — 이 차이는 재등록 경로가 없을 때는 드러나지 않았지만, #1599/#1602로 재등록이 실제로 동작하게 되면서 드러났다: 고객 관리 카드의 캐시된 주간 이행률은 삭제 시 손대지 않는데, 그 근거인 `clientRoutineHistory`는 실제로 지워져 있어 되살린 고객의 카드와 운동 기록 상세가 서로 다른 값을 보여줬다
* 이제 `removeClient`는 미등록 id 목록에 올리기만 하고 원본 행을 지우지 않는다. 여러 고객을 한 번에 보여주는 조회(오늘 일정·주간 캘린더·예약 날짜 점·사이드바 안읽음 배지)만 미등록 고객을 걸러 트레이너 화면에서 빠지게 한다 — 고객 상세처럼 이미 특정 고객 하나를 아는 조회는 원래도 등록 고객만 그 화면으로 갈 수 있어 손대지 않았다

---

## Changes

### 🐛 Fixes

* `DriftClientRepository.removeClient`가 스케줄·AI 루틴·운동 기록·채팅·리포트 피드백을 더 이상 삭제하지 않는다 — 확인창 문구·실 백엔드와 일치
* `DriftScheduleRepository`의 `watchDate`/`watchRange`/`watchBookedDates`가 미등록 고객의 슬롯을 걸러낸다 (원본은 보존)
* `DriftChatRepository.watchUnreadCounts`가 미등록 고객의 안읽음 메시지를 사이드바 배지·미읽음 목록에서 걸러낸다 (원본은 보존)

### 🔧 Improvements

* 미등록 id 목록을 db 인스턴스별 동기 스냅샷(`demoUnregisteredClientIdsSnapshot`)으로 캐시해, 여러 고객을 훑는 조회가 매 emission 마다 비동기로 다시 읽지 않게 했다
* 고객 삭제·(재)등록 호출부가 `invalidateClientVisibilityDependentViews`로 오늘 일정·주간 캘린더·안읽음 배지 provider를 함께 새로고침한다

---

## Notes

* 필터링을 매 emission 마다 비동기로 다시 읽는 방식(처음 구현)은 `client_status_toggle_test`·`dashboard_page_test`처럼 고정된 pump 예산으로 검증하는 위젯 테스트의 타이밍을 깨서, 동기 스냅샷 방식으로 바꿨다 — 커밋 과정에서 실제로 재현·확인했다
* 스냅샷은 db를 연 직후 아무 조회도 읽은 적 없으면 비어 있다. 실제로는 앱 부팅 직후 고객 목록(`watchClients`, 매 emission마다 최신값을 읽는다)을 거의 즉시 구독하므로 그 창은 실질적으로 없다

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [x] UI 확인
* [x] 빌드 성공 (`flutter analyze lib/ test/`)
* [x] 관련 테스트 통과 (`test/features/clients/`, `test/features/schedule/`, `test/features/messages/`, `test/features/dashboard/`, `test/features/my/` — 617개 전부 통과, 신규 테스트 2건 포함)

### Manual Test Steps

1. 고객 관리에서 채팅·오늘 일정이 있는 고객을 삭제한다 → 사이드바 안읽음 배지·오늘 일정에서 즉시 빠지는지 확인한다
2. 고객 탭에서 그 고객의 회원 ID로 다시 등록한다 → 채팅·일정·운동 기록(주간 이행률 포함)이 삭제 전과 같은 값으로 돌아오는지 확인한다

---

## Related Issues

Closes #1623

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인