### PR TITLE
fix(trainer): 신규 고객 등록 동기화 코드 입력창 겹침

### DIFF
--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/pairing_code_input.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/pairing_code_input.dart
@@ -92,10 +92,23 @@ class _PairingCodeInputState extends State<PairingCodeInput> {
             style: const TextStyle(color: Colors.transparent),
             cursorColor: Colors.transparent,
             showCursor: false,
+            // 테마(`AppTheme.inputDecorationTheme`)가 모든 입력에 회색 채움과
+            // 둥근 테두리를 주므로 [InputDecoration.border] 하나만 지워서는
+            // 지워지지 않는다 — `enabledBorder`·`focusedBorder` 가 그대로
+            // 남아 상자들 위에 가로로 긴 입력창이 겹쳐 그려진다(#1636).
+            // 여기서 보여야 하는 것은 자리 상자뿐이므로 채움·테두리를 모두
+            // 끄고, 높이도 상자 줄에 맡긴다.
             decoration: const InputDecoration(
               counterText: '',
-              border: InputBorder.none,
+              filled: false,
+              isCollapsed: true,
               contentPadding: EdgeInsets.zero,
+              border: InputBorder.none,
+              enabledBorder: InputBorder.none,
+              disabledBorder: InputBorder.none,
+              focusedBorder: InputBorder.none,
+              errorBorder: InputBorder.none,
+              focusedErrorBorder: InputBorder.none,
             ),
             onChanged: widget.onChanged,
             onTap: () => setState(() {}),

--- a/frontend/flutter_trainer/test/features/clients/client_connect_dialog_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_connect_dialog_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:oncare_trainer/core/errors/app_error.dart';
+import 'package:oncare_trainer/design_system/theme/app_theme.dart';
 import 'package:oncare_trainer/features/clients/data/repositories/client_invite_repository.dart';
 import 'package:oncare_trainer/features/clients/domain/entities/client_invite.dart';
 import 'package:oncare_trainer/features/clients/presentation/widgets/client_connect_dialog.dart';
@@ -79,6 +80,9 @@ void main() {
           clientInviteRepositoryProvider.overrideWithValue(repository),
         ],
         child: MaterialApp(
+          // 실제 앱 테마로 띄운다 — 기본 테마에는 없는 입력 채움·테두리가
+          // 코드 상자 위에 겹쳐 그려진 적이 있다(#1636).
+          theme: AppTheme.light(),
           locale: const Locale('ko'),
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
@@ -174,6 +178,27 @@ void main() {
     await tester.pump(const Duration(milliseconds: 100));
 
     expect(find.text('이미 다른 트레이너가 담당 중인 회원이에요.'), findsOneWidget);
+  });
+
+  testWidgets('코드 상자 위에 입력창이 겹쳐 그려지지 않는다', (tester) async {
+    // 상자 위에 겹쳐 둔 입력은 탭만 받고 아무것도 그리지 않아야 한다.
+    // 앱 테마가 모든 입력에 주는 회색 채움·둥근 테두리를 이 입력이 그대로
+    // 받으면, 가로로 긴 입력창이 여섯 상자를 덮어 숫자가 보이지 않는다.
+    await pumpDialog(tester, _FakeInviteRepository(paired: _paired()));
+
+    final InputDecorator decorator = tester.widget<InputDecorator>(
+      find.descendant(
+        of: find.byKey(const ValueKey<String>('client-connect-code')),
+        matching: find.byType(InputDecorator),
+      ),
+    );
+    final InputDecoration decoration = decorator.decoration;
+    expect(decoration.filled, isFalse);
+    expect(decoration.border, InputBorder.none);
+    expect(decoration.enabledBorder, InputBorder.none);
+    expect(decoration.focusedBorder, InputBorder.none);
+    expect(decoration.disabledBorder, InputBorder.none);
+    expect(decoration.errorBorder, InputBorder.none);
   });
 
   testWidgets('입력 칸은 여섯 자리를 한 상자씩 보여준다', (tester) async {


### PR DESCRIPTION
Closes #1636

## Summary

신규 고객 등록 창에서 6자리 동기화 코드 상자 위에 회색 입력창이 겹쳐 그려져 숫자가 가려지던 문제를 고친다.

## Cause

`PairingCodeInput` 은 자리 상자 위에 보이지 않아야 할 `TextField` 하나를 겹쳐 둔다(칸마다 컨트롤러를 두지 않기 위한 구조). 이 입력의 `InputDecoration` 은 `border: InputBorder.none` 만 지정했는데, 앱 테마가 모든 입력에 `filled` · `enabledBorder` · `focusedBorder` 를 주므로 `border` 하나로는 덮이지 않는다. 테마의 회색 채움과 둥근 테두리가 상자들 위에 그대로 그려졌다.

## Changes

- 겹쳐 둔 입력의 채움·테두리를 모두 끄고(`filled: false`, 테두리 전 상태 `InputBorder.none`) 높이는 상자 줄에 맡긴다. 입력 동작(붙여넣기·백스페이스·여섯 자리 완성 시 조회)은 그대로다.
- 이 창의 위젯 테스트를 기본 테마가 아닌 **실제 앱 테마**로 띄우도록 바꾸고, 겹쳐 둔 입력이 아무것도 그리지 않는지 확인하는 테스트를 더한다. 기본 테마에는 입력 채움·테두리가 없어 지금까지 이 문제가 테스트에 잡히지 않았다.

## Notes

- 회원 앱 쪽 동기화 코드 시트는 코드를 **보여주기만** 하므로 영향이 없다.
- 검증: `flutter analyze`(clients 범위) 무이슈, `client_connect_dialog_test` · `clients_page_test` 통과. 새 테스트는 수정 전 코드에서 실패하는 것을 확인했다.