### PR TITLE
test(schedule): 반복 미리보기 회차 수를 시작~종료일 기간에서 계산

### DIFF
--- a/frontend/flutter_trainer/test/features/schedule/schedule_recurring_test.dart
+++ b/frontend/flutter_trainer/test/features/schedule/schedule_recurring_test.dart
@@ -194,10 +194,25 @@ void main() {
 
       final preview = find.byKey(const ValueKey<String>('repeat-preview'));
       expect(preview, findsOneWidget);
-      // 기본 종료 기준은 8회다.
+
+      // 회차 수는 **시작~종료일 기간에서 나오는 값**이다. 여기에 숫자를 따로 적어
+      // 두면 기본 종료일이 바뀔 때 이 단언만 홀로 틀린다 — 실제로 그랬다(#1647).
+      // 미리보기가 말한 기간을 그대로 되짚어 견준다.
+      final String summary = tester
+          .widget<Text>(find.descendant(of: preview, matching: find.byType(Text)))
+          .data!;
+      final RegExpMatch? shown = RegExp(
+        r'(\d+).*?(\d{4}-\d{2}-\d{2}).*?(\d{4}-\d{2}-\d{2})',
+      ).firstMatch(summary);
+      expect(shown, isNotNull, reason: '미리보기 문구: $summary');
+
+      final DateTime first = DateTime.parse(shown!.group(2)!);
+      final DateTime last = DateTime.parse(shown.group(3)!);
+      // 주 1회 반복이라 첫 회차와 마지막 회차는 같은 요일이다.
+      expect(last.weekday, first.weekday);
       expect(
-        find.descendant(of: preview, matching: find.textContaining('8')),
-        findsOneWidget,
+        int.parse(shown.group(1)!),
+        last.difference(first).inDays ~/ 7 + 1,
       );
 
       // 다시 끄면 미리보기도 사라진다 — `매주` 는 토글이라 한 번 더 누르면


### PR DESCRIPTION
Closes #1647

## Summary

트레이너 앱 일정 시트의 반복 미리보기 테스트가 실패하고 있었습니다. 날짜에 따라
흔들리는 실패가 아니라 늘 이렇게 납니다.

## Changes

미리보기 문구에 `8` 이 들어 있는지를 보고 있었습니다. 기본 종료일이 `_date + 56일`
인데 56일 뒤는 **같은 요일**이라 그 주까지 포함돼 0~8주 = 9회가 만들어집니다.
기간이 8주라고 회차가 8회가 되지는 않습니다.

회차 수는 **시작~종료일 기간에서 나오는 값**입니다. 여기에 숫자를 따로 적어 두면
기본 종료일이 바뀔 때 이 단언만 홀로 틀립니다 — 미리보기가 말한 기간을 그대로
되짚어 견주게 했습니다. 첫 회차와 마지막 회차가 같은 요일인지도 함께 봅니다(주 1회).

## Notes

- 기본 종료일(56일)은 그대로 두었습니다. 미리보기가 무엇을 만들지 정확히 말하고
  있고, 트레이너가 날짜 필드를 눌러 언제든 다시 고를 수 있습니다. 회차 수를 8회로
  맞추고 싶다면 그것은 이 테스트가 아니라 기본 기간을 정하는 별개 판단입니다.
- 트레이너 앱 `flutter analyze` 클린, 해당 스위트 통과.
- #1646 의 CI 가 이 실패 하나로 빨간 상태였습니다. 이 PR 이 병합되면 그쪽을
  리베이스해 녹색으로 만들겠습니다.
