### PR TITLE
fix(trainer-clients): 동기화 코드 확인 단계 복원과 데모 코드 정렬

### DIFF
--- a/backend/app/api/v1/trainer.py
+++ b/backend/app/api/v1/trainer.py
@@ -2168,6 +2168,39 @@ def trainer_member_lookup(
 
 
 @router.post(
+    "/trainer/pairing-code/preview",
+    response_model=PairedMemberOut,
+    dependencies=[Depends(rate_limit("pairing-redeem"))],
+)
+def trainer_preview_pairing_code(
+    payload: PairingCodeRedeem,
+    trainer: RequireTrainer,
+    db: Annotated[Session, Depends(get_db)],
+) -> PairedMemberOut:
+    """코드가 가리키는 회원을 **연결하지 않고** 보여 준다. (#1634)
+
+    여섯 자리를 잘못 누르면 남의 식단·건강 기록이 열린다. 되돌릴 수 없는
+    사고라, 연결 전에 이름·성별·나이·목표를 눈으로 확인시킨다.
+
+    코드를 태우지 않는다 — 확인하고 그만두는 것이 정상 흐름이고, 그때마다
+    회원이 코드를 다시 띄워야 할 이유가 없다. 연결(`POST /trainer/pairing-code`)
+    이 쓰는 순간에만 사라진다.
+
+    소비와 같은 rate limit 버킷을 쓴다. 확인도 코드를 맞혀 보는 시도다.
+    """
+    try:
+        return trainer_client_invite_service.preview_pairing_code(
+            db, trainer.id, payload.code
+        )
+    except member_pairing_service.CodeNotFound as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except trainer_client_invite_service.MemberNotFound as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except trainer_client_invite_service.MemberAlreadyCoached as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+
+@router.post(
     "/trainer/pairing-code",
     response_model=PairedMemberOut,
     dependencies=[Depends(rate_limit("pairing-redeem"))],

--- a/backend/app/services/member_pairing_service.py
+++ b/backend/app/services/member_pairing_service.py
@@ -16,9 +16,14 @@
 트레이너가 코드를 쓰는 순간 담당이 바로 성립한다 — 회원에게 한 번 더
 수락받을 이유가 없다.
 
-**소비하지 않는 조회는 두지 않는다.** 코드가 맞는지만 물어볼 수 있으면 100만
-조합을 훑을 수 있다. 확인과 소비가 한 번의 호출이어야 실패가 곧 시도 소모다.
-그 위에 엔드포인트 rate limit 이 얹힌다.
+**쓰기 전에 한 번 확인시킨다.** 여섯 자리를 잘못 누르면 남의 식단·건강 기록이
+열린다 — 되돌릴 수 없는 사고다. 그래서 [peek] 으로 누구인지 보여 준 뒤
+[consume] 으로 잇는다. 확인만으로 코드를 태우지 않는 이유는, 확인하고 그만두는
+것이 정상 흐름이기 때문이다.
+
+그 대가로 확인 자리가 열거에 열린다. 다만 100만 가지에 5분 만료, 분당 10회
+제한이면 한 코드가 살아 있는 동안 시도할 수 있는 것은 쉰 번 남짓이라, 오입력
+쪽이 훨씬 무겁다.
 """
 
 from __future__ import annotations
@@ -136,15 +141,8 @@ class ConsumedCode(NamedTuple):
     consented_at: datetime
 
 
-def consume(db: Session, code: str) -> ConsumedCode:
-    """코드를 쓰고 누구의 것이었는지 돌려준다. **커밋하지 않는다.**
-
-    커밋을 부르는 쪽에 맡기는 것은 담당 링크 생성과 같은 트랜잭션이어야 하기
-    때문이다. 코드만 지워지고 링크는 안 생긴 상태가 되면 회원은 코드를 다시
-    받아야 하고, 그 사이 트레이너에게는 성공한 것처럼 보인다.
-    """
-    purge_expired(db)
-
+def _find(db: Session, code: str) -> MemberPairingCode:
+    """유효한 코드 행. 없으면 [CodeNotFound]."""
     normalized = "".join(ch for ch in code if ch.isdigit())
     if len(normalized) != CODE_LENGTH:
         raise CodeNotFound("동기화 코드가 맞지 않아요. 회원 화면의 6자리를 확인해 주세요.")
@@ -157,7 +155,29 @@ def consume(db: Session, code: str) -> ConsumedCode:
     )
     if row is None:
         raise CodeNotFound("동기화 코드가 맞지 않아요. 회원 화면의 6자리를 확인해 주세요.")
+    return row
 
+
+def peek(db: Session, code: str) -> ConsumedCode:
+    """코드가 누구의 것인지 보되 **쓰지 않는다.** 커밋하지 않는다.
+
+    트레이너가 연결 전에 "이 고객이 맞나요?" 를 확인하는 자리다. 확인만으로
+    코드가 사라지면, 확인하고 그만둔 회원이 아무 잘못 없이 다시 띄워야 한다.
+    """
+    purge_expired(db)
+    row = _find(db, code)
+    return ConsumedCode(member_id=row.member_id, consented_at=row.created_at)
+
+
+def consume(db: Session, code: str) -> ConsumedCode:
+    """코드를 쓰고 누구의 것이었는지 돌려준다. **커밋하지 않는다.**
+
+    커밋을 부르는 쪽에 맡기는 것은 담당 링크 생성과 같은 트랜잭션이어야 하기
+    때문이다. 코드만 지워지고 링크는 안 생긴 상태가 되면 회원은 코드를 다시
+    받아야 하고, 그 사이 트레이너에게는 성공한 것처럼 보인다.
+    """
+    purge_expired(db)
+    row = _find(db, code)
     used = ConsumedCode(member_id=row.member_id, consented_at=row.created_at)
     db.delete(row)
     return used

--- a/backend/app/services/trainer_client_invite_service.py
+++ b/backend/app/services/trainer_client_invite_service.py
@@ -146,6 +146,57 @@ def _age_on(birth_date: str, today: date) -> int | None:
     return age if 0 <= age < 150 else None
 
 
+def _paired_out(db: Session, member: User) -> PairedMemberOut:
+    profile = db.scalar(
+        select(HealthProfile).where(HealthProfile.user_id == member.id)
+    )
+    return PairedMemberOut(
+        member_id=member.id,
+        name=member.name,
+        gender=profile.gender if profile is not None else "",
+        age=(
+            _age_on(profile.birth_date, clock.today())
+            if profile is not None
+            else None
+        ),
+        goal=profile.goals if profile is not None else "",
+    )
+
+
+def preview_pairing_code(
+    db: Session, trainer_id: str, code: str
+) -> PairedMemberOut:
+    """코드가 가리키는 회원을 **쓰지 않고** 보여 준다. (#1634)
+
+    여섯 자리를 잘못 누르면 남의 식단·건강 기록이 이 트레이너에게 열린다.
+    100만분의 1이라도 그 사고는 되돌릴 수 없으므로, 연결 전에 이름·성별·나이·
+    목표를 눈으로 확인시킨다 — 회원 ID로 찾던 시절의 "이 고객이 맞나요?" 와
+    같은 자리다.
+
+    조회만으로 코드를 태우지 않는 이유는, 확인하고 그만두는 것이 정상 흐름이기
+    때문이다. 확인만으로 코드가 사라지면 회원은 아무 잘못 없이 다시 띄워야 한다.
+
+    그래서 이 자리가 열거에 열린다 — 다만 여섯 자리(100만 가지)에 5분 만료,
+    분당 10회 제한이면 한 코드가 살아 있는 동안 시도할 수 있는 것은 쉰 번
+    남짓이다. 오입력으로 남의 기록이 열리는 쪽이 훨씬 무겁다.
+
+    이미 담당이 있는 회원이면 여기서 막는다. 확인 화면까지 갔다가 마지막에
+    거절당하면 트레이너는 무엇이 잘못됐는지 알 수 없다.
+    """
+    used = member_pairing_service.peek(db, code)
+    member = db.get(User, used.member_id)
+    if member is None or member.role != "member":
+        raise MemberNotFound("회원을 찾지 못했어요.")
+
+    current = _active_trainer_id(db, member.id)
+    if current == trainer_id:
+        raise MemberAlreadyCoached("이미 담당하고 있는 회원이에요.")
+    if current is not None:
+        raise MemberAlreadyCoached("이미 다른 트레이너가 담당 중인 회원이에요.")
+
+    return _paired_out(db, member)
+
+
 def redeem_pairing_code(
     db: Session, trainer_id: str, code: str
 ) -> PairedMemberOut:
@@ -204,20 +255,7 @@ def redeem_pairing_code(
         db.rollback()
         raise
 
-    profile = db.scalar(
-        select(HealthProfile).where(HealthProfile.user_id == member.id)
-    )
-    return PairedMemberOut(
-        member_id=member.id,
-        name=member.name,
-        gender=profile.gender if profile is not None else "",
-        age=(
-            _age_on(profile.birth_date, clock.today())
-            if profile is not None
-            else None
-        ),
-        goal=profile.goals if profile is not None else "",
-    )
+    return _paired_out(db, member)
 
 
 def _notify_member_paired(db: Session, trainer_id: str, member_id: str) -> None:

--- a/backend/tests/test_member_pairing.py
+++ b/backend/tests/test_member_pairing.py
@@ -140,6 +140,14 @@ def _issue(client, member_token: str) -> str:
     return response.json()["code"]
 
 
+def _preview(client, trainer_token: str, code: str):
+    return client.post(
+        "/v1/trainer/pairing-code/preview",
+        json={"code": code},
+        headers=_auth(trainer_token),
+    )
+
+
 def _redeem(client, trainer_token: str, code: str):
     return client.post(
         "/v1/trainer/pairing-code",
@@ -279,6 +287,42 @@ def test_redeeming_tells_the_member_their_records_are_now_shared(
         .count()
         >= 1
     )
+
+
+def test_previewing_shows_who_it_is_without_using_the_code(client, db_session):
+    """여섯 자리가 하나만 틀려도 남의 식단·건강 기록이 열린다. 잇기 전에
+    누구인지 보여 주고, 그 확인만으로 코드를 태우지는 않는다."""
+    member_id, member_token = _member(client, name="확인대상")
+    _, trainer_token = _trainer(client, db_session)
+    code = _issue(client, member_token)
+
+    response = _preview(client, trainer_token, code)
+
+    assert response.status_code == 200, response.text
+    assert response.json()["member_id"] == member_id
+    assert response.json()["name"] == "확인대상"
+    # 담당은 아직 생기지 않았다.
+    assert member_id not in _roster_ids(client, trainer_token)
+    # 코드도 그대로다 — 확인하고 그만두는 것이 정상 흐름이다.
+    assert _redeem(client, trainer_token, code).status_code == 200
+
+
+def test_previewing_stops_a_member_who_already_has_a_coach(client, db_session):
+    """확인 화면까지 갔다가 마지막에 거절당하면 무엇이 잘못됐는지 알 수 없다."""
+    _, member_token = _member(client)
+    _, first_token = _trainer(client, db_session)
+    _, second_token = _trainer(client, db_session)
+    assert _redeem(client, first_token, _issue(client, member_token)).status_code == 200
+
+    response = _preview(client, second_token, _issue(client, member_token))
+
+    assert response.status_code == 409, response.text
+
+
+def test_previewing_an_unknown_code_is_not_found(client, db_session):
+    _, trainer_token = _trainer(client, db_session)
+
+    assert _preview(client, trainer_token, "000000").status_code == 404
 
 
 def test_a_code_works_only_once(client, db_session):

--- a/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
+++ b/frontend/flutter/lib/core/network/interceptors/local_api_interceptor.dart
@@ -2044,16 +2044,17 @@ class LocalApiInterceptor extends Interceptor {
     return _ok(options, await _mergedProfile());
   }
 
-  /// 데모의 동기화 코드. 실서버처럼 **한 번 뽑으면 유지된다** — 시트를 다시
-  /// 열 때마다 새 코드가 나오면 트레이너 데모에 받아 적은 값이 무효가 된다.
+  /// 데모 모드의 동기화 코드 — 김민수(데모 회원)의 고정 값이다. (#1634)
   ///
-  /// 데모에는 이 코드를 소비할 트레이너 백엔드가 없다. 트레이너 앱 데모는
-  /// 자기 쪽 고정 코드로 연결을 시연하므로, 여기서는 값을 만들어 화면이
-  /// 도는 것까지만 맞춘다. (#1634)
-  static String? _demoPairingCode;
+  /// **트레이너 앱의 `demoAlreadyLinkedPairingCode` 와 같은 값이어야 한다.**
+  /// 두 앱은 서로 다른 패키지라 상수를 나눠 가질 수 없고, 데모에는 코드를
+  /// 발급·소비할 서버도 없다. 여기서 무작위로 뽑으면 회원 화면이 보여 준
+  /// 여섯 자리를 트레이너 데모가 영영 알아보지 못한다.
+  ///
+  /// 실서비스에서는 서버가 발급한 한 값을 두 화면이 함께 본다.
+  static const String _demoPairingCode = '567812';
 
   Future<Response<Object?>> _pairingCodeIssue(RequestOptions options) async {
-    _demoPairingCode ??= (100000 + math.Random().nextInt(900000)).toString();
     return _ok(options, <String, Object?>{
       'code': _demoPairingCode,
       'expires_at': nowKst()
@@ -2064,7 +2065,8 @@ class LocalApiInterceptor extends Interceptor {
   }
 
   Future<Response<Object?>> _pairingCodeRevoke(RequestOptions options) async {
-    _demoPairingCode = null;
+    // 데모의 코드는 고정이라 버릴 것이 없다. 그래도 받아 주지 않으면 시트를
+    // 닫을 때마다 실 네트워크로 새어 나간다.
     return Response<Object?>(requestOptions: options, statusCode: 204);
   }
 

--- a/frontend/flutter_trainer/lib/core/storage/demo_member_directory.dart
+++ b/frontend/flutter_trainer/lib/core/storage/demo_member_directory.dart
@@ -118,9 +118,11 @@ const String demoAlreadyLinkedMemberId = 'user-7d4e9a2c5f18';
 
 /// 김민수가 자기 앱에 띄웠다고 가정하는 6자리 동기화 코드. (#1634)
 ///
-/// 회원 앱 데모의 목업 인터셉터는 코드를 무작위로 만들지만, 트레이너 데모는
-/// 답할 회원 백엔드가 없어 고정 값이 필요하다 — 시연 중에 두 앱이 서로 다른
-/// 값을 들고 있으면 흐름이 끊긴다. 실서비스에서는 서버가 발급한 한 값을 두
-/// 화면이 함께 본다.
+/// **회원 앱 `LocalApiInterceptor._demoPairingCode` 와 같은 값이어야 한다.**
+/// 두 앱은 서로 다른 패키지라 상수를 나눠 가질 수 없고, 데모에는 코드를
+/// 발급·소비할 서버도 없다. 값이 갈리면 회원 화면이 보여 준 여섯 자리를
+/// 트레이너 데모가 영영 알아보지 못한다.
+///
+/// 실서비스에서는 서버가 발급한 한 값을 두 화면이 함께 본다.
 const String demoAlreadyLinkedPairingCode = '567812';
 const String demoAlreadyLinkedClientId = 'seed-client-1';

--- a/frontend/flutter_trainer/lib/features/clients/data/repositories/client_invite_repository.dart
+++ b/frontend/flutter_trainer/lib/features/clients/data/repositories/client_invite_repository.dart
@@ -47,7 +47,18 @@ abstract interface class ClientInviteRepository {
   /// [ValidationError](서버 문구를 그대로 싣는다 — 어느 쪽인지는 서버만 안다).
   Future<ClientInvite> invite(String memberId, {String? message});
 
-  /// 회원이 자기 앱에 띄운 6자리 동기화 코드로 **바로** 담당이 된다. (#1634)
+  /// 코드가 가리키는 회원을 **연결하지 않고** 보여 준다. (#1634)
+  ///
+  /// 여섯 자리를 잘못 누르면 남의 식단·건강 기록이 열린다 — 되돌릴 수 없는
+  /// 사고라, 잇기 전에 "이 고객이 맞나요?" 를 눈으로 확인시킨다. 확인만으로
+  /// 코드가 사라지지는 않는다.
+  ///
+  /// 코드가 틀렸거나 만료됐거나 이미 쓰였으면 [NotFoundError]. 이미 담당이
+  /// 있는 회원이면 [ValidationError] — 확인 화면까지 갔다가 마지막에 거절하면
+  /// 무엇이 잘못됐는지 알 수 없다.
+  Future<PairedMember> previewPairingCode(String code);
+
+  /// 확인한 회원과 잇는다. 코드는 여기서 쓰인다. (#1634)
   ///
   /// [invite] 와 달리 회원의 수락을 기다리지 않는다 — 코드를 발급해 불러 준
   /// 것이 회원 본인이고 그 화면이 공유 범위를 말한다. 이미 받은 동의를 한 번
@@ -212,21 +223,38 @@ class DemoClientInviteRepository implements ClientInviteRepository {
     );
   }
 
-  @override
-  Future<PairedMember> redeemPairingCode(String code) async {
-    // 데모에는 코드를 발급하는 회원 백엔드가 없다. 명부에 박아 둔 고정 코드로
-    // 같은 흐름을 시연한다 — 화면이 실 API 와 같은 길을 지나야 한다.
+  /// 데모에는 코드를 발급하는 회원 백엔드가 없다. 명부에 박아 둔 고정 코드로
+  /// 같은 흐름을 시연한다 — 화면이 실 API 와 같은 길을 지나야 한다.
+  ///
+  /// 조회 규칙(`lookup`)을 그대로 태운다. 이미 담당 중인지, 담당이 해제된 기존
+  /// 고객인지 판단하는 자리가 둘이 되면 한쪽만 고쳐지는 날이 온다.
+  Future<(String, MemberLookup)> _resolveCode(String code) async {
     final String normalized = code.replaceAll(RegExp(r'\D'), '');
     final String? memberId = resolveDemoPairingCode(normalized);
     if (memberId == null) throw const NotFoundError();
 
-    // 조회 규칙을 그대로 태운다 — 이미 담당 중인지, 담당이 해제된 기존
-    // 고객인지 판단하는 자리가 둘이 되면 한쪽만 고쳐지는 날이 온다.
     final MemberLookup found = await lookup(memberId);
     if (!found.canInvite) {
       throw const ValidationError(message: '이미 담당하고 있는 회원이에요.');
     }
+    return (memberId, found);
+  }
 
+  @override
+  Future<PairedMember> previewPairingCode(String code) async {
+    final (String memberId, MemberLookup found) = await _resolveCode(code);
+    return PairedMember(
+      memberId: memberId,
+      name: found.name,
+      gender: found.gender ?? '',
+      age: found.age,
+      goal: found.goal ?? '',
+    );
+  }
+
+  @override
+  Future<PairedMember> redeemPairingCode(String code) async {
+    final (String memberId, MemberLookup found) = await _resolveCode(code);
     final invite = await this.invite(memberId);
     return PairedMember(
       memberId: invite.memberId,
@@ -306,10 +334,18 @@ class DioClientInviteRepository implements ClientInviteRepository {
   }
 
   @override
-  Future<PairedMember> redeemPairingCode(String code) async {
+  Future<PairedMember> previewPairingCode(String code) =>
+      _postCode('/trainer/pairing-code/preview', code);
+
+  @override
+  Future<PairedMember> redeemPairingCode(String code) =>
+      _postCode('/trainer/pairing-code', code);
+
+  /// 확인과 연결은 응답도 실패 처리도 같다 — 갈라 두면 한쪽만 고쳐진다.
+  Future<PairedMember> _postCode(String path, String code) async {
     try {
       final res = await _dio.post<Map<String, Object?>>(
-        '/trainer/pairing-code',
+        path,
         data: <String, Object?>{'code': code.trim()},
       );
       final data = res.data;

--- a/frontend/flutter_trainer/lib/features/clients/domain/entities/client_invite.dart
+++ b/frontend/flutter_trainer/lib/features/clients/domain/entities/client_invite.dart
@@ -1,3 +1,5 @@
+import 'package:oncare_trainer/shared/models/trainer_client.dart';
+
 /// 이메일 완전 일치로 찾은 회원 한 명.
 ///
 /// 요청을 보낼지 판단할 만큼만 담는다 — 이름, 이미 담당이 있는지, 내가 보낸
@@ -85,6 +87,16 @@ class PairedMember {
 
   /// 회원이 적어 둔 운동 목표. 비어 있을 수 있다.
   final String goal;
+
+  /// 화면에 쓸 성별·나이 — 고객 목록과 **같은 규칙**이다 (#1634).
+  ///
+  /// 회원이 프로필에 성별·생년월일을 넣지 않았으면 목록과 마찬가지로 id 에서
+  /// 만든 고정 값이 선다. 목록은 `남성 · 23세` 라고 하는데 확인 카드만 아무
+  /// 말이 없으면, 트레이너가 지금 잇는 사람이 목록의 그 사람인지 견줄 수 없다.
+  String get rosterGender =>
+      rosterGenderFor(id: memberId, name: name, gender: gender);
+
+  int get rosterAge => rosterAgeFor(id: memberId, age: age);
 
   factory PairedMember.fromJson(Map<String, Object?> json) => PairedMember(
     memberId: (json['member_id'] as String?) ?? '',

--- a/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_connect_dialog.dart
+++ b/frontend/flutter_trainer/lib/features/clients/presentation/widgets/client_connect_dialog.dart
@@ -14,6 +14,7 @@ import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 import 'package:oncare_trainer/shared/services/client_repository.dart';
 import 'package:oncare_trainer/shared/widgets/app_toast.dart';
 import 'package:oncare_trainer/shared/widgets/client_avatar.dart';
+import 'package:oncare_trainer/shared/widgets/client_identity.dart';
 
 /// 회원이 자기 앱에 띄운 6자리 동기화 코드로 연결하는 신규 고객 등록 창.
 /// (#919·#1634)
@@ -21,10 +22,13 @@ import 'package:oncare_trainer/shared/widgets/client_avatar.dart';
 /// 예전에는 회원 ID(`User.id`)를 완전 일치로 받았다. `user-<12자리 hex>` 는
 /// 마주 앉아 불러 주거나 받아 적을 수 있는 형태가 아니었다.
 ///
-/// **한 번에 연결된다.** 코드를 발급해 불러 준 것이 회원 본인이고 그 화면이
-/// 공유 범위를 말한다 — 이미 받은 동의를 한 번 더 받을 이유가 없다. 여섯
-/// 자리를 잘못 눌러도 100만분의 1 로 남에게 닿을 뿐이고, 연결된 뒤 결과
-/// 카드의 이름·성별·나이·목표로 곧바로 알아볼 수 있다.
+/// 두 단계다 — 코드로 **찾고**, 찾은 사람과 **연결한다**. 회원이 코드를
+/// 불러 준 것 자체가 동의라 회원에게 한 번 더 물을 일은 없지만, 여섯 자리를
+/// 잘못 누르면 **남의** 식단·건강 기록이 열린다. 되돌릴 수 없는 사고라
+/// 이름·성별·나이·목표를 눈으로 확인하고 나서 누르게 한다.
+///
+/// 확인만으로 코드가 사라지지는 않는다 — 확인하고 그만두는 것이 정상
+/// 흐름이고, 그때마다 회원이 다시 띄워야 할 이유가 없다.
 ///
 /// 성별·나이·신체 정보는 여기서 입력받지 않는다 — 연결되면 회원이 이미 자기
 /// 앱에 등록해 둔 값을 그대로 쓴다.
@@ -50,8 +54,8 @@ class _ClientConnectDialogState extends ConsumerState<ClientConnectDialog> {
   final TextEditingController _code = TextEditingController();
   final FocusNode _codeFocus = FocusNode();
 
-  /// 연결이 끝난 회원. 결과 카드가 이 값을 보여 준다.
-  PairedMember? _paired;
+  /// 코드로 찾은 회원. 아직 연결하지 않았다 — 확인 카드가 이 값을 보여 준다.
+  PairedMember? _found;
   String? _error;
   bool _busy = false;
 
@@ -71,13 +75,19 @@ class _ClientConnectDialogState extends ConsumerState<ClientConnectDialog> {
     super.dispose();
   }
 
-  /// 여섯 자리가 다 차면 곧바로 보낸다 — 따로 누를 버튼을 두지 않는다.
+  /// 여섯 자리가 다 차면 곧바로 찾는다 — 따로 누를 버튼을 두지 않는다.
+  /// 찾기만 하고 연결은 트레이너가 확인한 뒤에 한다.
   void _onCodeChanged(String value) {
-    if (_error != null) setState(() => _error = null);
-    if (value.length == PairingCodeInput.length) _connect();
+    if (_error != null || _found != null) {
+      setState(() {
+        _error = null;
+        _found = null;
+      });
+    }
+    if (value.length == PairingCodeInput.length) _lookup();
   }
 
-  Future<void> _connect() async {
+  Future<void> _lookup() async {
     if (_busy) return;
     final AppLocalizations l = AppLocalizations.of(context);
     final String code = _code.text.trim();
@@ -85,13 +95,35 @@ class _ClientConnectDialogState extends ConsumerState<ClientConnectDialog> {
       setState(() => _error = l.clientConnectCodeRequired);
       return;
     }
+    setState(() {
+      _busy = true;
+      _error = null;
+    });
+    try {
+      final found = await ref
+          .read(clientInviteRepositoryProvider)
+          .previewPairingCode(code);
+      if (!mounted || _code.text.trim() != code) return;
+      setState(() => _found = found);
+    } catch (error) {
+      if (!mounted) return;
+      setState(() => _error = _messageFor(l, error));
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _connect(PairedMember found) async {
+    if (_busy) return;
+    final AppLocalizations l = AppLocalizations.of(context);
+    final navigator = Navigator.of(context);
     final repository = ref.read(clientInviteRepositoryProvider);
     setState(() {
       _busy = true;
       _error = null;
     });
     try {
-      final paired = await repository.redeemPairingCode(code);
+      await repository.redeemPairingCode(_code.text.trim());
       ref.invalidate(pendingClientInvitesProvider);
       // 데모(즉시 연결)와 실 API 모두 고객 탭과 고객 관리가 같은 목록을 보므로
       // 두 provider 를 함께 새로고침한다.
@@ -100,34 +132,37 @@ class _ClientConnectDialogState extends ConsumerState<ClientConnectDialog> {
       // 미등록 동안 걸러졌던 오늘 일정·안읽음 배지도 다시 보인다(#1623).
       invalidateClientVisibilityDependentViews(ref);
       if (!mounted) return;
-      // 창을 곧바로 닫지 않는다 — 여섯 자리를 잘못 눌렀다면 여기서
-      // 이름·성별·나이·목표로 알아봐야 한다. 닫는 것은 트레이너가 정한다.
-      setState(() => _paired = paired);
-    } on NotFoundError {
-      if (!mounted) return;
-      setState(() => _error = l.clientConnectCodeInvalid);
-    } on AppError catch (error) {
-      if (!mounted) return;
-      // 서버가 이유를 문장으로 준 경우에는 그 문장이 다음에 할 일을 정한다.
-      // (한국어 로케일에서만 — 영어 화면에 한국어가 새지 않게 한다.)
-      setState(
-        () => _error = serverDetailOr(l, error.message, l.clientInviteFailed),
+      navigator.pop();
+      showAppToast(
+        context,
+        l.clientInviteConnected(found.name),
+        kind: AppToastKind.success,
       );
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        // 확인과 연결 사이에 코드가 만료됐거나 남이 먼저 썼을 수 있다.
+        // 그러면 확인 카드도 거둔다 — 누를 수 없는 버튼을 남기지 않는다.
+        _found = null;
+        _error = _messageFor(l, error);
+      });
     } finally {
       if (mounted) setState(() => _busy = false);
     }
   }
 
-  /// 결과를 확인했다 — 창을 닫는다.
-  void _done(PairedMember paired) {
-    final AppLocalizations l = AppLocalizations.of(context);
-    Navigator.of(context).pop();
-    showAppToast(
-      context,
-      l.clientInviteConnected(paired.name),
-      kind: AppToastKind.success,
-    );
-  }
+  /// 실패를 화면 문구로 옮긴다. 서버가 이유를 문장으로 준 경우에는 그 문장이
+  /// 트레이너가 다음에 할 일을 정한다(한국어 로케일에서만 — 영어 화면에
+  /// 한국어가 새지 않게 한다).
+  String _messageFor(AppLocalizations l, Object error) => switch (error) {
+    NotFoundError() => l.clientConnectCodeInvalid,
+    AppError(:final String? message) => serverDetailOr(
+      l,
+      message,
+      l.clientInviteFailed,
+    ),
+    _ => l.clientInviteFailed,
+  };
 
   Future<void> _cancel(ClientInvite invite) async {
     if (_busy) return;
@@ -231,7 +266,7 @@ class _ClientConnectDialogState extends ConsumerState<ClientConnectDialog> {
                 PairingCodeInput(
                   controller: _code,
                   focusNode: _codeFocus,
-                  enabled: !_busy && _paired == null,
+                  enabled: !_busy,
                   onChanged: _onCodeChanged,
                 ),
                 if (_error case final String error) ...<Widget>[
@@ -255,15 +290,28 @@ class _ClientConnectDialogState extends ConsumerState<ClientConnectDialog> {
                     ),
                   ),
                 ],
-                if (_paired case final PairedMember paired) ...<Widget>[
+                if (_found case final PairedMember found) ...<Widget>[
                   const SizedBox(height: AppSpacing.lg),
-                  _PairedMemberCard(paired: paired),
+                  // 바로 잇지 않고 한 번 더 확인시킨다 — 여섯 자리가 하나만
+                  // 틀려도 남의 식단·건강 기록이 열린다.
+                  Text(
+                    l.clientInviteConfirmPrompt,
+                    style: const TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w700,
+                      color: AppColors.foreground,
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.sm),
+                  _PairedMemberCard(paired: found),
                   const SizedBox(height: AppSpacing.md),
                   SizedBox(
                     height: 44,
-                    child: FilledButton(
-                      key: const ValueKey<String>('client-connect-done'),
-                      onPressed: () => _done(paired),
+                    child: FilledButton.icon(
+                      key: const ValueKey<String>('client-connect-register'),
+                      onPressed: _busy ? null : () => _connect(found),
+                      icon: const Icon(Icons.person_add_alt_1_rounded, size: 18),
+                      label: Text(l.clientInviteConnectAction),
                       style: FilledButton.styleFrom(
                         shape: const RoundedRectangleBorder(
                           borderRadius: BorderRadius.all(AppRadius.md),
@@ -273,7 +321,6 @@ class _ClientConnectDialogState extends ConsumerState<ClientConnectDialog> {
                           fontWeight: FontWeight.w700,
                         ),
                       ),
-                      child: Text(l.clientConnectDone),
                     ),
                   ),
                 ],
@@ -376,11 +423,10 @@ class _PendingInvitesList extends ConsumerWidget {
   }
 }
 
-/// 방금 연결된 회원 — 아바타·이름·성별/나이·목표. (#1634)
+/// 코드로 찾은 회원 — 아바타·이름·성별/나이·목표. (#1634)
 ///
-/// 코드를 발급해 불러 준 것이 회원 본인이라 신원 확인은 이미 끝났다. 그래도
-/// 이름만 보여 주지 않는 것은, 트레이너가 여섯 자리를 잘못 눌렀을 때 **연결된
-/// 뒤에라도** 그 사실을 알아볼 수 있어야 하기 때문이다.
+/// 이름만 보여 주지 않는 것은, 여섯 자리가 하나만 틀려도 **다른 사람**이
+/// 나오기 때문이다. 이름 하나로는 "이 고객이 맞나요?" 에 답할 수 없다.
 ///
 /// 여기 있는 값은 모두 회원이 자기 앱에 등록해 둔 것이다 — 트레이너가 지금
 /// 입력하는 값이 아니다. 키·몸무게·질환은 고객 상세의 건강 프로필에서 본다.
@@ -391,18 +437,12 @@ class _PairedMemberCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final bool korean = Localizations.localeOf(context).languageCode == 'ko';
-    String? demographics;
-    if (paired.gender.isNotEmpty && paired.age != null) {
-      final String genderLabel = switch (paired.gender) {
-        'female' => korean ? '여성' : 'Female',
-        'male' => korean ? '남성' : 'Male',
-        _ => korean ? '기타' : 'Other',
-      };
-      demographics = korean
-          ? '$genderLabel · ${paired.age}세'
-          : '$genderLabel · Age ${paired.age}';
-    }
+    // 고객 목록과 같은 함수로 적는다 — 표기가 갈리면 견주기 어렵다.
+    final String demographics = demographicsLabel(
+      context,
+      gender: paired.rosterGender,
+      age: paired.rosterAge,
+    );
     final String initial = paired.name.isEmpty
         ? '?'
         : String.fromCharCode(paired.name.runes.first);
@@ -437,20 +477,18 @@ class _PairedMemberCard extends StatelessWidget {
                         ),
                       ),
                     ),
-                    if (demographics != null) ...<Widget>[
-                      const SizedBox(width: AppSpacing.xs),
-                      Flexible(
-                        child: Text(
-                          demographics,
-                          overflow: TextOverflow.ellipsis,
-                          style: const TextStyle(
-                            fontSize: 12.5,
-                            fontWeight: FontWeight.w600,
-                            color: AppColors.subtleForeground,
-                          ),
+                    const SizedBox(width: AppSpacing.xs),
+                    Flexible(
+                      child: Text(
+                        demographics,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          fontSize: 12.5,
+                          fontWeight: FontWeight.w600,
+                          color: AppColors.subtleForeground,
                         ),
                       ),
-                    ],
+                    ),
                   ],
                 ),
                 if (paired.goal.isNotEmpty) ...<Widget>[

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations.dart
@@ -1394,12 +1394,6 @@ abstract class AppLocalizations {
   /// **'Member sync code'**
   String get clientConnectCodeLabel;
 
-  /// No description provided for @clientConnectDone.
-  ///
-  /// In en, this message translates to:
-  /// **'Done'**
-  String get clientConnectDone;
-
   /// No description provided for @clientConnectCodeRequired.
   ///
   /// In en, this message translates to:

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_en.dart
@@ -744,9 +744,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get clientConnectCodeLabel => 'Member sync code';
 
   @override
-  String get clientConnectDone => 'Done';
-
-  @override
   String get clientConnectCodeRequired => 'Enter all six digits';
 
   @override

--- a/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
+++ b/frontend/flutter_trainer/lib/gen/l10n/app_localizations_ko.dart
@@ -720,9 +720,6 @@ class AppLocalizationsKo extends AppLocalizations {
   String get clientConnectCodeLabel => '회원 동기화 코드';
 
   @override
-  String get clientConnectDone => '확인';
-
-  @override
   String get clientConnectCodeRequired => '6자리를 모두 입력해 주세요';
 
   @override

--- a/frontend/flutter_trainer/lib/l10n/app_en.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_en.arb
@@ -358,7 +358,6 @@
   "clientInviteIntro": "Enter the 6-digit sync code from the member's MY tab to connect right away.",
   "clientInviteIntroImmediate": "Enter the 6-digit sync code from the member's MY tab to connect right away.",
   "clientConnectCodeLabel": "Member sync code",
-  "clientConnectDone": "Done",
   "clientConnectCodeRequired": "Enter all six digits",
   "clientConnectCodeInvalid": "That code is wrong or expired. Ask the member for a new one",
   "clientInviteMemberIdLabel": "Member ID",

--- a/frontend/flutter_trainer/lib/l10n/app_ko.arb
+++ b/frontend/flutter_trainer/lib/l10n/app_ko.arb
@@ -221,7 +221,6 @@
   "clientInviteIntro": "회원 앱 MY 탭의 6자리 동기화 코드를 입력하면 바로 연결돼요.",
   "clientInviteIntroImmediate": "회원 앱 MY 탭의 6자리 동기화 코드를 입력하면 바로 연결돼요.",
   "clientConnectCodeLabel": "회원 동기화 코드",
-  "clientConnectDone": "확인",
   "clientConnectCodeRequired": "6자리를 모두 입력해 주세요",
   "clientConnectCodeInvalid": "코드가 맞지 않거나 만료됐어요. 회원에게 새 코드를 받아 주세요",
   "clientInviteMemberIdLabel": "회원 ID",

--- a/frontend/flutter_trainer/lib/shared/models/trainer_client.dart
+++ b/frontend/flutter_trainer/lib/shared/models/trainer_client.dart
@@ -23,6 +23,32 @@ const Map<String, String> _rosterGenderByName = <String, String>{
   '오세라': 'female',
 };
 
+/// 로스터가 보여 주는 성별 — 저장된 값이 있으면 그것, 없으면 고정된 폴백.
+///
+/// [TrainerClient.rosterGender] 의 알맹이를 밖으로 꺼낸 것이다. 신규 고객
+/// 등록의 확인 카드도 같은 값을 보여야 하기 때문이다 (#1634) — 목록은
+/// `남성 · 23세` 라고 하는데 확인 카드가 아무 말도 없으면, 트레이너가 지금
+/// 잇는 사람이 목록의 그 사람인지 견줄 수가 없다.
+String rosterGenderFor({
+  required String id,
+  required String name,
+  String gender = '',
+}) {
+  if (gender == 'male' || gender == 'female' || gender == 'other') {
+    return gender;
+  }
+  final fixed = _rosterGenderByName[name];
+  if (fixed != null) return fixed;
+  return _demographicSeedOf(id).isEven ? 'female' : 'male';
+}
+
+/// 로스터가 보여 주는 나이 — 저장된 값이 있으면 그것, 없으면 고정된 폴백.
+int rosterAgeFor({required String id, int? age}) =>
+    age ?? 20 + (_demographicSeedOf(id) % 20);
+
+int _demographicSeedOf(String id) =>
+    id.runes.fold<int>(0, (sum, rune) => sum + rune);
+
 /// A trainer's client, as shown on the 고객 관리 list and detail screens.
 /// Decoded from the drift `TrainerClients` row (the `weekCompletionJson`
 /// column becomes a `List<int>` here).
@@ -133,20 +159,12 @@ class TrainerClient {
   /// 적어 둔다 — 로스터가 데모 fixture 라 이름이 곧 그 회원이고, id 는 데모
   /// (`seed-client-8`)와 실 API(`user-sera`)가 서로 달라 한쪽만 고치면 두 모드가
   /// 갈린다.
-  String get rosterGender {
-    if (gender == 'male' || gender == 'female' || gender == 'other') {
-      return gender;
-    }
-    final fixed = _rosterGenderByName[name];
-    if (fixed != null) return fixed;
-    return _demographicSeed.isEven ? 'female' : 'male';
-  }
+  String get rosterGender =>
+      rosterGenderFor(id: id, name: name, gender: gender);
 
   /// Roster age, constrained to the requested twenties/thirties fixture range
   /// when the source does not provide one.
-  int get rosterAge => age ?? 20 + (_demographicSeed % 20);
-
-  int get _demographicSeed => id.runes.fold<int>(0, (sum, rune) => sum + rune);
+  int get rosterAge => rosterAgeFor(id: id, age: age);
 
   /// Sodium exceeds the [sodiumTargetMg] daily target — surfaced as a
   /// warning on the list card and counted by the AI summary.

--- a/frontend/flutter_trainer/lib/shared/widgets/client_identity.dart
+++ b/frontend/flutter_trainer/lib/shared/widgets/client_identity.dart
@@ -6,15 +6,30 @@ import 'package:oncare_trainer/shared/models/trainer_client.dart';
 
 /// Returns the localized demographic label used to distinguish clients who
 /// share a name.
-String clientDemographicsLabel(BuildContext context, TrainerClient client) {
+String clientDemographicsLabel(BuildContext context, TrainerClient client) =>
+    demographicsLabel(
+      context,
+      gender: client.rosterGender,
+      age: client.rosterAge,
+    );
+
+/// 로스터 행이 아닌 값으로도 같은 문구를 만든다 — `여성 · 29세`.
+///
+/// 신규 고객 등록의 확인 카드가 쓴다 (#1634). 목록과 다른 모양으로 적으면,
+/// 트레이너가 지금 잇는 사람이 목록의 그 사람인지 견줄 때 한 번 더 생각해야
+/// 한다.
+String demographicsLabel(
+  BuildContext context, {
+  required String gender,
+  required int age,
+}) {
   final korean = Localizations.localeOf(context).languageCode == 'ko';
-  final gender = switch (client.rosterGender) {
+  final genderLabel = switch (gender) {
     'female' => korean ? '여성' : 'Female',
     'male' => korean ? '남성' : 'Male',
     _ => korean ? '기타' : 'Other',
   };
-  final age = korean ? '${client.rosterAge}세' : 'Age ${client.rosterAge}';
-  return '$gender · $age';
+  return '$genderLabel · ${korean ? '$age세' : 'Age $age'}';
 }
 
 /// Returns a plain-text identity for places that cannot compose text styles.

--- a/frontend/flutter_trainer/test/features/clients/client_connect_dialog_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/client_connect_dialog_test.dart
@@ -11,32 +11,43 @@ import 'package:oncare_trainer/gen/l10n/app_localizations.dart';
 
 /// 회원이 자기 앱에 띄운 6자리 동기화 코드로 연결하는 창. (#919·#1634)
 ///
-/// 예전에는 회원 ID(`User.id`)를 완전 일치로 받고, 찾은 뒤 한 번 더 눌러
-/// 연결했다. 지금은 코드를 발급해 불러 준 것이 회원 본인이라 한 번에
-/// 연결되고, 결과 카드가 "이 사람이 맞나요"를 대신한다.
+/// 두 단계인 것이 이 창의 요지다 — 코드로 **찾고**, 확인하고 나서 **연결한다**.
+/// 회원이 코드를 불러 준 것 자체가 동의라 회원에게 다시 물을 일은 없지만,
+/// 여섯 자리가 하나만 틀려도 **남의** 식단·건강 기록이 열린다.
 class _FakeInviteRepository implements ClientInviteRepository {
   _FakeInviteRepository({this.paired, this.failure});
 
-  /// 연결에 성공하면 돌려줄 회원.
+  /// 코드가 가리키는 회원. 없으면 조회가 [NotFoundError] 로 끝난다.
   PairedMember? paired;
 
-  /// 있으면 연결이 이 오류로 끝난다.
+  /// 있으면 조회가 이 오류로 끝난다.
   AppError? failure;
 
   // 이 창은 코드로 그 자리에서 연결한다 — 기다릴 답이 없다.
   @override
   bool get connectsImmediately => true;
 
-  /// 실제로 서버에 넘어간 코드들 — 공백·하이픈을 그대로 흘려보내지 않는지 본다.
+  /// 조회에 넘어간 코드들.
+  final List<String> previewed = <String>[];
+
+  /// **연결**에 넘어간 코드들 — 확인 전에는 비어 있어야 한다.
   final List<String> redeemed = <String>[];
 
   @override
   bool get supportsInvites => true;
 
   @override
+  Future<PairedMember> previewPairingCode(String code) async {
+    previewed.add(code);
+    if (failure case final AppError error) throw error;
+    final result = paired;
+    if (result == null) throw const NotFoundError();
+    return result;
+  }
+
+  @override
   Future<PairedMember> redeemPairingCode(String code) async {
     redeemed.add(code);
-    if (failure case final AppError error) throw error;
     final result = paired;
     if (result == null) throw const NotFoundError();
     return result;
@@ -114,28 +125,32 @@ void main() {
     await tester.pump();
   }
 
-  testWidgets('여섯 자리를 다 채우면 바로 연결한다', (tester) async {
+  testWidgets('여섯 자리를 다 채우면 찾되, 연결하지는 않는다', (tester) async {
     final repository = _FakeInviteRepository(paired: _paired());
     await pumpDialog(tester, repository);
 
     await enterCode(tester, '979030');
     await tester.pump();
 
-    // 따로 누를 버튼을 두지 않는다 — 회원이 코드를 불러 주고 있는 자리다.
-    expect(repository.redeemed, <String>['979030']);
+    // 찾는 데는 따로 누를 버튼을 두지 않는다 — 회원이 코드를 불러 주고 있는
+    // 자리다. 다만 **연결은 아직이다.**
+    expect(repository.previewed, <String>['979030']);
+    expect(repository.redeemed, isEmpty);
   });
 
-  testWidgets('다 채우기 전에는 보내지 않는다', (tester) async {
+  testWidgets('다 채우기 전에는 찾지 않는다', (tester) async {
     final repository = _FakeInviteRepository(paired: _paired());
     await pumpDialog(tester, repository);
 
     await enterCode(tester, '97903');
     await tester.pump();
 
-    expect(repository.redeemed, isEmpty);
+    expect(repository.previewed, isEmpty);
   });
 
-  testWidgets('연결되면 이름·성별/나이·목표가 뜬다', (tester) async {
+  testWidgets('찾으면 이 고객이 맞는지 묻고 이름·성별/나이·목표를 보여준다', (
+    tester,
+  ) async {
     final repository = _FakeInviteRepository(paired: _paired());
     await pumpDialog(tester, repository);
 
@@ -143,15 +158,48 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
 
-    // 여섯 자리를 잘못 눌렀다면 연결된 뒤에라도 알아볼 수 있어야 한다.
+    // 여섯 자리가 하나만 틀려도 다른 사람이 나온다 — 이름 하나로는 답할 수 없다.
+    expect(find.text('이 고객이 맞나요?'), findsOneWidget);
     expect(find.text('이수아'), findsOneWidget);
     expect(find.text('여성 · 29세'), findsOneWidget);
     expect(find.text('체지방 감량'), findsOneWidget);
-    // 창은 스스로 닫히지 않는다 — 닫는 것은 확인한 트레이너가 정한다.
-    expect(
-      find.byKey(const ValueKey<String>('client-connect-done')),
-      findsOneWidget,
+  });
+
+  testWidgets('성별·나이를 안 넣은 회원도 목록과 같은 표기로 뜬다', (tester) async {
+    // 목록은 `남성 · 23세` 라고 하는데 확인 카드만 아무 말이 없으면, 트레이너가
+    // 지금 잇는 사람이 목록의 그 사람인지 견줄 수 없다. 목록과 같은 폴백을 쓴다.
+    final repository = _FakeInviteRepository(
+      paired: const PairedMember(
+        memberId: 'user-8f2a41c9d6e3',
+        name: '이수아',
+        goal: '체지방 감량',
+      ),
     );
+    await pumpDialog(tester, repository);
+
+    await enterCode(tester, '979030');
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.textContaining(RegExp(r'(남성|여성|기타) · \d+세')), findsOneWidget);
+  });
+
+  testWidgets('확인하고 눌러야 연결된다', (tester) async {
+    final repository = _FakeInviteRepository(paired: _paired());
+    await pumpDialog(tester, repository);
+
+    await enterCode(tester, '979030');
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(repository.redeemed, isEmpty);
+
+    await tester.tap(
+      find.byKey(const ValueKey<String>('client-connect-register')),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(repository.redeemed, <String>['979030']);
   });
 
   testWidgets('틀렸거나 만료된 코드는 왜인지 갈라 말하지 않는다', (tester) async {
@@ -167,7 +215,10 @@ void main() {
     expect(find.textContaining('새 코드를 받아'), findsOneWidget);
   });
 
-  testWidgets('이미 담당이 있는 회원이면 서버 문구를 그대로 보여준다', (tester) async {
+  testWidgets('이미 담당이 있는 회원이면 확인 화면 전에 막고 이유를 말한다', (
+    tester,
+  ) async {
+    // 확인까지 갔다가 마지막에 거절당하면 무엇이 잘못됐는지 알 수 없다.
     final repository = _FakeInviteRepository(
       failure: const ValidationError(message: '이미 다른 트레이너가 담당 중인 회원이에요.'),
     );
@@ -178,6 +229,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 100));
 
     expect(find.text('이미 다른 트레이너가 담당 중인 회원이에요.'), findsOneWidget);
+    expect(find.text('이 고객이 맞나요?'), findsNothing);
   });
 
   testWidgets('코드 상자 위에 입력창이 겹쳐 그려지지 않는다', (tester) async {

--- a/frontend/flutter_trainer/test/features/clients/clients_page_test.dart
+++ b/frontend/flutter_trainer/test/features/clients/clients_page_test.dart
@@ -38,6 +38,10 @@ class _NoInviteClientInviteRepository implements ClientInviteRepository {
       throw const NotFoundError();
 
   @override
+  Future<PairedMember> previewPairingCode(String code) async =>
+      throw const NotFoundError();
+
+  @override
   Future<PairedMember> redeemPairingCode(String code) async =>
       throw const NotFoundError();
 
@@ -648,8 +652,10 @@ void main() {
       expect(find.text('이수아'), findsWidgets);
       expect(find.textContaining('여성'), findsWidgets);
 
+      // 바로 잇지 않는다 — 이름·성별·나이를 확인하고 누른다.
+      expect(find.text('이 고객이 맞나요?'), findsOneWidget);
       await tester.tap(
-        find.byKey(const ValueKey<String>('client-connect-done')),
+        find.byKey(const ValueKey<String>('client-connect-register')),
       );
       await settle(tester);
 
@@ -693,8 +699,10 @@ void main() {
       expect(find.text('김민수'), findsWidgets);
       expect(find.text('이미 담당하고 있는 회원이에요.'), findsNothing);
 
+      // 바로 잇지 않는다 — 이름·성별·나이를 확인하고 누른다.
+      expect(find.text('이 고객이 맞나요?'), findsOneWidget);
       await tester.tap(
-        find.byKey(const ValueKey<String>('client-connect-done')),
+        find.byKey(const ValueKey<String>('client-connect-register')),
       );
       await settle(tester);
 


### PR DESCRIPTION
## Summary

* 배포(데모 모드)에서 회원 화면의 6자리를 그대로 넣어도 **"코드가 맞지 않거나 만료됐어요"** 만 돌아오던 문제를 고쳤습니다. 회원 앱 목업이 코드를 무작위로 만들고 트레이너 데모는 고정 코드만 알아봐서, 두 값이 만날 길이 없었습니다.
* 여섯 자리를 다 채우면 곧바로 잇던 것을 **"이 고객이 맞나요?" 확인 단계**로 되돌렸습니다. 한 자리만 틀려도 남의 식단·건강 기록이 열리는데 되돌릴 방법이 없습니다.
* 확인 카드에 **성별·나이**를 더했습니다. 고객 목록이 쓰는 것과 같은 표기입니다.

#1634 / #1635 의 후속입니다.

---

## Changes

### ✨ Features

* `POST /trainer/pairing-code/preview` — 코드가 가리키는 회원을 **쓰지 않고** 보여 줍니다. 연결은 기존 `POST /trainer/pairing-code` 가 그대로 합니다

### 🔧 Improvements

* 이미 담당이 있는 회원은 **확인 화면 전에** 막습니다 — 확인까지 갔다가 마지막에 거절하면 무엇이 잘못됐는지 알 수 없습니다
* 확인과 연결 사이에 코드가 만료되거나 남이 먼저 쓰면, 확인 카드를 거두고 이유를 말합니다 — 누를 수 없는 버튼을 남기지 않습니다
* 로스터의 성별·나이 폴백(`rosterGenderFor`·`rosterAgeFor`)과 표기(`demographicsLabel`)를 공용으로 열어 목록과 확인 카드가 같은 함수를 씁니다

### 🎨 UI/UX

* 신규 고객 등록: 코드 입력 → **"이 고객이 맞나요?" + 회원 카드** → `고객 등록` 버튼
* 확인 카드가 아바타 · 이름 · **성별/나이** · 목표를 보여 줍니다 (성별/나이가 새로 붙은 부분입니다)

### 📝 Docs

* 두 앱의 데모 코드 상수에 **서로를 가리키는 주석**을 남겼습니다 — 다른 패키지라 상수를 나눠 가질 수 없고, 값이 갈리면 데모가 조용히 끊깁니다

### 🐛 Fixes

* 회원 앱 목업이 김민수의 **고정** 동기화 코드를 내도록 되돌렸습니다

---

## Commits

1. `4c83d549` fix(trainer-clients): 코드 확인 단계 복원과 데모 코드 정렬

---

## Notes

**왜 데모가 끊겼나.** 배포 빌드는 `USE_MOCK_API` 기본값(true)이라 두 앱 다 백엔드에 닿지 않습니다. 옛 데모는 회원 앱이 고정 ID(`user-7d4e9a2c5f18`)를 보여 주고 트레이너 데모가 그 값을 알아봐서 통했는데, #1635 에서 코드를 무작위로 만들면서 그 연결을 끊었습니다.

**데모 시나리오.** 김민수는 트레이너 데모에서 이미 담당 중인 고객이라, 그의 코드(`567812`)는 이제 **"이미 담당하고 있는 회원이에요"** 라고 정확히 답합니다(옛 데모가 그의 ID에 답하던 것과 같습니다). 성공 연결은 이수아 `308214`·박준서 `741503` 로 보거나, 고객 관리에서 김민수를 담당 종료한 뒤 그의 코드로 되살리면 됩니다.

**확인 단계를 되살린 이유.** #1635 는 "코드를 불러 준 것이 회원 본인이니 한 번에 잇는다" 로 갔습니다. 회원 쪽 동의는 그 말이 맞지만, 트레이너가 여섯 자리를 잘못 누르는 경우가 남습니다 — 그러면 **남의** 식단·건강 기록이 열리고 되돌릴 수 없습니다. 회원 ID로 찾던 시절의 "이 고객이 맞나요?" 를 그대로 되살렸습니다.

**확인이 코드를 태우지 않습니다.** 확인하고 그만두는 것이 정상 흐름이라, 그때마다 회원이 다시 띄워야 할 이유가 없습니다. 그 대가로 확인 자리가 열거에 열리는데, 100만 가지에 5분 만료·분당 10회 제한이면 한 코드가 사는 동안 시도할 수 있는 것은 쉰 번 남짓입니다. 오입력으로 남의 기록이 열리는 쪽이 훨씬 무겁다고 봤습니다.

**성별·나이를 더한 이유.** 고객 목록은 이미 `남성 · 23세` 라고 말합니다. 확인 카드만 아무 말이 없으면 트레이너가 지금 잇는 사람이 목록의 그 사람인지 견줄 수 없습니다. 회원이 프로필에 성별·생년월일을 넣지 않았을 때도 목록과 **같은 폴백**이 서도록 그 규칙을 함께 나눠 씁니다.

`pairing_code_input.dart` 는 건드리지 않았습니다 — #1637 위로 리베이스했습니다.

---

## Screenshots (Optional)

| Before | After |
| ------ | ----- |
|        |       |

---

## Test Plan

* [x] 기능 정상 동작 확인
* [x] 예외 케이스 확인
* [ ] UI 확인
* [x] 빌드 성공
* [x] 관련 테스트 통과

`test_member_pairing.py` 에 확인 단계 3건을 더했습니다 — 확인이 **코드를 태우지 않는다**, 이미 담당이 있으면 확인 전에 막는다, 모르는 코드는 404. 트레이너 앱 등록 창 테스트는 "찾되 연결하지 않는다"·"확인하고 눌러야 연결된다"·"성별·나이를 안 넣은 회원도 목록과 같은 표기로 뜬다" 로 다시 썼습니다.

두 앱 `flutter analyze` 무결, 트레이너 앱 `test/features/clients` 332건 통과입니다. 백엔드 테스트는 DB 가 필요해 CI(Postgres)에서 실행됩니다.

### Manual Test Steps

1. 회원 앱 MY 탭 → 트레이너와 데이터 동기화 → 6자리 확인
2. 트레이너 앱 → 고객 → 신규 고객 등록 → 그 6자리 입력 → **"이 고객이 맞나요?"** 와 아바타·이름·성별/나이·목표 카드가 뜨는지 확인
3. `고객 등록` 을 누르기 전까지는 고객 목록이 그대로인지 확인
4. `고객 등록` → 목록에 즉시 나타나는지 확인
5. 이미 담당 중인 회원의 코드 → 확인 카드 없이 "이미 담당하고 있는 회원이에요" 만 뜨는지 확인
6. 데모: `308214`(이수아)·`741503`(박준서) 로 연결, `567812`(김민수) 로 중복 안내 확인

---

## Related Issues

#1634

## Checklist

* [x] 코드 리뷰 준비 완료
* [x] 불필요한 코드 제거
* [x] 하드코딩 값 점검
* [x] Merge 충돌 없음
* [x] 데모 시나리오 영향 확인
